### PR TITLE
fix: add global test env stubs for CI compatibility

### DIFF
--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -1,1 +1,7 @@
+import { vi } from 'vitest'
+
+vi.stubEnv('VITE_SUPABASE_URL', 'https://test.supabase.co')
+vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'test-anon-key')
+vi.stubEnv('VITE_TMDB_API_KEY', 'test-key')
+
 import '@testing-library/jest-dom'


### PR DESCRIPTION
## Summary\n- add global Vitest env stubs in src/test/setup.js\n- stubs are declared at the top of setup so tests get required VITE_* values in CI\n- keep per-file stubbing out of the targeted tests (none remained to remove)\n\n## Verification\n- npm run test\n- expected SectionErrorBoundary logs include "Error: always broken"\n- test suite passes without external env injection