### PR TITLE
fix: repair daily pipeline workflow

### DIFF
--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -38,6 +38,7 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
           OMDB_API_KEY: ${{ secrets.OMDB_API_KEY }}
+          TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       
       - name: Upload logs
@@ -53,10 +54,47 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: '⚠️ Daily Pipeline Failed - ' + new Date().toISOString().split('T')[0],
-              body: 'The daily movie discovery pipeline failed. Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.',
-              labels: ['bug', 'automation']
-            })
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const titlePrefix = '⚠️ Daily Pipeline Failed';
+            const rollingTitle = '⚠️ Daily Pipeline Failed (rolling)';
+            const now = new Date().toISOString();
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const commentBody =
+              `Daily pipeline failed again at ${now}.\n\n` +
+              `Workflow run: ${runUrl}`;
+
+            const { data: openIssues } = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100
+            });
+
+            const existingIssue = openIssues.find((issue) =>
+              !issue.pull_request &&
+              issue.title.startsWith(titlePrefix)
+            );
+
+            if (existingIssue) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: existingIssue.number,
+                body: commentBody
+              });
+              core.info(`Commented on existing issue #${existingIssue.number}`);
+            } else {
+              const createResult = await github.rest.issues.create({
+                owner,
+                repo,
+                title: rollingTitle,
+                body:
+                  `The daily movie discovery pipeline has failed.\n\n` +
+                  `First failure in this rolling issue: ${now}\n` +
+                  `Workflow run: ${runUrl}\n\n` +
+                  `Subsequent failures will be added as comments until the workflow is healthy again.`,
+                labels: ['bug', 'automation']
+              });
+              core.info(`Created rolling issue #${createResult.data.number}`);
+            }

--- a/scripts/pipeline/run-pipeline.js
+++ b/scripts/pipeline/run-pipeline.js
@@ -4,13 +4,36 @@ require('dotenv').config();
 const Logger = require('../utils/logger');
 const { logUpdateRun, completeUpdateRun } = require('../utils/supabase');
 const tmdbClient = require('../utils/tmdb-client');
-const omdbClient = require('../utils/omdb-client');
-const traktClient = require('../utils/trakt-client');
-const openaiClient = require('../utils/openai-client');
 const { spawn } = require('child_process');
 const path = require('path');
 
 const logger = new Logger('run-pipeline.log');
+
+/**
+ * Steps that depend on optional provider credentials.
+ * Missing keys should skip those steps instead of failing the whole run.
+ */
+const STEP_REQUIRED_ENV = {
+  '06-fetch-external-ratings': 'OMDB_API_KEY',
+  '06b-fetch-trakt-ratings': 'TRAKT_CLIENT_ID',
+  '08-generate-embeddings': 'OPENAI_API_KEY'
+};
+
+/**
+ * Load optional clients safely so missing provider keys don't crash startup.
+ */
+function loadOptionalClient(label, loader) {
+  try {
+    return loader();
+  } catch (error) {
+    logger.warn(`[INIT] ${label} client unavailable: ${error.message}`);
+    return null;
+  }
+}
+
+const omdbClient = loadOptionalClient('OMDb', () => require('../utils/omdb-client'));
+const traktClient = loadOptionalClient('Trakt', () => require('../utils/trakt-client'));
+const openaiClient = loadOptionalClient('OpenAI', () => require('../utils/openai-client'));
 
 /**
  * Run modes configuration
@@ -27,15 +50,15 @@ const RUN_MODES = {
       { name: '06-fetch-external-ratings', enabled: true, options: { limit: 100 } },
       { name: '06b-fetch-trakt-ratings',   enabled: true, options: { limit: 100 } },
       { name: '07-calculate-movie-scores', enabled: true },
-      { name: '08-generate-embeddings', enabled: true },
-      { name: '09-calculate-mood-scores', enabled: true }
+      { name: '08-generate-embeddings', enabled: true, options: { limit: 250 } },
+      { name: '09-calculate-mood-scores', enabled: true, options: { limit: 250 } }
     ]
   },
   refresh: {
     description: 'Refresh stale movie data (weekly)',
     steps: [
       { name: '01-discover-new-movies', enabled: false },
-      { name: '02-fetch-movie-metadata', enabled: true, options: { updateType: 'stale_metadata', limit: 500 } },
+      { name: '02-fetch-movie-metadata', enabled: true, options: { updateType: 'stale-metadata', limit: 500 } },
       { name: '03-fetch-genres-keywords', enabled: false },
       { name: '04-fetch-cast-crew', enabled: false },
       { name: '05-calculate-cast-metadata', enabled: false },
@@ -101,7 +124,7 @@ function executeStep(stepName, options = {}, dryRun = false) {
     
     // Build arguments for the script
     const args = [];
-    if (options.limit) args.push('--limit', options.limit.toString());
+    if (options.limit) args.push(`--limit=${options.limit}`);
     if (options.updateType) args.push('--' + options.updateType);
     
     // Spawn the script as a child process
@@ -128,6 +151,21 @@ function executeStep(stepName, options = {}, dryRun = false) {
       resolve({ success: false, error: error.message, duration: parseFloat(duration) });
     });
   });
+}
+
+function getMissingProviderEnvForStep(stepName) {
+  const requiredEnv = STEP_REQUIRED_ENV[stepName];
+  if (!requiredEnv) return null;
+  return process.env[requiredEnv] ? null : requiredEnv;
+}
+
+function formatOptionalUsage(client, formatter, unavailableLabel) {
+  if (!client) return unavailableLabel;
+  try {
+    return formatter(client);
+  } catch (error) {
+    return `N/A (${error.message})`;
+  }
 }
 
 /**
@@ -179,6 +217,13 @@ async function runPipeline(mode = 'discover', options = {}) {
       continue;
     }
 
+    const missingEnv = getMissingProviderEnvForStep(step.name);
+    if (missingEnv) {
+      logger.warn(`\n⊘ Skipping step: ${step.name} (missing ${missingEnv})`);
+      pipelineStats.stepsSkipped++;
+      continue;
+    }
+
     const stepOptions = { ...step.options, ...options.stepOptions };
     const result = await executeStep(step.name, stepOptions, options.dryRun);
 
@@ -215,9 +260,27 @@ async function runPipeline(mode = 'discover', options = {}) {
   
   logger.info(`\nAPI Usage:`);
   logger.info(`  - TMDB: ${tmdbClient.getRequestCount()} calls`);
-  logger.info(`  - OMDb: ${omdbClient.getRequestCount()} / 1000 calls (${omdbClient.getQuotaRemaining()} remaining)`);
-  logger.info(`  - Trakt: ${traktClient.getRequestCount()} calls`);
-  logger.info(`  - OpenAI: ${openaiClient.getRequestCount()} requests ($${openaiClient.getTotalCost()})`);
+  logger.info(
+    `  - OMDb: ${formatOptionalUsage(
+      omdbClient,
+      (client) => `${client.getRequestCount()} / 1000 calls (${client.getQuotaRemaining()} remaining)`,
+      'N/A (client not initialized)'
+    )}`
+  );
+  logger.info(
+    `  - Trakt: ${formatOptionalUsage(
+      traktClient,
+      (client) => `${client.getRequestCount()} calls`,
+      'N/A (client not initialized)'
+    )}`
+  );
+  logger.info(
+    `  - OpenAI: ${formatOptionalUsage(
+      openaiClient,
+      (client) => `${client.getRequestCount()} requests ($${client.getTotalCost()})`,
+      'N/A (client not initialized)'
+    )}`
+  );
   
   logger.info(`\nTotal duration: ${totalDuration}s (${(totalDuration / 60).toFixed(1)} minutes)`);
 


### PR DESCRIPTION
## Summary
- prevent daily pipeline startup crashes when optional provider keys are missing by safely loading optional clients in `run-pipeline.js`
- auto-skip provider-dependent steps when required env vars are absent:
  - `06-fetch-external-ratings` -> `OMDB_API_KEY`
  - `06b-fetch-trakt-ratings` -> `TRAKT_CLIENT_ID`
  - `08-generate-embeddings` -> `OPENAI_API_KEY`
- make API usage summary resilient when optional clients are unavailable (`N/A` instead of throwing)
- dedupe daily failure issues in workflow by reusing one rolling issue and appending comments on subsequent failures (ignoring PRs)

## Root Cause
`run-pipeline.js` eagerly required optional provider clients (`omdb-client`, `openai-client`) at module load, and those modules throw if their keys are missing. This caused the workflow to fail before step orchestration could handle degraded behavior.

## Validation
- `node --check scripts/pipeline/run-pipeline.js`
- `env -u OMDB_API_KEY node scripts/pipeline/run-pipeline.js discover --dry-run` (now succeeds; provider step is skipped instead of crashing)
- `node scripts/pipeline/run-pipeline.js discover --dry-run`
- `npm run build` (passes)
