### PR TITLE
Fix CLS: unified hero section + matched BFC wrapper

### DIFF
--- a/src/app/homepage/components/HeroTopPick.jsx
+++ b/src/app/homepage/components/HeroTopPick.jsx
@@ -548,54 +548,40 @@ export default function HeroTopPick({
     touchStartXRef.current = null
   }, [candidates.length])
 
-  // ── Loading skeleton ────────────────────────────────────────────────────────
+  // ── Loading state + null guards ──────────────────────────────────────────────
+  // WHY isHeroLoading flag instead of early-return skeleton: the early-return
+  // produced a different <section> subtree so React unmounted/remounted the node
+  // on data arrival, causing a layout recomputation the browser recorded as CLS.
+  // Single unified return keeps the same <section> DOM node alive throughout.
 
-  if (loading && !movie) {
-    return (
-      <section
-        className="relative w-full h-[75vh] min-h-[500px] max-h-[800px] overflow-hidden bg-black"
-      >
-        <div className="absolute inset-0 bg-gradient-to-br from-purple-950/30 via-black to-black" />
-        <div className="absolute bottom-0 left-0 right-0 h-2/3 pointer-events-none" style={{ background: 'radial-gradient(ellipse 65% 55% at 15% 100%, rgba(88,28,135,0.18) 0%, transparent 70%)' }} />
-        <div className="relative z-10 h-full max-w-[1400px] mx-auto px-4 sm:px-6 lg:px-10 flex items-end pb-12 lg:pb-16">
-          <div className="flex flex-col lg:flex-row gap-6 lg:gap-10 w-full">
-            <div className="hidden sm:block w-[200px] lg:w-[260px] flex-shrink-0">
-              <div className="aspect-[2/3] rounded-xl bg-white/[0.04] animate-pulse" />
-            </div>
-            <div className="flex-1 space-y-4 pb-2">
-              <div className="h-3 w-24 bg-white/[0.04] rounded animate-pulse" />
-              <div className="h-10 lg:h-14 w-2/3 bg-white/[0.04] rounded-xl animate-pulse" />
-              <div className="h-4 w-1/3 bg-white/[0.04] rounded-lg animate-pulse" />
-              <div className="h-16 w-full max-w-xl bg-white/[0.04] rounded-xl animate-pulse" />
-            </div>
-          </div>
-        </div>
-      </section>
-    )
-  }
-
-  if (!movie) return null
+  const isHeroLoading = loading && !movie
+  if (!isHeroLoading && !movie) return null          // empty recommendations
   if (error && !hookMovie && !preloadedData) return null
 
   // ── Derived display values ──────────────────────────────────────────────────
+  // Optional-chained: activeMovie is null while isHeroLoading; values are only
+  // consumed in the non-loading branch of the return below, so nulls are harmless.
 
-  const year = activeMovie.release_date ? new Date(activeMovie.release_date).getFullYear() : null
-  const hours = activeMovie.runtime ? Math.floor(activeMovie.runtime / 60) : 0
-  const mins = activeMovie.runtime ? activeMovie.runtime % 60 : 0
-  const hasAudience = activeMovie.ff_audience_rating != null && (activeMovie.ff_audience_confidence ?? 0) >= 50
-  const hasCritic = activeMovie.ff_critic_rating != null && (activeMovie.ff_critic_confidence ?? 0) >= 50
-  const displayRating = hasAudience ? activeMovie.ff_audience_rating
-    : hasCritic ? activeMovie.ff_critic_rating
+  const year = activeMovie?.release_date ? new Date(activeMovie.release_date).getFullYear() : null
+  const hours = activeMovie?.runtime ? Math.floor(activeMovie.runtime / 60) : 0
+  const mins = activeMovie?.runtime ? activeMovie.runtime % 60 : 0
+  const hasAudience = activeMovie?.ff_audience_rating != null && (activeMovie?.ff_audience_confidence ?? 0) >= 50
+  const hasCritic = activeMovie?.ff_critic_rating != null && (activeMovie?.ff_critic_confidence ?? 0) >= 50
+  const displayRating = hasAudience ? activeMovie?.ff_audience_rating
+    : hasCritic ? activeMovie?.ff_critic_rating
     : null
 
   return (
     <section
       className="relative w-full h-[75vh] min-h-[500px] max-h-[800px] overflow-hidden bg-black"
-      onTouchStart={handleTouchStart}
-      onTouchEnd={handleTouchEnd}
+      onTouchStart={isHeroLoading ? undefined : handleTouchStart}
+      onTouchEnd={isHeroLoading ? undefined : handleTouchEnd}
     >
 
-      {/* Shuffle button — top-right overlay, only when onShuffle provided */}
+      {/* Shuffle button — always in DOM from first mount when onShuffle is set.
+          WHY: the button sits at top:76px inside the viewport. If it only renders
+          after movie data arrives, its first paint counts as a CLS entry.
+          Disabled + faded (opacity-30) while loading; active when movie arrives. */}
       {onShuffle && (
         <div className="absolute right-4 z-30" style={{ top: '76px' }}>
           <button
@@ -610,6 +596,30 @@ export default function HeroTopPick({
           </button>
         </div>
       )}
+
+      {isHeroLoading ? (
+        /* ── Inline loading skeleton ───────────────────────────────────────────
+           Rendered inside the same <section> so the DOM node stays alive.      */
+        <>
+          <div className="absolute inset-0 bg-gradient-to-br from-purple-950/30 via-black to-black" />
+          <div className="absolute bottom-0 left-0 right-0 h-2/3 pointer-events-none" style={{ background: 'radial-gradient(ellipse 65% 55% at 15% 100%, rgba(88,28,135,0.18) 0%, transparent 70%)' }} />
+          <div className="relative z-10 h-full max-w-[1400px] mx-auto px-4 sm:px-6 lg:px-10 flex items-end pb-12 lg:pb-16">
+            <div className="flex flex-col lg:flex-row gap-6 lg:gap-10 w-full">
+              <div className="hidden sm:block w-[200px] lg:w-[260px] flex-shrink-0">
+                <div className="aspect-[2/3] rounded-xl bg-white/[0.04] animate-pulse" />
+              </div>
+              <div className="flex-1 space-y-4 pb-2">
+                <div className="h-3 w-24 bg-white/[0.04] rounded animate-pulse" />
+                <div className="h-10 lg:h-14 w-2/3 bg-white/[0.04] rounded-xl animate-pulse" />
+                <div className="h-4 w-1/3 bg-white/[0.04] rounded-lg animate-pulse" />
+                <div className="h-16 w-full max-w-xl bg-white/[0.04] rounded-xl animate-pulse" />
+              </div>
+            </div>
+          </div>
+        </>
+      ) : (
+        /* ── Real hero content ─────────────────────────────────────────────── */
+        <>
 
       {/* Refreshing overlay */}
       {isRefreshing && (
@@ -940,6 +950,9 @@ export default function HeroTopPick({
           >
             <ChevronRight className="h-5 w-5" />
           </button>
+        </>
+      )}
+
         </>
       )}
 

--- a/src/app/router.jsx
+++ b/src/app/router.jsx
@@ -89,56 +89,60 @@ function FullScreenSpinner() {
 
 // Hero-shaped skeleton for /home — matches HeroTopPick + first two carousel rows so the
 // Suspense swap produces zero layout shift on any viewport height. Uses animate-pulse, no spinner.
-// WHY rows: on large displays (hero capped at 800px, viewport ≥900px) the first carousel row
-// is partially visible. Without skeleton rows below the hero, Suspense swap reveals real carousel
-// content and registers as CLS.
+// WHY outer wrapper: must match HomePage's root div exactly (className + style).
+//   overflow-x-hidden creates a block formatting context; a different root at Suspense swap
+//   time changes the BFC boundary and shifts every child element = CLS.
+// WHY rows: on large displays (hero capped at 800px, viewport ≥900px) the first carousel
+//   row is partially visible. Without placeholders, Suspense swap pops them in as CLS.
 function HomeSkeleton() {
   return (
-    <div aria-hidden="true">
-      {/* Hero section — identical constraints to HeroTopPick's <section> */}
-      <div
-        className="relative w-full bg-black overflow-hidden"
-        style={{ height: '75vh', minHeight: 500, maxHeight: 800 }}
-      >
-        {/* Backdrop placeholder */}
-        <div className="absolute inset-0 animate-pulse bg-purple-500/[0.04]" />
-        {/* Gradient overlays matching the real hero */}
-        <div className="absolute bottom-0 inset-x-0 h-[65%] bg-gradient-to-t from-black via-black/75 to-transparent" />
-        {/* Content area skeleton — bottom-anchored like the real hero */}
-        <div className="absolute bottom-6 left-4 sm:left-6 lg:left-10 right-4 sm:right-6 lg:right-10 flex flex-col gap-3">
-          <div className="h-3 w-28 rounded-full animate-pulse bg-purple-500/[0.08]" />
-          <div className="h-8 w-2/3 sm:w-1/2 rounded-lg animate-pulse bg-white/[0.06]" />
-          <div className="h-4 w-1/3 rounded-full animate-pulse bg-white/[0.04]" />
-          <div className="flex gap-2 mt-1">
-            <div className="h-9 w-28 rounded-full animate-pulse bg-purple-500/[0.12]" />
-            <div className="h-9 w-9 rounded-full animate-pulse bg-white/[0.06]" />
-            <div className="h-9 w-9 rounded-full animate-pulse bg-white/[0.06]" />
+    <div className="overflow-x-hidden" style={{ background: 'var(--color-bg)' }}>
+      <div aria-hidden="true">
+        {/* Hero section — identical constraints to HeroTopPick's <section> */}
+        <div
+          className="relative w-full bg-black overflow-hidden"
+          style={{ height: '75vh', minHeight: 500, maxHeight: 800 }}
+        >
+          {/* Backdrop placeholder */}
+          <div className="absolute inset-0 animate-pulse bg-purple-500/[0.04]" />
+          {/* Gradient overlays matching the real hero */}
+          <div className="absolute bottom-0 inset-x-0 h-[65%] bg-gradient-to-t from-black via-black/75 to-transparent" />
+          {/* Content area skeleton — bottom-anchored like the real hero */}
+          <div className="absolute bottom-6 left-4 sm:left-6 lg:left-10 right-4 sm:right-6 lg:right-10 flex flex-col gap-3">
+            <div className="h-3 w-28 rounded-full animate-pulse bg-purple-500/[0.08]" />
+            <div className="h-8 w-2/3 sm:w-1/2 rounded-lg animate-pulse bg-white/[0.06]" />
+            <div className="h-4 w-1/3 rounded-full animate-pulse bg-white/[0.04]" />
+            <div className="flex gap-2 mt-1">
+              <div className="h-9 w-28 rounded-full animate-pulse bg-purple-500/[0.12]" />
+              <div className="h-9 w-9 rounded-full animate-pulse bg-white/[0.06]" />
+              <div className="h-9 w-9 rounded-full animate-pulse bg-white/[0.06]" />
+            </div>
           </div>
         </div>
-      </div>
 
-      {/* Carousel row skeletons — occupy the space that TopOfYourTasteRow etc. will fill.
-          Prevents any below-fold visible carousels from popping in as CLS. */}
-      <div className="mx-auto max-w-[1600px] pb-24 sm:pb-32">
-        {[0, 1].map(i => (
-          <div key={i} className="px-4 sm:px-6 pt-10 pb-4">
-            {/* Section header — matches the global section header pattern */}
-            <div className="flex items-center gap-2.5 mb-5">
-              <div className="w-[3px] h-5 rounded-full animate-pulse bg-purple-500/[0.12]" />
-              <div className="h-4 w-44 rounded-full animate-pulse bg-white/[0.06]" />
+        {/* Carousel row skeletons — occupy the space that TopOfYourTasteRow etc. will fill.
+            Prevents any below-fold visible carousels from popping in as CLS. */}
+        <div className="mx-auto max-w-[1600px] pb-24 sm:pb-32">
+          {[0, 1].map(i => (
+            <div key={i} className="px-4 sm:px-6 pt-10 pb-4">
+              {/* Section header — matches the global section header pattern */}
+              <div className="flex items-center gap-2.5 mb-5">
+                <div className="w-[3px] h-5 rounded-full animate-pulse bg-purple-500/[0.12]" />
+                <div className="h-4 w-44 rounded-full animate-pulse bg-white/[0.06]" />
+              </div>
+              {/* Card row — 5 poster-aspect placeholders at standard carousel card width */}
+              <div className="flex gap-3 overflow-hidden">
+                {[0, 1, 2, 3, 4].map(j => (
+                  <div
+                    key={j}
+                    className="flex-none rounded-lg animate-pulse bg-white/[0.04]"
+                    style={{ width: 148, height: 222 }}
+                  />
+                ))}
+              </div>
             </div>
-            {/* Card row — 5 poster-aspect placeholders at standard carousel card width */}
-            <div className="flex gap-3 overflow-hidden">
-              {[0, 1, 2, 3, 4].map(j => (
-                <div
-                  key={j}
-                  className="flex-none rounded-lg animate-pulse bg-white/[0.04]"
-                  style={{ width: 148, height: 222 }}
-                />
-              ))}
-            </div>
-          </div>
-        ))}
+          ))}
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

- **FIX 1** (`router.jsx`): `HomeSkeleton` root now wraps in `<div className="overflow-x-hidden" style={{background:'var(--color-bg)'}}>` — identical to `HomePage`'s outer div. The BFC created by `overflow-x-hidden` previously changed at Suspense swap time, shifting every child element and registering as CLS.
- **FIX 2** (`HeroTopPick.jsx`): Collapsed the early-return loading skeleton into the same `<section>` as the real hero. The old early-return produced a different subtree that React unmounted/remounted on data arrival, causing a layout recomputation. Single unified `return` keeps the DOM node alive across the loading→data transition. The shuffle button now renders from first mount (disabled while loading) so its first paint doesn't occur mid-viewport after data arrives.

## Test plan
- [ ] Deploy and run Lighthouse on `/home` — CLS should drop further from ~0.326
- [ ] Visually confirm shuffle button is visible (faded) during hero loading state
- [ ] Confirm hero loading skeleton still looks correct before movie data arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)