### PR TITLE
feat: edge middleware for bot OG meta injection

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,11 +76,6 @@
         "price": "0",
         "priceCurrency": "USD"
       },
-      "aggregateRating": {
-        "@type": "AggregateRating",
-        "ratingValue": "4.8",
-        "ratingCount": "1250"
-      },
       "creator": {
         "@type": "Organization",
         "name": "FeelFlick",

--- a/middleware.js
+++ b/middleware.js
@@ -1,0 +1,98 @@
+import { next } from '@vercel/edge'
+
+const BOT_PATTERNS = [
+  'facebookexternalhit', 'Facebot', 'Twitterbot', 'LinkedInBot',
+  'Slackbot', 'WhatsApp', 'TelegramBot', 'Discordbot',
+  'googlebot', 'bingbot', 'Applebot', 'iMessage'
+]
+
+export const config = {
+  matcher: ['/movie/:id'],
+}
+
+export default async function middleware(request) {
+  const ua = request.headers.get('user-agent') || ''
+  const isBot = BOT_PATTERNS.some(p =>
+    ua.toLowerCase().includes(p.toLowerCase())
+  )
+
+  if (!isBot) return next()
+
+  const url = new URL(request.url)
+  const movieId = url.pathname.split('/movie/')[1]
+  if (!movieId) return next()
+
+  try {
+    const tmdbRes = await fetch(
+      `https://api.themoviedb.org/3/movie/${movieId}?language=en-US`,
+      {
+        headers: {
+          Authorization: `Bearer ${process.env.TMDB_READ_ACCESS_TOKEN}`,
+          accept: 'application/json',
+        },
+      }
+    )
+
+    if (!tmdbRes.ok) return next()
+    const movie = await tmdbRes.json()
+
+    const title = movie.title || 'FeelFlick'
+    const year = movie.release_date
+      ? new Date(movie.release_date).getFullYear()
+      : null
+    const pageTitle = `${title}${year ? ` (${year})` : ''} — FeelFlick`
+    const description = movie.overview
+      ? `${movie.overview.slice(0, 150).trim()}… Discover ${title} and more on FeelFlick.`
+      : 'Discover movies based on your mood. Fast, private, and always free.'
+    const image = movie.poster_path
+      ? `https://image.tmdb.org/t/p/w1280${movie.poster_path}`
+      : 'https://app.feelflick.com/og.jpg'
+    const canonicalUrl = `https://app.feelflick.com/movie/${movieId}`
+
+    const htmlRes = await fetch(new URL('/', request.url).toString())
+    let html = await htmlRes.text()
+
+    const metaBlock = `
+    <title>${pageTitle}</title>
+    <meta name="description" content="${escapeAttr(description)}" />
+    <meta property="og:title" content="${escapeAttr(pageTitle)}" />
+    <meta property="og:description" content="${escapeAttr(description)}" />
+    <meta property="og:image" content="${escapeAttr(image)}" />
+    <meta property="og:url" content="${escapeAttr(canonicalUrl)}" />
+    <meta property="og:type" content="video.movie" />
+    <meta name="twitter:title" content="${escapeAttr(pageTitle)}" />
+    <meta name="twitter:description" content="${escapeAttr(description)}" />
+    <meta name="twitter:image" content="${escapeAttr(image)}" />
+    <meta name="twitter:url" content="${escapeAttr(canonicalUrl)}" />
+    <link rel="canonical" href="${escapeAttr(canonicalUrl)}" />`
+
+    html = html
+      .replace(/<title>[^<]*<\/title>/, '')
+      .replace(/<meta name="description"[^>]*>/i, '')
+      .replace(/<meta property="og:title"[^>]*>/i, '')
+      .replace(/<meta property="og:description"[^>]*>/i, '')
+      .replace(/<meta property="og:image"[^>]*>/i, '')
+      .replace(/<meta property="og:url"[^>]*>/i, '')
+      .replace(/<meta property="og:type"[^>]*>/i, '')
+      .replace(/<meta name="twitter:title"[^>]*>/i, '')
+      .replace(/<meta name="twitter:description"[^>]*>/i, '')
+      .replace(/<meta name="twitter:image"[^>]*>/i, '')
+      .replace(/<meta name="twitter:url"[^>]*>/i, '')
+      .replace(/<link rel="canonical"[^>]*>/i, '')
+      .replace('</head>', `${metaBlock}\n</head>`)
+
+    return new Response(html, {
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    })
+  } catch {
+    return next()
+  }
+}
+
+function escapeAttr(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@sentry/react": "^10.48.0",
         "@supabase/supabase-js": "^2.87.1",
         "@tanstack/react-query": "^5.96.2",
+        "@vercel/edge": "^1.2.2",
         "axios": "^1.15.0",
         "dotenv": "^17.2.3",
         "framer-motion": "^12.23.24",
@@ -2175,6 +2176,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@vercel/edge": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vercel/edge/-/edge-1.2.2.tgz",
+      "integrity": "sha512-1+y+f6rk0Yc9ss9bRDgz/gdpLimwoRteKHhrcgHvEpjbP1nyT3ByqEMWm2BTcpIO5UtDmIFXc8zdq4LR190PDA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@sentry/react": "^10.48.0",
     "@supabase/supabase-js": "^2.87.1",
     "@tanstack/react-query": "^5.96.2",
+    "@vercel/edge": "^1.2.2",
     "axios": "^1.15.0",
     "dotenv": "^17.2.3",
     "framer-motion": "^12.23.24",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,12 @@
+User-agent: *
+Allow: /
+
+# Disallow authenticated/private routes
+Disallow: /admin
+Disallow: /onboarding
+Disallow: /dev
+
+# Allow movie pages explicitly (for clarity)
+Allow: /movie/
+
+Sitemap: https://app.feelflick.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://app.feelflick.com/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://app.feelflick.com/discover</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>

--- a/src/app/pages/MovieDetail/index.jsx
+++ b/src/app/pages/MovieDetail/index.jsx
@@ -14,6 +14,7 @@ import DatabaseValidationPanel from '@/shared/components/DatabaseValidationPanel
 import MovieSentimentWidget from '@/shared/components/MovieSentimentWidget'
 import { useMovieRating } from '@/shared/hooks/useMovieRating'
 import { usePageView } from '@/shared/hooks/useInteractionTracking'
+import { usePageMeta } from '@/shared/hooks/usePageMeta'
 import { trackTrailerPlay, trackShare } from '@/shared/services/interactions'
 import { fetchJson, getMovieDetails } from '@/shared/api/tmdb'
 
@@ -211,6 +212,30 @@ export default function MovieDetail() {
   const tmdbRating = movie?.vote_average ? Math.round(movie.vote_average * 10) / 10 : null
   const year       = yearOf(movie?.release_date)
   const runtime    = formatRuntime(movie?.runtime)
+
+  const movieTitle = movie?.title
+  const movieYear = movie?.release_date
+    ? new Date(movie.release_date).getFullYear()
+    : null
+  const pageTitle = movieTitle
+    ? `${movieTitle}${movieYear ? ` (${movieYear})` : ''} — FeelFlick`
+    : null
+  const pageDesc = movie?.overview
+    ? `${movie.overview.slice(0, 150).trim()}… Discover ${movieTitle} and more on FeelFlick.`
+    : null
+  const pageImage = movie?.poster_path
+    ? `https://image.tmdb.org/t/p/w1280${movie.poster_path}`
+    : null
+  const pageUrl = movie?.id
+    ? `https://app.feelflick.com/movie/${movie.id}`
+    : null
+
+  usePageMeta({
+    title: pageTitle,
+    description: pageDesc,
+    image: pageImage,
+    url: pageUrl,
+  })
 
   // ── Mood pills (reused in hero + mobile content) ─────────────
   const MoodPills = () => movieMoods.length > 0 ? (

--- a/src/shared/hooks/usePageMeta.js
+++ b/src/shared/hooks/usePageMeta.js
@@ -1,0 +1,75 @@
+import { useEffect } from 'react'
+
+const DEFAULT_TITLE = 'FeelFlick — Movies that match your mood'
+const DEFAULT_DESC = 'Discover movies based on how you feel. Fast, private, and always free.'
+const DEFAULT_IMAGE = 'https://app.feelflick.com/og.jpg'
+const BASE_URL = 'https://app.feelflick.com'
+
+function setMeta(property, content, isName = false) {
+  if (!content) return
+
+  const attr = isName ? 'name' : 'property'
+  let el = document.querySelector(`meta[${attr}="${property}"]`)
+
+  if (!el) {
+    el = document.createElement('meta')
+    el.setAttribute(attr, property)
+    document.head.appendChild(el)
+  }
+
+  el.setAttribute('content', content)
+}
+
+function setCanonical(url) {
+  let el = document.querySelector('link[rel="canonical"]')
+
+  if (!el) {
+    el = document.createElement('link')
+    el.setAttribute('rel', 'canonical')
+    document.head.appendChild(el)
+  }
+
+  el.setAttribute('href', url)
+}
+
+/**
+ * Sets page-level SEO tags from runtime route data and restores FeelFlick defaults on cleanup.
+ *
+ * @param {Object} params - Dynamic page metadata.
+ * @param {string|null} params.title - Page title.
+ * @param {string|null} params.description - Meta description.
+ * @param {string|null} params.image - OG/Twitter image URL.
+ * @param {string|null} params.url - Canonical/OG/Twitter URL.
+ * @returns {void}
+ */
+export function usePageMeta({ title, description, image, url }) {
+  useEffect(() => {
+    const prevTitle = document.title
+
+    document.title = title || DEFAULT_TITLE
+    setMeta('description', description || DEFAULT_DESC, true)
+    setMeta('og:title', title || DEFAULT_TITLE)
+    setMeta('og:description', description || DEFAULT_DESC)
+    setMeta('og:image', image || DEFAULT_IMAGE)
+    setMeta('og:url', url || BASE_URL)
+    setMeta('twitter:title', title || DEFAULT_TITLE, true)
+    setMeta('twitter:description', description || DEFAULT_DESC, true)
+    setMeta('twitter:image', image || DEFAULT_IMAGE, true)
+    setMeta('twitter:url', url || BASE_URL, true)
+    setCanonical(url || BASE_URL)
+
+    return () => {
+      document.title = prevTitle
+      setMeta('description', DEFAULT_DESC, true)
+      setMeta('og:title', DEFAULT_TITLE)
+      setMeta('og:description', DEFAULT_DESC)
+      setMeta('og:image', DEFAULT_IMAGE)
+      setMeta('og:url', BASE_URL)
+      setMeta('twitter:title', DEFAULT_TITLE, true)
+      setMeta('twitter:description', DEFAULT_DESC, true)
+      setMeta('twitter:image', DEFAULT_IMAGE, true)
+      setMeta('twitter:url', BASE_URL, true)
+      setCanonical(BASE_URL)
+    }
+  }, [title, description, image, url])
+}

--- a/src/shared/hooks/usePageMeta.test.jsx
+++ b/src/shared/hooks/usePageMeta.test.jsx
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { render } from '@testing-library/react'
+
+import { usePageMeta } from './usePageMeta'
+
+const DEFAULT_TITLE = 'FeelFlick — Movies that match your mood'
+const DEFAULT_DESC = 'Discover movies based on how you feel. Fast, private, and always free.'
+const DEFAULT_IMAGE = 'https://app.feelflick.com/og.jpg'
+const BASE_URL = 'https://app.feelflick.com'
+
+function Probe({ title = null, description = null, image = null, url = null }) {
+  usePageMeta({ title, description, image, url })
+  return null
+}
+
+function getMetaByProperty(property) {
+  return document.querySelector(`meta[property="${property}"]`)?.getAttribute('content')
+}
+
+function getMetaByName(name) {
+  return document.querySelector(`meta[name="${name}"]`)?.getAttribute('content')
+}
+
+describe('usePageMeta', () => {
+  beforeEach(() => {
+    document.head.innerHTML = ''
+    document.title = 'Original title'
+  })
+
+  it('sets movie-specific title/meta/canonical values', () => {
+    render(
+      <Probe
+        title="Interstellar (2014) — FeelFlick"
+        description="A sci-fi epic with emotional depth."
+        image="https://image.tmdb.org/t/p/w1280/interstellar.jpg"
+        url="https://app.feelflick.com/movie/157336"
+      />
+    )
+
+    expect(document.title).toBe('Interstellar (2014) — FeelFlick')
+    expect(getMetaByName('description')).toBe('A sci-fi epic with emotional depth.')
+    expect(getMetaByProperty('og:title')).toBe('Interstellar (2014) — FeelFlick')
+    expect(getMetaByProperty('og:description')).toBe('A sci-fi epic with emotional depth.')
+    expect(getMetaByProperty('og:image')).toBe('https://image.tmdb.org/t/p/w1280/interstellar.jpg')
+    expect(getMetaByProperty('og:url')).toBe('https://app.feelflick.com/movie/157336')
+    expect(getMetaByName('twitter:title')).toBe('Interstellar (2014) — FeelFlick')
+    expect(getMetaByName('twitter:description')).toBe('A sci-fi epic with emotional depth.')
+    expect(getMetaByName('twitter:image')).toBe('https://image.tmdb.org/t/p/w1280/interstellar.jpg')
+    expect(getMetaByName('twitter:url')).toBe('https://app.feelflick.com/movie/157336')
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe('https://app.feelflick.com/movie/157336')
+  })
+
+  it('applies defaults when values are null', () => {
+    render(<Probe />)
+
+    expect(document.title).toBe(DEFAULT_TITLE)
+    expect(getMetaByName('description')).toBe(DEFAULT_DESC)
+    expect(getMetaByProperty('og:title')).toBe(DEFAULT_TITLE)
+    expect(getMetaByProperty('og:description')).toBe(DEFAULT_DESC)
+    expect(getMetaByProperty('og:image')).toBe(DEFAULT_IMAGE)
+    expect(getMetaByProperty('og:url')).toBe(BASE_URL)
+    expect(getMetaByName('twitter:title')).toBe(DEFAULT_TITLE)
+    expect(getMetaByName('twitter:description')).toBe(DEFAULT_DESC)
+    expect(getMetaByName('twitter:image')).toBe(DEFAULT_IMAGE)
+    expect(getMetaByName('twitter:url')).toBe(BASE_URL)
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(BASE_URL)
+  })
+
+  it('restores defaults and previous title on unmount', () => {
+    document.title = 'Page before movie detail'
+
+    const { unmount } = render(
+      <Probe
+        title="Blade Runner 2049 (2017) — FeelFlick"
+        description="Neo-noir mood and atmosphere."
+        image="https://image.tmdb.org/t/p/w1280/blade.jpg"
+        url="https://app.feelflick.com/movie/335984"
+      />
+    )
+
+    expect(document.title).toBe('Blade Runner 2049 (2017) — FeelFlick')
+
+    unmount()
+
+    expect(document.title).toBe('Page before movie detail')
+    expect(getMetaByName('description')).toBe(DEFAULT_DESC)
+    expect(getMetaByProperty('og:title')).toBe(DEFAULT_TITLE)
+    expect(getMetaByProperty('og:description')).toBe(DEFAULT_DESC)
+    expect(getMetaByProperty('og:image')).toBe(DEFAULT_IMAGE)
+    expect(getMetaByProperty('og:url')).toBe(BASE_URL)
+    expect(getMetaByName('twitter:title')).toBe(DEFAULT_TITLE)
+    expect(getMetaByName('twitter:description')).toBe(DEFAULT_DESC)
+    expect(getMetaByName('twitter:image')).toBe(DEFAULT_IMAGE)
+    expect(getMetaByName('twitter:url')).toBe(BASE_URL)
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(BASE_URL)
+  })
+})

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## Summary
- add Vercel Edge `middleware.js` for `/movie/:id` to inject movie-specific OG/Twitter/canonical tags for crawler user-agents
- use server-side `process.env.TMDB_READ_ACCESS_TOKEN` for TMDB movie fetches (no `VITE_` runtime env access)
- install `@vercel/edge`
- add `vercel.json` SPA rewrite to `/index.html`

## Verification
- `npm ci && npm run lint --silent && npm run build --silent`
