### PR TITLE
Discover: align typography, gradients, and tokens with landing page

### DIFF
--- a/src/app/pages/discover/DiscoverPage.jsx
+++ b/src/app/pages/discover/DiscoverPage.jsx
@@ -366,7 +366,7 @@ export default function DiscoverPage() {
                     <div
                       key={i}
                       className={`w-1.5 h-1.5 rounded-full transition-colors duration-300 ${
-                        i < progress.answered ? 'bg-purple-400' : 'bg-white/15'
+                        i < progress.answered ? 'bg-purple-400' : 'bg-white/20'
                       }`}
                     />
                   ))}
@@ -450,11 +450,11 @@ export default function DiscoverPage() {
                   <motion.button
                     onClick={handleSubmitBrief}
                     aria-label="Find my films"
-                    whileHover={{ scale: 1.03 }}
-                    whileTap={{ scale: 0.97 }}
-                    className="relative px-8 py-3.5 rounded-full text-base font-semibold text-white bg-gradient-to-r from-purple-500 to-pink-500 shadow-lg shadow-purple-500/25 hover:shadow-xl hover:shadow-purple-500/30 transition-shadow"
+                    whileHover={{ scale: 1.02 }}
+                    whileTap={{ scale: 0.98 }}
+                    className="relative px-8 py-3 rounded-full text-base font-bold text-white bg-gradient-to-r from-purple-500 to-pink-500 shadow-lg shadow-purple-500/20 hover:from-purple-400 hover:to-pink-400 transition-all duration-200"
                   >
-                    <span className="absolute inset-0 rounded-full bg-gradient-to-r from-purple-500 to-pink-500 animate-pulse opacity-30 blur-md" />
+                    <span className="absolute inset-0 rounded-full bg-gradient-to-r from-purple-500 to-pink-500 animate-pulse opacity-30 blur-md" aria-hidden="true" />
                     <span className="relative">Find my films</span>
                   </motion.button>
 

--- a/src/app/pages/discover/components/BriefSynthesis.jsx
+++ b/src/app/pages/discover/components/BriefSynthesis.jsx
@@ -65,10 +65,7 @@ export default function BriefSynthesis({ answers, notes }) {
       <p className="text-[10px] font-semibold uppercase tracking-widest text-purple-400/60 mb-3">
         Your brief
       </p>
-      <h1
-        className="text-xl sm:text-2xl font-light tracking-tight leading-snug bg-gradient-to-r from-white via-white/90 to-purple-200 bg-clip-text text-transparent"
-        style={{ fontFamily: 'var(--font-display, serif)' }}
-      >
+      <h1 className="text-xl sm:text-2xl font-semibold tracking-tight leading-snug text-white/90">
         {synthesis}
       </h1>
     </motion.div>

--- a/src/app/pages/discover/components/QuestionSlot.jsx
+++ b/src/app/pages/discover/components/QuestionSlot.jsx
@@ -1,17 +1,7 @@
 // src/app/pages/discover/components/QuestionSlot.jsx
 import { AnimatePresence, motion } from 'framer-motion'
 
-// === Vibe card gradient map ===
-const VIBE_GRADIENTS = {
-  curious_sharp:   'from-orange-500/20 to-red-600/10',
-  curious_warm:    'from-amber-400/20 to-orange-500/10',
-  cozy_warm:       'from-rose-400/20 to-amber-400/10',
-  adventurous_any: 'from-cyan-400/20 to-blue-600/10',
-  dark_sharp:      'from-indigo-600/25 to-slate-900/20',
-  heartbroken_bs:  'from-pink-500/20 to-purple-600/10',
-  silly_warm:      'from-lime-400/20 to-emerald-500/10',
-  inspired_warm:   'from-yellow-400/20 to-orange-400/10',
-}
+// === ANIMATION VARIANTS ===
 
 const containerVariants = {
   hidden: { opacity: 0 },
@@ -28,14 +18,14 @@ const pillVariant = {
   show: { opacity: 1, y: 0, transition: { type: 'spring', stiffness: 260, damping: 20 } },
 }
 
+// === VIBE CARD ===
+// Unselected: neutral glass (matching landing/onboarding pill tokens).
+// Selected: brand gradient from-purple-500 to-pink-500 (exact landing token).
+
 /**
- * Renders a single vibe card with ambient gradient background.
- *
  * @param {{ opt: Object, isSelected: boolean, onSelect: () => void }} props
  */
 function VibeCard({ opt, isSelected, onSelect }) {
-  const gradient = VIBE_GRADIENTS[opt.value] || 'from-purple-500/15 to-pink-500/10'
-
   return (
     <motion.button
       type="button"
@@ -45,36 +35,26 @@ function VibeCard({ opt, isSelected, onSelect }) {
       whileTap={{ scale: 0.97 }}
       aria-pressed={isSelected}
       className={`
-        relative overflow-hidden rounded-2xl p-5 text-left transition-all duration-200
-        bg-gradient-to-br ${gradient}
+        relative overflow-hidden rounded-2xl p-5 text-left transition-all duration-200 border
         ${isSelected
-          ? 'ring-2 ring-purple-400 shadow-lg shadow-purple-500/20 scale-[1.02]'
-          : 'ring-1 ring-white/[0.08] hover:ring-white/20'
+          ? 'bg-gradient-to-r from-purple-500 to-pink-500 border-transparent shadow-lg shadow-purple-500/20 scale-[1.02]'
+          : 'bg-white/5 border-white/10 hover:bg-white/10 hover:border-white/20'
         }
       `}
     >
-      {/* Ambient glow on selection */}
-      {isSelected && (
-        <motion.div
-          layoutId="vibe-glow"
-          className="absolute inset-0 bg-gradient-to-br from-purple-500/15 to-pink-500/10"
-          transition={{ type: 'spring', stiffness: 300, damping: 25 }}
-        />
-      )}
-      <span
-        className={`relative block text-lg font-semibold tracking-tight ${isSelected ? 'text-white' : 'text-white/90'}`}
-        style={{ fontFamily: 'var(--font-display, serif)' }}
-      >
+      <span className={`relative block text-lg font-semibold tracking-tight ${isSelected ? 'text-white' : 'text-white/80'}`}>
         {opt.label}
       </span>
       {opt.hint && (
-        <span className="relative block text-[10px] uppercase tracking-wider text-white/40 mt-1">
+        <span className={`relative block text-[10px] uppercase tracking-wider mt-1 ${isSelected ? 'text-white/60' : 'text-white/40'}`}>
           {opt.hint}
         </span>
       )}
     </motion.button>
   )
 }
+
+// === QUESTION SLOT ===
 
 /**
  * Renders the currently active question with animated options.
@@ -96,11 +76,8 @@ export default function QuestionSlot({ question, currentValue, onAnswer }) {
         transition={{ duration: 0.4, ease: [0.16, 1, 0.3, 1] }}
         className="py-10"
       >
-        {/* Question prompt */}
-        <h2
-          className="text-4xl sm:text-5xl font-bold tracking-tight mb-10 bg-gradient-to-r from-white via-white/90 to-purple-200 bg-clip-text text-transparent"
-          style={{ fontFamily: 'var(--font-display, serif)' }}
-        >
+        {/* Question prompt — matches landing headline weight/tracking */}
+        <h2 className="text-4xl sm:text-5xl font-black tracking-tight text-white leading-[1.05] mb-10">
           {question.prompt}
         </h2>
 
@@ -141,16 +118,16 @@ export default function QuestionSlot({ question, currentValue, onAnswer }) {
                   onClick={() => onAnswer(question.id, opt.value)}
                   aria-pressed={isSelected}
                   className={`
-                    rounded-full px-6 py-3 text-sm font-medium transition-all duration-200
+                    rounded-full px-6 py-3 text-sm font-semibold transition-all duration-200 border
                     ${isSelected
-                      ? 'bg-gradient-to-r from-purple-500/25 to-pink-500/15 text-white ring-2 ring-purple-400/60 shadow-lg shadow-purple-500/10'
-                      : 'bg-white/[0.04] ring-1 ring-white/[0.1] text-white/80 hover:ring-white/25 hover:bg-white/[0.06] hover:text-white'
+                      ? 'bg-gradient-to-r from-purple-500 to-pink-500 border-transparent text-white shadow-lg shadow-purple-500/20'
+                      : 'bg-white/5 border-white/10 text-white/80 hover:bg-white/10 hover:border-white/20 hover:text-white'
                     }
                   `}
                 >
                   <span>{opt.label}</span>
                   {opt.hint && (
-                    <span className={`ml-2 text-[10px] ${isSelected ? 'text-white/50' : 'text-white/30'}`}>
+                    <span className={`ml-2 text-[10px] ${isSelected ? 'text-white/60' : 'text-white/30'}`}>
                       {opt.hint}
                     </span>
                   )}

--- a/src/app/pages/discover/components/TopPickCard.jsx
+++ b/src/app/pages/discover/components/TopPickCard.jsx
@@ -150,10 +150,7 @@ export default function TopPickCard({ film, isWatchlisted, isSeen, onOpenDetail,
 
           {/* Title */}
           <button type="button" onClick={handleClick} className="text-left mb-2">
-            <h2
-              className="text-3xl sm:text-4xl font-bold text-white leading-tight tracking-tight hover:text-purple-200 transition-colors"
-              style={{ fontFamily: 'var(--font-display, serif)' }}
-            >
+            <h2 className="text-3xl sm:text-4xl font-black text-white leading-tight tracking-tight hover:text-purple-200 transition-colors">
               {film.title}
             </h2>
           </button>


### PR DESCRIPTION
## Summary
- **QuestionSlot**: drop per-vibe tinted gradients; unselected cards → `bg-white/5 border-white/10`; selected → solid `from-purple-500 to-pink-500`; `font-black` heading; remove `var(--font-display, serif)` everywhere
- **Pill options**: selected state now uses solid brand gradient (was `/25` tinted)
- **TopPickCard**: `font-black` title, remove serif style
- **BriefSynthesis**: `font-semibold`, remove serif, plain `text-white/90` (no gradient clip-text)
- **DiscoverPage**: inactive progress dots `bg-white/20`; "Find my films" button matches `Button.primary` exactly (`font-bold`, `shadow-purple-500/20`, `hover:from-purple-400`)

## Test plan
- [ ] Visit `/discover` — question prompts render `font-black`, no serif
- [ ] Vibe cards unselected: neutral glass; selected: solid purple-to-pink gradient
- [ ] Pill options (attention, time, company) selected: solid gradient, not tinted
- [ ] Results: TopPickCard title is `font-black`, no serif
- [ ] "Find my films" button visually matches landing page CTA
- [ ] 497 tests pass, lint clean, build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)