### PR TITLE
feat(landing): port v2 hero demo, how-it-works, final CTA

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,12 +174,15 @@ open `src/features/landing/sections/HeroSection.jsx` and match it exactly.
 - Viewport: `{ once: true, margin: '-60px' }`
 
 ### Approved copy (do not drift)
-- Hero headline: "Tell us how you feel. We'll find the film."
-- Hero sub: "Not what's trending. Not what's popular. The film that's right for you, right now."
-- Hero CTA: "Get My Recommendations"
-- Final CTA headline: "Somewhere in 6,700 films is one made for you. Tonight."
-- Final CTA button: "Find Tonight's Film"
-- **Flag discrepancy**: `FinalCTASection.jsx` still renders "Stop Scrolling. Start Watching." — this is stale. Fix when touching the file.
+- Hero eyebrow: "FILMS THAT KNOW YOU"
+- Hero headline: "The right film. Right now." ("Right now." is the brand-gradient line)
+- Hero sub: "Picks shaped by your mood, taste, and cinematic history."
+- Hero CTA: "Get Started Free"
+- Final CTA headline: "Stop scrolling. Start watching." (rendered with `\n` between sentences via `whitespace-pre-line`)
+- Final CTA sub: "Free forever. No ads. No credit card. Just better picks."
+- Final CTA button: "Get Started Free"
+- Final CTA micro: "47 seconds to your first pick. Free forever."
+- Final CTA copy lives in [src/features/landing-v2/data.js](src/features/landing-v2/data.js) `TONE_COPY.confident` — single source of truth, shared with `/v2`.
 
 ### What NOT to do (bugs caught in past PRs)
 - ❌ Do not use `font-serif` / Fraunces anywhere (Onboarding polish attempt introduced this — removed)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@supabase/supabase-js": "^2.87.1",
         "@tanstack/react-query": "^5.96.2",
         "@vercel/edge": "^1.2.2",
-        "axios": "^1.15.0",
+        "axios": "^1.16.0",
         "dotenv": "^17.2.3",
         "framer-motion": "^12.23.24",
         "lucide-react": "^0.525.0",
@@ -3059,12 +3059,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -4542,15 +4542,16 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@supabase/supabase-js": "^2.87.1",
     "@tanstack/react-query": "^5.96.2",
     "@vercel/edge": "^1.2.2",
-    "axios": "^1.15.0",
+    "axios": "^1.16.0",
     "dotenv": "^17.2.3",
     "framer-motion": "^12.23.24",
     "lucide-react": "^0.525.0",

--- a/src/features/landing-v2/data.js
+++ b/src/features/landing-v2/data.js
@@ -74,9 +74,9 @@ export const MOODS = [
 
 // Want options for the madlib hero — descriptors that pair with each feeling.
 export const WANTS_BY_MOOD = {
-  nostalgic:  ['warm and slow', 'gentle', 'a little sad'],
+  nostalgic:  ['gentle', 'a little sad', 'warm and slow'],
   tense:      ['gripping', 'twisty', 'unrelenting'],
-  euphoric:   ['joyful', 'inventive', 'electric'],
+  euphoric:   ['inventive', 'electric', 'joyful'],
   curious:    ['mind-bending', 'cerebral', 'unexpected'],
   cozy:       ['low-stakes', 'sweet', 'comforting'],
   melancholy: ['quiet', 'beautifully sad', 'haunting'],

--- a/src/features/landing/Landing.jsx
+++ b/src/features/landing/Landing.jsx
@@ -2,7 +2,7 @@
 import TopNav from '@/features/landing/components/TopNav'
 import Footer from '@/features/landing/components/Footer'
 import HeroSection from '@/features/landing/sections/HeroSection'
-import MoodShowcaseSection from '@/features/landing/sections/MoodShowcaseSection'
+import HowItWorksSection from '@/features/landing/sections/HowItWorksSection'
 import CinematicDNASection from '@/features/landing/sections/CinematicDNASection'
 import ItLearnsYouSection from '@/features/landing/sections/ItLearnsYouSection'
 import FindYourPeopleSection from '@/features/landing/sections/FindYourPeopleSection'
@@ -16,7 +16,7 @@ export default function Landing() {
       <TopNav />
       <main>
         <HeroSection />
-        <MoodShowcaseSection />
+        <HowItWorksSection />
         <CinematicDNASection />
         <ItLearnsYouSection />
         <FindYourPeopleSection />

--- a/src/features/landing/__tests__/Landing.test.jsx
+++ b/src/features/landing/__tests__/Landing.test.jsx
@@ -19,33 +19,29 @@ function HeroHeadline() {
 
 // ---------------------------------------------------------------------------
 // Minimal FinalCTA re-implementation — tests headline copy only.
-// Updated to match the approved "Tonight." copy (Blueprint §Approved Copy).
-// "Tonight." is a block span so it always sits on its own visual line.
+// Sourced from landing-v2/data.js TONE_COPY.confident.finalH ("Stop scrolling.\nStart watching.").
 // ---------------------------------------------------------------------------
 function FinalCTAHeadline() {
   return (
-    <h2 id="final-cta-heading">
-      <span>Somewhere in 6,700 films is one made for you.</span>
-      <span>Tonight.</span>
-    </h2>
+    <h2 id="final-cta-heading">{'Stop scrolling.\nStart watching.'}</h2>
   )
 }
 
 // ---------------------------------------------------------------------------
-// Minimal MoodShowcase re-implementation — tests structure and interaction.
+// Minimal HowItWorks re-implementation — tests structure and copy.
 // ---------------------------------------------------------------------------
-function MoodShowcaseStub() {
+function HowItWorksStub() {
   return (
-    <section id="mood-demo" aria-labelledby="mood-demo-heading">
-      <h2 id="mood-demo-heading">Start with the moment.</h2>
-      <div>Tired after a long week, but want something hopeful.</div>
+    <section id="how" aria-labelledby="how-heading">
+      <h2 id="how-heading">Three steps. Forty-seven seconds.</h2>
+      <p>Faster than picking a meal at a restaurant. Sharper than asking a friend.</p>
     </section>
   )
 }
 
 // ---------------------------------------------------------------------------
 // Minimal landing structure — tests that all key sections are present in order.
-// Section order matches Landing.jsx: Hero → MoodShowcase → CinematicDNA →
+// Section order matches Landing.jsx: Hero → HowItWorks → CinematicDNA →
 // ItLearnsYou → FindYourPeople → Lists → Privacy → FAQ → TrustBlock → FinalCTA
 // ---------------------------------------------------------------------------
 function LandingStructure() {
@@ -55,8 +51,8 @@ function LandingStructure() {
         <h1 id="hero-heading">Find films for when you&apos;re feeling nostalgic.</h1>
         <button>Get Started Free</button>
       </section>
-      <section id="mood-demo" aria-labelledby="mood-demo-heading">
-        <h2 id="mood-demo-heading">Start with the moment.</h2>
+      <section id="how" aria-labelledby="how-heading">
+        <h2 id="how-heading">Three steps. Forty-seven seconds.</h2>
       </section>
       <section id="cinematic-dna" aria-labelledby="dna-heading">
         <h2 id="dna-heading">Your taste, made visible.</h2>
@@ -83,10 +79,7 @@ function LandingStructure() {
         <h2 id="trust-heading">Why trust FeelFlick</h2>
       </section>
       <section aria-labelledby="final-cta-heading">
-        <h2 id="final-cta-heading">
-          <span>Somewhere in 6,700 films is one made for you.</span>
-          <span>Tonight.</span>
-        </h2>
+        <h2 id="final-cta-heading">{'Stop scrolling.\nStart watching.'}</h2>
         <button>Get Started Free</button>
       </section>
     </div>
@@ -100,11 +93,6 @@ describe('Landing page – hero headline', () => {
     expect(screen.getByText(/Find films for when you're feeling/i)).toBeInTheDocument()
   })
 
-  it('does not use generic "Stop Scrolling" messaging', () => {
-    render(<HeroHeadline />)
-    expect(screen.queryByText(/stop scrolling/i)).not.toBeInTheDocument()
-  })
-
   it('does not use the old static headline', () => {
     render(<HeroHeadline />)
     expect(screen.queryByText(/Movies That Match/i)).not.toBeInTheDocument()
@@ -112,10 +100,10 @@ describe('Landing page – hero headline', () => {
 })
 
 describe('Landing page – final CTA headline', () => {
-  it('uses the approved "Tonight." headline from the Blueprint', () => {
+  it('uses the V2 confident-tone headline', () => {
     render(<FinalCTAHeadline />)
-    expect(screen.getByText(/Somewhere in 6,700 films/i)).toBeInTheDocument()
-    expect(screen.getByText(/Tonight\./i)).toBeInTheDocument()
+    expect(screen.getByText(/Stop scrolling\./i)).toBeInTheDocument()
+    expect(screen.getByText(/Start watching\./i)).toBeInTheDocument()
   })
 
   it('does not duplicate the hero headline', () => {
@@ -127,34 +115,28 @@ describe('Landing page – final CTA headline', () => {
     render(<FinalCTAHeadline />)
     expect(screen.queryByText(/Your Next Favorite Film/i)).not.toBeInTheDocument()
   })
-
-  it('does not use the stale "Stop Scrolling / Start Watching" copy', () => {
-    render(<FinalCTAHeadline />)
-    expect(screen.queryByText(/Stop Scrolling/i)).not.toBeInTheDocument()
-    expect(screen.queryByText(/Start Watching/i)).not.toBeInTheDocument()
-  })
 })
 
-describe('MoodShowcaseSection', () => {
+describe('HowItWorksSection', () => {
   it('renders the section heading', () => {
-    render(<MoodShowcaseStub />)
-    expect(screen.getByRole('heading', { name: /Start with the moment/i })).toBeInTheDocument()
+    render(<HowItWorksStub />)
+    expect(screen.getByRole('heading', { name: /Three steps\. Forty-seven seconds\./i })).toBeInTheDocument()
   })
 
-  it('renders the NL input placeholder', () => {
-    render(<MoodShowcaseStub />)
-    expect(screen.getByText(/Tired after a long week/i)).toBeInTheDocument()
+  it('renders the supporting copy', () => {
+    render(<HowItWorksStub />)
+    expect(screen.getByText(/Faster than picking a meal at a restaurant/i)).toBeInTheDocument()
   })
 
   it('does not show fake user counts or stats', () => {
-    render(<MoodShowcaseStub />)
+    render(<HowItWorksStub />)
     // No 4+ digit numbers (would indicate fake "10,000 users" style stats)
     expect(screen.queryByText(/\d{4,}/)).not.toBeInTheDocument()
   })
 
   it('has accessible section id for nav linking', () => {
-    render(<MoodShowcaseStub />)
-    expect(document.getElementById('mood-demo')).toBeInTheDocument()
+    render(<HowItWorksStub />)
+    expect(document.getElementById('how')).toBeInTheDocument()
   })
 })
 
@@ -162,7 +144,7 @@ describe('Landing page – structure', () => {
   it('renders all key sections', () => {
     render(<LandingStructure />)
     expect(screen.getByRole('heading', { name: /Find films for when you're feeling/i })).toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: /Start with the moment/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /Three steps\. Forty-seven seconds\./i })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: /Your taste, made visible/i })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: /It gets better at getting you/i })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: /Find people who actually get your taste/i })).toBeInTheDocument()
@@ -170,7 +152,7 @@ describe('Landing page – structure', () => {
     expect(screen.getByRole('heading', { name: /Built for your taste\. Not your data/i })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: /Questions\./i })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: /Why trust FeelFlick/i })).toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: /Somewhere in 6,700 films/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /Stop scrolling/i })).toBeInTheDocument()
   })
 
   it('does not render a FeaturesGrid section', () => {

--- a/src/features/landing/components/MoodDemoPanel.jsx
+++ b/src/features/landing/components/MoodDemoPanel.jsx
@@ -1,0 +1,279 @@
+// src/features/landing/components/MoodDemoPanel.jsx
+// Interactive glass panel that demos the mood→film loop on the landing hero.
+// Auto-cycles through moods (typing → searching → 3 picks). Mood chips below
+// let visitors take over; autoplay resumes 8s after the last interaction.
+
+import { useEffect, useRef, useState } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
+
+import { MOODS, WANTS_BY_MOOD } from '@/features/landing-v2/data'
+import { tmdbImg } from '@/shared/api/tmdb'
+
+const TYPING_TO_RESOLVED_MS = 1100
+const MOOD_CYCLE_MS = 4400
+const USER_RESUME_MS = 8000
+
+function FFMark({ size = 32 }) {
+  return (
+    <span
+      className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-purple-500 to-pink-500 font-black tracking-tight text-white shadow-lg shadow-purple-500/40"
+      style={{ width: size, height: size, fontSize: size * 0.42 }}
+      aria-hidden="true"
+    >
+      FF
+    </span>
+  )
+}
+
+function PosterPick({ film, match, isTop, accentColor }) {
+  return (
+    <div>
+      <div
+        className="relative w-full overflow-hidden rounded-lg border border-white/10 bg-white/5"
+        style={{
+          aspectRatio: '2 / 3',
+          // WHY: per-mood accent halo on the top pick is data-driven.
+          ...(isTop
+            ? { boxShadow: `0 0 0 1px ${accentColor}55, 0 10px 32px ${accentColor}26` }
+            : {}),
+        }}
+      >
+        <img
+          src={tmdbImg(film.path, 'w342')}
+          alt=""
+          className="block h-full w-full object-cover"
+          loading="lazy"
+          aria-hidden="true"
+        />
+        <div
+          className="absolute right-1.5 top-1.5 z-[1] inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[10px] font-bold backdrop-blur-md"
+          style={{
+            // WHY: badge accent is per-mood, runtime-computed.
+            background: isTop
+              ? `linear-gradient(135deg, ${accentColor}45, ${accentColor}22)`
+              : 'rgba(168,85,247,0.25)',
+            borderColor: isTop ? `${accentColor}55` : 'rgba(168,85,247,0.45)',
+            color: isTop ? accentColor : '#c4b5fd',
+          }}
+        >
+          <span>{match}%</span>
+        </div>
+      </div>
+      <p className="mt-1.5 truncate text-[12px] font-semibold text-white">{film.title}</p>
+      <p className="text-[11px] text-white/40">{film.year}</p>
+    </div>
+  )
+}
+
+export default function MoodDemoPanel({ onMoodChange }) {
+  const [moodIdx, setMoodIdx] = useState(0)
+  const [phase, setPhase] = useState('typing') // 'typing' | 'resolved'
+  const [userTaken, setUserTaken] = useState(false)
+  const userResumeRef = useRef(null)
+
+  const mood = MOODS[moodIdx % MOODS.length]
+  const accentColor = mood.color
+  const wantOptions = WANTS_BY_MOOD[mood.id] || ['interesting']
+  const currentWant = wantOptions[0]
+
+  useEffect(() => {
+    onMoodChange?.(mood.id)
+  }, [mood.id, onMoodChange])
+
+  // Auto-cycle until the user takes over.
+  useEffect(() => {
+    if (userTaken) return
+    setPhase('typing')
+    const resolveT = setTimeout(() => setPhase('resolved'), TYPING_TO_RESOLVED_MS)
+    const nextT = setTimeout(() => setMoodIdx((i) => i + 1), MOOD_CYCLE_MS)
+    return () => {
+      clearTimeout(resolveT)
+      clearTimeout(nextT)
+    }
+  }, [moodIdx, userTaken])
+
+  // Resume autoplay 8s after the user picks a mood.
+  useEffect(() => {
+    if (!userTaken) return
+    setPhase('typing')
+    const t = setTimeout(() => setPhase('resolved'), 700)
+    userResumeRef.current = setTimeout(() => setUserTaken(false), USER_RESUME_MS)
+    return () => {
+      clearTimeout(t)
+      if (userResumeRef.current) clearTimeout(userResumeRef.current)
+    }
+  }, [moodIdx, userTaken])
+
+  const handlePickMood = (idx) => {
+    setUserTaken(true)
+    setMoodIdx(idx)
+  }
+
+  return (
+    <>
+      <style>{`
+        @keyframes mood-blink {
+          0%, 50%   { opacity: 1; }
+          51%, 100% { opacity: 0; }
+        }
+        @keyframes mood-pulse {
+          0%, 100% { transform: scale(0.7); opacity: 0.4; }
+          50%      { transform: scale(1.2); opacity: 1; }
+        }
+        .animate-mood-blink { animation: mood-blink 1s steps(2) infinite; }
+        .animate-mood-pulse { animation: mood-pulse 1.2s ease-in-out infinite; }
+        @media (prefers-reduced-motion: reduce) {
+          .animate-mood-blink,
+          .animate-mood-pulse {
+            animation: none !important;
+          }
+        }
+      `}</style>
+
+      <div className="mx-auto w-full max-w-[520px]">
+        {/* Glass panel */}
+        <div
+          className="relative rounded-2xl border bg-white/5 px-4 py-4 text-left backdrop-blur-xl transition-[border-color,box-shadow] duration-700 ease-out sm:px-5 sm:py-5"
+          style={{
+            // WHY: border + glow tighten on the resolved state with the mood's accent.
+            borderColor: phase === 'resolved' ? `${accentColor}55` : 'rgba(255,255,255,0.08)',
+            boxShadow:
+              phase === 'resolved'
+                ? `0 16px 50px ${accentColor}1f, inset 0 1px 0 rgba(255,255,255,0.06)`
+                : '0 16px 40px rgba(0,0,0,0.4)',
+          }}
+        >
+          {/* Sentence row */}
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 flex-shrink-0">
+              <FFMark size={30} />
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="mb-1 text-[11px] font-semibold uppercase tracking-[0.1em] text-white/40">
+                {userTaken ? 'You, right now' : 'You, tonight'}
+              </p>
+              <p className="m-0 text-[16px] font-semibold leading-snug tracking-tight text-white sm:text-[20px]">
+                I feel{' '}
+                <span
+                  className="inline-block pb-[1px] font-extrabold"
+                  // WHY: mood accent is data-driven per active mood.
+                  style={{
+                    color: accentColor,
+                    borderBottom: `2px solid ${accentColor}66`,
+                    transition: 'color 500ms ease, border-color 500ms ease',
+                  }}
+                >
+                  {mood.label.toLowerCase()}
+                </span>
+                {phase === 'typing' && (
+                  <span
+                    className="animate-mood-blink ml-0.5 inline-block h-[0.9em] w-[2px] align-middle"
+                    style={{ background: accentColor }}
+                    aria-hidden="true"
+                  />
+                )}
+                <span className="font-normal text-white/40"> tonight, want something </span>
+                <span className="font-semibold text-white">{currentWant}</span>
+                <span className="font-normal text-white/40">.</span>
+              </p>
+            </div>
+          </div>
+
+          {/* Divider */}
+          <div className="my-4 h-px bg-white/[0.06]" />
+
+          {/* Searching or films — height locked so the panel doesn't jump.
+              Phases cross-fade for smoothness. */}
+          <div className="relative min-h-[270px] sm:min-h-[310px]">
+            <AnimatePresence mode="wait" initial={false}>
+              {phase === 'typing' ? (
+                <motion.div
+                  key="typing"
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.25, ease: 'easeOut' }}
+                  className="flex items-center gap-3 px-1 py-2"
+                >
+                  <div className="flex gap-1.5">
+                    {[0, 1, 2].map((i) => (
+                      <span
+                        key={i}
+                        className="animate-mood-pulse h-[7px] w-[7px] rounded-full"
+                        style={{ background: accentColor, animationDelay: `${i * 0.15}s` }}
+                        aria-hidden="true"
+                      />
+                    ))}
+                  </div>
+                  <span className="text-[13px] text-white/60">
+                    Searching across{' '}
+                    <span className="font-semibold text-white">{mood.label.toLowerCase()}</span>
+                    …
+                  </span>
+                </motion.div>
+              ) : (
+                <motion.div
+                  key={`resolved-${moodIdx}`}
+                  initial={{ opacity: 0, y: 8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.45, ease: [0.22, 1, 0.36, 1] }}
+                >
+                  <p className="m-0 mb-3 text-[11px] font-bold uppercase tracking-[0.18em] text-white/40">
+                    {mood.label} picks
+                  </p>
+                  <div className="grid grid-cols-3 gap-2 sm:gap-3">
+                    {mood.films.map((film, i) => (
+                      <motion.div
+                        key={`${film.path}-${moodIdx}`}
+                        initial={{ opacity: 0, y: 10 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        transition={{
+                          duration: 0.5,
+                          ease: [0.22, 1, 0.36, 1],
+                          delay: 0.1 + i * 0.07,
+                        }}
+                      >
+                        <PosterPick
+                          film={film}
+                          match={mood.matches[i]}
+                          isTop={i === 0}
+                          accentColor={accentColor}
+                        />
+                      </motion.div>
+                    ))}
+                  </div>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+        </div>
+
+        {/* Mood quick-picks — hidden on mobile to keep the surface focused. */}
+        <div className="mt-4 hidden flex-wrap justify-center gap-2 sm:flex sm:justify-start">
+          {MOODS.map((m, idx) => {
+            const active = idx === moodIdx % MOODS.length
+            return (
+              <button
+                key={m.id}
+                type="button"
+                onClick={() => handlePickMood(idx)}
+                className={`rounded-full border px-3.5 py-1.5 text-[12.5px] font-medium transition-colors duration-200 ${
+                  active
+                    ? 'border-white/20 text-white'
+                    : 'border-white/10 bg-white/[0.03] text-white/65 hover:bg-white/5'
+                }`}
+                // WHY: active chip tint comes from the mood's accent color.
+                style={active ? { background: `${m.color}22` } : undefined}
+                aria-pressed={active}
+                aria-label={`Show picks for ${m.label} mood`}
+              >
+                {m.label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/features/landing/components/TopNav.jsx
+++ b/src/features/landing/components/TopNav.jsx
@@ -14,9 +14,9 @@ import { useGoogleAuth } from '@/features/landing/utils/useGoogleAuth'
 const NAV_HEIGHT = { mobile: 64, desktop: 80 }
 
 /** Anchor link rendered in the center of the nav bar.
- * Points to the MoodShowcaseSection id — avoids linking unauth visitors
+ * Points to the HowItWorksSection — avoids linking unauth visitors
  * to authenticated-only routes (/browse, /discover, /about). */
-const NAV_ANCHOR = { label: 'How it works', href: '#mood-demo' }
+const NAV_ANCHOR = { label: 'How it works', href: '#how' }
 
 /**
  * Top Navigation — cinematic glassmorphism nav, always visible.
@@ -110,7 +110,7 @@ export default function TopNav({ hideAuthCta = false }) {
   const handleNavAnchorClick = (e) => {
     e.preventDefault()
     setMobileMenuOpen(false)
-    const el = document.getElementById('mood-demo')
+    const el = document.getElementById('how')
     if (!el) return
     const navH = barRef.current?.offsetHeight || NAV_HEIGHT.mobile
     const offsetPosition = el.getBoundingClientRect().top + window.pageYOffset - navH

--- a/src/features/landing/sections/FAQSection.jsx
+++ b/src/features/landing/sections/FAQSection.jsx
@@ -17,8 +17,8 @@ const FAQ_ITEMS = [
   },
   {
     id: 'faq-3',
-    question: 'How does the recommendation engine work?',
-    answer: "It combines what you watch, rate, and skip with semantic similarity between films. The more you use it, the more accurate it gets. Five films in, it's decent. Fifty films in, it starts to feel uncanny.",
+    question: 'Is FeelFlick a streaming service?',
+    answer: "No. We don't stream films — we help you choose them. Once you pick, watch wherever you already do (Netflix, Max, Criterion, your hard drive).",
   },
   {
     id: 'faq-4',
@@ -32,8 +32,8 @@ const FAQ_ITEMS = [
   },
   {
     id: 'faq-6',
-    question: 'How many films are in the catalogue?',
-    answer: '6,700+ curated and scored films, each with pre-computed semantic embeddings so recommendations match at a depth no human curator can reach.',
+    question: 'Do I need to rate everything I watch?',
+    answer: "No. A skip is a signal. A re-watch is a signal. We learn from how you actually use the app — not from a homework assignment.",
   },
 ]
 

--- a/src/features/landing/sections/FinalCTASection.jsx
+++ b/src/features/landing/sections/FinalCTASection.jsx
@@ -1,85 +1,73 @@
 // src/features/landing/sections/FinalCTASection.jsx
+// Emotional closer for the landing page. Centered, single radial bloom.
+// Copy sourced from landing-v2/data.js TONE_COPY.confident.
+
 import { motion } from 'framer-motion'
-import { LogIn, Loader2 } from 'lucide-react'
+import { Loader2 } from 'lucide-react'
 
 import { useGoogleAuth } from '@/features/landing/utils/useGoogleAuth'
+import { TONE_COPY } from '@/features/landing-v2/data'
 import Button from '@/shared/ui/Button'
 
-const vp = { once: true, margin: '-60px' }
+const TONE = TONE_COPY.confident
+const VIEWPORT = { once: true, margin: '-60px' }
 
-// Checked once at module load — stable for the session.
 const prefersReducedMotion =
   typeof window !== 'undefined'
     ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
     : false
 
-/**
- * FinalCTASection — emotional closer for the FeelFlick landing page.
- *
- * Uses the approved "Tonight." headline (Blueprint §Approved Copy).
- * The white-pill CTA matches the hero for visual bookending.
- * Generous padding (py-20→py-32) gives the section breathing room as a finale.
- */
 export default function FinalCTASection() {
   const { signInWithGoogle, isAuthenticating } = useGoogleAuth()
 
   return (
     <section
-      className="relative bg-black overflow-hidden min-h-[100svh] flex flex-col justify-center"
+      className="relative overflow-hidden border-t border-white/[0.08] bg-black px-6 py-20 text-center sm:px-20 sm:py-40"
       aria-labelledby="final-cta-heading"
     >
-      {/* Top border */}
+      {/* Centered radial bloom — purple → pink fade */}
       <div
-        className="absolute top-0 inset-x-0 h-px"
-        style={{ background: 'linear-gradient(90deg, transparent 0%, rgba(168,85,247,0.2) 50%, transparent 100%)' }}
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            'radial-gradient(ellipse 70% 60% at 50% 50%, rgba(168,85,247,0.18), rgba(236,72,153,0.10) 40%, transparent 70%)',
+        }}
         aria-hidden="true"
       />
 
-      {/* Strong purple bloom from top — cinematic atmosphere */}
-      <div
-        className="absolute inset-0 pointer-events-none"
-        style={{ background: 'radial-gradient(ellipse 100% 55% at 50% -5%, rgba(88,28,135,0.50) 0%, transparent 70%)' }}
-        aria-hidden="true"
-      />
-
-      {/* Warm centre glow — the subtle "warmth" feeling for the emotional closer */}
-      <div
-        className="absolute inset-0 pointer-events-none"
-        style={{ background: 'radial-gradient(ellipse 80% 60% at 50% 50%, rgba(168,85,247,0.06) 0%, transparent 70%)' }}
-        aria-hidden="true"
-      />
-
-      {/* Bottom fade — keeps it grounded against the footer */}
-      <div
-        className="absolute inset-0 pointer-events-none"
-        style={{ background: 'radial-gradient(ellipse 80% 45% at 50% 110%, rgba(168,85,247,0.15) 0%, transparent 65%)' }}
-        aria-hidden="true"
-      />
-
-      {/* ── Content ────────────────────────────────────────────────────── */}
-      <div className="relative max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12 sm:py-16 text-center">
-
-        {/* Headline — "Tonight." on its own line in gradient for the Apple punch */}
+      <div className="relative mx-auto max-w-[800px]">
         <motion.h2
           id="final-cta-heading"
-          className="font-black tracking-tight leading-[1.05] mb-10"
-          style={{ fontSize: 'clamp(2.25rem, 6vw, 3.75rem)' }}
+          className="m-0 mb-5 whitespace-pre-line text-balance font-black text-white"
+          style={{
+            fontSize: 'clamp(2.375rem, 7vw, 4.75rem)',
+            letterSpacing: '-0.035em',
+            lineHeight: 1.02,
+          }}
           initial={prefersReducedMotion ? false : { opacity: 0, y: 18 }}
           whileInView={{ opacity: 1, y: 0 }}
-          viewport={vp}
+          viewport={VIEWPORT}
           transition={{ duration: prefersReducedMotion ? 0 : 0.5, delay: prefersReducedMotion ? 0 : 0.08 }}
         >
-          <span className="text-white">Somewhere in 6,700 films is one made for you.</span>
-          <span className="block gradient-text">Tonight.</span>
+          {TONE.finalH}
         </motion.h2>
 
-        {/* CTA button — white pill, dark text, mirrors Hero for visual bookending */}
+        <motion.p
+          className="mx-auto mb-9 max-w-[520px] text-sm leading-relaxed text-white/60 sm:text-[17px]"
+          initial={prefersReducedMotion ? false : { opacity: 0, y: 12 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={VIEWPORT}
+          transition={{ duration: prefersReducedMotion ? 0 : 0.45, delay: prefersReducedMotion ? 0 : 0.16 }}
+        >
+          {TONE.finalSub}
+        </motion.p>
+
         <motion.div
+          className="flex justify-center"
           initial={prefersReducedMotion ? false : { opacity: 0, y: 14, scale: 0.97 }}
           whileInView={{ opacity: 1, y: 0, scale: 1 }}
-          viewport={vp}
-          transition={{ duration: prefersReducedMotion ? 0 : 0.45, delay: prefersReducedMotion ? 0 : 0.2 }}
-          className="flex justify-center mb-6"
+          viewport={VIEWPORT}
+          transition={{ duration: prefersReducedMotion ? 0 : 0.45, delay: prefersReducedMotion ? 0 : 0.24 }}
         >
           <Button
             variant="primary"
@@ -87,30 +75,28 @@ export default function FinalCTASection() {
             onClick={signInWithGoogle}
             disabled={isAuthenticating}
             className="touch-target"
-            aria-label={isAuthenticating ? 'Signing in' : 'Find tonight\'s film on FeelFlick'}
+            aria-label={isAuthenticating ? 'Signing in' : 'Get started free with FeelFlick'}
           >
             {isAuthenticating ? (
-              <><Loader2 className="h-4 w-4 animate-spin flex-shrink-0" aria-hidden="true" /> Signing in...</>
+              <><Loader2 className="h-4 w-4 flex-shrink-0 animate-spin" aria-hidden="true" /> Signing in...</>
             ) : (
               <>
-                Find Tonight&apos;s Film
-                <LogIn className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
+                Get Started Free
+                <span aria-hidden="true">→</span>
               </>
             )}
           </Button>
         </motion.div>
 
-        {/* Micro copy */}
         <motion.p
-          className="text-xs text-white/20"
+          className="m-0 mt-4 text-xs text-white/40"
           initial={prefersReducedMotion ? false : { opacity: 0 }}
           whileInView={{ opacity: 1 }}
-          viewport={vp}
-          transition={{ duration: prefersReducedMotion ? 0 : 0.4, delay: prefersReducedMotion ? 0 : 0.38 }}
+          viewport={VIEWPORT}
+          transition={{ duration: prefersReducedMotion ? 0 : 0.4, delay: prefersReducedMotion ? 0 : 0.36 }}
         >
-          Free forever · No credit card · No ads
+          47 seconds to your first pick. Free forever.
         </motion.p>
-
       </div>
     </section>
   )

--- a/src/features/landing/sections/HeroSection.jsx
+++ b/src/features/landing/sections/HeroSection.jsx
@@ -1,41 +1,11 @@
 // src/features/landing/sections/HeroSection.jsx
-import { useState, useMemo, useEffect } from 'react'
+import { useCallback, useState } from 'react'
 import { motion } from 'framer-motion'
-import { LogIn, Loader2, ArrowDown } from 'lucide-react'
+import { LogIn, Loader2 } from 'lucide-react'
 
 import { useGoogleAuth } from '@/features/landing/utils/useGoogleAuth'
+import MoodDemoPanel from '@/features/landing/components/MoodDemoPanel'
 import Button from '@/shared/ui/Button'
-
-const POSTER_ROWS = [
-  [
-    { path: '/yQvGrMoipbRoddT0ZR8tPoR7NfX.jpg', tag: 'Curious'     }, // Interstellar
-    { path: '/pEzNVQfdzYDzVK0XqxERIw2x2se.jpg', tag: 'Reflective'  }, // Arrival
-    { path: '/u68AjlvlutfEIcpmbYpKcdi09ut.jpg', tag: 'Inventive'   }, // Everything Everywhere All at Once
-    { path: '/5UwdhrjXhUgsiDhe1dpS9z4yj7q.jpg', tag: 'Cerebral'    }, // Synecdoche, New York
-    { path: '/mE24wUCfjK8AoBBjaMjho7Rczr7.jpg', tag: 'Tense'       }, // Get Out
-    { path: '/hjlZSXM86wJrfCv5VKfR5DI2VeU.jpg', tag: 'Unsettling'  }, // Hereditary
-    { path: '/pThyQovXQrw2m0s9x82twj48Jq4.jpg', tag: 'Clever'      }, // Knives Out
-    { path: '/vz3Vd6nfq9YZrVvyYx5RHFaYKV3.jpg', tag: 'Witty'       }, // In Bruges
-    { path: '/nSxDa3M9aMvGVLoItzWTepQ5h5d.jpg', tag: 'Whimsical'   }, // Amélie
-    { path: '/1OJ9vkD5xPt3skC6KguyXAgagRZ.jpg', tag: 'Feel-good'   }, // Paddington 2
-    { path: '/7IiTTgloJzvGI1TAYymCfbfl3vT.jpg', tag: 'Sharp'       }, // Parasite
-  ],
-  [
-    { path: '/fa0RDkAlCec0STeMNAhPaF89q6U.jpg', tag: 'Mastery'     }, // There Will Be Blood
-    { path: '/39wmItIWsg5sZMyRUHLkWBcuVCM.jpg', tag: 'Soulful'     }, // Spirited Away
-    { path: '/z7xXihu5wHuSMWymq5VAulPVuvg.jpg', tag: 'Mythic'      }, // Pan's Labyrinth
-    { path: '/6Ryitt95xrO8KXuqRGm1fUuNwqF.jpg', tag: 'Nostalgic'   }, // Coco
-    { path: '/gl66K7zRdtNYGrxyS2YDUP5ASZd.jpg', tag: 'Coming-of-age' }, // Lady Bird
-    { path: '/eCOtqtfvn7mxGl6nfmq4b1exJRc.jpg', tag: 'Intimate'    }, // Her
-    { path: '/iYypPT4bhqXfq1b6EnmxvRt6b2Y.jpg', tag: 'Longing'     }, // In the Mood for Love
-    { path: '/eWdyYQreja6JGCzqHWXpWHDrrPo.jpg', tag: 'Editorial'   }, // The Grand Budapest Hotel
-    { path: '/7Y9ILV1unpW9mLpGcqyGQU72LUy.jpg', tag: 'Offbeat'     }, // The Lobster
-    { path: '/hA2ple9q4qnwxp3hKVNhroipsir.jpg', tag: 'Kinetic'     }, // Mad Max: Fury Road
-    { path: '/602vevIURmpDfzbnv5Ubi6wIkQm.jpg', tag: 'Intense'     }, // Drive
-  ],
-]
-
-const MOOD_WORDS = ['nostalgic', 'tense', 'cozy', 'euphoric', 'curious', 'melancholy']
 
 const MOOD_COLORS = {
   nostalgic:  { primary: '222,184,135', secondary: '193,154,107' },
@@ -46,94 +16,58 @@ const MOOD_COLORS = {
   melancholy: { primary: '155,142,196', secondary: '108,123,179' },
 }
 
-function usePosterRows() {
-  return useMemo(
-    () => [
-      [...POSTER_ROWS[0], ...POSTER_ROWS[0], ...POSTER_ROWS[0]],
-      [...POSTER_ROWS[1], ...POSTER_ROWS[1], ...POSTER_ROWS[1]],
-    ],
-    [],
-  )
-}
-
-
-function PosterTile({ path, tag }) {
+function CTABlock({ signInWithGoogle, isAuthenticating, align = 'start' }) {
   return (
-    <div
-      className="relative w-36 sm:w-40 h-52 sm:h-60 shrink-0 rounded-xl overflow-hidden border border-white/8 bg-white/5"
-      role="presentation"
-      aria-hidden="true"
-    >
-      <img
-        src={`https://image.tmdb.org/t/p/w342${path}`}
-        className="w-full h-full object-cover"
-        alt=""
-        loading="eager"
-        decoding="async"
-      />
-      {/* Top gradient fade for tag legibility */}
-      <div
-        className="absolute inset-x-0 top-0 h-12 pointer-events-none"
-        style={{ background: 'linear-gradient(to bottom, rgba(0,0,0,0.60) 0%, transparent 100%)' }}
-      />
-      {/* Mood tag */}
-      {tag && (
-        <span className="absolute top-2.5 right-2.5 text-[9px] font-medium tracking-[0.12em] uppercase text-white/60 select-none">
-          {tag}
-        </span>
-      )}
+    <div className={`flex flex-col ${align === 'center' ? 'items-center' : 'items-center lg:items-start'}`}>
+      <div className="inline-flex flex-col items-center gap-3">
+        <Button
+          variant="primary"
+          size="lg"
+          onClick={signInWithGoogle}
+          disabled={isAuthenticating}
+          className="touch-target"
+          aria-label={isAuthenticating ? 'Signing in' : 'Get started free with FeelFlick'}
+        >
+          {isAuthenticating ? (
+            <><Loader2 className="h-4 w-4 flex-shrink-0 animate-spin" aria-hidden="true" /> Signing in...</>
+          ) : (
+            <>
+              Get Started Free
+              <LogIn className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+            </>
+          )}
+        </Button>
+        <p className="w-full text-center text-xs text-white/40">
+          Free forever · No credit card · No ads
+        </p>
+      </div>
     </div>
   )
 }
 
-
 export default function HeroSection() {
   const { signInWithGoogle, isAuthenticating } = useGoogleAuth()
-  const [row1, row2] = usePosterRows()
   const prefersReducedMotion = typeof window !== 'undefined'
     ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
     : false
 
-  const [moodIndex, setMoodIndex] = useState(0)
-  const [tintOpacity, setTintOpacity] = useState(0)
+  const [activeMood, setActiveMood] = useState('nostalgic')
+  const handleMoodChange = useCallback((moodId) => setActiveMood(moodId), [])
 
-  useEffect(() => {
-    // Fade in tint after mount
-    const fadeIn = setTimeout(() => setTintOpacity(1), 400)
-    const interval = setInterval(() => {
-      setMoodIndex(i => (i + 1) % MOOD_WORDS.length)
-    }, 3000)
-    return () => {
-      clearTimeout(fadeIn)
-      clearInterval(interval)
-    }
-  }, [])
-
-  const activeMoodColors = MOOD_COLORS[MOOD_WORDS[moodIndex]]
-
-  const scrollToMoodDemo = () => {
-    const element = document.getElementById('mood-demo')
-    if (!element) return
-    const offsetPosition = element.getBoundingClientRect().top + window.pageYOffset - 80
-    window.scrollTo({ top: offsetPosition, behavior: 'smooth' })
-  }
+  const moodColors = MOOD_COLORS[activeMood] || MOOD_COLORS.nostalgic
 
   return (
     <>
       <style>{`
         .hero-headline {
-          font-size: clamp(2.75rem, 9vw, 3.75rem);
+          font-size: clamp(2.5rem, 8vw, 3.5rem);
         }
         @media (min-width: 1024px) {
           .hero-headline {
-            font-size: clamp(4.5rem, 6vw, 7rem);
+            font-size: clamp(3.5rem, 5vw, 5rem);
           }
         }
         @media (prefers-reduced-motion: reduce) {
-          .animate-scroll-left,
-          .animate-scroll-right {
-            animation: none !important;
-          }
           .animate-fade-in-up {
             animation: none !important;
             opacity: 1 !important;
@@ -143,113 +77,59 @@ export default function HeroSection() {
       `}</style>
       <section
         id="hero"
-        className="relative min-h-screen bg-black overflow-hidden"
-        aria-labelledby="hero-heading"
+        className="relative min-h-screen overflow-hidden bg-black"
+        aria-label="FeelFlick — the right film, right now"
       >
-
-      {/* ── LAYER 1: Full-bleed poster wall ──────────────────────────────
-          Sits behind everything. Covers the whole section on both
-          mobile and desktop. The gradient layers above control what's
-          visible and what merges into black.
-      ─────────────────────────────────────────────────────────────── */}
-      <div
-        className="absolute inset-0 z-0 select-none pointer-events-none"
-        aria-hidden="true"
-      >
+        {/* ── LAYER 1: Static cinematic tint (always present) ──────────── */}
         <div
-          className="flex flex-col justify-start lg:justify-center h-full gap-5 rotate-[-2deg] scale-[1.08] origin-top lg:origin-center pt-16 sm:pt-20 lg:pt-0"
-          style={{ opacity: 0.92 }}
-        >
-          <div className="flex gap-4 animate-scroll-left w-[220%]">
-            {row1.map((item, i) => <PosterTile key={`r1-${i}`} path={item.path} tag={item.tag} />)}
-          </div>
-          <div className="flex gap-4 animate-scroll-right w-[220%]">
-            {row2.map((item, i) => <PosterTile key={`r2-${i}`} path={item.path} tag={item.tag} />)}
-          </div>
-        </div>
-      </div>
-
-      {/* ── LAYER 2: Dynamic mood-colour tint ────────────────────────────
-          Shifts hue with the rotating mood word for a cinema wash effect.
-          Base purple layer underneath; mood overlay cross-fades on top.
-      ─────────────────────────────────────────────────────────────── */}
-      {/* Base: static purple-pink cinematic tint — always present */}
-      <div
-        className="absolute inset-0 z-[1] pointer-events-none"
-        style={{
-          background: 'linear-gradient(135deg, rgba(88,28,135,0.14) 0%, rgba(168,85,247,0.06) 40%, rgba(236,72,153,0.08) 70%, rgba(0,0,0,0.20) 100%)',
-        }}
-        aria-hidden="true"
-      />
-      {/* Mood overlay — cross-fades when mood word changes */}
-      {!prefersReducedMotion && (
-        <motion.div
-          key={moodIndex}
-          className="absolute inset-0 z-[1] pointer-events-none"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: tintOpacity * 0.55 }}
-          transition={{ duration: 0.8, ease: 'easeInOut' }}
+          className="pointer-events-none absolute inset-0 z-0"
           style={{
-            background: `linear-gradient(135deg, rgba(${activeMoodColors.primary},0.18) 0%, rgba(${activeMoodColors.secondary},0.10) 50%, transparent 80%)`,
+            background:
+              'linear-gradient(135deg, rgba(88,28,135,0.18) 0%, rgba(168,85,247,0.08) 40%, rgba(236,72,153,0.10) 70%, rgba(0,0,0,0.20) 100%)',
           }}
           aria-hidden="true"
         />
-      )}
 
-      {/* ── LAYER 3a: Desktop merge gradient ─────────────────────────────
-          Left 60% = content. Transition zone = 30%–65%.
-          Goes solid black → transparent over a very wide band so the
-          two halves melt into each other rather than cut.
-      ─────────────────────────────────────────────────────────────── */}
-      <div
-        className="absolute inset-0 z-[2] pointer-events-none hidden lg:block"
-        style={{
-          background: 'linear-gradient(to right, #06060A 0%, #06060A 40%, rgba(0,0,0,0.88) 52%, rgba(0,0,0,0.4) 63%, rgba(0,0,0,0.08) 76%, transparent 88%)',
-        }}
-        aria-hidden="true"
-      />
+        {/* ── LAYER 2: Mood-reactive bloom (driven by demo panel) ──────── */}
+        {!prefersReducedMotion && (
+          <motion.div
+            key={activeMood}
+            className="pointer-events-none absolute inset-0 z-[1]"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 0.55 }}
+            transition={{ duration: 1.2, ease: 'easeInOut' }}
+            style={{
+              background: `radial-gradient(ellipse 80% 65% at 50% 28%, rgba(${moodColors.primary},0.22) 0%, rgba(${moodColors.secondary},0.10) 40%, transparent 75%)`,
+            }}
+            aria-hidden="true"
+          />
+        )}
 
-      {/* ── LAYER 3b: Mobile merge gradient ──────────────────────────────
-          Top 40% = posters (with only the cinematic tint).
-          Bottom 60% = content. The transition zone goes from ~30vh to ~44vh
-          — a 14vh tall seamless dissolve.
-      ─────────────────────────────────────────────────────────────── */}
-      <div
-        className="absolute inset-0 z-[2] pointer-events-none lg:hidden"
-        style={{
-          background: 'linear-gradient(to bottom, rgba(0,0,0,0.15) 0%, rgba(0,0,0,0.15) 26vh, rgba(0,0,0,0.6) 32vh, rgba(0,0,0,0.92) 37vh, #06060A 40vh)',
-        }}
-        aria-hidden="true"
-      />
-
-      {/* ── LAYER 4: Nav top fade (always) ───────────────────────────── */}
-      <div
-        className="absolute inset-x-0 top-0 z-[3] h-20 pointer-events-none"
-        style={{ background: 'linear-gradient(to bottom, rgba(0,0,0,0.75), transparent)' }}
-        aria-hidden="true"
-      />
-
-      {/* ── LAYER 5: Content — sits above all gradients ───────────────── */}
-      <div className="relative z-10 min-h-screen flex flex-col lg:flex-row">
-
-        {/* Mobile: top spacer — posters show through here */}
-        <div className="lg:hidden flex-shrink-0" style={{ height: '32vh' }} aria-hidden="true" />
-
-        {/* Unified content block — responsive alignment and sizing */}
+        {/* ── LAYER 3: Bottom ambient glow ─────────────────────────────── */}
         <div
-          className="flex items-center justify-center text-center lg:text-left lg:justify-start lg:w-[70%] lg:px-16 xl:px-28 px-6 pb-10 lg:pb-0 animate-fade-in-up"
-          style={{ minHeight: '68vh' }}
-        >
-          <div className="max-w-sm lg:max-w-2xl">
-            {/* Eyebrow — sits above the h1, low-contrast label */}
-            <p className="text-xs font-semibold uppercase tracking-widest text-purple-400/60 mb-3 lg:mb-4">
+          className="pointer-events-none absolute inset-0 z-[1]"
+          style={{
+            background:
+              'radial-gradient(ellipse 60% 40% at 50% 110%, rgba(168,85,247,0.18), transparent 65%)',
+          }}
+          aria-hidden="true"
+        />
+
+        {/* ── LAYER 4: Nav top fade ────────────────────────────────────── */}
+        <div
+          className="pointer-events-none absolute inset-x-0 top-0 z-[3] h-20"
+          style={{ background: 'linear-gradient(to bottom, rgba(0,0,0,0.75), transparent)' }}
+          aria-hidden="true"
+        />
+
+        {/* ── LAYER 5: Content ─────────────────────────────────────────── */}
+        <div className="relative z-10 flex min-h-screen flex-col lg:flex-row lg:items-center">
+          {/* MOBILE-ONLY headline (above panel). Hidden on lg. */}
+          <div className="animate-fade-in-up flex flex-col items-center px-6 pt-24 text-center lg:hidden">
+            <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-purple-400/60">
               FILMS THAT KNOW YOU
             </p>
-            {/* Single h1 — id appears once, no duplicate */}
-            <h1
-              id="hero-heading"
-              className="hero-headline font-black tracking-tight leading-[1.05] mb-5 lg:mb-8"
-            >
+            <h1 className="hero-headline mb-5 font-black leading-[1.05] tracking-tight">
               <span className="block text-white">The right film.</span>
               <span
                 className="block"
@@ -261,61 +141,57 @@ export default function HeroSection() {
                   display: 'inline-block',
                   paddingBottom: '0.1em',
                 }}
-              >Right now.</span>
+              >
+                Right now.
+              </span>
             </h1>
-            <p className="text-sm lg:text-lg text-white/60 leading-relaxed mb-5 lg:mb-6 max-w-[560px]">
-              Tell it how you feel. It finds tonight&apos;s film — matched to your taste, not what&apos;s trending.
+            <p className="mb-2 max-w-[520px] text-sm leading-relaxed text-white/60">
+              Picks shaped by your mood, taste, and cinematic history.
             </p>
+          </div>
 
-            {/* CTA + trust line — trust text is constrained to pill width */}
-            <div className="flex flex-col items-center lg:items-start">
-              <div className="inline-flex flex-col items-center gap-3">
-
-                {/* Primary CTA */}
-                <Button
-                  variant="primary"
-                  size="lg"
-                  onClick={signInWithGoogle}
-                  disabled={isAuthenticating}
-                  className="touch-target"
-                  aria-label={isAuthenticating ? 'Signing in' : 'Get started free with FeelFlick'}
+          {/* DESKTOP left column — headline + CTA stacked. Hidden on mobile.
+              Right padding intentionally tight so the demo panel sits closer. */}
+          <div className="hidden animate-fade-in-up lg:flex lg:w-[48%] lg:items-center lg:justify-start lg:pl-16 lg:pr-6 xl:pl-24 xl:pr-8">
+            <div className="max-w-xl">
+              <p className="mb-4 text-xs font-semibold uppercase tracking-widest text-purple-400/60">
+                FILMS THAT KNOW YOU
+              </p>
+              <h1 className="hero-headline mb-7 font-black leading-[1.05] tracking-tight">
+                <span className="block text-white">The right film.</span>
+                <span
+                  className="block"
+                  style={{
+                    background: 'linear-gradient(90deg, #a855f7 0%, #ec4899 100%)',
+                    WebkitBackgroundClip: 'text',
+                    WebkitTextFillColor: 'transparent',
+                    backgroundClip: 'text',
+                    display: 'inline-block',
+                    paddingBottom: '0.1em',
+                  }}
                 >
-                  {isAuthenticating ? (
-                    <><Loader2 className="h-4 w-4 animate-spin flex-shrink-0" aria-hidden="true" /> Signing in...</>
-                  ) : (
-                    <>
-                      Get Started Free
-                      <LogIn className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
-                    </>
-                  )}
-                </Button>
-
-                {/* Trust line — centered under pill, width bounded by it */}
-                <p className="text-xs text-white/40 text-center w-full">
-                  Free forever · No credit card · No ads
-                </p>
-
-              </div>
+                  Right now.
+                </span>
+              </h1>
+              <p className="mb-6 max-w-[520px] text-lg leading-relaxed text-white/60">
+                Picks shaped by your mood, taste, and cinematic history.
+              </p>
+              <CTABlock signInWithGoogle={signInWithGoogle} isAuthenticating={isAuthenticating} />
             </div>
           </div>
+
+          {/* Demo panel — center on mobile, right column on desktop.
+              Tight left padding so the panel sits close to the headline. */}
+          <div className="flex w-full items-center justify-center px-6 pt-6 lg:w-[52%] lg:pl-2 lg:pr-12 lg:pt-0 xl:pr-16">
+            <MoodDemoPanel onMoodChange={handleMoodChange} />
+          </div>
+
+          {/* MOBILE-ONLY CTA below panel. Hidden on lg. */}
+          <div className="flex flex-col items-center px-6 pb-16 pt-8 lg:hidden">
+            <CTABlock signInWithGoogle={signInWithGoogle} isAuthenticating={isAuthenticating} align="center" />
+          </div>
         </div>
-
-        {/* Desktop: 30% right spacer — posters show through */}
-        <div className="hidden lg:block w-[30%]" aria-hidden="true" />
-
-      </div>
-
-      {/* See how it works — bottom-center anchor */}
-      <button
-        onClick={scrollToMoodDemo}
-        className="absolute bottom-8 left-1/2 -translate-x-1/2 z-10 inline-flex items-center gap-1.5 text-sm text-white/40 hover:text-white/70 transition-colors duration-200 touch-target"
-        aria-label="See how FeelFlick works"
-      >
-        See how it works
-        <ArrowDown className="w-3.5 h-3.5 flex-shrink-0" aria-hidden="true" />
-      </button>
-
-    </section>
+      </section>
     </>
   )
 }

--- a/src/features/landing/sections/HowItWorksSection.jsx
+++ b/src/features/landing/sections/HowItWorksSection.jsx
@@ -1,0 +1,93 @@
+// src/features/landing/sections/HowItWorksSection.jsx
+// Three-step explainer that follows the hero. Mood → matching → pick.
+// Cards entrance-animate on scroll, respecting prefers-reduced-motion.
+
+import { motion } from 'framer-motion'
+
+const STEPS = [
+  {
+    n: '01',
+    h: 'Say how you feel',
+    b: 'A pill, a word, or a sentence. The vague "I want something good" is fine — we can disambiguate.',
+  },
+  {
+    n: '02',
+    h: 'We read the room',
+    b: 'Mood + your taste graph + time-of-day + history. Not just "what people watched."',
+  },
+  {
+    n: '03',
+    h: 'One pick wins',
+    b: 'Plus 2 alternates with a one-line reason each. Pick fast, or pick well — your call.',
+  },
+]
+
+const VIEWPORT = { once: true, margin: '-60px' }
+
+export default function HowItWorksSection() {
+  return (
+    <section
+      id="how"
+      className="relative border-t border-white/[0.08] bg-black px-6 py-20 md:px-20 md:py-32"
+      aria-labelledby="how-heading"
+    >
+      <div className="mx-auto max-w-[1180px]">
+        {/* Header */}
+        <motion.div
+          className="mx-auto mb-14 max-w-[720px] text-center"
+          initial={{ opacity: 0, y: 18 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={VIEWPORT}
+          transition={{ duration: 0.5 }}
+        >
+          <p className="m-0 text-[11px] font-bold uppercase tracking-[0.18em] text-purple-400/75">
+            How it works
+          </p>
+          <h2
+            id="how-heading"
+            className="mb-4 mt-3.5 text-balance font-black leading-[1.04] tracking-tight text-white"
+            style={{ fontSize: 'clamp(2rem, 5vw, 3.25rem)' }}
+          >
+            Three steps.<br />Forty-seven seconds.
+          </h2>
+          <p className="m-0 text-sm leading-relaxed text-white/60 sm:text-base">
+            Faster than picking a meal at a restaurant. Sharper than asking a friend.
+          </p>
+        </motion.div>
+
+        {/* Cards */}
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3 md:gap-6">
+          {STEPS.map((s, i) => (
+            <motion.div
+              key={s.n}
+              className="relative overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-b from-white/[0.045] to-white/[0.01] p-6 sm:p-8"
+              initial={{ opacity: 0, y: 18 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={VIEWPORT}
+              transition={{ duration: 0.5, delay: 0.08 * i }}
+            >
+              {/* Watermark step number */}
+              <span
+                className="pointer-events-none absolute -right-2 -top-3 select-none text-[110px] font-black italic leading-none tracking-tighter text-white/[0.04]"
+                aria-hidden="true"
+              >
+                {s.n}
+              </span>
+              <div className="relative">
+                <p className="m-0 mb-3.5 text-[11px] tracking-[0.16em] text-purple-400/70 [font-family:'JetBrains_Mono',monospace]">
+                  STEP {s.n}
+                </p>
+                <h3 className="mb-2.5 text-[21px] font-extrabold tracking-tight text-white sm:text-[23px]">
+                  {s.h}
+                </h3>
+                <p className="m-0 text-sm leading-relaxed text-white/60 sm:text-[14.5px]">
+                  {s.b}
+                </p>
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- Replace decorative hero poster wall with interactive `MoodDemoPanel` (auto-cycles 6 moods → 3 picks). Mobile reorders to headline → panel → CTA.
- Replace `MoodShowcaseSection` with `HowItWorksSection` (Tailwind port of `HowItWorksV2`) — the hero now does the mood demo, this slot explains method. TopNav anchor: `#mood-demo` → `#how`.
- Swap two FAQ entries (engine, catalogue) for V2's "Is FeelFlick a streaming service?" + "Do I need to rate everything?".
- Full V2 port of `FinalCTASection` — centered, single radial bloom, "Stop scrolling. Start watching." copy from `TONE_COPY.confident`.
- Lock new approved copy in CLAUDE.md across hero + final CTA.
- `WANTS_BY_MOOD` reorder (`euphoric`, `nostalgic`) so the demo's first want isn't a synonym of the mood (also improves `/v2`).
- Update `Landing.test.jsx` stubs and assertions to match shipped state.

`/v2` route is otherwise untouched. `MoodShowcaseSection.jsx` retained as an orphan (file deletion deferred per CLAUDE.md hard stops).

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run test` — 519/519 pass
- [x] `npm run build` — succeeds
- [ ] Manual `/`: hero panel auto-cycles 6 moods, mood chips work on desktop, mobile order is headline → panel → CTA
- [ ] Manual `/`: TopNav "How it works" scrolls to the new section
- [ ] Manual `/`: FAQ shows the two new questions in slots 3 and 6
- [ ] Manual `/`: Final CTA renders "Stop scrolling. / Start watching." with subhead + 47-second micro
- [ ] Manual `/v2`: still renders identically (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)