### PR TITLE
feat: add Sentry error monitoring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ Three files own card hover. Read all three before touching any:
 VITE_SUPABASE_URL      # Supabase project URL (non-secret)
 VITE_SUPABASE_ANON_KEY # Supabase anon key (RLS enforces access)
 VITE_TMDB_API_KEY      # TMDB read-only key (rate-limited 40 req/10s)
+VITE_SENTRY_DSN        # Sentry DSN — only fires in PROD (enabled: import.meta.env.PROD)
 VITE_ADMIN_EMAILS      # Comma-separated admin emails
 ```
 **OpenAI key is server-side only. Never add `VITE_OPENAI_*`.**

--- a/env.example
+++ b/env.example
@@ -20,6 +20,10 @@ VITE_SUPABASE_ANON_KEY=
 # Acceptable in the bundle — read-only, rate-limited to 40 req/10s.
 VITE_TMDB_API_KEY=
 
+# ── Sentry ────────────────────────────────────────────────────────────────────
+# Sentry DSN for error monitoring (get from sentry.io/settings/projects/feelflick-app/keys/)
+VITE_SENTRY_DSN=
+
 # ── Admin access ──────────────────────────────────────────────────────────────
 # Comma-separated list of Google OAuth email addresses that get /admin access.
 # Example: admin@example.com,other@example.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "feelflick-app",
       "version": "0.1.0",
       "dependencies": {
+        "@sentry/react": "^10.48.0",
         "@supabase/supabase-js": "^2.87.1",
         "@tanstack/react-query": "^5.96.2",
         "axios": "^1.15.0",
@@ -1759,6 +1760,97 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.48.0.tgz",
+      "integrity": "sha512-SCiTLBXzugFKxev6NoKYBIhQoDk0gUh0AVVVepCBqfCJiWBG01Zvv0R5tCVohr4cWRllkQ8mlBdNQd/I7s9tdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.48.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.48.0.tgz",
+      "integrity": "sha512-tGkEyOM1HDS9qebDphUMEnyk3qq/50AnuTBiFmMJyjNzowylVGmRRk0sr3xkmbVHCDXQCiYnDmSVlJ2x4SDMrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.48.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.48.0.tgz",
+      "integrity": "sha512-sevRTePfuk4PNuz9KAKpmTZEomAU0aLXyIhOwA0OnUDdxPhkY8kq5lwDbuxTHv6DQUjUX3YgFbY45VH1JEqHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.48.0",
+        "@sentry/core": "10.48.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.48.0.tgz",
+      "integrity": "sha512-9nWuN2z4O+iwbTfuYV5ZmngBgJU/ZxfOo47A5RJP3Nu/kl59aJ1lUhILYOKyeNOIC/JyeERmpIcTxnlPXQzZ3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.48.0",
+        "@sentry/core": "10.48.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.48.0.tgz",
+      "integrity": "sha512-4jt2zX2ExgFcNe2x+W+/k81fmDUsOrquGtt028CiGuDuma6kEsWBI4JbooT1jhj2T+eeUxe3YGbM23Zhh7Ghhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.48.0",
+        "@sentry-internal/feedback": "10.48.0",
+        "@sentry-internal/replay": "10.48.0",
+        "@sentry-internal/replay-canvas": "10.48.0",
+        "@sentry/core": "10.48.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.48.0.tgz",
+      "integrity": "sha512-h8F+fXVwYC9ro5ZaO8V+v3vqc0awlXHGblEAuVxSGgh4IV/oFX+QVzXeDTTrFOFS6v/Vn5vAyu240eJrJAS6/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.48.0.tgz",
+      "integrity": "sha512-uc93vKjmu6gNns+JAX4qquuxWpAMit0uGPA1TYlMjct9NG1uX3TkDPJAr9Pgd1lOXx8mKqCmj5fK33QeExMpPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.48.0",
+        "@sentry/core": "10.48.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
     },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@sentry/react": "^10.48.0",
     "@supabase/supabase-js": "^2.87.1",
     "@tanstack/react-query": "^5.96.2",
     "axios": "^1.15.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 // src/app/App.jsx
+import * as Sentry from '@sentry/react'
 import { RouterProvider } from 'react-router-dom'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { router } from '@/app/router'
@@ -9,10 +10,26 @@ import { queryClient } from '@/shared/queryClient'
 export default function App() {
   useSessionTracking()
   return (
-    <QueryClientProvider client={queryClient}>
-      <WatchlistProvider>
-        <RouterProvider router={router} />
-      </WatchlistProvider>
-    </QueryClientProvider>
+    <Sentry.ErrorBoundary
+      fallback={({ error }) => (
+        <div className="min-h-screen bg-neutral-950 flex items-center justify-center text-white text-center p-8">
+          <div>
+            <h1 className="text-2xl font-bold mb-2">
+              Something went wrong
+            </h1>
+            <p className="text-neutral-400 text-sm">
+              {error?.message || 'An unexpected error occurred'}
+            </p>
+          </div>
+        </div>
+      )}
+      showDialog
+    >
+      <QueryClientProvider client={queryClient}>
+        <WatchlistProvider>
+          <RouterProvider router={router} />
+        </WatchlistProvider>
+      </QueryClientProvider>
+    </Sentry.ErrorBoundary>
   )
 }

--- a/src/app/router.jsx
+++ b/src/app/router.jsx
@@ -1,4 +1,5 @@
 // src/app/router.jsx
+import * as Sentry from '@sentry/react'
 import {
   createBrowserRouter,
   Navigate,
@@ -184,7 +185,9 @@ function SignOutRoute() {
 }
 
 /* -------------------------------- Router --------------------------------- */
-export const router = createBrowserRouter([
+const sentryCreateBrowserRouter = Sentry.wrapCreateBrowserRouterV7(createBrowserRouter)
+
+export const router = sentryCreateBrowserRouter([
   // Public branch (no app chrome)
   {
     element: <PublicShell />,

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,4 +1,5 @@
 // src/main.jsx
+import * as Sentry from '@sentry/react'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
@@ -9,6 +10,22 @@ import {
   consumeOAuthCallbackNonce,
   readOAuthNonceFromUrl,
 } from './shared/lib/auth/oauthNonce'
+
+Sentry.init({
+  dsn: import.meta.env.VITE_SENTRY_DSN,
+  enabled: import.meta.env.PROD,
+  environment: import.meta.env.MODE,
+  integrations: [
+    Sentry.browserTracingIntegration(),
+    Sentry.replayIntegration({
+      maskAllText: false,
+      blockAllMedia: false,
+    }),
+  ],
+  tracesSampleRate: 0.2,
+  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 1.0,
+})
 
 // Handle OAuth callback hash immediately, before React Router processes anything
 async function handleOAuthHash() {


### PR DESCRIPTION
## Summary
- add @sentry/react and initialize Sentry in src/main.jsx with prod-only enablement and replay/tracing sampling
- wrap React Router creation with Sentry in src/app/router.jsx using the v7 wrapper API from the installed SDK
- add top-level Sentry.ErrorBoundary in src/App.jsx with the requested fallback UI and showDialog
- add VITE_SENTRY_DSN to env.example and AGENTS.md

## Verification
- npm ci && npm run lint --silent && npm run test --silent && npm run build --silent (exit 0)
- confirmed route wrapper + ErrorBoundary + env/docs updates are present
- DSN check: local .env VITE_SENTRY_DSN literal is present in dist output after production build
