### PR TITLE
chore: remove unused import in Row

### DIFF
--- a/src/components/carousel/Row/index.jsx
+++ b/src/components/carousel/Row/index.jsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { useVirtualization } from '../hooks/useVirtualization'
-import { useMovieCardHover, CARD_EXPAND_DELAY_MS } from '../hooks/useMovieCardHover'
+import { useMovieCardHover } from '../hooks/useMovieCardHover'
 import { MovieCard } from '../CardContent/MovieCard'
 
 export { CARD_EXPAND_DELAY_MS } from '../hooks/useMovieCardHover'


### PR DESCRIPTION
## Summary
- removed unused `CARD_EXPAND_DELAY_MS` import from `src/components/carousel/Row/index.jsx`
- kept the existing re-export intact (`export { CARD_EXPAND_DELAY_MS } ...`)

## Verification
- ran `npm run lint`
- result: 0 warnings, 0 errors
- log: `/tmp/row-unused-import-lint.txt`
