### PR TITLE
chore: add Google Search Console verification tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,9 @@
     <meta name="author" content="FeelFlick" />
     <meta name="theme-color" content="#a855f7" media="(prefers-color-scheme: dark)" />
     <meta name="theme-color" content="#ec4899" media="(prefers-color-scheme: light)" />
+
+    <!-- Google Search Console Verification -->
+    <meta name="google-site-verification" content="mx9Z6Q3XxD92mxS8GWHERBFrb8WdwWLv3WJj_R1AePg" />
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
@@ -53,12 +56,6 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 
-    <!-- In index.html <head> or a React head manager -->
-    <link rel="preconnect" href="https://image.tmdb.org" />
-    <link rel="dns-prefetch" href="https://image.tmdb.org" />
-
-
-    
     <!-- Structured Data (JSON-LD) for SEO -->
     <script type="application/ld+json">
     {


### PR DESCRIPTION
Adds the `google-site-verification` meta tag to `index.html` to verify ownership of `https://app.feelflick.com` in Google Search Console.

**What changed**
- Added `<meta name="google-site-verification" content="mx9Z6Q3XxD92mxS8GWHERBFrb8WdwWLv3WJj_R1AePg" />` to `<head>` in `index.html`
- Removed duplicate `<link rel="preconnect">` and `<link rel="dns-prefetch">` tags for `image.tmdb.org` that were redundant

**After merging**
1. Wait for Vercel to deploy (~1 min)
2. Go back to Google Search Console and click **Verify**
3. Then submit sitemap: `https://app.feelflick.com/sitemap.xml`