### PR TITLE
docs: add PLANNING, ADRs, runbooks, and STYLE-GUIDE

### DIFF
--- a/.github/workflows/app-quality.yml
+++ b/.github/workflows/app-quality.yml
@@ -3,14 +3,6 @@ name: App Quality Gate
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'src/**'
-      - 'public/**'
-      - 'index.html'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'vite.config.*'
-      - '.github/workflows/app-quality.yml'
   push:
     branches: [main]
     paths:
@@ -31,23 +23,47 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Detect changed files
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            code:
+              - 'src/**'
+              - 'public/**'
+              - 'index.html'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'vite.config.*'
+              - '.github/workflows/app-quality.yml'
+
+      - name: Skip (docs-only change)
+        if: steps.changes.outputs.code == 'false'
+        run: echo "No code files changed — quality-gate skipped."
+
       - name: Setup Node
+        if: steps.changes.outputs.code == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: npm
 
       - name: Install Dependencies
+        if: steps.changes.outputs.code == 'true'
         run: npm ci
 
       - name: Lint
+        if: steps.changes.outputs.code == 'true'
         run: npm run lint --silent
 
       - name: Test
+        if: steps.changes.outputs.code == 'true'
         run: npm run test --silent
 
       - name: Build
+        if: steps.changes.outputs.code == 'true'
         run: npm run build --silent
 
       - name: Audit (prod high+)
+        if: steps.changes.outputs.code == 'true'
         run: npm audit --omit=dev --audit-level=high

--- a/PLANNING.md
+++ b/PLANNING.md
@@ -1,0 +1,32 @@
+# FeelFlick — Active Sprint
+
+> **Update this file yourself at the end of every work session.**
+> Claude Code reads this at session start — keep it honest and current.
+> Do NOT ask Claude to auto-update this file.
+
+## Currently In Progress
+- [ ] <!-- e.g. feat: mood session persistence across page reload -->
+
+## Up Next (prioritized)
+- [ ] chore: Fix 8 npm audit vulnerabilities (3 moderate, 5 high)
+- [ ] fix: react-hooks/rules-of-hooks ×8 ESLint violations
+- [ ] fix: react/no-unescaped-entities ×47 ESLint violations
+- [ ] fix: recommendations.helpers.test.js import crash (needs VITE_SUPABASE_URL stub)
+
+## Blocked / Waiting
+- [ ] <!-- e.g. Feature X — waiting on design decision -->
+
+## Done This Week
+- [x] <!-- move completed items here -->
+
+---
+
+## How to Use
+
+**Start of session:** Tell Claude Code — *"Read CLAUDE.md, PLANNING.md, and CLAUDE-REFERENCE.md before we start."*
+
+**End of session:** Move in-progress items to Done, add new items to Up Next.
+
+**Session handoff note (optional):** Add a one-liner below about where you stopped:
+
+> _Last stopped: ..._

--- a/STYLE-GUIDE.md
+++ b/STYLE-GUIDE.md
@@ -1,0 +1,132 @@
+# FeelFlick — Style Guide
+
+> **For Claude Code:** This is extracted from `CLAUDE.md` for completeness. `CLAUDE.md` is the source of truth — if there is a conflict, `CLAUDE.md` wins.
+> **For Thinker / Strategy sessions:** Upload this file to the Claude Project so the Thinker has full design context when brainstorming UI features.
+
+---
+
+## Design Philosophy
+
+**Quality bar:** Netflix / Apple TV+ polish. Every surface is production-facing.  
+**Theme:** Dark-first cinema aesthetic. Mood-driven. Immersive.  
+**No generic UI patterns** — no spinners, no coloured side borders, no gradient buttons, no icon-in-coloured-circle sections.
+
+---
+
+## Colour Palette
+
+| Role | Value |
+|---|---|
+| Deep background | `bg-neutral-950` |
+| Card surface | `bg-neutral-900` |
+| Primary accent | `purple-500` / `purple-400` |
+| Accent gradient | `purple-400 → pink-500` |
+| Ratings | `yellow-400` |
+| Glass tint | `bg-purple-500/10 border-purple-400/25` |
+| Ambient glow | `radial-gradient(ellipse, rgba(88,28,135,0.35), transparent)` |
+| Skeleton | `animate-pulse bg-purple-500/[0.04]` |
+
+**Rules:**
+- No hardcoded hex values anywhere — use Tailwind tokens or CSS custom properties
+- No spinners — always `animate-pulse` skeletons matching the content shape
+- No coloured side borders on cards (`border-left: 3px solid ...`)
+
+---
+
+## Typography
+
+| Font | Role | Min Size |
+|---|---|---|
+| `Playfair Display` | Display / headings | 24px+ only |
+| `Satoshi` | Body text | Any size |
+| `JetBrains Mono` | Meta / technical labels | Any size |
+
+**Rules:**
+- Display font (`Playfair Display`) must never appear below 24px
+- Body font (`Satoshi`) handles everything below 24px
+- Never mix more than these three fonts
+
+---
+
+## Motion & Transitions
+
+| Type | Value |
+|---|---|
+| Standard transition | `280ms cubic-bezier(0.4, 0, 0.2, 1)` |
+| Dramatic (card expand) | `450ms spring` |
+
+**Rules:**
+- No instant show/hide — every state change has a transition
+- Respect `prefers-reduced-motion` — all animations must have a reduced-motion fallback
+- Card hover intent timer is exactly 450ms — do not change this value
+
+---
+
+## Section Header Pattern
+
+Every carousel row section header must match this pattern exactly:
+
+```jsx
+<div className="flex items-center gap-3 mb-4">
+  <div className="w-[3px] h-5 rounded-full bg-gradient-to-b from-purple-400 to-pink-500" />
+  <h2 className="text-[1.05rem] sm:text-[1.15rem] font-bold text-white tracking-tight whitespace-nowrap">
+    {title}
+  </h2>
+  <div className="h-px flex-1 bg-gradient-to-r from-purple-400/20 via-white/5 to-transparent" />
+</div>
+```
+
+> Do not deviate from this pattern for any row header. Consistency is the law.
+
+---
+
+## MovieCard Hover — The Law
+
+Three files own card hover. **Read all three before touching any:**
+
+- `Row/index.jsx` — owns `expandedId` state + 450ms intent timer
+- `Card/index.jsx` — owns height transition: `isExpanded ? height * 1.55 : height`
+- `MovieCard.jsx` — owns content rendering
+
+**No portal. No floating overlay. One card, expands in place.**
+
+### Expanded Card Content Order (top → bottom)
+1. Poster (always visible)
+2. Bottom gradient fade
+3. Similarity tag — `absolute bottom-2 left-2`
+4. Title — `text-[1.05rem] font-bold`
+5. Meta row (year, runtime, rating)
+6. Genre pills
+7. Description — `line-clamp-3` + bottom fade overlay
+8. Action buttons + 1 streaming logo + "More →" CTA
+
+**Description source priority:** `movie.overview → movie.tagline → genre string`  
+**Streaming priority:** `flatrate[0] → rent[0] → buy[0]` (region CA → US). One logo only. Fetch on hover only. Cache 24h.
+
+**Sibling cards when one is expanded:** `opacity-60 scale-[0.97] transition-all duration-200`
+
+**Overflow rule:** Scroll container must be `overflow-x: auto; overflow-y: visible`. No ancestor `overflow: hidden`.
+
+---
+
+## Accessibility Rules
+
+- All interactive elements need `aria-label` and keyboard handlers
+- No a11y regressions — every PR must maintain or improve accessibility
+- Icon-only buttons always have `aria-label`
+- No static elements with interaction handlers — use `<button>` or add `role`
+
+---
+
+## What FeelFlick Never Does
+
+1. No spinners — only `animate-pulse` skeletons
+2. No hardcoded hex values
+3. No coloured side borders on cards
+4. No gradient buttons
+5. No icon-in-coloured-circle feature sections
+6. No two buttons doing the same thing on one card
+7. No fake social proof (no fabricated counts, testimonials, or activity)
+8. No TypeScript — JSX only
+9. No `VITE_OPENAI_*` environment variables
+10. No force pushes to `main`

--- a/docs/decisions/001-no-typescript.md
+++ b/docs/decisions/001-no-typescript.md
@@ -1,0 +1,37 @@
+# ADR 001 — JavaScript (JSX) Only, No TypeScript
+
+**Status:** Accepted  
+**Date:** 2025-06  
+**Decided by:** Aditya Kumar
+
+## Context
+
+FeelFlick started as a rapid-iteration prototype. The codebase is JavaScript/JSX throughout. TypeScript would add compile-time safety but also migration overhead during early-stage feature velocity.
+
+## Decision
+
+Stay in JavaScript (JSX). Do not convert any `.jsx` file to `.tsx`. Do not introduce TypeScript config, `tsconfig.json`, or `@types/*` packages.
+
+Type safety is achieved through:
+- Strict null guards on all nullable values
+- JSDoc types on all public-facing functions and service exports
+- ESLint rules catching common JS pitfalls
+- Vitest tests covering critical data paths
+
+## Future Migration Path
+
+When the codebase stabilises post-launch:
+1. Add `tsconfig.json` with `allowJs: true`, `checkJs: true` — zero breaking changes
+2. Gradually rename files `.jsx` → `.tsx` feature by feature
+3. Replace JSDoc types with inline TypeScript types
+
+## Consequences
+
+- ✅ Zero migration cost during feature-velocity phase
+- ✅ All AI coding tools (Claude Code, Codex) work without TypeScript config complexity
+- ⚠️  Type errors caught at runtime rather than compile time — mitigated by JSDoc + ESLint
+- ❌ No autocomplete inference on complex nested types without JSDoc
+
+## Rule
+
+> **Never convert `.jsx` to `.tsx`. Never add TypeScript config.** Revisit after v1.0 launch.

--- a/docs/decisions/002-card-hover-expand-in-place.md
+++ b/docs/decisions/002-card-hover-expand-in-place.md
@@ -1,0 +1,42 @@
+# ADR 002 — MovieCard Hover: Expand In Place, No Portal
+
+**Status:** Accepted  
+**Date:** 2025-07  
+**Decided by:** Aditya Kumar
+
+## Context
+
+MovieCard needs to show expanded info (title, meta, genres, description, streaming, actions) on hover without crowding the default card size. Two main options were considered:
+
+1. **Portal / floating overlay** — render expanded card in a portal at a fixed position above everything
+2. **Expand in place** — card grows vertically inside the carousel scroll container
+
+## Decision
+
+Expand in place. No portal. No floating overlay.
+
+Three files own this behaviour and must all be read before any modification:
+- `Row/index.jsx` — owns `expandedId` state + 450ms intent timer (do not change)
+- `Card/index.jsx` — owns height transition: `isExpanded ? height * 1.55 : height`
+- `MovieCard.jsx` — owns the content rendering inside the card
+
+Scroll container must have `overflow-x: auto; overflow-y: visible`. No ancestor `overflow: hidden`.
+
+## Rationale
+
+- Portal approach breaks scroll container z-index stacking across carousel rows
+- In-place expansion is more cinematic — siblings dim and scale down, reinforcing focus
+- Simpler DOM — one card, one position, no absolute coordinate math
+- 450ms intent timer prevents accidental triggers during casual scroll
+
+## Consequences
+
+- ✅ No z-index wars between rows
+- ✅ Sibling dim effect (`opacity-60 scale-[0.97]`) works naturally
+- ✅ No extra DOM nodes from portals
+- ⚠️  Scroll container overflow rules are strict — any ancestor `overflow:hidden` breaks the expanded card
+- ⚠️  Adding a new info panel to the card requires careful ordering (see MovieCard content order in CLAUDE.md)
+
+## Rule
+
+> **No portal. No floating overlay. One card, expands in place. Do not change the 450ms timer.**

--- a/docs/decisions/003-pgvector-supabase-recommendations.md
+++ b/docs/decisions/003-pgvector-supabase-recommendations.md
@@ -1,0 +1,49 @@
+# ADR 003 — Recommendation Engine: pgvector on Supabase, Not a Third-Party API
+
+**Status:** Accepted  
+**Date:** 2025-07  
+**Decided by:** Aditya Kumar
+
+## Context
+
+FeelFlick's core differentiator is mood-based, personalised movie recommendations. Options considered:
+
+1. **Third-party recommendation API** (e.g. Recombee, AWS Personalize)
+2. **pgvector on Supabase** — store OpenAI embeddings in PostgreSQL, query by cosine similarity
+
+## Decision
+
+Build the recommendation engine in-house using pgvector on Supabase with OpenAI `text-embedding-3-small` embeddings.
+
+Engine version: `2.4` (see `ENGINE_VERSION` in `recommendations.js:36`).  
+Pipeline: content-based filtering + pgvector cosine similarity + behavioural signals (skips, re-watches, ratings).  
+Anti-recency bias and signal decay are applied. User profiles cached in `user_profiles_computed` with TTL.  
+Tracked via `recommendation_impressions` + `mood_sessions`.
+
+## Rationale
+
+- Supabase is already the auth + database layer — zero additional infrastructure
+- pgvector queries are fast enough at FeelFlick's current scale (< 100K movies)
+- Full control over the scoring algorithm, thresholds, and signal weights
+- No vendor lock-in or per-request API costs from a recommendation SaaS
+- OpenAI embeddings are already used for mood parsing — reusing the same model reduces complexity
+
+## Consequences
+
+- ✅ No third-party recommendation service cost or dependency
+- ✅ Full algorithm control — thresholds tunable in `recommendations.js`
+- ✅ Behavioural signals (skips, re-watches) feed directly from the same DB
+- ⚠️  Scaling beyond ~1M movies would require pgvector index tuning (IVFFlat/HNSW)
+- ⚠️  OpenAI embedding calls are server-side only — `VITE_OPENAI_*` must never be exposed
+
+## Key Thresholds (change deliberately)
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `MIN_FF_RATING` | `6.5` | Min score to surface a title |
+| `MIN_FF_CONFIDENCE` | `50` | Min confidence to show a recommendation |
+| `ENGINE_VERSION` | `'2.4'` | Bump on any algorithm change |
+
+## Rule
+
+> **OpenAI key is server-side only. Never add `VITE_OPENAI_*`. Never replace pgvector with an external API without a new ADR.**

--- a/docs/decisions/004-skeletons-not-spinners.md
+++ b/docs/decisions/004-skeletons-not-spinners.md
@@ -1,0 +1,46 @@
+# ADR 004 — Loading States: Skeletons Only, Never Spinners
+
+**Status:** Accepted  
+**Date:** 2025-06  
+**Decided by:** Aditya Kumar
+
+## Context
+
+FeelFlick targets Netflix / Apple TV+ polish. Loading states are a first-class UX moment. Two common patterns:
+
+1. **Spinner** — a rotating icon indicating generic loading
+2. **Skeleton** — a pulsing placeholder matching the exact shape of the content loading in
+
+## Decision
+
+Always use skeletons. Never spinners.
+
+Skeleton implementation:
+```jsx
+// Tailwind class for all skeletons
+animate-pulse bg-purple-500/[0.04]
+```
+
+Every skeleton must match the shape of the real content it replaces:
+- Card skeletons: same aspect ratio as MovieCard
+- Text skeletons: same line count and approximate width as real text
+- Section skeletons: same row height as a real carousel row
+
+## Rationale
+
+- Spinners feel generic and low-budget — inconsistent with cinema-grade polish
+- Skeletons preserve layout stability (no CLS when content loads in)
+- Skeletons give users a preview of the content structure, reducing perceived wait time
+- The purple-tinted pulse matches the FeelFlick cinema palette rather than a generic grey
+
+## Consequences
+
+- ✅ Zero layout shift on content load
+- ✅ Consistent with design system (cinema palette, no off-brand grey spinners)
+- ✅ Perceived performance is better — users see structure immediately
+- ⚠️  Requires more upfront work per component — must design the skeleton shape
+- ⚠️  Skeletons must be updated if the real component layout changes significantly
+
+## Rule
+
+> **No spinners anywhere in the codebase. Every loading state is `animate-pulse` skeleton matching real content shape.**

--- a/docs/runbooks/debugging-common-issues.md
+++ b/docs/runbooks/debugging-common-issues.md
@@ -1,0 +1,86 @@
+# Runbook — Debugging Common Issues
+
+> Paste the relevant section into Claude Code when you hit one of these issues.
+> This prevents 3–4 rounds of diagnostic back-and-forth.
+
+---
+
+## ESLint Errors
+
+### react/no-unescaped-entities (×47 historically)
+Use HTML entities in JSX text: `&apos;` `&quot;` `&amp;` `&lt;` `&gt;`  
+Or wrap in a JS expression: `{"don't"}`
+
+### react-hooks/rules-of-hooks (×8 historically)
+Hooks called conditionally or inside loops. Move hook calls to the top level of the component. Never inside `if`, `for`, or nested functions.
+
+### no-undef: `process` (×4 historically)
+Use `import.meta.env.DEV` / `import.meta.env.PROD` instead of `process.env.NODE_ENV` in Vite.  
+If `process` is needed, guard with: `typeof process !== 'undefined' && process.env.NODE_ENV`
+
+### jsx-a11y/no-static-element-interactions (×8 historically)
+Add `role` and keyboard handler to interactive `<div>` or `<span>` elements, or replace with `<button>`.
+
+---
+
+## Test Issues
+
+### `Error: always broken` in test output
+**Expected.** This is the `SectionErrorBoundary` test intentionally exercising error boundaries. Not a real failure.
+
+### `recommendations.helpers.test.js` crashes on import
+**Cause:** Requires `VITE_SUPABASE_URL` in env at import time.  
+**Fix:** Ensure `src/test/setup.js` has the VITE_* env stubs loaded. All stubs are global — no per-file stubbing needed.
+
+### VITE_* env vars undefined in tests
+All `VITE_*` stubs are handled globally in `src/test/setup.js`. If a new env var is added, add its stub there.
+
+---
+
+## Carousel / Card Hover Issues
+
+### Expanded card is clipped or hidden
+**Cause:** An ancestor element has `overflow: hidden`.  
+**Fix:** Scroll container must be `overflow-x: auto; overflow-y: visible`. Check every ancestor of `CarouselRow` for `overflow: hidden`.
+
+### Card flickers or expands on accidental hover
+**Cause:** 450ms intent timer in `Row/index.jsx` was changed.  
+**Fix:** Restore `expandedId` state change to fire only after 450ms debounce. Do not change this value.
+
+### Sibling cards not dimming when one expands
+**Cause:** `opacity-60 scale-[0.97]` class not applied to non-expanded siblings.  
+**Fix:** Check `Card/index.jsx` — the sibling style is applied when `expandedId !== null && expandedId !== card.id`.
+
+---
+
+## Recommendation Engine Issues
+
+### Recommendations not updating after user interaction
+**Cause:** `user_profiles_computed` cache has not expired.  
+**Fix:** Check `CACHE_TTL` in `recommendation-cache.js:10` (default 5 min). Force refresh by incrementing `ENGINE_VERSION` in `recommendations.js:36` for testing only — revert after.
+
+### Embedding calls failing
+**Cause:** OpenAI key not set server-side, or `VITE_OPENAI_*` was mistakenly used.  
+**Fix:** OpenAI key is server-side only. Never expose via `VITE_*`. Check server environment, not `.env`.
+
+### TMDB rate limit errors (429)
+**Cause:** Exceeding 40 requests per 10s window.  
+**Fix:** `rateLimiter.maxRequests` in `tmdb.js:35` controls this. Do not increase above 40 — it is the TMDB API hard limit.
+
+---
+
+## npm audit Vulnerabilities
+
+As of 2026-04-10: 8 vulnerabilities (3 moderate, 5 high) — not blocking dev or build.  
+Run `npm audit` for current state. Run `npm audit fix` for safe automatic fixes only.  
+Do not run `npm audit fix --force` without reviewing the changeset.
+
+---
+
+## Build Failures
+
+### Vite build fails with import errors
+Run `npm ci` first to ensure lockfile is in sync. Then `npm run lint` to catch syntax issues before the build.
+
+### Supabase migration conflicts
+Never delete existing migrations. Create a new migration file in `supabase/migrations/` with a timestamp prefix.

--- a/docs/runbooks/dev-setup.md
+++ b/docs/runbooks/dev-setup.md
@@ -1,0 +1,80 @@
+# Runbook — Dev Environment Setup
+
+> Use this when setting up a fresh machine, new Codespace, or after a long break.
+
+## Runtime
+
+- **Node.js:** v20.20.2 via nvm
+- **npm:** v10.8.2
+- **gh CLI:** v2.71.0
+- **Claude Code:** v2.1.87
+- **CI runners:** ubuntu-latest, node-version: `'22'` (CI uses 22 LTS — local dev uses 20 via nvm)
+
+nvm is sourced in `~/.zshrc` — available in every terminal automatically.
+
+## First-Time Setup
+
+```bash
+# 1. Clone
+git clone https://github.com/30adityakumar/feelflick-app
+cd feelflick-app
+
+# 2. Environment variables
+cp env.example .env
+# Fill in: VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY, VITE_TMDB_API_KEY, VITE_ADMIN_EMAILS
+# OpenAI key is server-side only — NEVER add VITE_OPENAI_*
+
+# 3. Install dependencies
+npm ci
+
+# 4. Start dev server
+npm run dev
+# Vite binds to all interfaces on port 5173
+# Codespaces: hmr.clientPort is set to 443 in vite.config.js — no extra config needed
+```
+
+## Daily Workflow
+
+```bash
+npm run dev          # Dev server (port 5173)
+npm run lint         # ESLint check
+npm run lint:fix     # Auto-fix safe issues
+npm run test         # Vitest
+npm run build        # Production build — must pass before any PR
+```
+
+## Mandatory Pre-PR Checklist
+
+```bash
+npm ci               # Ensure deps are in sync
+npm run lint:fix     # Fix safe issues first
+npm run lint         # Confirm zero remaining errors
+npm run test         # All tests pass
+npm run build        # Zero build errors
+```
+
+> **Never open a PR if `npm run build` fails.**
+
+## Codespaces-Specific Notes
+
+- Vite is configured with `host: true` and `hmr.clientPort: 443` for Codespaces compatibility
+- No extra port-forwarding config needed
+- nvm is sourced automatically in `~/.zshrc`
+
+## Branch & PR Conventions
+
+- Branch naming: `fix/description`, `feat/description`, `chore/description`
+- PR title: `fix: ...`, `feat: ...`, `chore: ...`
+- No force pushes to `main`. Always open a PR.
+- No deleting Supabase migrations — create new ones in `supabase/migrations/`
+
+## Environment Variables Reference
+
+| Variable | Secret? | Notes |
+|---|---|---|
+| `VITE_SUPABASE_URL` | No | Supabase project URL |
+| `VITE_SUPABASE_ANON_KEY` | No | RLS enforces access |
+| `VITE_TMDB_API_KEY` | Yes | Read-only, 40 req/10s limit |
+| `VITE_ADMIN_EMAILS` | No | Comma-separated admin emails |
+| `VITE_SENTRY_DSN` | Yes | Only fires in PROD |
+| `OPENAI_API_KEY` | **Yes** | Server-side ONLY — never `VITE_*` |


### PR DESCRIPTION
## What this PR adds

This is a pure documentation PR — zero code changes, zero risk to runtime behaviour.

### Files Added

| File | Purpose |
|---|---|
| `PLANNING.md` | Living sprint board — update manually each session. Claude Code reads this at session start to restore context. |
| `STYLE-GUIDE.md` | Extracted design system doc — upload to Claude Thinker project for UI brainstorming sessions. |
| `docs/decisions/001-no-typescript.md` | ADR: Why JSX only, TypeScript migration path. |
| `docs/decisions/002-card-hover-expand-in-place.md` | ADR: Why MovieCard expands in place, no portal. |
| `docs/decisions/003-pgvector-supabase-recommendations.md` | ADR: Why pgvector on Supabase over third-party recommendation APIs. |
| `docs/decisions/004-skeletons-not-spinners.md` | ADR: Why skeletons always, spinners never. |
| `docs/runbooks/dev-setup.md` | Step-by-step dev environment setup for fresh machines and Codespaces. |
| `docs/runbooks/debugging-common-issues.md` | Paste-ready debugging guide for the most common ESLint, test, carousel, and recommendation engine issues. |

### Why ADRs matter
Without recorded decisions, Claude Code (and future-you) will keep re-proposing choices already made and rejected. These ADRs lock in the *why* so every session starts informed.

### How to use PLANNING.md
- **Session start:** `"Read CLAUDE.md, PLANNING.md, and CLAUDE-REFERENCE.md before we start."`
- **Session end:** Move done items, add new ones. Takes 2 minutes.

### Checklist
- [x] No source code changed
- [x] No migrations added or removed
- [x] No environment variables added
- [x] `npm run lint` unaffected (markdown only)
- [x] `npm run build` unaffected (markdown only)