### PR TITLE
fix(seo): GSC verification + crawler-visible app description

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,35 +100,32 @@
   </head>
   <body>
     <!-- App Root -->
-    <div id="root" style="background:#08060d;min-height:100vh"></div>
+    <div id="root" style="background:#08060d;min-height:100vh">
+  <!-- Pre-hydration content for crawlers. React replaces this on mount. -->
+  <div style="visibility:hidden;position:absolute;left:-9999px" aria-hidden="true">
+    <h1>FeelFlick — Movies that match how you feel</h1>
+    <p>FeelFlick is a mood-first movie discovery platform that recommends films based on your mood, taste, and the moment you're in.</p>
+    <a href="https://app.feelflick.com/privacy">Privacy Policy</a>
+    <a href="https://app.feelflick.com/terms">Terms of Service</a>
+    <a href="https://app.feelflick.com/about">About FeelFlick</a>
+  </div>
+</div>
     
     <!-- Main App Script -->
     <script type="module" src="/src/main.jsx"></script>
     
     <!-- Fallback for No JavaScript -->
     <noscript>
-      <div style="
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        min-height: 100vh;
-        background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
-        color: #f8fafc;
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-        text-align: center;
-        padding: 2rem;
-      ">
-        <h1 style="font-size: 2rem; margin-bottom: 1rem; background: linear-gradient(135deg, #a855f7, #ec4899); -webkit-background-clip: text; -webkit-text-fill-color: transparent;">
-          FeelFlick
-        </h1>
-        <p style="font-size: 1.125rem; color: #94a3b8; margin-bottom: 2rem;">
-          JavaScript is required to run this application.
-        </p>
-        <p style="font-size: 0.875rem; color: #64748b;">
-          Please enable JavaScript in your browser settings and refresh the page.
-        </p>
-      </div>
-    </noscript>
+  <div style="max-width:720px;margin:0 auto;padding:4rem 1.5rem;background:#08060d;color:#f8fafc;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;line-height:1.6">
+    <h1 style="font-size:2.25rem;font-weight:900;margin-bottom:1rem;background:linear-gradient(135deg,#a855f7,#ec4899);-webkit-background-clip:text;-webkit-text-fill-color:transparent">FeelFlick — Movies that match how you feel</h1>
+    <p style="font-size:1.125rem;color:#cbd5e1;margin-bottom:1.5rem">FeelFlick is a free mood-first movie discovery platform. It recommends films based on your mood, your taste, and the moment you're in — so you spend less time scrolling and more time watching. Sign in with Google to build your Cinematic DNA across 6,700+ curated films.</p>
+    <p style="font-size:1rem;color:#94a3b8;margin-bottom:2rem">FeelFlick requires JavaScript. Please enable it to continue.</p>
+    <nav style="font-size:0.95rem">
+      <a href="https://app.feelflick.com/about" style="color:#c4b5fd;margin-right:1.5rem">About</a>
+      <a href="https://app.feelflick.com/privacy" style="color:#c4b5fd;margin-right:1.5rem">Privacy Policy</a>
+      <a href="https://app.feelflick.com/terms" style="color:#c4b5fd">Terms of Service</a>
+    </nav>
+  </div>
+</noscript>
   </body>
 </html>

--- a/public/google246413e30c9bee30.html
+++ b/public/google246413e30c9bee30.html
@@ -1,0 +1,1 @@
+google-site-verification: google246413e30c9bee30.html


### PR DESCRIPTION
## Summary

- Add `public/google246413e30c9bee30.html` — Google Search Console HTML verification file (served as static asset by Vite, bypasses SPA routing)
- Replace the minimal noscript block with a full app description including brand headline, product copy, and links to About / Privacy / Terms
- Add hidden pre-hydration `<div>` inside `#root` with H1, description, and key links for crawlers that don't execute JS

## Why

Required for OAuth branding verification — Google needs to confirm domain ownership via GSC before approving the OAuth consent screen.

## Test plan

- [x] `npm run build` passes (verified locally)
- [ ] After merge + deploy: visit `https://app.feelflick.com/google246413e30c9bee30.html` — should return the single-line verification string
- [ ] Submit verification in Google Search Console

🤖 Generated with [Claude Code](https://claude.com/claude-code)