### PR TITLE
feat: report web vitals to Sentry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 ## Project
 Mood-first movie/TV discovery app. Users express how they feel → get curated recommendations.
 **Quality bar:** Netflix / Apple TV+ polish. Every surface is production-facing.
-**Stack:** React 18 · React Router v7 · Framer Motion · Tailwind CSS · Vite · Supabase (PostgreSQL + pgvector) · TMDB API · OpenAI (text-embedding-3-small) · Resend · Google OAuth · Vitest
+**Stack:** React 18 · React Router v7 · Framer Motion · Tailwind CSS · Vite · Supabase (PostgreSQL + pgvector) · TMDB API · OpenAI (text-embedding-3-small) · Resend · Google OAuth · Vitest · web-vitals (LCP/CLS/INP/TTFB → Sentry)
 **Language:** JavaScript (JSX). No TypeScript — never convert `.jsx` to `.tsx`.
 
 ## Mandatory Workflow — Run Before Every PR

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^7.14.0",
-        "resend": "^6.6.0"
+        "resend": "^6.6.0",
+        "web-vitals": "^4.2.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -7915,6 +7916,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^7.14.0",
-    "resend": "^6.6.0"
+    "resend": "^6.6.0",
+    "web-vitals": "^4.2.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,6 @@
 // src/main.jsx
 import * as Sentry from '@sentry/react'
+import { reportWebVitals } from '@/shared/lib/vitals'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
@@ -83,3 +84,5 @@ handleOAuthHash().then((handled) => {
     )
   }
 })
+
+reportWebVitals()

--- a/src/shared/lib/vitals.js
+++ b/src/shared/lib/vitals.js
@@ -1,0 +1,21 @@
+import * as Sentry from '@sentry/react'
+import { onCLS, onFCP, onFID, onINP, onLCP, onTTFB } from 'web-vitals'
+
+function sendToSentry({ name, value, rating, id }) {
+  Sentry.metrics.distribution(`web_vitals.${name.toLowerCase()}`, value, {
+    tags: {
+      rating,        // 'good' | 'needs-improvement' | 'poor'
+      metric_id: id,
+    },
+    unit: 'millisecond',
+  })
+}
+
+export function reportWebVitals() {
+  onCLS(sendToSentry)
+  onFCP(sendToSentry)
+  onFID(sendToSentry)
+  onINP(sendToSentry)
+  onLCP(sendToSentry)
+  onTTFB(sendToSentry)
+}


### PR DESCRIPTION
## Summary
- add `web-vitals` dependency and pin to a compatible version that exports `onFID`
- add `src/shared/lib/vitals.js` to capture CLS, FCP, FID, INP, LCP, and TTFB and send distributions to Sentry metrics
- wire `reportWebVitals()` into `src/main.jsx`
- update `AGENTS.md` stack line to include web-vitals reporting to Sentry

## Verification
- `npm ci && npm run lint --silent && npm run test --silent && npm run build --silent`
  - passed (exit 0)
