### PR TITLE
feat: schema cleanup, mood chip tracking, taste fingerprint cache

### DIFF
--- a/src/app/pages/MovieDetail/MoodChips.jsx
+++ b/src/app/pages/MovieDetail/MoodChips.jsx
@@ -1,5 +1,7 @@
 import { Link } from 'react-router-dom'
 
+import { trackInteraction } from '@/shared/services/interactions'
+
 const MOOD_COLORS = {
   // warm
   cozy: { bg: 'rgba(251,191,36,0.12)', border: 'rgba(251,191,36,0.3)', text: '#fcd34d' },
@@ -68,6 +70,7 @@ export default function MoodChips({ movie }) {
       {fitProfile && (
         <Link
           to={`/browse/fit/${fitProfile}`}
+          onClick={() => trackInteraction('mood_chip_click', { metadata: { tag: fitProfile, type: 'fit' } })}
           className="inline-flex items-center px-2.5 py-1 rounded-full text-[11px] font-bold uppercase tracking-wider bg-white/[0.06] border border-white/15 text-white/85 hover:bg-white/[0.1] hover:border-white/25 transition-colors"
         >
           {FIT_PROFILE_LABELS[fitProfile] || fitProfile.replace(/_/g, ' ')}
@@ -79,6 +82,7 @@ export default function MoodChips({ movie }) {
           <Link
             key={`m-${tag}`}
             to={`/mood/${encodeURIComponent(tag)}`}
+            onClick={() => trackInteraction('mood_chip_click', { metadata: { tag, type: 'mood' } })}
             className="inline-flex items-center px-2.5 py-1 rounded-full text-[11px] font-semibold transition-all hover:scale-105"
             style={{ background: c.bg, border: `1px solid ${c.border}`, color: c.text }}
           >
@@ -90,6 +94,7 @@ export default function MoodChips({ movie }) {
         <Link
           key={`t-${tag}`}
           to={`/tone/${encodeURIComponent(tag)}`}
+          onClick={() => trackInteraction('mood_chip_click', { metadata: { tag, type: 'tone' } })}
           className="inline-flex items-center px-2.5 py-1 rounded-full text-[11px] font-medium bg-transparent border border-white/12 text-white/55 hover:text-white/80 hover:border-white/25 transition-colors"
         >
           {tag}

--- a/src/app/pages/profile/PublicProfile.jsx
+++ b/src/app/pages/profile/PublicProfile.jsx
@@ -11,6 +11,7 @@ import { tmdbImg } from '@/shared/api/tmdb'
 import { useAuthSession } from '@/shared/hooks/useAuthSession'
 import FollowButton from '@/shared/components/FollowButton'
 import TasteFingerprint from './TasteFingerprint'
+import { useTasteFingerprint } from '@/shared/hooks/useTasteFingerprint'
 
 import {
   RATING_PERSONALITY,
@@ -298,6 +299,7 @@ export default function PublicProfile() {
   const navigate = useNavigate()
   const { userId: currentUserId } = useAuthSession()
 
+  const { fingerprint } = useTasteFingerprint(userId)
   const [loading, setLoading] = useState(true)
   const [notFound, setNotFound] = useState(false)
   const [profile, setProfile] = useState(null)
@@ -860,7 +862,7 @@ export default function PublicProfile() {
                 </div>
 
                 {/* === TASTE FINGERPRINT === */}
-                <TasteFingerprint history={history} />
+                <TasteFingerprint fingerprint={fingerprint} history={history} />
 
                 {/* === RECENTLY WATCHED === */}
                 {stats.recentlyWatched.length > 0 && (

--- a/src/app/pages/profile/TasteFingerprint.jsx
+++ b/src/app/pages/profile/TasteFingerprint.jsx
@@ -3,10 +3,22 @@ import { Link } from 'react-router-dom'
 
 /**
  * Visual taste signature from watched film aggregates.
- * @param {Array} history - user_history rows with nested movies(mood_tags, tone_tags, fit_profile)
+ * @param {object} props
+ * @param {object} [props.fingerprint] - Cached fingerprint from useTasteFingerprint
+ * @param {Array}  [props.history] - Fallback: raw user_history rows for client-side compute
  */
-export default function TasteFingerprint({ history }) {
+export default function TasteFingerprint({ fingerprint, history }) {
+  // Use cached fingerprint if available, otherwise compute client-side from history
   const { topMoods, topTones, topFits, total } = useMemo(() => {
+    if (fingerprint) {
+      return {
+        topMoods: fingerprint.topMoodTags || [],
+        topTones: fingerprint.topToneTags || [],
+        topFits: fingerprint.topFitProfiles || [],
+        total: fingerprint.total || 0,
+      }
+    }
+
     const moods = {}, tones = {}, fits = {}
     let count = 0
 
@@ -30,7 +42,7 @@ export default function TasteFingerprint({ history }) {
       topFits: top(fits, 5),
       total: count,
     }
-  }, [history])
+  }, [fingerprint, history])
 
   if (total < 5) {
     return (

--- a/src/app/pages/profile/TasteProfile.jsx
+++ b/src/app/pages/profile/TasteProfile.jsx
@@ -10,6 +10,7 @@ import { supabase } from '@/shared/lib/supabase/client'
 import { tmdbImg } from '@/shared/api/tmdb'
 import FollowButton from '@/shared/components/FollowButton'
 import TasteFingerprint from './TasteFingerprint'
+import { useTasteFingerprint } from '@/shared/hooks/useTasteFingerprint'
 
 import {
   RATING_PERSONALITY_SELF,
@@ -101,6 +102,7 @@ export default function TasteProfile() {
   const userId = outlet.userId
   const authUser = outlet.user
 
+  const { fingerprint } = useTasteFingerprint(userId)
   const [loading, setLoading] = useState(true)
   const [profile, setProfile] = useState(null)
   const [history, setHistory] = useState([])
@@ -600,7 +602,7 @@ export default function TasteProfile() {
                 </div>
 
                 {/* === TASTE FINGERPRINT === */}
-                <TasteFingerprint history={history} />
+                <TasteFingerprint fingerprint={fingerprint} history={history} />
                 {history.length >= 10 && (
                   <Link
                     to="/challenges"

--- a/src/shared/hooks/useTasteFingerprint.js
+++ b/src/shared/hooks/useTasteFingerprint.js
@@ -1,0 +1,34 @@
+import { useState, useEffect } from 'react'
+
+import { getTasteFingerprint } from '@/shared/services/tasteCache'
+
+/**
+ * Hook to fetch cached taste fingerprint for a user.
+ * Returns server-cached aggregates; falls back to null while loading.
+ * @param {string|null} userId
+ * @returns {{ fingerprint: object|null, loading: boolean }}
+ */
+export function useTasteFingerprint(userId) {
+  const [fingerprint, setFingerprint] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (!userId) {
+      setLoading(false)
+      return
+    }
+
+    let cancelled = false
+    setLoading(true)
+
+    getTasteFingerprint(userId).then(result => {
+      if (cancelled) return
+      setFingerprint(result)
+      setLoading(false)
+    })
+
+    return () => { cancelled = true }
+  }, [userId])
+
+  return { fingerprint, loading }
+}

--- a/src/shared/services/tasteCache.js
+++ b/src/shared/services/tasteCache.js
@@ -1,0 +1,112 @@
+// src/shared/services/tasteCache.js
+
+/**
+ * Taste fingerprint cache — aggregates mood_tags, tone_tags, fit_profile from
+ * watch history and caches results in user_profiles_computed for 24h.
+ *
+ * Mirrors personalRating.js caching pattern.
+ */
+
+import { supabase } from '@/shared/lib/supabase/client'
+
+// === CONFIG ===
+
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000
+const MIN_FILMS_FOR_FINGERPRINT = 5
+
+// === PUBLIC API ===
+
+/**
+ * Get or compute taste fingerprint for a user.
+ * Returns cached result if fresh (<24h), otherwise computes from watch history.
+ * @param {string} userId
+ * @returns {Promise<{topMoodTags: Array, topToneTags: Array, topFitProfiles: Array, total: number}|null>}
+ */
+export async function getTasteFingerprint(userId) {
+  if (!userId) return null
+
+  // Check cache
+  const { data: cached } = await supabase
+    .from('user_profiles_computed')
+    .select('taste_fingerprint, taste_fingerprint_computed_at')
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  const now = Date.now()
+  const isFresh = cached?.taste_fingerprint_computed_at &&
+    (now - new Date(cached.taste_fingerprint_computed_at).getTime()) < CACHE_TTL_MS
+
+  if (isFresh && cached.taste_fingerprint) {
+    return cached.taste_fingerprint
+  }
+
+  // Compute fresh from watch history
+  const result = await computeFingerprint(userId)
+  if (!result) return null
+
+  // Write to cache
+  await supabase.from('user_profiles_computed').upsert({
+    user_id: userId,
+    taste_fingerprint: result,
+    taste_fingerprint_computed_at: new Date().toISOString(),
+  }, { onConflict: 'user_id' })
+
+  return result
+}
+
+/**
+ * Invalidate the taste fingerprint cache for a user.
+ * Call after rating, watch status, or sentiment changes.
+ * @param {string} userId
+ */
+export function invalidateTasteFingerprint(userId) {
+  return supabase
+    .from('user_profiles_computed')
+    .update({ taste_fingerprint: null, taste_fingerprint_computed_at: null })
+    .eq('user_id', userId)
+}
+
+// === INTERNAL ===
+
+/**
+ * Aggregate mood_tags, tone_tags, fit_profile from user's watched films.
+ * @param {string} userId
+ * @returns {Promise<object|null>}
+ */
+async function computeFingerprint(userId) {
+  const { data: history, error } = await supabase
+    .from('user_history')
+    .select('movies(mood_tags, tone_tags, fit_profile)')
+    .eq('user_id', userId)
+    .eq('status', 'watched')
+
+  if (error || !history) return null
+
+  const moods = {}
+  const tones = {}
+  const fits = {}
+  let total = 0
+
+  for (const h of history) {
+    const m = h.movies
+    if (!m) continue
+    total++
+    ;(m.mood_tags || []).forEach(t => { moods[t] = (moods[t] || 0) + 1 })
+    ;(m.tone_tags || []).forEach(t => { tones[t] = (tones[t] || 0) + 1 })
+    if (m.fit_profile) fits[m.fit_profile] = (fits[m.fit_profile] || 0) + 1
+  }
+
+  if (total < MIN_FILMS_FOR_FINGERPRINT) return null
+
+  const topN = (obj, n) => Object.entries(obj)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, n)
+    .map(([key, count]) => ({ key, count, share: count / total }))
+
+  return {
+    topMoodTags: topN(moods, 12),
+    topToneTags: topN(tones, 6),
+    topFitProfiles: topN(fits, 5),
+    total,
+  }
+}

--- a/supabase/migrations/20260506000000_drop_unused_tables.sql
+++ b/supabase/migrations/20260506000000_drop_unused_tables.sql
@@ -1,6 +1,9 @@
 -- MIGRATION: Drop confirmed-unused tables
 -- Audited 2026-04-19: zero rows AND zero code references in src/ and scripts/
 
+-- Drop FK constraint referencing recommendation_experiments
+ALTER TABLE public.mood_sessions DROP CONSTRAINT IF EXISTS mood_sessions_experiment_fkey;
+
 DROP TABLE IF EXISTS public.user_movie_interactions;
 DROP TABLE IF EXISTS public.mood_transitions;
 DROP TABLE IF EXISTS public.movie_content_features;
@@ -14,7 +17,9 @@ DROP TABLE IF EXISTS public.movie_update_queue;
 DROP TABLE IF EXISTS public.homepage_recommendation_cache;
 DROP TABLE IF EXISTS public.user_movie_notes;
 DROP TABLE IF EXISTS public.user_preferences_audit;
-DROP TABLE IF EXISTS public.user_engagement_stats;
+
+-- user_engagement_stats is a materialized view, not a table
+DROP MATERIALIZED VIEW IF EXISTS public.user_engagement_stats;
 
 -- Dead column: codebase uses user_movie_feedback.movie_id exclusively
 ALTER TABLE public.user_movie_feedback DROP COLUMN IF EXISTS tmdb_id;

--- a/supabase/migrations/20260506000000_drop_unused_tables.sql
+++ b/supabase/migrations/20260506000000_drop_unused_tables.sql
@@ -1,0 +1,30 @@
+-- MIGRATION: Drop confirmed-unused tables
+-- Audited 2026-04-19: zero rows AND zero code references in src/ and scripts/
+
+DROP TABLE IF EXISTS public.user_movie_interactions;
+DROP TABLE IF EXISTS public.mood_transitions;
+DROP TABLE IF EXISTS public.movie_content_features;
+DROP TABLE IF EXISTS public.recommendation_experiments;
+DROP TABLE IF EXISTS public.mood_genre_affinity;
+DROP TABLE IF EXISTS public.movie_engagement_events;
+DROP TABLE IF EXISTS public.movie_cowatch_patterns;
+DROP TABLE IF EXISTS public.movie_completion_stats;
+DROP TABLE IF EXISTS public.staging_ratings_external;
+DROP TABLE IF EXISTS public.movie_update_queue;
+DROP TABLE IF EXISTS public.homepage_recommendation_cache;
+DROP TABLE IF EXISTS public.user_movie_notes;
+DROP TABLE IF EXISTS public.user_preferences_audit;
+DROP TABLE IF EXISTS public.user_engagement_stats;
+
+-- Dead column: codebase uses user_movie_feedback.movie_id exclusively
+ALTER TABLE public.user_movie_feedback DROP COLUMN IF EXISTS tmdb_id;
+
+-- KEPT (have active code references):
+-- movie_recommendations  → src/shared/services/recommendations.js
+-- user_similarity        → src/app/pages/people/UserSearchPage.jsx
+-- update_runs            → scripts/utils/supabase.js, pipeline-logger.js
+-- user_events            → src/shared/services/events-tracker.js
+-- moods                  → scripts/pipeline/09-calculate-mood-scores.js
+-- viewing_contexts       → scripts/phase1/02-populate-viewing-contexts.js
+-- experience_types       → scripts/phase1/03-populate-experience-types.js
+-- recommendation_events  → src/shared/hooks/useRecommendationTracking.js

--- a/supabase/migrations/20260506100000_add_taste_fingerprint_cache.sql
+++ b/supabase/migrations/20260506100000_add_taste_fingerprint_cache.sql
@@ -1,0 +1,11 @@
+-- MIGRATION: Add taste fingerprint cache to user_profiles_computed
+
+ALTER TABLE public.user_profiles_computed
+  ADD COLUMN IF NOT EXISTS taste_fingerprint jsonb,
+  ADD COLUMN IF NOT EXISTS taste_fingerprint_computed_at timestamptz;
+
+CREATE INDEX IF NOT EXISTS idx_upc_taste_fingerprint_at
+  ON public.user_profiles_computed(taste_fingerprint_computed_at);
+
+COMMENT ON COLUMN public.user_profiles_computed.taste_fingerprint IS
+  'Cached {topMoodTags, topToneTags, topFitProfiles} aggregated from watch history. TTL 24h.';


### PR DESCRIPTION
## Summary
- **14 dead tables dropped** via migration (audited: zero rows + zero code refs). 8 tables with live references kept and documented
- **Dead column removed**: `user_movie_feedback.tmdb_id` (codebase uses `movie_id` exclusively)
- **Mood chip click tracking** on MovieDetail — `trackInteraction('mood_chip_click', { tag, type })` for mood/tone/fit chips
- **Taste fingerprint caching** in `user_profiles_computed` (24h TTL). New `tasteCache.js` service + `useTasteFingerprint` hook. Component accepts cached prop with client-side history fallback

## New files
- `supabase/migrations/20260506000000_drop_unused_tables.sql`
- `supabase/migrations/20260506100000_add_taste_fingerprint_cache.sql`
- `src/shared/services/tasteCache.js`
- `src/shared/hooks/useTasteFingerprint.js`

## Test plan
- [ ] Apply migrations via `supabase db push` — verify no 404s on live site
- [ ] Open movie detail, click a mood chip — verify row in `user_interactions`
- [ ] Open profile page — verify `user_profiles_computed.taste_fingerprint` populates
- [ ] Revisit profile within 24h — verify cached fingerprint loads (no re-compute)
- [ ] Lint/test/build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)