### PR TITLE
feat(analytics): PostHog instrumentation across all key surfaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "framer-motion": "^12.23.24",
         "lucide-react": "^0.525.0",
         "openai": "^6.10.0",
+        "posthog-js": "^1.369.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^7.14.0",
@@ -1397,6 +1398,252 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+      "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.208.0.tgz",
+      "integrity": "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-exporter-base": "0.208.0",
+        "@opentelemetry/otlp-transformer": "0.208.0",
+        "@opentelemetry/sdk-logs": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
+      "integrity": "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-transformer": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
+      "integrity": "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/sdk-logs": "0.208.0",
+        "@opentelemetry/sdk-metrics": "2.2.0",
+        "@opentelemetry/sdk-trace-base": "2.2.0",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.0.tgz",
+      "integrity": "sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.0.tgz",
+      "integrity": "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz",
+      "integrity": "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
+      "integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
+      "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1406,6 +1653,82 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.25.3",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.25.3.tgz",
+      "integrity": "sha512-yE0T2NUwRMsfS/fSh7lK7/mt4JXRDVmTTwq/vLanDVzH2Rw7C9RVlMw7YePlNxRHvW8ef3PrZ0X9zwWa4MRRDg==",
+      "license": "MIT"
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.369.5",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.369.5.tgz",
+      "integrity": "sha512-yajos1l/pugBrp3++MDc/k2Dz6vExxJVERiR6felxlWjSN+HOjkJfWsGqDw5PsG0fFQ43n3IR2B0OHKKApX/Kw==",
+      "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
@@ -2168,6 +2491,13 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -3098,6 +3428,17 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3353,6 +3694,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dotenv": {
       "version": "17.2.3",
@@ -4121,6 +4471,12 @@
       "engines": {
         "node": "^12.20 || >= 14.13"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -5435,6 +5791,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -6281,6 +6643,43 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "node_modules/posthog-js": {
+      "version": "1.369.5",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.369.5.tgz",
+      "integrity": "sha512-RmvxOd8DHWyd5LwlKDeem3m6C9OKgsmZJSxUwmOc+Ldp5TgR+De6OiB0OW+Re0GqoVGqANCBSxYgYX4aD8YPLA==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.208.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
+        "@opentelemetry/resources": "^2.2.0",
+        "@opentelemetry/sdk-logs": "^0.208.0",
+        "@posthog/core": "1.25.3",
+        "@posthog/types": "1.369.5",
+        "core-js": "^3.38.1",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.28.2",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.1.0"
+      }
+    },
+    "node_modules/posthog-js/node_modules/web-vitals": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
+      "integrity": "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/preact": {
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6361,6 +6760,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -6379,6 +6802,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/querystringify": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "framer-motion": "^12.23.24",
     "lucide-react": "^0.525.0",
     "openai": "^6.10.0",
+    "posthog-js": "^1.369.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^7.14.0",

--- a/src/app/AppShell.jsx
+++ b/src/app/AppShell.jsx
@@ -6,6 +6,7 @@ import Header from '@/app/header/Header'
 import SearchBar from '@/app/header/components/SearchBar'
 import { useAuthSession } from '@/shared/hooks/useAuthSession'
 import { useGoogleAuth } from '@/features/landing/utils/useGoogleAuth'
+import { identify, resetAnalytics, track } from '@/shared/services/analytics'
 
 export default function AppShell() {
   const [searchOpen, setSearchOpen] = useState(false)
@@ -13,7 +14,7 @@ export default function AppShell() {
   const lastScrollY = useRef(0)
   const ticking = useRef(false)
   const location = useLocation()
-  const { isAuthenticated } = useAuthSession()
+  const { user, isAuthenticated } = useAuthSession()
 
   // Keyboard shortcut for search (/)
   useEffect(() => {
@@ -68,9 +69,10 @@ export default function AppShell() {
     return () => window.removeEventListener('scroll', handleScroll)
   }, [])
 
-  // Reset header visibility on route change
+  // Reset header visibility on route change + track page view
   useEffect(() => {
     setHeaderVisible(true)
+    track('page_viewed', { path: location.pathname })
 
     const prefersReducedMotion =
       window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
@@ -80,6 +82,21 @@ export default function AppShell() {
       behavior: prefersReducedMotion ? 'auto' : 'smooth',
     })
   }, [location.pathname])
+
+  // Identify / reset on auth state change
+  const prevUserIdRef = useRef(null)
+  useEffect(() => {
+    const uid = user?.id ?? null
+    if (uid && uid !== prevUserIdRef.current) {
+      identify(uid, {
+        email: user.email,
+        name: user.user_metadata?.name,
+      })
+    } else if (!uid && prevUserIdRef.current) {
+      resetAnalytics()
+    }
+    prevUserIdRef.current = uid
+  }, [user])
 
   return (
     <div className="relative min-h-screen text-white">

--- a/src/app/header/components/SearchBar.jsx
+++ b/src/app/header/components/SearchBar.jsx
@@ -2,6 +2,7 @@ import { useDeferredValue, useEffect, useId, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Clock, Search as SearchIcon, X } from 'lucide-react'
 import { searchMovies } from '@/shared/api/tmdb'
+import { track } from '@/shared/services/analytics'
 
 const RECENT_SEARCHES_KEY = 'recentSearches'
 const MAX_RECENT_SEARCHES = 5
@@ -142,6 +143,12 @@ export default function SearchBar({ open, onClose }) {
 
   function goToMovie(movie) {
     saveRecentSearch(movie)
+    track('search_performed', {
+      query: q.trim(),
+      result_count: results.length,
+      movie_id: movie.id,
+      movie_title: movie.title,
+    })
     onClose?.()
     nav(`/movie/${movie.id}`)
   }

--- a/src/app/homepage/components/HeroTopPick.jsx
+++ b/src/app/homepage/components/HeroTopPick.jsx
@@ -19,6 +19,7 @@ import { useTopPick } from '@/shared/hooks/useRecommendations'
 import { supabase } from '@/shared/lib/supabase/client'
 import { useUserMovieStatus } from '@/shared/hooks/useUserMovieStatus'
 import { updateImpression } from '@/shared/services/recommendations'
+import { track } from '@/shared/services/analytics'
 import Button from '@/shared/ui/Button'
 
 // ============================================================================
@@ -178,6 +179,7 @@ export default function HeroTopPick({
   const loadingRef = useRef(false)
   const refetchTimerRef = useRef(null)
   const lastEmittedHeroIdRef = useRef(null)
+  const lastTrackedViewIdRef = useRef(null)
 
   const { data: hookMovie, loading, error, refetch } = useTopPick({
     enabled: true,
@@ -254,6 +256,20 @@ export default function HeroTopPick({
     if (!loading && movie && isRefreshing) setIsRefreshing(false)
   }, [loading, movie, isRefreshing])
 
+  // Track hero_viewed once per unique activeMovie
+  useEffect(() => {
+    if (!revealed || !activeMovie?.id) return
+    if (lastTrackedViewIdRef.current === activeMovie.id) return
+    lastTrackedViewIdRef.current = activeMovie.id
+    track('hero_viewed', {
+      movie_id: activeMovie.tmdb_id ?? activeMovie.id,
+      movie_title: activeMovie.title,
+      candidate_index: heroIdx,
+      candidate_count: candidates.length,
+      reason_type: activeReason?.type ?? null,
+    })
+  }, [revealed, activeMovie?.id]) // eslint-disable-line react-hooks/exhaustive-deps
+
   // Progressive reveal
   useEffect(() => {
     if (!movie) return
@@ -321,6 +337,10 @@ export default function HeroTopPick({
 
     if (isInWatchlist && !prevWatchlistRef.current) {
       updateImpression(userId, activeMovie.id, 'hero', { added_to_watchlist: true })
+      track('hero_watchlisted', {
+        movie_id: activeMovie.tmdb_id ?? activeMovie.id,
+        movie_title: activeMovie.title,
+      })
     }
 
     if (isWatched && !prevWatchedRef.current) {
@@ -333,12 +353,16 @@ export default function HeroTopPick({
 
     prevWatchlistRef.current = isInWatchlist
     prevWatchedRef.current = isWatched
-  }, [isInWatchlist, isWatched, userId, activeMovie?.id, activeMovie?.tmdb_id, scheduleRefetchIfIdle])
+  }, [isInWatchlist, isWatched, userId, activeMovie?.id, activeMovie?.tmdb_id, activeMovie?.title, scheduleRefetchIfIdle])
 
   const goToDetails = useCallback(() => {
     const tmdbId = activeMovie?.tmdb_id
     if (!tmdbId) return
     if (userId && activeMovie?.id) updateImpression(userId, activeMovie.id, 'hero', { clicked: true })
+    track('hero_clicked', {
+      movie_id: tmdbId,
+      movie_title: activeMovie?.title,
+    })
     navigate(`/movie/${tmdbId}`)
   }, [activeMovie, navigate, userId])
 
@@ -402,6 +426,11 @@ export default function HeroTopPick({
     if (userId && activeMovie.id) updateImpression(userId, activeMovie.id, 'hero', { skipped: true })
 
     logFeedback({ feedbackType: 'hero_skip_not_today' })
+    track('hero_skipped', {
+      movie_id: activeMovie.tmdb_id ?? activeMovie.id,
+      movie_title: activeMovie.title,
+      skip_count: skippedTmdbIds.length + 1,
+    })
 
     if (tmdbId) setSkippedTmdbIds((prev) => (prev.includes(tmdbId) ? prev : [...prev, tmdbId]))
 
@@ -414,7 +443,25 @@ export default function HeroTopPick({
     }
 
     scheduleRefetchIfIdle(120)
-  }, [activeMovie, isRefreshing, userId, logFeedback, scheduleRefetchIfIdle])
+  }, [activeMovie, isRefreshing, skippedTmdbIds.length, userId, logFeedback, scheduleRefetchIfIdle])
+
+  // ── Carousel navigation ─────────────────────────────────────────────────────
+
+  const handlePrevPick = useCallback(() => {
+    setHeroIdx((prev) => {
+      const next = (prev - 1 + candidates.length) % candidates.length
+      track('hero_cycled', { direction: 'prev', from_idx: prev, to_idx: next })
+      return next
+    })
+  }, [candidates.length])
+
+  const handleNextPick = useCallback(() => {
+    setHeroIdx((prev) => {
+      const next = (prev + 1) % candidates.length
+      track('hero_cycled', { direction: 'next', from_idx: prev, to_idx: next })
+      return next
+    })
+  }, [candidates.length])
 
   // ── Touch swipe handlers ────────────────────────────────────────────────────
 
@@ -783,14 +830,14 @@ export default function HeroTopPick({
       {candidates.length > 1 && (
         <>
           <button
-            onClick={() => setHeroIdx((prev) => (prev - 1 + candidates.length) % candidates.length)}
+            onClick={handlePrevPick}
             aria-label="Previous pick"
             className="absolute left-2 sm:left-4 top-1/2 -translate-y-1/2 z-20 h-10 w-10 rounded-full bg-black/40 hover:bg-black/60 backdrop-blur-sm border border-white/10 hover:border-white/20 text-white/60 hover:text-white flex items-center justify-center transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
           >
             <ChevronLeft className="h-5 w-5" />
           </button>
           <button
-            onClick={() => setHeroIdx((prev) => (prev + 1) % candidates.length)}
+            onClick={handleNextPick}
             aria-label="Next pick"
             className="absolute right-2 sm:right-4 top-1/2 -translate-y-1/2 z-20 h-10 w-10 rounded-full bg-black/40 hover:bg-black/60 backdrop-blur-sm border border-white/10 hover:border-white/20 text-white/60 hover:text-white flex items-center justify-center transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
           >

--- a/src/app/pages/MovieDetail/index.jsx
+++ b/src/app/pages/MovieDetail/index.jsx
@@ -16,6 +16,7 @@ import { useMovieRating } from '@/shared/hooks/useMovieRating'
 import { usePageView } from '@/shared/hooks/useInteractionTracking'
 import { usePageMeta } from '@/shared/hooks/usePageMeta'
 import { trackTrailerPlay, trackShare } from '@/shared/services/interactions'
+import { track } from '@/shared/services/analytics'
 import { invalidatePersonalCache } from '@/shared/services/personalRating'
 import { fetchJson, getMovieDetails } from '@/shared/api/tmdb'
 
@@ -110,6 +111,15 @@ export default function MovieDetail() {
   const { user } = useAuthSession()
 
   usePageView(internalMovieId, 'movie_detail')
+
+  // Track PostHog event once per movie load
+  useEffect(() => {
+    if (!movie) return
+    track('movie_detail_viewed', {
+      movie_id: movie.id,
+      movie_title: movie.title,
+    })
+  }, [movie?.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     const startTime = Date.now()

--- a/src/app/pages/discover/DiscoverPage.jsx
+++ b/src/app/pages/discover/DiscoverPage.jsx
@@ -17,6 +17,7 @@ import { useRecommendationTracking } from '@/shared/hooks/useRecommendationTrack
 import { useRecommendations } from '@/shared/hooks/useRecommendations'
 import { useNLMoodParse } from '@/shared/hooks/useNLMoodParse'
 import { unpackVibe } from '@/shared/services/brief-scoring'
+import { track } from '@/shared/services/analytics'
 import Button from '@/shared/ui/Button'
 
 import { useDiscoverTracking } from './hooks/useDiscoverTracking'
@@ -213,6 +214,29 @@ export default function DiscoverPage() {
     briefForEngine,
   )
 
+  // Track discover_started when the user first picks a feeling
+  const prevFeelingRef = useRef(null)
+  useEffect(() => {
+    if (feeling && !prevFeelingRef.current) {
+      track('discover_started', { feeling, mood_id: moodId })
+    }
+    prevFeelingRef.current = feeling
+  }, [feeling, moodId])
+
+  // Track discover_completed when results phase begins
+  const prevPhaseRef = useRef('briefing')
+  useEffect(() => {
+    if (phase === 'results' && prevPhaseRef.current !== 'results') {
+      track('discover_completed', {
+        feeling,
+        mood_id: moodId,
+        is_surprise_me: isSurpriseMe,
+        result_count: recommendations.length,
+      })
+    }
+    prevPhaseRef.current = phase
+  }, [phase]) // eslint-disable-line react-hooks/exhaustive-deps
+
   // Keep abandonment ref in sync
   useEffect(() => {
     abandonmentStateRef.current = { phase, moodId }
@@ -223,6 +247,7 @@ export default function DiscoverPage() {
     return () => {
       const { phase: p, moodId: m } = abandonmentStateRef.current
       if (p === 'results') return
+      track('discover_abandoned', { mood_id: m, reached_stage: p })
       supabase.from('mood_session_abandoned').insert({
         user_id:          userId ?? null,
         selected_mood_id: m ?? null,
@@ -288,6 +313,7 @@ export default function DiscoverPage() {
 
   /** "Surprise me" — bypass brief, day-rotated profile-driven picks. */
   function handleSurpriseMe() {
+    track('surprise_me_clicked')
     setPhase('loading')
     setIsSurpriseMe(true)
     startTransition(() => {

--- a/src/components/carousel/CardContent/MovieCard.jsx
+++ b/src/components/carousel/CardContent/MovieCard.jsx
@@ -8,6 +8,7 @@ import { tmdbImg } from '@/shared/api/tmdb'
 import { useWatchlistContext } from '@/contexts/WatchlistContext'
 import { useUserMovieStatus } from '@/shared/hooks/useUserMovieStatus'
 import { updateImpression } from '@/shared/services/recommendations'
+import { track } from '@/shared/services/analytics'
 import { WatchProviders } from '../WatchProviders'
 import { Card } from '../Card'
 
@@ -96,6 +97,7 @@ export const MovieCard = memo(function MovieCard({
   priority = false,
   onClick,
   placement = null,
+  rowTitle = null,
   reducedMotion = false,
   dimmed = false,
   siblingOffset = 0,
@@ -171,10 +173,27 @@ export const MovieCard = memo(function MovieCard({
         clicked_at: new Date().toISOString(),
       })
     }
+    track('card_clicked', {
+      movie_id: tmdbId,
+      movie_title: movie?.title,
+      row_title: rowTitle,
+      index,
+    })
 
     if (onClick) onClick(movie)
     else navigate(`/movie/${tmdbId}`)
-  }, [movie, navigate, onClick, placement, tmdbId, user?.id])
+  }, [index, movie, navigate, onClick, placement, rowTitle, tmdbId, user?.id])
+
+  const handleToggleWatchlist = useCallback(() => {
+    if (!isInWatchlist) {
+      track('card_watchlisted', {
+        movie_id: tmdbId,
+        movie_title: movie?.title,
+        row_title: rowTitle,
+      })
+    }
+    toggleWatchlist()
+  }, [isInWatchlist, movie?.title, rowTitle, tmdbId, toggleWatchlist])
 
   const handleRootBlur = useCallback(
     (event) => {
@@ -405,7 +424,7 @@ export const MovieCard = memo(function MovieCard({
                       <>
                         <ActionButton
                           label={isInWatchlist ? 'Remove from watchlist' : 'Add to watchlist'}
-                          onClick={toggleWatchlist}
+                          onClick={handleToggleWatchlist}
                           icon={Plus}
                           activeIcon={Check}
                           active={isInWatchlist}

--- a/src/components/carousel/Row/index.jsx
+++ b/src/components/carousel/Row/index.jsx
@@ -3,6 +3,7 @@ import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { useVirtualization } from '../hooks/useVirtualization'
 import { useMovieCardHover } from '../hooks/useMovieCardHover'
 import { MovieCard } from '../CardContent/MovieCard'
+import { track } from '@/shared/services/analytics'
 
 export { CARD_EXPAND_DELAY_MS } from '../hooks/useMovieCardHover'
 
@@ -107,6 +108,8 @@ export const CarouselRow = memo(function CarouselRow({
   })
 
   const rafScrollRef = useRef(null)
+  const scrollTrackTimerRef = useRef(null)
+
   const updateScrollState = useCallback(() => {
     // Always defer to after paint — measuring during layout gives stale/zero dimensions
     if (rafScrollRef.current) cancelAnimationFrame(rafScrollRef.current)
@@ -150,7 +153,12 @@ export const CarouselRow = memo(function CarouselRow({
   const handleScrollArea = useCallback(() => {
     updateScrollState()  // already RAF-deferred inside
     hover.closeNow()
-  }, [hover, updateScrollState])
+    // Debounced row_scrolled — fires once per scroll gesture, 500ms after last event
+    if (scrollTrackTimerRef.current) clearTimeout(scrollTrackTimerRef.current)
+    scrollTrackTimerRef.current = setTimeout(() => {
+      track('row_scrolled', { row_title: typeof title === 'string' ? title : undefined })
+    }, 500)
+  }, [hover, title, updateScrollState])
 
   const activeId = hover.openId ?? hover.intentId
   const activeExpandedIndex = useMemo(
@@ -327,6 +335,7 @@ export const CarouselRow = memo(function CarouselRow({
                 onCardLeave={hover.handleCardLeave}
                 onCardFocus={hover.handleCardFocus}
                 onCardBlur={hover.handleCardBlur}
+                rowTitle={typeof title === 'string' ? title : undefined}
                 {...props}
               />
             )

--- a/src/features/auth/OAuthCallback.jsx
+++ b/src/features/auth/OAuthCallback.jsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { supabase } from '@/shared/lib/supabase/client'
 import Button from '@/shared/ui/Button'
+import { track } from '@/shared/services/analytics'
 import {
   consumeOAuthCallbackNonce,
   readOAuthNonceFromUrl,
@@ -179,6 +180,10 @@ export default function OAuthCallback() {
 
         // Route to appropriate page
         const destination = isOnboarded ? '/home' : '/onboarding'
+
+        if (!isOnboarded) {
+          track('signup', { method: 'google' })
+        }
 
         if (mounted) {
           navigate(destination, { replace: true })

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
 // src/main.jsx
 import * as Sentry from '@sentry/react'
 import { reportWebVitals } from '@/shared/lib/vitals'
+import { initAnalytics } from '@/shared/services/analytics'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
@@ -11,6 +12,8 @@ import {
   consumeOAuthCallbackNonce,
   readOAuthNonceFromUrl,
 } from './shared/lib/auth/oauthNonce'
+
+initAnalytics()
 
 Sentry.init({
   dsn: import.meta.env.VITE_SENTRY_DSN,

--- a/src/shared/services/analytics.js
+++ b/src/shared/services/analytics.js
@@ -1,0 +1,50 @@
+// src/shared/services/analytics.js
+import posthog from 'posthog-js'
+
+let _initialized = false
+
+/**
+ * Initialise PostHog. Call once before React mounts.
+ * No-ops silently when VITE_POSTHOG_KEY is absent (e.g. local dev without the key).
+ */
+export function initAnalytics() {
+  const key = import.meta.env.VITE_POSTHOG_KEY
+  if (!key) return
+  posthog.init(key, {
+    api_host: import.meta.env.VITE_POSTHOG_HOST ?? 'https://us.i.posthog.com',
+    capture_pageview: false,
+    autocapture: false,
+    loaded(ph) {
+      if (import.meta.env.DEV) ph.debug()
+    },
+  })
+  _initialized = true
+}
+
+/**
+ * Associate the current session with an authenticated user.
+ * @param {string} userId
+ * @param {{ email?: string, name?: string }} [traits]
+ */
+export function identify(userId, traits = {}) {
+  if (!_initialized) return
+  posthog.identify(userId, traits)
+}
+
+/**
+ * Send a named analytics event.
+ * @param {string} event
+ * @param {Record<string, unknown>} [properties]
+ */
+export function track(event, properties = {}) {
+  if (!_initialized) return
+  posthog.capture(event, properties)
+}
+
+/**
+ * Reset identity on sign-out.
+ */
+export function resetAnalytics() {
+  if (!_initialized) return
+  posthog.reset()
+}


### PR DESCRIPTION
## Summary
- Installs `posthog-js` and creates `src/shared/services/analytics.js` — a thin wrapper (`initAnalytics`, `identify`, `track`, `resetAnalytics`) that no-ops when `VITE_POSTHOG_KEY` is absent
- All events are manually instrumented (no autocapture) to keep the event schema clean

## Events added

| Surface | Events |
|---|---|
| App lifecycle | `page_viewed` (every route change), `identify` on sign-in, `reset` on sign-out |
| HeroTopPick | `hero_viewed`, `hero_cycled`, `hero_clicked`, `hero_watchlisted`, `hero_skipped` |
| CarouselRow | `row_scrolled` (debounced 500ms) |
| MovieCard | `card_clicked`, `card_watchlisted` (both include `row_title` + card index) |
| SearchBar | `search_performed` (on result selection, includes query + result count) |
| MovieDetail | `movie_detail_viewed` |
| OAuthCallback | `signup` (new users only) |
| DiscoverPage | `discover_started`, `discover_completed`, `discover_abandoned`, `surprise_me_clicked` |

## Config
Add `VITE_POSTHOG_KEY` (and optionally `VITE_POSTHOG_HOST`) to Vercel env vars. Without the key the service is silent — no errors, no network calls.

## Test plan
- [ ] Add `VITE_POSTHOG_KEY` to Vercel preview env
- [ ] Open preview, sign in — verify identify event fires in PostHog Live Events
- [ ] Navigate pages — verify `page_viewed` fires per route
- [ ] Interact with Hero (cycle, click, watchlist, skip) — verify 5 hero events
- [ ] Scroll a carousel row — verify `row_scrolled` fires once per gesture
- [ ] Click a card / watchlist a card — verify `card_clicked` / `card_watchlisted` with correct row_title
- [ ] Search and select a result — verify `search_performed`
- [ ] Open a movie detail — verify `movie_detail_viewed`
- [ ] Run through Discover brief — verify started → completed flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)