### PR TITLE
fix(loading): delay BrandSplash visibility 200ms

### DIFF
--- a/src/shared/ui/BrandSplash.jsx
+++ b/src/shared/ui/BrandSplash.jsx
@@ -1,0 +1,67 @@
+// src/shared/ui/BrandSplash.jsx
+import { useEffect, useState } from 'react'
+import Button from '@/shared/ui/Button'
+
+/**
+ * Full-screen branded splash — replaces every spinner and duplicate splash in the app.
+ *
+ * Delays visibility by 200ms so fast loads never flash the splash.
+ * Error state is always immediate — errors must never be delayed.
+ *
+ * @param {{ label?: string, error?: string | null }} props
+ */
+export default function BrandSplash({ label, error = null }) {
+  const [visible, setVisible] = useState(false)
+  useEffect(() => {
+    const t = setTimeout(() => setVisible(true), 200)
+    return () => clearTimeout(t)
+  }, [])
+  if (!visible && !error) return null
+
+  return (
+    <div className="fixed inset-0 z-[9999] grid place-items-center bg-black">
+      {/* Ambient glows */}
+      <div className="absolute inset-0 overflow-hidden pointer-events-none" aria-hidden="true">
+        <div
+          className="absolute inset-0"
+          style={{ background: 'radial-gradient(ellipse 80% 50% at 50% 0%, rgba(88,28,135,0.3) 0%, transparent 65%)' }}
+        />
+        <div
+          className="absolute inset-0"
+          style={{ background: 'radial-gradient(ellipse 60% 40% at 50% 100%, rgba(168,85,247,0.12) 0%, transparent 65%)' }}
+        />
+      </div>
+
+      <div className="relative flex flex-col items-center gap-8 px-4 text-center">
+        {/* Wordmark */}
+        <span className="text-3xl font-black tracking-tight bg-gradient-to-r from-purple-500 to-pink-500 bg-clip-text text-transparent">
+          FEELFLICK
+        </span>
+
+        {error ? (
+          <>
+            <div className="w-16 h-16 rounded-2xl bg-red-500/10 border border-red-500/20 flex items-center justify-center">
+              <svg className="w-7 h-7 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </div>
+            <p className="text-sm text-white/60 max-w-sm leading-relaxed">{error}</p>
+            <Button variant="secondary" onClick={() => { window.location.href = '/' }}>
+              Return home
+            </Button>
+          </>
+        ) : (
+          <>
+            {/* 1px shimmer line — animation defined in animations.css */}
+            <div className="w-20 h-px overflow-hidden bg-white/5 rounded-full">
+              <div className="h-full w-full bg-gradient-to-r from-transparent via-purple-400 to-transparent brand-shimmer" />
+            </div>
+            {label && (
+              <p className="text-sm text-white/35">{label}</p>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/shared/ui/__tests__/BrandSplash.test.jsx
+++ b/src/shared/ui/__tests__/BrandSplash.test.jsx
@@ -1,0 +1,68 @@
+// src/shared/ui/__tests__/BrandSplash.test.jsx
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import BrandSplash from '../BrandSplash'
+
+describe('BrandSplash', () => {
+  // Loading-state tests must advance past the 200ms visibility delay.
+  describe('loading state (after 200ms)', () => {
+    beforeEach(() => { vi.useFakeTimers() })
+    afterEach(() => { vi.useRealTimers() })
+
+    it('renders the FEELFLICK wordmark', async () => {
+      await act(async () => { render(<BrandSplash />) })
+      await act(async () => { await vi.runAllTimersAsync() })
+      expect(screen.getByText('FEELFLICK')).toBeInTheDocument()
+    })
+
+    it('renders an optional label below the shimmer', async () => {
+      await act(async () => { render(<BrandSplash label="Signing you in…" />) })
+      await act(async () => { await vi.runAllTimersAsync() })
+      expect(screen.getByText('Signing you in…')).toBeInTheDocument()
+    })
+  })
+
+  // Before 200ms the component returns null — nothing should be visible.
+  describe('loading state (before 200ms)', () => {
+    beforeEach(() => { vi.useFakeTimers() })
+    afterEach(() => { vi.useRealTimers() })
+
+    it('renders nothing before the delay fires', async () => {
+      await act(async () => { render(<BrandSplash />) })
+      expect(screen.queryByText('FEELFLICK')).not.toBeInTheDocument()
+    })
+
+    it('does not render error UI in loading state', async () => {
+      await act(async () => { render(<BrandSplash />) })
+      expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    })
+
+    it('does not render Return home button in loading state', async () => {
+      await act(async () => { render(<BrandSplash />) })
+      expect(screen.queryByRole('button', { name: /return home/i })).not.toBeInTheDocument()
+    })
+
+    it('does not render label when not provided', async () => {
+      await act(async () => { render(<BrandSplash />) })
+      expect(screen.queryByText(/signing/i)).not.toBeInTheDocument()
+    })
+  })
+
+  // Error state is always immediate — no delay.
+  describe('error state (immediate)', () => {
+    it('renders the error message when error prop is provided', () => {
+      render(<BrandSplash error="Network error" />)
+      expect(screen.getByText('Network error')).toBeInTheDocument()
+    })
+
+    it('renders a Return home button in error state', () => {
+      render(<BrandSplash error="Something failed" />)
+      expect(screen.getByRole('button', { name: /return home/i })).toBeInTheDocument()
+    })
+
+    it('renders the FEELFLICK wordmark in error state', () => {
+      render(<BrandSplash error="Something failed" />)
+      expect(screen.getByText('FEELFLICK')).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Adds a 200ms render delay to `BrandSplash` so fast loads produce no visible flash. Error state bypasses the delay entirely — errors are always immediate.

**Before:** BrandSplash renders on the first frame, flashing on fast connections  
**After:** Returns `null` for 200ms; if React unmounts it before the timer fires (fast load), users see nothing

```jsx
const [visible, setVisible] = useState(false)
useEffect(() => {
  const t = setTimeout(() => setVisible(true), 200)
  return () => clearTimeout(t)
}, [])
if (!visible && !error) return null
```

## Why 200ms

Below this threshold, perceived-performance research shows users experience the absence of feedback as a single fluid transition rather than "stuck." Above 200ms they need acknowledgment — so the splash appears exactly when it's needed.

## Test changes

Reorganised `BrandSplash.test.jsx` into three groups:
- **loading state (after 200ms)** — advance fake timers before asserting visible content
- **loading state (before 200ms)** — new group confirming `null` render before delay fires  
- **error state (immediate)** — no timers needed, error renders synchronously

534 tests passing (+2 net new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)