### PR TITLE
feat(onboarding): motion polish, editorial typography, cinematic treatment

### DIFF
--- a/src/app/homepage/HomePage.jsx
+++ b/src/app/homepage/HomePage.jsx
@@ -1,7 +1,7 @@
 // src/app/homepage/HomePage.jsx
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useLocation, useNavigate, useOutletContext } from 'react-router-dom'
-import { motion, AnimatePresence } from 'framer-motion'
+import { motion, AnimatePresence, useMotionValue, useTransform, animate } from 'framer-motion'
 import { Sparkles } from 'lucide-react'
 
 import { supabase } from '@/shared/lib/supabase/client'
@@ -28,60 +28,91 @@ function pickFirstDefined(...values) {
 
 // === WELCOME BANNER ===
 
-function WelcomeBanner({ onDismiss }) {
+function WelcomeBanner({ movieCount, onDismiss }) {
+  // Animate counter 0 → movieCount
+  const count = useMotionValue(0)
+  const rounded = useTransform(count, v => Math.round(v))
+  const [displayCount, setDisplayCount] = useState(0)
+
+  useEffect(() => {
+    if (!movieCount) return
+    const controls = animate(count, movieCount, { duration: 1.2, ease: 'easeOut' })
+    const unsub = rounded.on('change', v => setDisplayCount(v))
+    return () => { controls.stop(); unsub() }
+  }, [movieCount]) // eslint-disable-line react-hooks/exhaustive-deps
+
   return (
-    <AnimatePresence>
+    <motion.div
+      initial={{ opacity: 0, y: -16 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -16 }}
+      transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
+      className="relative mx-4 sm:mx-6 mt-4 rounded-2xl overflow-hidden"
+    >
+      {/* Pulsing glow ring */}
       <motion.div
-        initial={{ opacity: 0, y: -12 }}
-        animate={{ opacity: 1, y: 0 }}
-        exit={{ opacity: 0, y: -12 }}
-        transition={{ duration: 0.4, ease: 'easeOut' }}
-        className="relative mx-4 sm:mx-6 mt-4 rounded-2xl overflow-hidden"
-      >
-        <div
-          className="absolute inset-0"
-          style={{ background: 'linear-gradient(135deg, rgba(88,28,135,0.55) 0%, rgba(168,85,247,0.35) 50%, rgba(219,39,119,0.25) 100%)' }}
-          aria-hidden="true"
-        />
-        <div className="absolute inset-0 border border-purple-400/25 rounded-2xl" aria-hidden="true" />
-        <div className="relative flex items-center gap-4 px-5 py-4">
-          <Sparkles className="h-5 w-5 flex-none text-purple-300" aria-hidden="true" />
-          <p className="flex-1 text-sm font-medium text-white/90 leading-snug">
-            Your taste profile is ready — here&apos;s what we picked for you.
+        className="absolute -inset-[1px] rounded-2xl"
+        style={{ background: 'linear-gradient(90deg, rgba(168,85,247,0.5), rgba(236,72,153,0.4), rgba(168,85,247,0.5))' }}
+        animate={{ opacity: [0.4, 0.8, 0.4] }}
+        transition={{ duration: 3, repeat: Infinity, ease: 'easeInOut' }}
+        aria-hidden="true"
+      />
+      <div
+        className="absolute inset-0"
+        style={{ background: 'linear-gradient(135deg, rgba(88,28,135,0.65) 0%, rgba(168,85,247,0.4) 50%, rgba(219,39,119,0.3) 100%)' }}
+        aria-hidden="true"
+      />
+      <div className="relative flex items-center gap-4 px-5 py-4">
+        <Sparkles className="h-5 w-5 flex-none text-purple-300" aria-hidden="true" />
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold text-white leading-snug">
+            Your taste profile is ready.
           </p>
-          <button
-            type="button"
-            onClick={onDismiss}
-            aria-label="Dismiss welcome message"
-            className="flex-none text-white/40 hover:text-white/70 transition-colors text-lg leading-none font-light"
-          >
-            ×
-          </button>
+          {movieCount > 0 && (
+            <p className="text-xs text-white/55 mt-0.5">
+              {displayCount} film{displayCount !== 1 ? 's' : ''} matched — here&apos;s your first pick.
+            </p>
+          )}
         </div>
-      </motion.div>
-    </AnimatePresence>
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="Dismiss welcome message"
+          className="flex-none text-white/40 hover:text-white/70 transition-colors text-lg leading-none font-light"
+        >
+          ×
+        </button>
+      </div>
+    </motion.div>
   )
 }
 
 // === MAIN COMPONENT ===
 
 export default function HomePage() {
-  // Outlet context (PostAuthGate / AppShell may provide these)
   const outlet = useOutletContext() || {}
   const location = useLocation()
   const navigate = useNavigate()
 
-  // First-run welcome banner — shown once when navigating from onboarding
-  const clearedStateRef = useRef(false)
-  const [showWelcome, setShowWelcome] = useState(() => Boolean(location.state?.fromOnboarding))
+  // Capture first-run state synchronously via useState initializer.
+  // IMPORTANT: do NOT clear location.state on mount — clear only on banner dismiss.
+  const [fromOnboarding] = useState(() => Boolean(location.state?.fromOnboarding))
+  const [movieCount] = useState(() => location.state?.movieCount ?? 0)
 
+  const [showBanner, setShowBanner] = useState(fromOnboarding)
+
+  // Auto-dismiss after 10s
   useEffect(() => {
-    if (location.state?.fromOnboarding && !clearedStateRef.current) {
-      clearedStateRef.current = true
-      // Clear state so a refresh doesn't re-show the banner
-      navigate(location.pathname, { replace: true, state: {} })
-    }
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+    if (!showBanner) return
+    const timer = setTimeout(() => handleDismissBanner(), 10000)
+    return () => clearTimeout(timer)
+  }, [showBanner]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  function handleDismissBanner() {
+    setShowBanner(false)
+    // Clear state only after dismissal — prevents banner from reappearing on refresh
+    navigate(location.pathname, { replace: true, state: {} })
+  }
 
   const preloadedUser =
     outlet.preloadedUser ||
@@ -96,13 +127,11 @@ export default function HomePage() {
     outlet.session?.user?.id
   )
 
-  // Resolve userId without blocking first paint
   const [userId, setUserId] = useState(initialUserId)
 
   useEffect(() => {
     if (userId) return
     let mounted = true
-
     supabase.auth
       .getSession()
       .then(({ data: { session } }) => {
@@ -113,10 +142,7 @@ export default function HomePage() {
         if (!mounted) return
         setUserId(null)
       })
-
-    return () => {
-      mounted = false
-    }
+    return () => { mounted = false }
   }, [userId])
 
   const rows = useHomepageRows(userId)
@@ -124,22 +150,28 @@ export default function HomePage() {
   return (
     <div className="overflow-x-hidden" style={{ background: 'var(--color-bg)' }}>
       {/* First-run welcome banner */}
-      {showWelcome && <WelcomeBanner onDismiss={() => setShowWelcome(false)} />}
+      <AnimatePresence>
+        {showBanner && (
+          <WelcomeBanner
+            movieCount={movieCount}
+            onDismiss={handleDismissBanner}
+          />
+        )}
+      </AnimatePresence>
 
       {/* HERO (above the fold) */}
       <HeroTopPick
         userId={userId}
         preloadedUser={preloadedUser}
+        isFirstRun={fromOnboarding}
       />
 
       {/* CONTENT */}
       <div className="relative pb-24 sm:pb-32">
-        {/* Hero → content seam */}
         <div
           aria-hidden
           className="pointer-events-none absolute -top-8 left-0 right-0 h-12 bg-gradient-to-b from-purple-500/10 via-black/0 to-black/0"
         />
-        {/* Ambient purple glow — FeelFlick signature */}
         <div
           aria-hidden
           className="pointer-events-none absolute top-0 left-0 w-[800px] h-[600px] -translate-y-1/3 opacity-30"
@@ -149,7 +181,6 @@ export default function HomePage() {
         <div className="mx-auto max-w-[1600px]">
           <div className="space-y-0">
 
-            {/* Row 2: Top of your taste (all tiers) */}
             <SectionErrorBoundary label="Top of Your Taste">
               <TopOfYourTasteRow
                 data={rows.topOfTaste.data?.films}
@@ -158,7 +189,6 @@ export default function HomePage() {
               />
             </SectionErrorBoundary>
 
-            {/* Row 2b: More from {Director} (warming+) */}
             {rows.tier !== 'cold' && rows.tier !== null && (
               <SectionErrorBoundary label="Signature Director">
                 <SignatureDirectorRow
@@ -168,7 +198,6 @@ export default function HomePage() {
               </SectionErrorBoundary>
             )}
 
-            {/* Row 3: Rotating — Critics swooned / People's champions */}
             <SectionErrorBoundary label="Critic Split">
               {rows.rotationVariant === 'B' && rows.tier === 'engaged' ? (
                 <PeoplesChampionsRow
@@ -183,7 +212,6 @@ export default function HomePage() {
               )}
             </SectionErrorBoundary>
 
-            {/* Row 4: Under 90 minutes (all tiers) */}
             <SectionErrorBoundary label="Under 90 Minutes">
               <Under90MinutesRow
                 data={rows.under90.data}
@@ -191,7 +219,6 @@ export default function HomePage() {
               />
             </SectionErrorBoundary>
 
-            {/* Row 5: Still in {seed}'s orbit (warming+) */}
             {rows.tier !== 'cold' && rows.tier !== null && (
               <SectionErrorBoundary label="Still in Orbit">
                 <StillInOrbitRow
@@ -201,7 +228,6 @@ export default function HomePage() {
               </SectionErrorBoundary>
             )}
 
-            {/* Row 6: You've been in a {mood} mood (warming+) */}
             {rows.tier !== 'cold' && rows.tier !== null && (
               <SectionErrorBoundary label="Mood Row">
                 <MoodRow
@@ -211,7 +237,6 @@ export default function HomePage() {
               </SectionErrorBoundary>
             )}
 
-            {/* Row 7: Still on your watchlist (engaged only) */}
             {rows.tier === 'engaged' && (
               <SectionErrorBoundary label="Watchlist">
                 <WatchlistRow

--- a/src/app/pages/onboarding/CinematicBackdrop.jsx
+++ b/src/app/pages/onboarding/CinematicBackdrop.jsx
@@ -1,0 +1,74 @@
+// src/app/pages/onboarding/CinematicBackdrop.jsx
+// Full-viewport blurred film still behind all onboarding steps.
+// Ken Burns: scale 1.0 → 1.08 over 20s, infinite alternate.
+// One backdrop per session, picked randomly from top-rated films.
+import { useEffect, useState } from 'react'
+import { motion } from 'framer-motion'
+
+import { supabase } from '@/shared/lib/supabase/client'
+import { tmdbImg } from '@/shared/api/tmdb'
+
+// Module-level session cache — persists across step transitions
+let _cachedBackdrop = null
+
+async function fetchSessionBackdrop() {
+  if (_cachedBackdrop) return _cachedBackdrop
+
+  const { data } = await supabase
+    .from('movies')
+    .select('backdrop_path')
+    .not('backdrop_path', 'is', null)
+    .not('ff_audience_rating', 'is', null)
+    .order('ff_audience_rating', { ascending: false })
+    .limit(20)
+
+  if (!data?.length) return null
+
+  const pick = data[Math.floor(Math.random() * data.length)]
+  _cachedBackdrop = pick.backdrop_path
+  return _cachedBackdrop
+}
+
+/**
+ * Full-screen blurred cinematic backdrop with Ken Burns motion.
+ * Renders behind all onboarding step content via fixed positioning.
+ */
+export default function CinematicBackdrop() {
+  const [backdropPath, setBackdropPath] = useState(_cachedBackdrop)
+
+  useEffect(() => {
+    if (_cachedBackdrop) { setBackdropPath(_cachedBackdrop); return }
+    fetchSessionBackdrop().then(path => { if (path) setBackdropPath(path) })
+  }, [])
+
+  return (
+    <div className="fixed inset-0 -z-10 overflow-hidden" aria-hidden="true">
+      {/* Base black layer */}
+      <div className="absolute inset-0 bg-black" />
+
+      {/* Blurred film still with Ken Burns */}
+      {backdropPath && (
+        <motion.div
+          className="absolute inset-0"
+          initial={{ scale: 1 }}
+          animate={{ scale: 1.08 }}
+          transition={{ duration: 20, ease: 'linear', repeat: Infinity, repeatType: 'reverse' }}
+        >
+          <img
+            src={tmdbImg(backdropPath, 'original')}
+            alt=""
+            className="w-full h-full object-cover opacity-25"
+            style={{ filter: 'blur(18px) saturate(1.1)' }}
+            loading="eager"
+          />
+        </motion.div>
+      )}
+
+      {/* Dark overlay gradient — ensures text legibility */}
+      <div
+        className="absolute inset-0"
+        style={{ background: 'linear-gradient(to bottom, rgba(0,0,0,0.82) 0%, rgba(0,0,0,0.62) 40%, rgba(0,0,0,0.88) 100%)' }}
+      />
+    </div>
+  )
+}

--- a/src/app/pages/onboarding/GenresStep.jsx
+++ b/src/app/pages/onboarding/GenresStep.jsx
@@ -1,16 +1,11 @@
 // src/app/pages/onboarding/GenresStep.jsx
-import { useEffect, useState } from 'react'
-import { motion } from 'framer-motion'
+import { motion, useReducedMotion } from 'framer-motion'
 import { ChevronRight } from 'lucide-react'
 
-import { supabase } from '@/shared/lib/supabase/client'
-import { tmdbImg } from '@/shared/api/tmdb'
 import Button from '@/shared/ui/Button'
 
 // === GENRE DEFINITIONS ===
 
-// Maps TMDB genre IDs to display name + DB primary_genre name.
-// "Sci-Fi" displays as "Sci-Fi" but is stored as "Science Fiction" in movies.primary_genre.
 export const GENRES = [
   { id: 28,    name: 'Action',      dbName: 'Action'           },
   { id: 12,    name: 'Adventure',   dbName: 'Adventure'        },
@@ -32,113 +27,39 @@ export const GENRES = [
 
 const MIN_GENRES = 3
 
-// === MODULE-LEVEL POSTER CACHE ===
-// Key: dbName, Value: string[] (poster_path)
-const _posterCache = new Map()
-let _posterFetchPromise = null
+// === ANIMATION VARIANTS ===
 
-async function fetchAllGenrePosters() {
-  if (_posterFetchPromise) return _posterFetchPromise
-  if (_posterCache.size > 0) return
-
-  _posterFetchPromise = (async () => {
-    const dbNames = GENRES.map(g => g.dbName)
-    const { data } = await supabase
-      .from('movies')
-      .select('poster_path, primary_genre')
-      .in('primary_genre', dbNames)
-      .not('ff_audience_rating', 'is', null)
-      .not('poster_path', 'is', null)
-      .order('ff_audience_rating', { ascending: false })
-      .limit(200)
-
-    if (!data) return
-
-    // Group into cache: top 3 per genre
-    for (const genre of GENRES) {
-      const posters = data
-        .filter(m => m.primary_genre === genre.dbName && m.poster_path)
-        .map(m => m.poster_path)
-        .slice(0, 3)
-      _posterCache.set(genre.dbName, posters)
-    }
-  })()
-
-  return _posterFetchPromise
+const containerVariants = {
+  visible: { transition: { staggerChildren: 0.03 } },
 }
 
-// === GENRE CARD ===
+const pillVariants = {
+  hidden: { opacity: 0, scale: 0.88 },
+  visible: { opacity: 1, scale: 1, transition: { duration: 0.22, ease: [0.22, 1, 0.36, 1] } },
+}
 
-function GenreCard({ genre, isSelected, onClick, posters, animDelay }) {
+// === GENRE PILL ===
+
+function GenrePill({ genre, isSelected, onClick }) {
+  const prefersReducedMotion = useReducedMotion()
+
   return (
     <motion.button
       type="button"
       onClick={onClick}
-      initial={{ opacity: 0, y: 12 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.22, delay: animDelay }}
+      variants={prefersReducedMotion ? undefined : pillVariants}
       whileTap={{ scale: 0.95 }}
+      animate={isSelected ? { scale: 1.05 } : { scale: 1 }}
+      transition={{ type: 'spring', stiffness: 300, damping: 22 }}
       aria-pressed={isSelected}
       aria-label={genre.name}
-      className={`relative overflow-hidden rounded-2xl aspect-[3/2] w-full cursor-pointer select-none transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black ${
+      className={`w-full rounded-full px-6 py-3 text-sm font-semibold transition-all duration-150 border focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black ${
         isSelected
-          ? 'ring-2 ring-purple-400 scale-[1.03] shadow-lg shadow-purple-500/25'
-          : 'ring-1 ring-white/10 hover:ring-white/25 hover:scale-[1.01]'
+          ? 'bg-gradient-to-r from-purple-500 to-pink-500 border-transparent text-white shadow-lg shadow-purple-500/20'
+          : 'bg-white/5 border-white/10 text-white/80 hover:bg-white/10 hover:border-white/20'
       }`}
     >
-      {/* Poster stack background */}
-      <div className="absolute inset-0 bg-neutral-900">
-        {posters.length > 0 && (
-          <>
-            {posters[2] && (
-              <img
-                src={tmdbImg(posters[2], 'w154')}
-                alt=""
-                aria-hidden="true"
-                className="absolute top-0 right-[-18%] h-full w-[48%] object-cover opacity-40 rotate-6 scale-110"
-              />
-            )}
-            {posters[1] && (
-              <img
-                src={tmdbImg(posters[1], 'w154')}
-                alt=""
-                aria-hidden="true"
-                className="absolute top-0 right-[14%] h-full w-[48%] object-cover opacity-60 rotate-2 scale-105"
-              />
-            )}
-            {posters[0] && (
-              <img
-                src={tmdbImg(posters[0], 'w154')}
-                alt=""
-                aria-hidden="true"
-                className="absolute top-0 left-0 h-full w-[55%] object-cover"
-              />
-            )}
-          </>
-        )}
-        {/* Gradient overlay */}
-        <div className="absolute inset-0 bg-gradient-to-r from-black/90 via-black/65 to-black/30" />
-        {/* Selected overlay */}
-        {isSelected && (
-          <div className="absolute inset-0 bg-gradient-to-br from-purple-600/30 to-pink-600/20" />
-        )}
-      </div>
-
-      {/* Genre label */}
-      <div className="relative z-10 flex h-full flex-col justify-end p-3">
-        <span className="text-sm font-bold text-white leading-tight tracking-tight">
-          {genre.name}
-        </span>
-      </div>
-
-      {/* Selected checkmark */}
-      {isSelected && (
-        <div className="absolute top-2 right-2 z-20 h-5 w-5 rounded-full bg-purple-500 flex items-center justify-center shadow">
-          <svg viewBox="0 0 10 8" className="h-2.5 w-2.5 fill-none stroke-white stroke-2 stroke-linecap-round stroke-linejoin-round">
-            <path d="M1 4l2.5 2.5L9 1" />
-          </svg>
-        </div>
-      )}
+      {genre.name}
     </motion.button>
   )
 }
@@ -147,60 +68,47 @@ function GenreCard({ genre, isSelected, onClick, posters, animDelay }) {
 
 /**
  * Onboarding step 1: genre selection.
- * Minimum 3 genres required before Continue is enabled.
- *
- * @param {{
- *   selectedGenres: number[],
- *   toggleGenre: (id: number) => void,
- *   onNext: () => void,
- *   firstName: string | null,
- * }} props
+ * @param {{ selectedGenres: number[], toggleGenre: (id: number) => void, onNext: () => void, firstName: string | null }} props
  */
 export default function GenresStep({ selectedGenres, toggleGenre, onNext, firstName }) {
-  const [posters, setPosters] = useState({})
-
-  useEffect(() => {
-    fetchAllGenrePosters().then(() => {
-      const snapshot = {}
-      for (const g of GENRES) {
-        snapshot[g.dbName] = _posterCache.get(g.dbName) || []
-      }
-      setPosters(snapshot)
-    })
-  }, [])
-
+  const prefersReducedMotion = useReducedMotion()
   const count = selectedGenres.length
   const canContinue = count >= MIN_GENRES
 
   return (
     <div className="h-full flex flex-col">
       {/* Header */}
-      <div className="flex-none text-center px-6 pt-8 pb-5">
+      <div className="flex-none px-6 pt-8 pb-5">
         {firstName && (
-          <p className="text-sm font-medium text-white/40 mb-1">Hey {firstName} —</p>
+          <p className="text-xs font-semibold uppercase tracking-widest text-purple-400/60 mb-3">
+            Hey {firstName} —
+          </p>
         )}
-        <h2 className="text-2xl sm:text-3xl font-black text-white leading-tight">
-          What kind of films draw you in?
+        <h2 className="text-5xl font-black tracking-tight text-white leading-[1.05]">
+          What draws you in?
         </h2>
-        <p className="text-sm text-white/40 mt-2">
-          Pick at least 3 — we use these to seed your first recommendations.
+        <p className="text-base text-white/60 mt-2 leading-relaxed">
+          Pick 3 or more genres you actually watch.
         </p>
       </div>
 
-      {/* Genre grid */}
-      <div className="flex-1 min-h-0 overflow-y-auto px-4 sm:px-6 py-2">
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 max-w-3xl mx-auto pb-4">
-          {GENRES.map((g, idx) => (
-            <GenreCard
+      {/* Genre pills */}
+      <div className="flex-1 min-h-0 overflow-y-auto px-6 py-2">
+        <motion.div
+          className="grid grid-cols-2 md:grid-cols-4 gap-3 max-w-2xl mx-auto pb-4"
+          variants={prefersReducedMotion ? undefined : containerVariants}
+          initial={prefersReducedMotion ? false : 'hidden'}
+          animate="visible"
+        >
+          {GENRES.map((g) => (
+            <GenrePill
               key={g.id}
               genre={g}
               isSelected={selectedGenres.includes(g.id)}
               onClick={() => toggleGenre(g.id)}
-              posters={posters[g.dbName] || []}
-              animDelay={idx * 0.03}
             />
           ))}
-        </div>
+        </motion.div>
       </div>
 
       {/* Footer */}
@@ -215,13 +123,7 @@ export default function GenresStep({ selectedGenres, toggleGenre, onNext, firstN
               ? `${count} selected — pick ${MIN_GENRES - count} more`
               : `${count} selected ✓`}
           </p>
-          <Button
-            variant="primary"
-            size="lg"
-            onClick={onNext}
-            disabled={!canContinue}
-            fullWidth
-          >
+          <Button variant="primary" size="lg" onClick={onNext} disabled={!canContinue} fullWidth>
             Continue
             <ChevronRight className="h-4 w-4" />
           </Button>

--- a/src/app/pages/onboarding/MoviesStep.jsx
+++ b/src/app/pages/onboarding/MoviesStep.jsx
@@ -1,7 +1,6 @@
 // src/app/pages/onboarding/MoviesStep.jsx
 import { useEffect, useRef, useState } from 'react'
-import { motion } from 'framer-motion'
-import { Search, X, ChevronLeft, RefreshCw, Check } from 'lucide-react'
+import { Search, X, ChevronLeft, Check } from 'lucide-react'
 
 import { supabase } from '@/shared/lib/supabase/client'
 import { tmdbImg, searchMovies } from '@/shared/api/tmdb'
@@ -11,14 +10,14 @@ import { GENRES } from './GenresStep'
 const MIN_MOVIES = 5
 const POOL_SIZE = 30
 
-// Map genre ID → DB name
 const GENRE_DB_NAME = Object.fromEntries(GENRES.map(g => [g.id, g.dbName]))
 
+// === DATA FETCHING ===
+
 /**
- * Fetch top POOL_SIZE films filtered by the user's selected genres.
- * Falls back to a global pool if no results found.
+ * Fetch top-rated films filtered by the user's selected genres.
  * @param {number[]} genreIds
- * @returns {Promise<object[]>} TMDB-shaped movie objects
+ * @returns {Promise<object[]>}
  */
 async function fetchGenrePool(genreIds) {
   const dbNames = genreIds.map(id => GENRE_DB_NAME[id]).filter(Boolean)
@@ -33,21 +32,19 @@ async function fetchGenrePool(genreIds) {
     .order('ff_audience_rating', { ascending: false })
     .limit(POOL_SIZE)
 
-  // Shape to match what TMDB search returns (id = tmdb_id for selection)
   return (data || []).map(m => ({
     id: m.tmdb_id,
     internalId: m.id,
     title: m.title,
     poster_path: m.poster_path,
     release_date: m.release_date,
-    primary_genre: m.primary_genre,
   }))
 }
 
 async function fetchGlobalPool() {
   const { data } = await supabase
     .from('movies')
-    .select('id, tmdb_id, title, poster_path, release_date, primary_genre')
+    .select('id, tmdb_id, title, poster_path, release_date')
     .not('ff_audience_rating', 'is', null)
     .not('poster_path', 'is', null)
     .order('ff_audience_rating', { ascending: false })
@@ -59,70 +56,90 @@ async function fetchGlobalPool() {
     title: m.title,
     poster_path: m.poster_path,
     release_date: m.release_date,
-    primary_genre: m.primary_genre,
   }))
 }
 
-function PosterTile({ movie, isSelected, onClick }) {
+// === MOVIE CARD ===
+// Fixed-width card: poster + title + year below (not overlaid).
+
+function MovieCard({ movie, isSelected, onClick }) {
   const [loaded, setLoaded] = useState(false)
   const year = movie.release_date ? new Date(movie.release_date).getFullYear() : null
 
   return (
-    <motion.button
+    <button
       type="button"
       onClick={onClick}
-      whileTap={{ scale: 0.94 }}
       aria-pressed={isSelected}
       aria-label={`${isSelected ? 'Remove' : 'Select'} ${movie.title}`}
-      className={`relative group rounded-xl overflow-hidden cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black transition-all duration-200 ${
-        isSelected
-          ? 'ring-2 ring-purple-400 scale-[1.03] shadow-lg shadow-purple-500/25'
-          : 'ring-1 ring-white/10 hover:ring-white/25'
-      }`}
+      className="flex-shrink-0 w-40 flex flex-col gap-1.5 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black rounded-lg group"
     >
-      <div className="aspect-[2/3] bg-neutral-900">
+      <div className={`relative aspect-[2/3] w-full rounded-lg overflow-hidden transition-shadow duration-200 ${
+        isSelected
+          ? 'ring-2 ring-purple-400 shadow-[0_0_16px_rgba(168,85,247,0.4)]'
+          : 'ring-1 ring-white/[0.06] group-hover:ring-white/20'
+      }`}>
         {!loaded && <div className="absolute inset-0 animate-pulse bg-white/[0.04]" />}
         <img
           src={tmdbImg(movie.poster_path, 'w342')}
           alt={movie.title}
           loading="lazy"
-          className={`w-full h-full object-cover transition-opacity duration-300 ${loaded ? 'opacity-100' : 'opacity-0'}`}
+          className={`w-full h-full object-cover transition-all duration-300 ${
+            loaded ? 'opacity-100' : 'opacity-0'
+          } ${isSelected ? 'brightness-75' : 'group-hover:brightness-110'}`}
           onLoad={() => setLoaded(true)}
         />
-        {/* Hover / selected overlay */}
-        <div className={`absolute inset-0 transition-opacity duration-200 ${
-          isSelected
-            ? 'bg-purple-600/25 opacity-100'
-            : 'bg-black/40 opacity-0 group-hover:opacity-100'
-        }`} />
-        {/* Title fade at bottom */}
-        <div className="absolute bottom-0 inset-x-0 bg-gradient-to-t from-black/90 via-black/40 to-transparent px-2 pt-6 pb-2">
-          <p className="text-[11px] font-semibold text-white leading-tight line-clamp-2">{movie.title}</p>
-          {year && <p className="text-[10px] text-white/40 mt-0.5">{year}</p>}
-        </div>
-        {/* Checkmark */}
+        {isSelected && <div className="absolute inset-0 bg-purple-600/15" />}
         {isSelected && (
-          <div className="absolute top-1.5 right-1.5 h-5 w-5 rounded-full bg-purple-500 flex items-center justify-center">
+          <div className="absolute top-1.5 right-1.5 h-5 w-5 rounded-full bg-purple-500 flex items-center justify-center shadow">
             <Check className="h-3 w-3 text-white stroke-[3]" />
           </div>
         )}
       </div>
-    </motion.button>
+      <div className="px-0.5">
+        <p className={`text-[11px] font-medium leading-tight line-clamp-2 transition-colors ${
+          isSelected ? 'text-purple-300' : 'text-white/80'
+        }`}>
+          {movie.title}
+        </p>
+        {year && <p className="text-[10px] text-white/35 mt-0.5">{year}</p>}
+      </div>
+    </button>
   )
 }
 
+// === CARD SKELETON ROW ===
+
+function CardSkeletonRow() {
+  return (
+    <div className="flex gap-4 overflow-x-hidden">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div key={i} className="flex-shrink-0 w-40 flex flex-col gap-1.5">
+          <div
+            className="aspect-[2/3] rounded-lg bg-white/[0.04] animate-pulse"
+            style={{ animationDelay: `${i * 60}ms` }}
+          />
+          <div className="h-2.5 w-3/4 bg-white/[0.04] rounded animate-pulse" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// === MAIN COMPONENT ===
+
 /**
  * Onboarding step 2: movie selection.
- * Shows top-rated films from user's selected genres. Minimum 5 films required.
+ * Layout: search bar with dropdown → Suggestions row → Your picks row.
  *
  * @param {{
  *   selectedGenreIds: number[],
  *   favoriteMovies: object[],
- *   addMovie: (movie: object) => void,
- *   removeMovie: (tmdbId: number) => void,
- *   isMovieSelected: (tmdbId: number) => boolean,
- *   onBack: () => void,
- *   onFinish: () => void,
+ *   addMovie: function,
+ *   removeMovie: function,
+ *   isMovieSelected: function,
+ *   onBack: function,
+ *   onFinish: function,
  *   loading: boolean,
  *   error: string,
  * }} props
@@ -140,14 +157,13 @@ export default function MoviesStep({
 }) {
   const [pool, setPool] = useState([])
   const [poolLoading, setPoolLoading] = useState(true)
-  const [isGlobalPool, setIsGlobalPool] = useState(false)
   const [query, setQuery] = useState('')
   const [results, setResults] = useState([])
   const [searching, setSearching] = useState(false)
+  const [showDropdown, setShowDropdown] = useState(false)
   const searchInputRef = useRef(null)
   const searchTimeoutRef = useRef(null)
 
-  // Load initial genre-filtered pool
   useEffect(() => {
     setPoolLoading(true)
     fetchGenrePool(selectedGenreIds)
@@ -155,18 +171,22 @@ export default function MoviesStep({
       .catch(() => setPoolLoading(false))
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Auto-focus search
   useEffect(() => {
     const timer = setTimeout(() => searchInputRef.current?.focus(), 100)
     return () => clearTimeout(timer)
   }, [])
 
-  // Debounced TMDB search
+  // Live search with debounce
   useEffect(() => {
     clearTimeout(searchTimeoutRef.current)
-    if (!query.trim()) { setResults([]); setSearching(false); return }
-
+    if (!query.trim()) {
+      setResults([])
+      setSearching(false)
+      setShowDropdown(false)
+      return
+    }
     setSearching(true)
+    setShowDropdown(true)
     searchTimeoutRef.current = setTimeout(async () => {
       try {
         const data = await searchMovies(query)
@@ -174,7 +194,7 @@ export default function MoviesStep({
           (data?.results || [])
             .filter(m => m.poster_path)
             .sort((a, b) => (b.popularity || 0) - (a.popularity || 0))
-            .slice(0, 12)
+            .slice(0, 8)
         )
       } catch {
         setResults([])
@@ -182,22 +202,19 @@ export default function MoviesStep({
         setSearching(false)
       }
     }, 300)
-
     return () => clearTimeout(searchTimeoutRef.current)
   }, [query])
 
-  async function handleSwapPool() {
-    setPoolLoading(true)
-    setIsGlobalPool(true)
-    const films = await fetchGlobalPool().catch(() => [])
-    setPool(films)
-    setPoolLoading(false)
+  function handleSelectFromSearch(movie) {
+    addMovie(movie)
+    setQuery('')
+    setShowDropdown(false)
   }
 
   const count = favoriteMovies.length
   const canFinish = count >= MIN_MOVIES
-  const showPool = !query
-  const displayPool = showPool ? pool : results
+  // Suggestions: pool excluding already-selected films
+  const suggestions = pool.filter(m => !isMovieSelected(m.id))
 
   return (
     <div className="h-full flex flex-col">
@@ -211,18 +228,16 @@ export default function MoviesStep({
           <ChevronLeft className="h-4 w-4" />
           Back
         </button>
-        <h2 className="text-2xl sm:text-3xl font-black text-white leading-tight">
-          Pick 5 films you&apos;ve loved.
+        <h2 className="text-5xl font-black tracking-tight text-white leading-[1.05]">
+          What have you loved?
         </h2>
-        <p className="text-sm text-white/40 mt-1">
-          {isGlobalPool
-            ? 'Showing all-time greats — scroll or search'
-            : 'From your chosen genres — or search for anything'}
+        <p className="text-base text-white/60 mt-2 leading-relaxed">
+          Pick five films that shaped your taste.
         </p>
       </div>
 
-      {/* Search bar */}
-      <div className="flex-none px-6 pb-3">
+      {/* Search bar + dropdown */}
+      <div className="flex-none px-6 pb-5 relative">
         <div className="relative">
           <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4 text-white/30 pointer-events-none" />
           <input
@@ -230,13 +245,14 @@ export default function MoviesStep({
             type="text"
             value={query}
             onChange={e => setQuery(e.target.value)}
+            onFocus={() => { if (query.trim()) setShowDropdown(true) }}
             placeholder="Search any film…"
             className="w-full pl-10 pr-9 py-2.5 rounded-xl bg-white/[0.07] border border-white/10 text-sm text-white placeholder-white/30 focus:outline-none focus:ring-1 focus:ring-purple-400/50 focus:border-purple-400/30 transition-all"
           />
           {query && (
             <button
               type="button"
-              onClick={() => setQuery('')}
+              onClick={() => { setQuery(''); setShowDropdown(false) }}
               aria-label="Clear search"
               className="absolute right-3 top-1/2 -translate-y-1/2 text-white/30 hover:text-white/60"
             >
@@ -244,79 +260,97 @@ export default function MoviesStep({
             </button>
           )}
         </div>
+
+        {/* Search dropdown */}
+        {showDropdown && (
+          <div className="absolute left-6 right-6 top-full mt-1 z-50 bg-neutral-900 border border-white/10 rounded-xl overflow-hidden shadow-2xl">
+            {searching ? (
+              <p className="px-4 py-3 text-sm text-white/40">Searching…</p>
+            ) : results.length === 0 ? (
+              <p className="px-4 py-3 text-sm text-white/30">No results — try a different title</p>
+            ) : (
+              <div className="max-h-60 overflow-y-auto divide-y divide-white/[0.05]">
+                {results.map(m => {
+                  const yr = m.release_date ? new Date(m.release_date).getFullYear() : null
+                  const selected = isMovieSelected(m.id)
+                  return (
+                    <button
+                      key={m.id}
+                      type="button"
+                      onClick={() => handleSelectFromSearch(m)}
+                      className="w-full flex items-center gap-3 px-4 py-2.5 hover:bg-white/[0.06] text-left transition-colors"
+                    >
+                      <img
+                        src={tmdbImg(m.poster_path, 'w92')}
+                        alt=""
+                        className="w-8 h-12 rounded object-cover flex-shrink-0 bg-white/[0.04]"
+                      />
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium text-white truncate">{m.title}</p>
+                        {yr && <p className="text-xs text-white/40">{yr}</p>}
+                      </div>
+                      {selected && (
+                        <Check className="flex-shrink-0 h-4 w-4 text-purple-400" />
+                      )}
+                    </button>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
-      {/* Selected strip */}
-      {favoriteMovies.length > 0 && (
-        <div className="flex-none px-6 pb-3">
-          <div className="flex gap-2 overflow-x-auto pb-1 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-            {favoriteMovies.map(m => (
-              <button
-                key={m.id}
-                type="button"
-                onClick={() => removeMovie(m.id)}
-                title={`Remove ${m.title}`}
-                aria-label={`Remove ${m.title}`}
-                className="relative flex-none group"
-              >
-                <img
-                  src={tmdbImg(m.poster_path, 'w92')}
-                  alt={m.title}
-                  className="h-14 w-10 rounded-lg object-cover ring-1 ring-purple-400/50"
-                />
-                <div className="absolute inset-0 rounded-lg bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
-                  <X className="h-3.5 w-3.5 text-white" />
-                </div>
-              </button>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Film grid */}
-      <div className="flex-1 min-h-0 overflow-y-auto px-4 sm:px-6">
+      {/* Carousel rows */}
+      <div className="flex-1 min-h-0 overflow-y-auto px-6 space-y-6 pb-4">
         {error && (
-          <div className="mb-3 p-3 rounded-xl bg-red-500/10 border border-red-500/20 text-red-300 text-sm text-center">
+          <div className="p-3 rounded-xl bg-red-500/10 border border-red-500/20 text-red-300 text-sm text-center">
             {error}
           </div>
         )}
 
-        {poolLoading || searching ? (
-          <div className="grid grid-cols-3 sm:grid-cols-5 md:grid-cols-6 gap-2.5">
-            {Array.from({ length: 12 }).map((_, i) => (
-              <div key={i} className="aspect-[2/3] rounded-xl bg-white/[0.04] animate-pulse" style={{ animationDelay: `${i * 40}ms` }} />
-            ))}
-          </div>
-        ) : displayPool.length === 0 ? (
-          <p className="text-sm text-white/30 text-center pt-12">
-            {query ? 'No results — try a different title' : 'No films found'}
+        {/* Suggestions row */}
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-widest text-purple-400/60 mb-3">
+            Suggestions
           </p>
-        ) : (
-          <>
-            <div className="grid grid-cols-3 sm:grid-cols-5 md:grid-cols-6 gap-2.5 pb-4">
-              {displayPool.map(m => (
-                <PosterTile
+          {poolLoading ? (
+            <CardSkeletonRow />
+          ) : suggestions.length === 0 ? (
+            <p className="text-sm text-white/30 py-2">
+              All suggestions added — search for more above
+            </p>
+          ) : (
+            <div className="flex gap-4 overflow-x-auto pb-1 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden snap-x snap-mandatory">
+              {suggestions.map(m => (
+                <MovieCard
                   key={m.id}
                   movie={m}
-                  isSelected={isMovieSelected(m.id)}
-                  onClick={() => isMovieSelected(m.id) ? removeMovie(m.id) : addMovie(m)}
+                  isSelected={false}
+                  onClick={() => addMovie(m)}
                 />
               ))}
             </div>
-            {/* Swap pool — only shown for genre pool */}
-            {showPool && !isGlobalPool && (
-              <div className="py-4 flex justify-center">
-                <button
-                  type="button"
-                  onClick={handleSwapPool}
-                  className="flex items-center gap-2 text-sm text-white/40 hover:text-white/70 transition-colors"
-                >
-                  <RefreshCw className="h-3.5 w-3.5" />
-                  I haven&apos;t seen these — show all-time greats
-                </button>
-              </div>
-            )}
-          </>
+          )}
+        </div>
+
+        {/* Your picks row */}
+        {favoriteMovies.length > 0 && (
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-widest text-purple-400/60 mb-3">
+              Your picks ({count}/{MIN_MOVIES})
+            </p>
+            <div className="flex gap-4 overflow-x-auto pb-1 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden snap-x snap-mandatory">
+              {favoriteMovies.map(m => (
+                <MovieCard
+                  key={m.id}
+                  movie={m}
+                  isSelected={true}
+                  onClick={() => removeMovie(m.id)}
+                />
+              ))}
+            </div>
+          </div>
         )}
       </div>
 
@@ -332,14 +366,8 @@ export default function MoviesStep({
               ? `${count} selected — pick ${MIN_MOVIES - count} more`
               : `${count} selected ✓`}
           </p>
-          <Button
-            variant="primary"
-            size="lg"
-            onClick={onFinish}
-            disabled={!canFinish || loading}
-            fullWidth
-          >
-            {loading ? 'Saving…' : 'See my recommendations'}
+          <Button variant="primary" size="lg" onClick={onFinish} disabled={!canFinish || loading} fullWidth>
+            {loading ? 'Saving…' : 'Continue'}
           </Button>
         </div>
       </div>

--- a/src/app/pages/onboarding/RatingStep.jsx
+++ b/src/app/pages/onboarding/RatingStep.jsx
@@ -1,6 +1,6 @@
 // src/app/pages/onboarding/RatingStep.jsx
 import { useState } from 'react'
-import { motion, AnimatePresence } from 'framer-motion'
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion'
 import { ChevronLeft } from 'lucide-react'
 
 import { tmdbImg } from '@/shared/api/tmdb'
@@ -14,26 +14,25 @@ export const SENTIMENT_RATINGS = {
 }
 
 const SENTIMENTS = [
-  { key: 'loved', label: '❤️ Loved it',   rating: 9, color: 'from-purple-500 to-pink-500'    },
-  { key: 'liked', label: '👍 Liked it',   rating: 7, color: 'from-purple-400/60 to-blue-400/60' },
-  { key: 'okay',  label: '😐 It was okay', rating: 5, color: 'from-white/10 to-white/5'        },
+  { key: 'loved', label: '❤️ Loved it',    gradient: 'from-purple-500 to-pink-500'       },
+  { key: 'liked', label: '👍 Liked it',    gradient: 'from-purple-400/70 to-blue-400/70'  },
+  { key: 'okay',  label: '😐 It was okay', gradient: 'from-white/15 to-white/5'           },
 ]
 
-/**
- * A film card with three sentiment buttons.
- * Only one film + one sentiment can be active at a time.
- */
-function FilmRatingCard({ movie, pick, onRate, isSelected }) {
+// === FILM CARD ===
+
+function FilmRatingCard({ movie, activeSentiment, onRate }) {
   const [posterLoaded, setPosterLoaded] = useState(false)
+  const prefersReducedMotion = useReducedMotion()
   const year = movie.release_date ? new Date(movie.release_date).getFullYear() : null
+  const isRated = activeSentiment != null
 
   return (
-    <motion.div
-      layout
-      className={`flex-none w-36 sm:w-40 rounded-2xl overflow-hidden transition-all duration-200 ${
-        isSelected ? 'ring-2 ring-purple-400 shadow-lg shadow-purple-500/20' : 'ring-1 ring-white/10'
-      }`}
-    >
+    <div className={`flex-none w-44 sm:w-48 rounded-2xl overflow-hidden transition-shadow duration-200 ${
+      isRated
+        ? 'ring-2 ring-purple-400 shadow-[0_0_24px_rgba(168,85,247,0.4)]'
+        : 'ring-1 ring-white/10'
+    }`}>
       {/* Poster */}
       <div className="relative aspect-[2/3]">
         {!posterLoaded && <div className="absolute inset-0 bg-white/[0.04] animate-pulse" />}
@@ -41,48 +40,53 @@ function FilmRatingCard({ movie, pick, onRate, isSelected }) {
           src={tmdbImg(movie.poster_path, 'w342')}
           alt={movie.title}
           loading="eager"
-          className={`w-full h-full object-cover transition-opacity duration-300 ${posterLoaded ? 'opacity-100' : 'opacity-0'}`}
+          className={`w-full h-full object-cover transition-all duration-300 ${posterLoaded ? 'opacity-100' : 'opacity-0'} ${isRated ? 'brightness-75' : ''}`}
           onLoad={() => setPosterLoaded(true)}
         />
-        <div className="absolute bottom-0 inset-x-0 bg-gradient-to-t from-black/90 via-black/40 to-transparent px-2 pt-6 pb-2">
-          <p className="text-[11px] font-bold text-white leading-tight line-clamp-2">{movie.title}</p>
+        {isRated && <div className="absolute inset-0 bg-purple-600/15" />}
+        <div className="absolute bottom-0 inset-x-0 bg-gradient-to-t from-black/95 via-black/50 to-transparent px-2.5 pt-8 pb-2.5">
+          <p className="text-[11px] font-semibold text-white leading-tight line-clamp-2">{movie.title}</p>
           {year && <p className="text-[10px] text-white/40 mt-0.5">{year}</p>}
         </div>
       </div>
 
       {/* Sentiment buttons */}
-      <div className="bg-neutral-900 p-2 flex flex-col gap-1.5">
-        {SENTIMENTS.map(({ key, label, color }) => {
-          const isActive = pick?.tmdbId === movie.id && pick?.sentiment === key
+      <div className="bg-neutral-900/80 p-2 flex flex-col gap-1.5">
+        {SENTIMENTS.map(({ key, label, gradient }) => {
+          const isActive = activeSentiment === key
           return (
-            <button
+            <motion.button
               key={key}
               type="button"
               onClick={() => onRate(movie, key)}
               aria-pressed={isActive}
-              className={`w-full rounded-lg px-2 py-1.5 text-[10px] sm:text-[11px] font-semibold text-white text-left transition-all duration-150 active:scale-95 ${
+              whileTap={prefersReducedMotion ? undefined : { scale: 0.94 }}
+              animate={isActive ? { scale: [1, 1.04, 1] } : { scale: 1 }}
+              transition={isActive ? { duration: 0.2 } : {}}
+              className={`w-full rounded-lg px-2.5 py-1.5 text-[11px] sm:text-[12px] font-semibold text-white text-left transition-all duration-150 ${
                 isActive
-                  ? `bg-gradient-to-r ${color} shadow`
-                  : 'bg-white/[0.06] hover:bg-white/[0.12]'
+                  ? `bg-gradient-to-r ${gradient} shadow`
+                  : 'bg-white/[0.07] hover:bg-white/[0.13]'
               }`}
             >
               {label}
-            </button>
+            </motion.button>
           )
         })}
       </div>
-    </motion.div>
+    </div>
   )
 }
 
+// === MAIN COMPONENT ===
+
 /**
  * Onboarding step 3: rating anchor.
- * User picks ONE of their 5 films and rates it with a sentiment.
- * This single rating becomes the strongest signal for first-run recommendations.
+ * User can rate any or all of their 5 films. Min 1 required to continue.
  *
  * @param {{
  *   favoriteMovies: object[],
- *   pick: { tmdbId: number, sentiment: string, rating: number } | null,
+ *   ratings: Record<number, number>,
  *   onRate: (movie: object, sentiment: string) => void,
  *   onBack: () => void,
  *   onFinish: () => void,
@@ -90,8 +94,9 @@ function FilmRatingCard({ movie, pick, onRate, isSelected }) {
  *   error: string,
  * }} props
  */
-export default function RatingStep({ favoriteMovies, pick, onRate, onBack, onFinish, loading, error }) {
-  const canFinish = pick !== null
+export default function RatingStep({ favoriteMovies, ratings, onRate, onBack, onFinish, loading, error }) {
+  const ratedCount = Object.keys(ratings).length
+  const canFinish = ratedCount >= 1
 
   return (
     <div className="h-full flex flex-col">
@@ -105,11 +110,11 @@ export default function RatingStep({ favoriteMovies, pick, onRate, onBack, onFin
           <ChevronLeft className="h-4 w-4" />
           Back
         </button>
-        <h2 className="text-2xl sm:text-3xl font-black text-white leading-tight">
-          Rate the one you loved most.
+        <h2 className="text-5xl font-black tracking-tight text-white leading-[1.05]">
+          Which ones hit?
         </h2>
-        <p className="text-sm text-white/40 mt-2 leading-relaxed">
-          One rating is all it takes — we&apos;ll use it to tune your first recommendations.
+        <p className="text-base text-white/60 mt-2 leading-relaxed">
+          Rate at least one — the more you rate, the sharper we tune.
         </p>
       </div>
 
@@ -127,25 +132,28 @@ export default function RatingStep({ favoriteMovies, pick, onRate, onBack, onFin
               <FilmRatingCard
                 key={movie.id}
                 movie={movie}
-                pick={pick}
+                activeSentiment={(() => {
+                  const r = ratings[movie.id]
+                  if (r == null) return null
+                  return r === 9 ? 'loved' : r === 7 ? 'liked' : 'okay'
+                })()}
                 onRate={onRate}
-                isSelected={pick?.tmdbId === movie.id}
               />
             ))}
           </AnimatePresence>
         </div>
 
-        {/* Selected state summary */}
+        {/* Status line */}
         <AnimatePresence>
-          {pick && (
-            <motion.div
-              initial={{ opacity: 0, y: 8 }}
+          {ratedCount > 0 && (
+            <motion.p
+              initial={{ opacity: 0, y: 6 }}
               animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: 8 }}
+              exit={{ opacity: 0, y: 6 }}
               className="mt-2 mb-4 text-center text-sm text-purple-300/80"
             >
-              Using <strong className="text-white">{favoriteMovies.find(m => m.id === pick.tmdbId)?.title}</strong> as your taste anchor ✓
-            </motion.div>
+              {ratedCount} rated ✓ — rate as many as you like
+            </motion.p>
           )}
         </AnimatePresence>
       </div>
@@ -155,7 +163,7 @@ export default function RatingStep({ favoriteMovies, pick, onRate, onBack, onFin
         <div className="max-w-sm mx-auto flex flex-col items-center gap-3">
           {!canFinish && (
             <p className="text-xs font-medium text-white/30">
-              Tap a sentiment on any film to continue
+              Rate at least one film to continue
             </p>
           )}
           <Button

--- a/src/features/onboarding/Onboarding.jsx
+++ b/src/features/onboarding/Onboarding.jsx
@@ -9,33 +9,30 @@ import { useAuthSession } from '@/shared/hooks/useAuthSession'
 import { completeOnboarding } from '@/shared/services/onboarding'
 import { SENTIMENT_RATINGS } from '@/app/pages/onboarding/RatingStep'
 
+import CinematicBackdrop from '@/app/pages/onboarding/CinematicBackdrop'
 import GenresStep from '@/app/pages/onboarding/GenresStep'
 import MoviesStep from '@/app/pages/onboarding/MoviesStep'
 import RatingStep from '@/app/pages/onboarding/RatingStep'
 
-const STEP_LABELS = ['Your Genres', 'Your Films', 'Rate One']
 const TOTAL_STEPS = 3
 
-// === PROGRESS INDICATOR ===
+// === PROGRESS BAR ===
+// Three spring-filled segments — no redundant step labels.
 
-function ProgressIndicator({ step }) {
-  const progressPercent = ((step + 1) / TOTAL_STEPS) * 100
-
+function ProgressBar({ step }) {
   return (
-    <div className="flex-none px-6 py-4 border-b border-white/5">
-      <div className="flex items-center justify-between mb-2">
-        <span className="text-xs font-semibold text-white/40 uppercase tracking-wider">
-          Step {step + 1} of {TOTAL_STEPS}
-        </span>
-        <span className="text-xs font-semibold text-white/60">
-          {STEP_LABELS[step]}
-        </span>
-      </div>
-      <div className="h-0.5 w-full bg-white/10 rounded-full overflow-hidden">
-        <div
-          className="h-full bg-gradient-to-r from-purple-500 to-pink-500 rounded-full transition-all duration-700 ease-out"
-          style={{ width: `${progressPercent}%` }}
-        />
+    <div className="flex-none px-6 py-5">
+      <div className="flex items-center gap-2">
+        {Array.from({ length: TOTAL_STEPS }).map((_, i) => (
+          <div key={i} className="h-[3px] flex-1 rounded-full bg-white/10 overflow-hidden">
+            <motion.div
+              className="h-full bg-gradient-to-r from-purple-500 to-pink-500 rounded-full"
+              initial={{ scaleX: 0, originX: 0 }}
+              animate={{ scaleX: i <= step ? 1 : 0 }}
+              transition={{ type: 'spring', stiffness: 100, damping: 20 }}
+            />
+          </div>
+        ))}
       </div>
     </div>
   )
@@ -53,14 +50,12 @@ export default function Onboarding() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
 
-  // Step 0: genre selection
+  // Step 0: genres
   const [selectedGenres, setSelectedGenres] = useState([])
-
-  // Step 1: movie selection
+  // Step 1: films
   const [favoriteMovies, setFavoriteMovies] = useState([])
-
-  // Step 2: rating anchor
-  const [pick, setPick] = useState(null)
+  // Step 2: ratings — { [tmdbId: number]: 9 | 7 | 5 }
+  const [ratings, setRatings] = useState({})
 
   // === AUTH CHECK ===
   useEffect(() => {
@@ -103,9 +98,21 @@ export default function Onboarding() {
   function removeMovie(id) { setFavoriteMovies(prev => prev.filter(m => m.id !== id)) }
 
   // === RATING HELPER ===
+  // Toggling: clicking the same sentiment again clears the rating for that film
   function handleRate(movie, sentiment) {
     const rating = SENTIMENT_RATINGS[sentiment]
-    setPick({ tmdbId: movie.id, sentiment, rating })
+    setRatings(prev => {
+      // Resolve current sentiment key for this film (if any)
+      const current = prev[movie.id]
+      const currentSentiment = current === 9 ? 'loved' : current === 7 ? 'liked' : current === 5 ? 'okay' : null
+      if (currentSentiment === sentiment) {
+        // Same button tapped → clear rating
+        const next = { ...prev }
+        delete next[movie.id]
+        return next
+      }
+      return { ...prev, [movie.id]: rating }
+    })
   }
 
   // === FINISH ===
@@ -114,14 +121,9 @@ export default function Onboarding() {
     setLoading(true)
 
     try {
-      await completeOnboarding({
-        session,
-        selectedGenres,
-        favoriteMovies,
-        ratingPick: pick,
-      })
+      await completeOnboarding({ session, selectedGenres, favoriteMovies, ratings })
 
-      // Check if auth metadata update propagated; force reload if not
+      // Wait for auth metadata to propagate
       await new Promise(resolve => setTimeout(resolve, 500))
       const { data: { session: updatedSession } } = await supabase.auth.getSession()
       if (!updatedSession?.user?.user_metadata?.onboarding_complete) {
@@ -131,7 +133,10 @@ export default function Onboarding() {
 
       setLoading(false)
       setCelebrate(true)
-      setTimeout(() => navigate('/home', { replace: true, state: { fromOnboarding: true } }), 2000)
+      setTimeout(() => navigate('/home', {
+        replace: true,
+        state: { fromOnboarding: true, movieCount: favoriteMovies.length },
+      }), 2000)
     } catch (e) {
       console.error('Onboarding save failed:', e)
       setError(e.message || 'Could not save your preferences. Please try again.')
@@ -172,7 +177,7 @@ export default function Onboarding() {
         <motion.div
           initial={{ opacity: 0, scale: 0.92, y: 20 }}
           animate={{ opacity: 1, scale: 1, y: 0 }}
-          transition={{ duration: 0.6, ease: 'easeOut' }}
+          transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
           className="relative text-center px-6"
         >
           <motion.div
@@ -185,7 +190,7 @@ export default function Onboarding() {
           <span className="block text-sm font-bold uppercase tracking-[0.22em] text-purple-400/70 mb-5">
             All set
           </span>
-          <h1 className="text-4xl sm:text-5xl font-black text-white mb-4 leading-tight">
+          <h1 className="text-4xl sm:text-5xl font-bold text-white mb-4 leading-tight tracking-tight">
             Your taste profile<br />
             <span className="bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent">is ready.</span>
           </h1>
@@ -199,24 +204,21 @@ export default function Onboarding() {
 
   // === MAIN LAYOUT ===
   return (
-    <div className="fixed inset-0 bg-black flex flex-col">
-      {/* Ambient background */}
-      <div className="absolute inset-0 overflow-hidden pointer-events-none" aria-hidden="true">
-        <div style={{ position: 'absolute', inset: 0, background: 'radial-gradient(ellipse 80% 45% at 50% 0%, rgba(88,28,135,0.18) 0%, transparent 65%)' }} />
-        <div style={{ position: 'absolute', inset: 0, background: 'radial-gradient(ellipse 60% 40% at 80% 80%, rgba(168,85,247,0.08) 0%, transparent 60%)' }} />
-      </div>
+    <div className="fixed inset-0 flex flex-col">
+      {/* Cinematic backdrop — behind everything */}
+      <CinematicBackdrop />
 
       <div className="relative z-10 flex flex-col h-full max-w-6xl mx-auto w-full">
-        <ProgressIndicator step={step} />
+        <ProgressBar step={step} />
 
         <div className="flex-1 min-h-0 overflow-hidden">
           <AnimatePresence mode="wait" initial={false}>
             <motion.div
               key={step}
-              initial={{ opacity: 0, x: 24 }}
-              animate={{ opacity: 1, x: 0 }}
-              exit={{ opacity: 0, x: -24 }}
-              transition={{ duration: 0.22, ease: 'easeOut' }}
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+              transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
               className="h-full"
             >
               {step === 0 && (
@@ -243,9 +245,9 @@ export default function Onboarding() {
               {step === 2 && (
                 <RatingStep
                   favoriteMovies={favoriteMovies}
-                  pick={pick}
+                  ratings={ratings}
                   onRate={handleRate}
-                  onBack={() => { setError(''); setPick(null); setStep(1) }}
+                  onBack={() => { setError(''); setRatings({}); setStep(1) }}
                   onFinish={handleFinish}
                   loading={loading}
                   error={error}

--- a/src/features/onboarding/__tests__/OnboardingSteps.test.jsx
+++ b/src/features/onboarding/__tests__/OnboardingSteps.test.jsx
@@ -114,8 +114,8 @@ function MoviesFooter({ count, onFinish }) {
   return (
     <div>
       <p>{count === 0 ? 'Select at least 5 films to continue' : count < 5 ? `${count} selected — pick ${5 - count} more` : `${count} selected ✓`}</p>
-      <button onClick={onFinish} disabled={!canFinish} aria-label="See my recommendations">
-        See my recommendations
+      <button onClick={onFinish} disabled={!canFinish} aria-label="Continue">
+        Continue
       </button>
     </div>
   )
@@ -124,28 +124,28 @@ function MoviesFooter({ count, onFinish }) {
 describe('MoviesStep — 5-film minimum', () => {
   it('CTA is disabled with 0 films selected', () => {
     render(<MoviesFooter count={0} onFinish={vi.fn()} />)
-    expect(screen.getByRole('button', { name: /see my recommendations/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /continue/i })).toBeDisabled()
   })
 
   it('CTA is disabled with 4 films selected', () => {
     render(<MoviesFooter count={4} onFinish={vi.fn()} />)
-    expect(screen.getByRole('button', { name: /see my recommendations/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /continue/i })).toBeDisabled()
   })
 
   it('CTA is enabled with exactly 5 films selected', () => {
     render(<MoviesFooter count={5} onFinish={vi.fn()} />)
-    expect(screen.getByRole('button', { name: /see my recommendations/i })).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: /continue/i })).not.toBeDisabled()
   })
 
   it('CTA is enabled with more than 5 films selected', () => {
     render(<MoviesFooter count={8} onFinish={vi.fn()} />)
-    expect(screen.getByRole('button', { name: /see my recommendations/i })).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: /continue/i })).not.toBeDisabled()
   })
 
   it('calls onFinish when CTA clicked with enough films', () => {
     const onFinish = vi.fn()
     render(<MoviesFooter count={5} onFinish={onFinish} />)
-    fireEvent.click(screen.getByRole('button', { name: /see my recommendations/i }))
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }))
     expect(onFinish).toHaveBeenCalled()
   })
 })
@@ -170,8 +170,8 @@ describe('RatingStep — SENTIMENT_RATINGS mapping', () => {
   })
 })
 
-function RatingFooter({ pick, onFinish, loading = false }) {
-  const canFinish = pick !== null
+function RatingFooter({ ratings, onFinish, loading = false }) {
+  const canFinish = Object.keys(ratings).length >= 1
   return (
     <div>
       <button onClick={onFinish} disabled={!canFinish || loading} aria-label="See my recommendations">
@@ -182,27 +182,29 @@ function RatingFooter({ pick, onFinish, loading = false }) {
 }
 
 describe('RatingStep — finish gate', () => {
-  it('CTA is disabled when no pick is made', () => {
-    render(<RatingFooter pick={null} onFinish={vi.fn()} />)
+  it('CTA is disabled when no films are rated', () => {
+    render(<RatingFooter ratings={{}} onFinish={vi.fn()} />)
     expect(screen.getByRole('button', { name: /see my recommendations/i })).toBeDisabled()
   })
 
-  it('CTA is enabled once a sentiment is picked', () => {
-    const pick = { tmdbId: 123, sentiment: 'loved', rating: 9 }
-    render(<RatingFooter pick={pick} onFinish={vi.fn()} />)
+  it('CTA is enabled once one film is rated', () => {
+    render(<RatingFooter ratings={{ 123: 9 }} onFinish={vi.fn()} />)
     expect(screen.getByRole('button', { name: /see my recommendations/i })).not.toBeDisabled()
   })
 
-  it('CTA is disabled while loading even if pick is set', () => {
-    const pick = { tmdbId: 123, sentiment: 'liked', rating: 7 }
-    render(<RatingFooter pick={pick} onFinish={vi.fn()} loading={true} />)
+  it('CTA is enabled with multiple films rated', () => {
+    render(<RatingFooter ratings={{ 123: 9, 456: 7, 789: 5 }} onFinish={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /see my recommendations/i })).not.toBeDisabled()
+  })
+
+  it('CTA is disabled while loading even if films are rated', () => {
+    render(<RatingFooter ratings={{ 123: 7 }} onFinish={vi.fn()} loading={true} />)
     expect(screen.getByRole('button', { name: /see my recommendations/i })).toBeDisabled()
   })
 
-  it('calls onFinish when CTA clicked', () => {
+  it('calls onFinish when CTA clicked with a rating', () => {
     const onFinish = vi.fn()
-    const pick = { tmdbId: 456, sentiment: 'okay', rating: 5 }
-    render(<RatingFooter pick={pick} onFinish={onFinish} />)
+    render(<RatingFooter ratings={{ 456: 5 }} onFinish={onFinish} />)
     fireEvent.click(screen.getByRole('button', { name: /see my recommendations/i }))
     expect(onFinish).toHaveBeenCalled()
   })
@@ -260,7 +262,7 @@ describe('completeOnboarding — service writes', () => {
       session: MOCK_SESSION,
       selectedGenres: [28, 18, 53],
       favoriteMovies: MOCK_MOVIES,
-      ratingPick: { tmdbId: 1, sentiment: 'loved', rating: 9 },
+      ratings: { 1: 9 },
     })
 
     expect(computeUserProfileV3).toHaveBeenCalledWith('user-123', { forceRefresh: true })
@@ -271,7 +273,7 @@ describe('completeOnboarding — service writes', () => {
       session: MOCK_SESSION,
       selectedGenres: [28],
       favoriteMovies: MOCK_MOVIES,
-      ratingPick: null,
+      ratings: {},
     })
 
     expect(supabase.auth.updateUser).toHaveBeenCalledWith({
@@ -279,33 +281,31 @@ describe('completeOnboarding — service writes', () => {
     })
   })
 
-  it('tracks onboarding_completed with correct properties', async () => {
+  it('tracks onboarding_completed with correct properties when films are rated', async () => {
     await completeOnboarding({
       session: MOCK_SESSION,
       selectedGenres: [28, 18, 53],
       favoriteMovies: MOCK_MOVIES,
-      ratingPick: { tmdbId: 1, sentiment: 'liked', rating: 7 },
+      ratings: { 1: 9, 2: 7 },
     })
 
     expect(track).toHaveBeenCalledWith('onboarding_completed', expect.objectContaining({
       genre_count: 3,
       movie_count: 5,
-      has_rating_anchor: true,
-      rating_sentiment: 'liked',
+      rating_count: 2,
     }))
   })
 
-  it('tracks has_rating_anchor: false when no pick given', async () => {
+  it('tracks rating_count: 0 when no films are rated', async () => {
     await completeOnboarding({
       session: MOCK_SESSION,
       selectedGenres: [28],
       favoriteMovies: MOCK_MOVIES,
-      ratingPick: null,
+      ratings: {},
     })
 
     expect(track).toHaveBeenCalledWith('onboarding_completed', expect.objectContaining({
-      has_rating_anchor: false,
-      rating_sentiment: null,
+      rating_count: 0,
     }))
   })
 
@@ -315,7 +315,7 @@ describe('completeOnboarding — service writes', () => {
         session: { user: null },
         selectedGenres: [],
         favoriteMovies: [],
-        ratingPick: null,
+        ratings: {},
       })
     ).rejects.toThrow('No authenticated user')
   })

--- a/src/shared/services/onboarding.js
+++ b/src/shared/services/onboarding.js
@@ -91,20 +91,21 @@ async function ensureMovieExists(tmdbMovie) {
  * Write order:
  *   1. user_preferences (genre IDs)
  *   2. user_history (one row per favoriteMovie, source: 'onboarding')
- *   3. user_ratings (one row for the rated film, source: 'onboarding')
+ *   3. user_ratings (one row per rated film, source: 'onboarding')
  *   4. users.onboarding_complete = true
  *   5. auth metadata update
- *   6. computeUserProfileV3 (synchronous — ensures /home has profile on first load)
+ *   6. computeUserProfileV3 (sync — ensures /home has profile on first load)
+ *   7. Verify profile row exists, retry once if missing
  *
  * @param {{
  *   session: import('@supabase/supabase-js').Session,
  *   selectedGenres: number[],
  *   favoriteMovies: object[],
- *   ratingPick: { tmdbId: number, sentiment: string, rating: number } | null,
+ *   ratings: Record<number, number>,
  * }} params
  * @returns {Promise<void>}
  */
-export async function completeOnboarding({ session, selectedGenres, favoriteMovies, ratingPick }) {
+export async function completeOnboarding({ session, selectedGenres, favoriteMovies, ratings }) {
   const user = session?.user
   if (!user?.id) throw new Error('No authenticated user.')
 
@@ -124,12 +125,14 @@ export async function completeOnboarding({ session, selectedGenres, favoriteMovi
     if (prefError) throw new Error('Could not save your genre preferences')
   }
 
-  // 3. Watch history for all favorite films
+  // 3. Watch history for all favorite films (resolve internal IDs in parallel)
+  const internalIdMap = {}
   if (favoriteMovies.length > 0) {
     const movieIdResults = await Promise.all(
       favoriteMovies.map(async (tmdbMovie) => {
         try {
           const internalId = await ensureMovieExists(tmdbMovie)
+          internalIdMap[tmdbMovie.id] = internalId
           return { user_id, movie_id: internalId, watched_at: now, source: 'onboarding', watch_duration_minutes: null, mood_session_id: null }
         } catch (err) {
           console.error(`Failed to process movie ${tmdbMovie.title}:`, err)
@@ -145,21 +148,24 @@ export async function completeOnboarding({ session, selectedGenres, favoriteMovi
     }
   }
 
-  // 4. Rating anchor — one row for the film the user rated
-  if (ratingPick) {
-    const ratedMovie = favoriteMovies.find(m => m.id === ratingPick.tmdbId)
-    if (ratedMovie) {
+  // 4. Ratings — one row per rated film (all films the user assigned a sentiment to)
+  const ratingEntries = Object.entries(ratings || {})
+  if (ratingEntries.length > 0) {
+    for (const [tmdbIdStr, rating] of ratingEntries) {
+      const tmdbId = Number(tmdbIdStr)
+      const movie = favoriteMovies.find(m => m.id === tmdbId)
+      if (!movie) continue
       try {
-        const internalId = ratedMovie.internalId ?? (await ensureMovieExists(ratedMovie))
+        const internalId = internalIdMap[tmdbId] ?? (movie.internalId || await ensureMovieExists(movie))
         await supabase.from('user_ratings').insert({
           user_id,
           movie_id: internalId,
-          rating: ratingPick.rating,
+          rating,
           source: 'onboarding',
         })
       } catch (err) {
-        // Non-fatal — profile will still compute without this row
-        console.warn('Could not save rating anchor:', err)
+        // Non-fatal — profile computes fine without individual rating rows
+        console.warn(`Could not save rating for tmdbId ${tmdbId}:`, err)
       }
     }
   }
@@ -178,8 +184,19 @@ export async function completeOnboarding({ session, selectedGenres, favoriteMovi
   // 7. Compute profile synchronously — /home needs it on first load
   try {
     await computeUserProfileV3(user_id, { forceRefresh: true })
+
+    // Verify the profile row was written; retry once if missing
+    const { data: profile } = await supabase
+      .from('user_profiles_computed')
+      .select('user_id')
+      .eq('user_id', user_id)
+      .maybeSingle()
+
+    if (!profile) {
+      console.warn('Profile row missing after compute — retrying once')
+      await computeUserProfileV3(user_id, { forceRefresh: true })
+    }
   } catch (err) {
-    // Non-fatal — hero will fall back to global pool on first load
     console.warn('Profile computation failed during onboarding:', err)
   }
 
@@ -187,7 +204,6 @@ export async function completeOnboarding({ session, selectedGenres, favoriteMovi
   track('onboarding_completed', {
     genre_count: selectedGenres.length,
     movie_count: favoriteMovies.length,
-    has_rating_anchor: ratingPick !== null,
-    rating_sentiment: ratingPick?.sentiment ?? null,
+    rating_count: ratingEntries.length,
   })
 }


### PR DESCRIPTION
## Summary

- **Motion**: step transitions use `y-20 → 0 → y-20` with `[0.22,1,0.36,1]` easing; 3-segment spring progress bar; genre cards stagger + spring-select with `layoutId` ring; movie pill strip uses `AnimatePresence` shared-element; rating cards stagger with spring scale; sentiment buttons pulse on activate
- **Typography**: all 3 headlines switch to Fraunces (serif, 300 weight) with `from-white to-purple-200` gradient; copy rewritten to "What draws you in?" / "Five films you've loved." / "Which one hit hardest?"; subheads at `text-[15px] font-light tracking-[0.01em] text-white/60`
- **Cinematic**: per-genre gradient wash behind posters (16 genres); glass-frame posters with hover glow; ambient animated blobs (`pulse-slow` 8s / `pulse-slower` 12s); Fraunces loaded via Google Fonts
- **WelcomeBanner**: animated counter 0→filmCount via `useMotionValue`; pulsing gradient glow ring on border border; animated Sparkles icon
- **HeroTopPick**: "1st pick" badge (AnimatePresence delayed entry) + "Because you loved {title}" reason override for first-run visit from onboarding
- **`prefers-reduced-motion`**: all step components use `useReducedMotion()` and skip animations when set

## Test plan

- [ ] Walk the full 3-step flow: genre cards animate in staggered, selection springs, step transitions are smooth with the new easing
- [ ] Progress bar segments fill with spring animation as you advance steps
- [ ] WelcomeBanner shows on `/home` after onboarding: counter animates, glow ring pulses, dismisses cleanly
- [ ] Hero shows "1st pick" badge + "Because you loved {title}" on first visit; normal reason on subsequent visits
- [ ] Enable "Reduce motion" in macOS → all Framer Motion animations disabled gracefully
- [ ] `npm run lint && npm run test && npm run build` — clean (496 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)