### PR TITLE
fix(mobile): watchlist buttons, header overflow, hero chevron tap targets

### DIFF
--- a/src/app/header/Header.jsx
+++ b/src/app/header/Header.jsx
@@ -205,7 +205,7 @@ export default function Header({ onOpenSearch }) {
 
                 {/* Dropdown panel */}
                 {dropdownOpen && (
-                  <div className="absolute right-0 mt-2.5 w-56 rounded-2xl bg-black/95 border border-white/10 shadow-2xl shadow-black/60 backdrop-blur-xl overflow-hidden z-50"
+                  <div className="absolute right-0 mt-2.5 w-[min(14rem,calc(100vw-1rem))] rounded-2xl bg-black/95 border border-white/10 shadow-2xl shadow-black/60 backdrop-blur-xl overflow-hidden z-50"
                     style={{ animation: 'dropdownIn 0.15s ease-out' }}
                   >
                     {/* Top accent line */}

--- a/src/app/homepage/components/HeroTopPick.jsx
+++ b/src/app/homepage/components/HeroTopPick.jsx
@@ -62,7 +62,7 @@ function LanguageBadge({ lang }) {
   if (!lang || lang === 'en') return null
   const label = LANGUAGE_LABELS[lang] || lang.toUpperCase()
   return (
-    <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-semibold tracking-wide uppercase bg-white/10 text-white/60 border border-white/10">
+    <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold tracking-wide uppercase bg-white/10 text-white/60 border border-white/10">
       {label}
     </span>
   )
@@ -144,7 +144,7 @@ function StreamingBadge({ providers, revealed }) {
         className="h-8 w-8 rounded object-cover"
       />
       <div className="min-w-0">
-        <p className="text-[9px] uppercase tracking-widest text-white/40 font-medium leading-none mb-0.5">{label}</p>
+        <p className="text-xs uppercase tracking-widest text-white/40 font-medium leading-none mb-0.5">{label}</p>
         <p className="text-xs text-white/80 font-semibold truncate leading-none">{provider.provider_name}</p>
       </div>
     </div>
@@ -785,14 +785,16 @@ export default function HeroTopPick({
           <button
             onClick={() => setHeroIdx((prev) => (prev - 1 + candidates.length) % candidates.length)}
             aria-label="Previous pick"
-            className="absolute left-2 sm:left-4 top-1/2 -translate-y-1/2 z-20 h-10 w-10 rounded-full bg-black/40 hover:bg-black/60 backdrop-blur-sm border border-white/10 hover:border-white/20 text-white/60 hover:text-white flex items-center justify-center transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
+            className="absolute top-1/2 -translate-y-1/2 z-20 h-11 w-11 sm:h-12 sm:w-12 rounded-full bg-black/40 hover:bg-black/60 backdrop-blur-sm border border-white/10 hover:border-white/20 text-white/60 hover:text-white flex items-center justify-center transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
+            style={{ left: 'max(0.75rem, env(safe-area-inset-left))' }}
           >
             <ChevronLeft className="h-5 w-5" />
           </button>
           <button
             onClick={() => setHeroIdx((prev) => (prev + 1) % candidates.length)}
             aria-label="Next pick"
-            className="absolute right-2 sm:right-4 top-1/2 -translate-y-1/2 z-20 h-10 w-10 rounded-full bg-black/40 hover:bg-black/60 backdrop-blur-sm border border-white/10 hover:border-white/20 text-white/60 hover:text-white flex items-center justify-center transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
+            className="absolute top-1/2 -translate-y-1/2 z-20 h-11 w-11 sm:h-12 sm:w-12 rounded-full bg-black/40 hover:bg-black/60 backdrop-blur-sm border border-white/10 hover:border-white/20 text-white/60 hover:text-white flex items-center justify-center transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
+            style={{ right: 'max(0.75rem, env(safe-area-inset-right))' }}
           >
             <ChevronRight className="h-5 w-5" />
           </button>

--- a/src/app/pages/discover/components/TopPickCard.jsx
+++ b/src/app/pages/discover/components/TopPickCard.jsx
@@ -189,6 +189,7 @@ export default function TopPickCard({ film, isWatchlisted, isSeen, onOpenDetail,
               size="sm"
               onClick={handleClick}
               aria-label={`View details for ${film.title}`}
+              className="min-h-[44px] sm:min-h-0"
             >
               <Play className="h-3.5 w-3.5" />
               Details
@@ -199,6 +200,7 @@ export default function TopPickCard({ film, isWatchlisted, isSeen, onOpenDetail,
               onClick={() => onAddWatchlist(film)}
               disabled={isWatchlisted}
               aria-label={isWatchlisted ? `${film.title} added to watchlist` : `Add ${film.title} to watchlist`}
+              className="min-h-[44px] sm:min-h-0"
             >
               {isWatchlisted ? <BookmarkCheck className="h-3.5 w-3.5" /> : <Bookmark className="h-3.5 w-3.5" />}
               {isWatchlisted ? 'Added' : 'Watchlist'}
@@ -209,6 +211,7 @@ export default function TopPickCard({ film, isWatchlisted, isSeen, onOpenDetail,
               onClick={() => onMarkSeen(film)}
               disabled={isSeen}
               aria-label={isSeen ? `${film.title} marked as seen` : `Mark ${film.title} as seen`}
+              className="min-h-[44px] sm:min-h-0"
             >
               {isSeen ? <Eye className="h-3.5 w-3.5" /> : <Check className="h-3.5 w-3.5" />}
               {isSeen ? 'Seen' : 'Seen it'}

--- a/src/app/pages/watchlist/Watchlist.jsx
+++ b/src/app/pages/watchlist/Watchlist.jsx
@@ -214,7 +214,7 @@ export default function Watchlist() {
             {searchQuery && (
               <p className="text-xs text-white/20 mb-4">{filteredMovies.length} of {movies.length} films</p>
             )}
-            <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 gap-3 sm:gap-4">
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3 sm:gap-4">
               <AnimatePresence>
                 {filteredMovies.map((movie, idx) => (
                   <motion.div
@@ -328,11 +328,11 @@ function MovieCard({ movie, removing, marking, onRemove, onMarkWatched, onClick 
         onClick={e => { e.stopPropagation(); onMarkWatched() }}
         disabled={marking || removing}
         aria-label={`Mark ${movie.title} as watched`}
-        className="absolute top-1.5 left-1.5 z-20 h-6 w-6 rounded-full bg-black/70 border border-white/12 flex items-center justify-center text-white/40 hover:text-purple-400 hover:bg-black/90 hover:border-purple-500/30 transition-all duration-150 opacity-100 md:opacity-0 md:group-hover:opacity-100 disabled:opacity-30"
+        className="absolute top-2 left-2 z-20 h-11 w-11 sm:h-8 sm:w-8 rounded-full bg-black/70 border border-white/12 flex items-center justify-center text-white/40 hover:text-purple-400 hover:bg-black/90 hover:border-purple-500/30 active:scale-90 transition-all duration-150 opacity-100 md:opacity-0 md:group-hover:opacity-100 disabled:opacity-30"
       >
         {marking
-          ? <Loader2 className="h-3 w-3 animate-spin" />
-          : <Check className="h-3 w-3" />}
+          ? <Loader2 className="h-4 w-4 sm:h-3 sm:w-3 animate-spin" />
+          : <Check className="h-4 w-4 sm:h-3 sm:w-3" />}
       </button>
 
       {/* Remove — top right */}
@@ -340,11 +340,11 @@ function MovieCard({ movie, removing, marking, onRemove, onMarkWatched, onClick 
         onClick={e => { e.stopPropagation(); onRemove() }}
         disabled={removing || marking}
         aria-label={`Remove ${movie.title} from watchlist`}
-        className="absolute top-1.5 right-1.5 z-20 h-6 w-6 rounded-full bg-black/70 border border-white/12 flex items-center justify-center text-white/40 hover:text-red-400 hover:bg-black/90 hover:border-red-500/25 transition-all duration-150 opacity-100 md:opacity-0 md:group-hover:opacity-100 disabled:opacity-30"
+        className="absolute top-2 right-2 z-20 h-11 w-11 sm:h-8 sm:w-8 rounded-full bg-black/70 border border-white/12 flex items-center justify-center text-white/40 hover:text-red-400 hover:bg-black/90 hover:border-red-500/25 active:scale-90 transition-all duration-150 opacity-100 md:opacity-0 md:group-hover:opacity-100 disabled:opacity-30"
       >
         {removing
-          ? <Loader2 className="h-3 w-3 animate-spin" />
-          : <Trash2 className="h-3 w-3" />}
+          ? <Loader2 className="h-4 w-4 sm:h-3 sm:w-3 animate-spin" />
+          : <Trash2 className="h-4 w-4 sm:h-3 sm:w-3" />}
       </button>
     </div>
   )


### PR DESCRIPTION
## Summary
- **BLOCKER** Watchlist grid `grid-cols-3` → `grid-cols-2` at mobile; action buttons `h-6 w-6` → `h-11 w-11` (44px) with `sm:h-8 sm:w-8` shrink-back. Icons scaled to match. Added `active:scale-90` touch feedback.
- **MAJOR** Header dropdown `w-56` → `w-[min(14rem,calc(100vw-1rem))]` — stays in viewport at 375px
- **MAJOR** Hero chevrons `h-10 w-10` → `h-11 w-11 sm:h-12 sm:w-12`; position uses `max(0.75rem, env(safe-area-inset-left/right))` to clear system gesture zones
- **MAJOR** TopPickCard action buttons: added `min-h-[44px] sm:min-h-0` — `size="sm"` was ~28px
- **MINOR** LanguageBadge + StreamingBadge label: `text-[10px]`/`text-[9px]` → `text-xs`

## Test plan
- [ ] iPhone SE (375px): watchlist shows 2-col grid, buttons easily tappable in corners
- [ ] iPhone 14 (390px): same; chevrons don't conflict with edge swipe gesture
- [ ] Account dropdown open on mobile: stays fully within viewport, no horizontal scroll
- [ ] Discover top pick: Details / Watchlist / Seen buttons hit-area ≥ 44px
- [ ] No horizontal scroll on any screen at 375px

🤖 Generated with [Claude Code](https://claude.com/claude-code)