### PR TITLE
fix: pipeline coverage gaps — TRAKT_CLIENT_ID, step 08, option forwarding

### DIFF
--- a/.github/workflows/monthly-deep-refresh.yml
+++ b/.github/workflows/monthly-deep-refresh.yml
@@ -37,6 +37,7 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
           OMDB_API_KEY: ${{ secrets.OMDB_API_KEY }}
+          TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       
       - name: Upload logs

--- a/.github/workflows/weekly-refresh.yml
+++ b/.github/workflows/weekly-refresh.yml
@@ -37,6 +37,7 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
           OMDB_API_KEY: ${{ secrets.OMDB_API_KEY }}
+          TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       
       - name: Upload logs

--- a/scripts/pipeline/08-generate-embeddings.js
+++ b/scripts/pipeline/08-generate-embeddings.js
@@ -17,10 +17,11 @@
  *   - Status updated to 'complete'
  *
  * Options:
- *   --limit=N       Process max N movies (default: 10000)
- *   --dry-run       Simulate without making changes
- *   --rebuild       Re-embed already-embedded movies (ignores has_embeddings)
- *   --model=NAME    Override embedding model
+ *   --limit=N              Process max N movies (default: 10000)
+ *   --dry-run              Simulate without making changes
+ *   --rebuild              Re-embed already-embedded movies (ignores has_embeddings)
+ *   --stale-enrichment     Re-embed movies where llm_enriched_at > last_embedding_at
+ *   --model=NAME           Override embedding model
  *
  * ============================================================================
  */
@@ -239,6 +240,7 @@ async function main(options = {}) {
     maxMovies: options.maxMovies || CONFIG.MAX_MOVIES,
     dryRun: options.dryRun || false,
     rebuild: options.rebuild || false,
+    staleEnrichment: options.staleEnrichment || false,
     model: options.model || CONFIG.MODEL,
   };
 
@@ -247,6 +249,7 @@ async function main(options = {}) {
   logger.info(`Max movies: ${config.maxMovies.toLocaleString()}`);
   logger.info(`Dry run: ${config.dryRun ? 'YES' : 'NO'}`);
   logger.info(`Rebuild: ${config.rebuild ? 'YES' : 'NO'}`);
+  logger.info(`Stale enrichment: ${config.staleEnrichment ? 'YES' : 'NO'}`);
 
   // Check API key
   if (!process.env.OPENAI_API_KEY) {
@@ -258,13 +261,23 @@ async function main(options = {}) {
 
   try {
     // Build query — rebuild mode ignores has_embeddings filter
+    const selectCols = 'id, title, overview, tagline, genres, keywords, director_name, writer_name, cinematographer_name, collection_name, production_countries, release_date, original_language, mood_tags, tone_tags, fit_profile'
+      + (config.staleEnrichment ? ', llm_enriched_at, last_embedding_at' : '');
+
     let query = supabase
       .from('movies')
-      .select('id, title, overview, tagline, genres, keywords, director_name, writer_name, cinematographer_name, collection_name, production_countries, release_date, original_language, mood_tags, tone_tags, fit_profile')
+      .select(selectCols)
       .limit(config.maxMovies);
 
     if (config.rebuild) {
       query = query.in('status', ['scoring', 'complete']);
+    } else if (config.staleEnrichment) {
+      // Fetch enriched films with existing embeddings; filter client-side
+      // because PostgREST can't compare two columns directly
+      query = query
+        .in('status', ['scoring', 'complete'])
+        .not('embedding', 'is', null)
+        .not('llm_enriched_at', 'is', null);
     } else {
       query = query
         .eq('status', 'scoring')
@@ -272,9 +285,19 @@ async function main(options = {}) {
         .is('embedding', null);
     }
 
-    const { data: movies, error } = await query;
+    let { data: movies, error } = await query;
 
     if (error) throw error;
+
+    // Client-side staleness filter: keep films where enrichment is newer than embedding
+    if (config.staleEnrichment && movies?.length) {
+      const before = movies.length;
+      movies = movies.filter(m => {
+        if (!m.last_embedding_at) return true;
+        return new Date(m.llm_enriched_at) > new Date(m.last_embedding_at);
+      });
+      logger.info(`Staleness filter: ${before} candidates → ${movies.length} stale embeddings`);
+    }
 
     if (!movies || movies.length === 0) {
       logger.info('✓ All movies have embeddings');
@@ -459,6 +482,7 @@ if (require.main === module) {
   const options = {
     dryRun: args.includes('--dry-run'),
     rebuild: args.includes('--rebuild'),
+    staleEnrichment: args.includes('--stale-enrichment'),
     maxMovies: CONFIG.MAX_MOVIES
   };
 
@@ -485,9 +509,10 @@ USAGE:
 OPTIONS:
   --limit=N          Process max N movies (default: ${CONFIG.MAX_MOVIES.toLocaleString()})
   --max-movies=N     Alias for --limit
-  --dry-run          Simulate without making changes
-  --rebuild          Re-embed already-embedded movies
-  --model=NAME       Override embedding model (default: ${EMBEDDING_MODEL})
+  --dry-run              Simulate without making changes
+  --rebuild              Re-embed already-embedded movies
+  --stale-enrichment     Re-embed where llm_enriched_at > last_embedding_at
+  --model=NAME           Override embedding model (default: ${EMBEDDING_MODEL})
   --help, -h         Show this help message
 
 MODEL:

--- a/scripts/pipeline/run-pipeline.js
+++ b/scripts/pipeline/run-pipeline.js
@@ -90,7 +90,7 @@ const RUN_MODES = {
       { name: '06b-fetch-trakt-ratings',   enabled: true, options: { limit: 1000 } },
       { name: '07-calculate-movie-scores', enabled: true },
       { name: '07b-enrich-mood-llm', enabled: true, options: { limit: 2000, mode: 'stale' } },
-      { name: '08-generate-embeddings', enabled: false },
+      { name: '08-generate-embeddings', enabled: true, options: { limit: 2000, staleEnrichment: true } },
       { name: '09-calculate-mood-scores', enabled: false },
       { name: '10-aggregate-user-satisfaction', enabled: true, options: { limit: 10000 } }
     ]
@@ -141,6 +141,10 @@ function executeStep(stepName, options = {}, dryRun = false) {
     const args = [];
     if (options.limit) args.push(`--limit=${options.limit}`);
     if (options.updateType) args.push('--' + options.updateType);
+    if (options.mode) args.push(`--mode=${options.mode}`);
+    if (options.rebuild) args.push('--rebuild');
+    if (options.batch) args.push('--batch');
+    if (options.staleEnrichment) args.push('--stale-enrichment');
     
     // Spawn the script as a child process
     const child = spawn('node', [scriptPath, ...args], {


### PR DESCRIPTION
## Summary
- **TRAKT_CLIENT_ID** added to weekly and monthly workflow env blocks (was only in daily)
- **Step 08 enabled in deep-refresh** with `staleEnrichment: true` — re-embeds films where `llm_enriched_at > last_embedding_at` after step 07b re-enriches stale mood tags
- **executeStep option forwarding fixed** — was only passing `--limit` and `--updateType`, silently dropping `mode`, `rebuild`, `batch`. Step 07b's `mode=stale` in weekly/deep-refresh was never actually applied
- **`--stale-enrichment` flag** added to step 08 — client-side filter (PostgREST can't compare two columns), no new migration needed

## Test plan
- [ ] Trigger weekly workflow manually — verify Trakt calls > 0 in API stats
- [ ] `node scripts/pipeline/run-pipeline.js deep-refresh --dry-run` — verify step 08 appears in executed list
- [ ] Verify step 07b logs show `Mode: stale` in next weekly run (was silently running as `mode=new`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)