### PR TITLE
feat(home-v2): mount Briefing-style homepage at /home-v2

### DIFF
--- a/src/app/home-v2/HomeV2.jsx
+++ b/src/app/home-v2/HomeV2.jsx
@@ -1,0 +1,124 @@
+// FeelFlick — Home v2 (Briefing edition).
+// Mounted at /home-v2 for parallel comparison against /home.
+import { useCallback, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AnimatePresence } from 'framer-motion';
+
+import { useAuthSession } from '@/shared/hooks/useAuthSession';
+import ToastNotification from '@/components/ToastNotification';
+
+import { FILMS, HP, MOODS, USER as USER_FALLBACK } from './data';
+import { HPNav } from './atoms';
+import { BriefMasthead, MoodReactor, TheBriefing } from './sections-top';
+import {
+  ContinueWatching, CinematicDNA, RecentlyLogged,
+  TasteMatch, CuratedLists, QuickLog,
+} from './sections-bottom';
+import './home-v2.css';
+
+const TOAST_TIMEOUT_MS = 4500;
+
+export default function HomeV2() {
+  const navigate = useNavigate();
+  const { user: authUser } = useAuthSession();
+  const [currentMood, setMood] = useState(MOODS[0]);
+  const [shuffleSeed, setShuffleSeed] = useState(0);
+  const [toast, setToast] = useState(null);
+
+  // Derive a USER object from the live auth session, falling back to the
+  // prototype default if the session hasn't loaded yet.
+  const user = useMemo(() => {
+    if (!authUser) return USER_FALLBACK;
+    const meta = authUser.user_metadata || {};
+    const name = meta.name?.split(' ')[0] || meta.first_name || authUser.email?.split('@')[0] || USER_FALLBACK.name;
+    return { name, watched: USER_FALLBACK.watched };
+  }, [authUser]);
+
+  const showToast = useCallback((message, subtext, opts = {}) => {
+    setToast({ message, subtext, ...opts });
+  }, []);
+
+  // === Handlers wired through the page ===
+  const goToFilm = useCallback((filmKey) => {
+    const film = FILMS[filmKey];
+    if (film?.tmdbId) navigate(`/movie/${film.tmdbId}`);
+  }, [navigate]);
+
+  const onWatch = useCallback((filmKey) => goToFilm(filmKey), [goToFilm]);
+  const onResume = useCallback((filmKey) => goToFilm(filmKey), [goToFilm]);
+  const onCardClick = useCallback((filmKey) => goToFilm(filmKey), [goToFilm]);
+
+  const onSave = useCallback((filmKey) => {
+    const film = FILMS[filmKey];
+    showToast(`Saved ${film?.title ?? 'film'} to your watchlist.`, 'Open watchlist', {
+      ctaLabel: 'View watchlist',
+      ctaHref: '/watchlist',
+    });
+  }, [showToast]);
+
+  const onSkip = useCallback((filmKey) => {
+    const film = FILMS[filmKey];
+    showToast(`Skipped ${film?.title ?? 'film'}.`, "We'll learn from this for tomorrow.");
+  }, [showToast]);
+
+  const onReshuffle = useCallback(() => {
+    setShuffleSeed((s) => s + 1);
+    showToast('Briefing reshuffled.', 'Same mood, new order.');
+  }, [showToast]);
+
+  const onLog = useCallback((query) => {
+    const trimmed = (query || '').trim();
+    navigate(trimmed ? `/discover?q=${encodeURIComponent(trimmed)}` : '/discover');
+  }, [navigate]);
+
+  const onOpenList = useCallback((slug) => {
+    navigate(slug ? `/lists/curated/${slug}` : '/lists/curated');
+  }, [navigate]);
+
+  const onOpenFriends = useCallback(() => navigate('/people'), [navigate]);
+  const onOpenAccount = useCallback(() => navigate('/account'), [navigate]);
+
+  return (
+    <div className="ff-home-v2" style={{ minHeight: '100vh', background: HP.bg, color: HP.text, position: 'relative', overflowX: 'hidden' }}>
+      {/* Mood-tuned ambient gradient — reactive */}
+      <div aria-hidden style={{
+        position: 'fixed', inset: 0, pointerEvents: 'none', zIndex: 0,
+        background: `radial-gradient(ellipse 80% 50% at 15% 0%, ${currentMood.hex}1f 0%, transparent 55%), radial-gradient(ellipse 60% 40% at 85% 100%, ${currentMood.hex}14 0%, transparent 50%)`,
+        transition: 'background 0.6s ease',
+      }} />
+      <div style={{ position: 'relative', zIndex: 1 }}>
+        <HPNav user={user} onAvatarClick={onOpenAccount} />
+        <BriefMasthead user={user} currentMood={currentMood} />
+        <MoodReactor currentMood={currentMood} setMood={setMood} />
+        <TheBriefing
+          currentMood={currentMood}
+          shuffleSeed={shuffleSeed}
+          onWatch={onWatch}
+          onSave={onSave}
+          onSkip={onSkip}
+          onReshuffle={onReshuffle}
+        />
+        <ContinueWatching onResume={onResume} />
+        <CinematicDNA />
+        <RecentlyLogged onCardClick={onCardClick} />
+        <TasteMatch onOpenFriends={onOpenFriends} />
+        <CuratedLists onOpenList={onOpenList} />
+        <QuickLog onLog={onLog} />
+      </div>
+
+      <AnimatePresence>
+        {toast && (
+          <ToastNotification
+            key={`${toast.message}-${toast.subtext ?? ''}`}
+            message={toast.message}
+            subtext={toast.subtext}
+            ctaLabel={toast.ctaLabel}
+            ctaHref={toast.ctaHref}
+            duration={TOAST_TIMEOUT_MS}
+            onDismiss={() => setToast(null)}
+          />
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/app/home-v2/atoms.jsx
+++ b/src/app/home-v2/atoms.jsx
@@ -1,0 +1,139 @@
+// FeelFlick — Home v2 atoms / primitives.
+import { useState } from 'react';
+import { NavLink, useNavigate } from 'react-router-dom';
+import { FILMS, POSTER, HP, HP_GRAD, gradFor } from './data';
+
+export function FFMark({ size = 28 }) {
+  return (
+    <div style={{
+      width: size, height: size, borderRadius: size * 0.22,
+      display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+      background: HP_GRAD, color: '#fff',
+      fontFamily: 'Outfit, Inter, sans-serif', fontWeight: 700, fontSize: size * 0.5,
+      letterSpacing: '-0.02em',
+      boxShadow: '0 4px 18px -2px rgba(167,139,250,0.5)',
+    }}>FF</div>
+  );
+}
+
+const NAV_LINKS = [
+  { label: 'Home',      to: '/home-v2' },
+  { label: 'Discover',  to: '/discover' },
+  { label: 'Watchlist', to: '/watchlist' },
+  { label: 'Diary',     to: '/watched' },
+];
+
+export function HPNav({ user, onAvatarClick }) {
+  const navigate = useNavigate();
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+      padding: '14px 28px',
+      borderBottom: `1px solid ${HP.border}`,
+      position: 'relative', zIndex: 5,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 32 }}>
+        <NavLink to="/home-v2" style={{ display: 'flex', alignItems: 'center', gap: 10, textDecoration: 'none' }}>
+          <FFMark size={28} />
+          <span style={{ fontFamily: 'Outfit, sans-serif', fontWeight: 600, fontSize: 17, letterSpacing: '-0.01em', color: HP.text }}>FeelFlick</span>
+        </NavLink>
+        <nav style={{ display: 'flex', gap: 22 }}>
+          {NAV_LINKS.map((l) => (
+            <NavLink
+              key={l.label}
+              to={l.to}
+              end
+              style={({ isActive }) => ({
+                fontSize: 13, fontWeight: isActive ? 600 : 500,
+                color: isActive ? HP.text : HP.textSoft,
+                borderBottom: isActive ? `2px solid ${HP.purple}` : '2px solid transparent',
+                paddingBottom: 4,
+                textDecoration: 'none',
+                transition: 'color 0.2s ease',
+              })}
+            >
+              {l.label}
+            </NavLink>
+          ))}
+        </nav>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+        <button
+          type="button"
+          onClick={() => navigate('/discover')}
+          aria-label="Search films and moods"
+          style={{
+            display: 'flex', alignItems: 'center', gap: 8,
+            padding: '6px 12px', borderRadius: 999,
+            background: 'rgba(255,255,255,0.04)', border: `1px solid ${HP.border}`,
+            fontSize: 12, color: HP.textSoft, fontFamily: 'inherit',
+            cursor: 'pointer',
+          }}
+        >
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none"><circle cx="11" cy="11" r="7" stroke="currentColor" strokeWidth="2"/><path d="m20 20-3-3" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/></svg>
+          <span>Search films, moods…</span>
+          <span style={{ fontSize: 10, padding: '2px 6px', borderRadius: 4, background: 'rgba(255,255,255,0.06)', color: HP.textMuted, marginLeft: 8 }}>⌘K</span>
+        </button>
+        <button
+          type="button"
+          onClick={onAvatarClick}
+          aria-label="Open account"
+          style={{
+            width: 32, height: 32, borderRadius: 999, background: HP_GRAD,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontSize: 13, fontWeight: 700, color: '#fff', fontFamily: 'Outfit',
+            border: 'none', cursor: 'pointer', padding: 0,
+          }}
+        >
+          {user.name.charAt(0)}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function SmartImg({ filmKey, alt, style, big = false }) {
+  const [failed, setFailed] = useState(false);
+  const f = FILMS[filmKey];
+  if (failed) {
+    const [a, b] = gradFor(filmKey);
+    return (
+      <div style={{ ...style, display:'flex', alignItems:'flex-end', padding: big?28:14, background:`linear-gradient(135deg, ${a} 0%, ${b} 100%)`, position:'relative', overflow:'hidden' }}>
+        <div style={{ position:'absolute', inset:0, background:'radial-gradient(circle at 30% 20%, rgba(255,255,255,0.16), transparent 50%), radial-gradient(circle at 80% 90%, rgba(0,0,0,0.4), transparent 60%)' }} />
+        <div style={{ position:'relative', zIndex:2 }}>
+          <div style={{ fontFamily:'Outfit', fontWeight:700, fontSize: big?42:18, lineHeight:1, letterSpacing:'-0.02em', color:'#fff', textShadow:'0 2px 12px rgba(0,0,0,0.3)' }}>{f.title}</div>
+          <div style={{ fontSize: big?13:10, color:'rgba(255,255,255,0.75)', marginTop: big?8:4, fontFamily:'Outfit', letterSpacing:'0.04em' }}>{f.year}</div>
+        </div>
+      </div>
+    );
+  }
+  return <img src={POSTER(filmKey)} alt={alt || f.title} style={style} onError={() => setFailed(true)} loading="lazy" />;
+}
+
+export function Stars({ value, size = 12 }) {
+  return (
+    <div style={{ display:'inline-flex', gap: 2 }}>
+      {[0,1,2,3,4].map(i => (
+        <svg key={i} width={size} height={size} viewBox="0 0 24 24" fill={i<value?HP.amber:'transparent'} stroke={i<value?HP.amber:HP.textFaint} strokeWidth="2">
+          <path d="M12 2l3 7 7 1-5 5 1 7-6-3-6 3 1-7-5-5 7-1z"/>
+        </svg>
+      ))}
+    </div>
+  );
+}
+
+export function MoodBG({ tint = 'purple', intensity = 0.5 }) {
+  const tints = {
+    purple:['#3b1d6e','#1a0d3a'], pink:['#6e1d4d','#3a0d1f'],
+    amber:['#6e4d1d','#3a2d0d'],  indigo:['#1d2c6e','#0d1a3a'],
+  };
+  const [c1, c2] = tints[tint] || tints.purple;
+  const a1 = Math.round(intensity * 95).toString(16).padStart(2,'0');
+  const a2 = Math.round(intensity * 75).toString(16).padStart(2,'0');
+  return (
+    <>
+      <div style={{ position:'absolute', inset:0, pointerEvents:'none', background:`radial-gradient(ellipse 90% 50% at 20% 0%, ${c1}${a1} 0%, transparent 60%)`, transition:'background 0.6s ease' }} />
+      <div style={{ position:'absolute', inset:0, pointerEvents:'none', background:`radial-gradient(ellipse 70% 40% at 90% 100%, ${c2}${a2} 0%, transparent 55%)`, transition:'background 0.6s ease' }} />
+    </>
+  );
+}

--- a/src/app/home-v2/data.js
+++ b/src/app/home-v2/data.js
@@ -1,0 +1,103 @@
+// FeelFlick — Home v2 data layer.
+// Production-leaning shape; swap with real API/Supabase later.
+
+const TMDB = (path, size = 'w500') => `https://image.tmdb.org/t/p/${size}${path}`;
+
+// Real TMDB ids + canonical poster paths (matched against Supabase movies table).
+// `tmdbId` powers /movie/:id navigation from this page. `id` is a stable local key.
+export const FILMS = {
+  parasite:       { id: 1,  tmdbId: 496243, title: 'Parasite',                year: 2019, runtime: 132, director: 'Bong Joon-ho',         poster: '/7IiTTgloJzvGI1TAYymCfbfl3vT.jpg' },
+  past_lives:     { id: 2,  tmdbId: 666277, title: 'Past Lives',              year: 2023, runtime: 105, director: 'Celine Song',          poster: '/k3waqVXSnvCZWfJYNtdamTgTtTA.jpg' },
+  drive:          { id: 3,  tmdbId:  64690, title: 'Drive',                   year: 2011, runtime: 100, director: 'Nicolas Winding Refn', poster: '/602vevIURmpDfzbnv5Ubi6wIkQm.jpg' },
+  arrival:        { id: 4,  tmdbId: 329865, title: 'Arrival',                 year: 2016, runtime: 116, director: 'Denis Villeneuve',     poster: '/pEzNVQfdzYDzVK0XqxERIw2x2se.jpg' },
+  paddington:     { id: 5,  tmdbId: 346648, title: 'Paddington 2',            year: 2017, runtime: 103, director: 'Paul King',            poster: '/1OJ9vkD5xPt3skC6KguyXAgagRZ.jpg' },
+  her:            { id: 6,  tmdbId: 152601, title: 'Her',                     year: 2013, runtime: 126, director: 'Spike Jonze',          poster: '/eCOtqtfvn7mxGl6nfmq4b1exJRc.jpg' },
+  whiplash:       { id: 7,  tmdbId: 244786, title: 'Whiplash',                year: 2014, runtime: 106, director: 'Damien Chazelle',      poster: '/7fn624j5lj3xTme2SgiLCeuedmO.jpg' },
+  the_handmaiden: { id: 8,  tmdbId: 290098, title: 'The Handmaiden',          year: 2016, runtime: 145, director: 'Park Chan-wook',       poster: '/dLlH4aNHdnmf62umnInL8xPlPzw.jpg' },
+  before_sunrise: { id: 9,  tmdbId:     76, title: 'Before Sunrise',          year: 1995, runtime: 101, director: 'Richard Linklater',    poster: '/kf1Jb1c2JAOqjuzA3H4oDM263uB.jpg' },
+  spirited:       { id: 10, tmdbId:    129, title: 'Spirited Away',           year: 2001, runtime: 125, director: 'Hayao Miyazaki',       poster: '/39wmItIWsg5sZMyRUHLkWBcuVCM.jpg' },
+  oldboy:         { id: 11, tmdbId:    670, title: 'Oldboy',                  year: 2003, runtime: 120, director: 'Park Chan-wook',       poster: '/pWDtjs568ZfOTMbURQBYuT4Qxka.jpg' },
+  amelie:         { id: 12, tmdbId:    194, title: 'Amélie',                  year: 2001, runtime: 122, director: 'Jean-Pierre Jeunet',   poster: '/nSxDa3M9aMvGVLoItzWTepQ5h5d.jpg' },
+  call_me:        { id: 13, tmdbId: 398818, title: 'Call Me By Your Name',    year: 2017, runtime: 132, director: 'Luca Guadagnino',      poster: '/mZ4gBdfkhP9tvLH1DO4m4HYtiyi.jpg' },
+  blade_2049:     { id: 14, tmdbId: 335984, title: 'Blade Runner 2049',       year: 2017, runtime: 164, director: 'Denis Villeneuve',     poster: '/gajva2L0rPYkEWjzgFlBXCAVBE5.jpg' },
+  moonlight:      { id: 15, tmdbId: 376867, title: 'Moonlight',               year: 2016, runtime: 111, director: 'Barry Jenkins',        poster: '/qLnfEmPrDjJfPyyddLJPkXmshkp.jpg' },
+  in_bruges:      { id: 16, tmdbId:   8321, title: 'In Bruges',               year: 2008, runtime: 107, director: 'Martin McDonagh',      poster: '/vz3Vd6nfq9YZrVvyYx5RHFaYKV3.jpg' },
+};
+export const POSTER = (key) => TMDB(FILMS[key].poster);
+
+export const HP = {
+  bg:'#000000', bgDeep:'#06060a',
+  panel:'rgba(255,255,255,0.04)',
+  border:'rgba(255,255,255,0.08)', borderStrong:'rgba(255,255,255,0.14)',
+  text:'#FAFAFA', textSoft:'rgba(250,250,250,0.72)', textMuted:'rgba(250,250,250,0.45)', textFaint:'rgba(250,250,250,0.28)',
+  purple:'#A78BFA', purpleDeep:'#7C3AED', pink:'#EC4899', amber:'#F59E0B',
+};
+export const HP_GRAD = 'linear-gradient(135deg, #A78BFA 0%, #EC4899 100%)';
+
+export const USER = { name:'Aditya', watched: 7 };
+
+export const MOODS = [
+  { id:'tender',     label:'Tender',     hex:'#F59FA8', tint:'pink',
+    pool:['past_lives','her','before_sunrise','moonlight','call_me'],
+    rationale:{ past_lives:'Two-handers, slow-burning, often bittersweet — your three deepest signals.', her:"Closest to Past Lives in the catalog. You haven't logged Spike Jonze yet.", before_sunrise:'Pure two-hander. The Linklater foundation for everything tender.', moonlight:"Quiet endings — a motif you've returned to four times.", call_me:'Sun-drenched, aching. Your aesthetic in summer.' } },
+  { id:'thrilled',   label:'Thrilled',   hex:'#EF4444', tint:'pink',
+    pool:['parasite','oldboy','whiplash','drive','the_handmaiden'],
+    rationale:{ parasite:'Tense, surprising, beautifully built — your highest-rated thriller.', oldboy:'Park Chan-wook again. You loved The Handmaiden.', whiplash:'Intense, driven. 106 minutes of held breath.', drive:'Slow-burn, cool. A different kind of thrill.', the_handmaiden:'Sumptuous, twisty. Your kind of trap.' } },
+  { id:'curious',    label:'Curious',    hex:'#A78BFA', tint:'purple',
+    pool:['arrival','blade_2049','her','parasite','spirited'],
+    rationale:{ arrival:'Contemplative sci-fi. Big idea, quiet pace.', blade_2049:'Vast, lonely. 164 patient minutes.', her:"Sci-fi that's really about loneliness.", parasite:'Class tension is one of your recurring motifs.', spirited:'Magical, gentle. Curiosity in pure form.' } },
+  { id:'cozy',       label:'Cozy',       hex:'#FBBF24', tint:'amber',
+    pool:['paddington','amelie','spirited','before_sunrise','her'],
+    rationale:{ paddington:'When in doubt, choose kindness. Universally beloved.', amelie:'Whimsical, bright. Joy, concentrated.', spirited:'No bad mood survives Miyazaki.', before_sunrise:'Two people, one night, talking. Cozy in disguise.', her:'Soft melancholy. The cozy edge of sad.' } },
+  { id:'melancholy', label:'Melancholy', hex:'#7DD3FC', tint:'indigo',
+    pool:['past_lives','her','moonlight','call_me','blade_2049'],
+    rationale:{ past_lives:'A love letter to roads not taken.', her:'Melancholy, soft. Loneliness rendered tender.', moonlight:'Three chapters, three silences.', call_me:'Sun-drenched ache. The ending alone.', blade_2049:'Lonely as architecture. Vast, patient, cold.' } },
+  { id:'witty',      label:'Witty',      hex:'#34D399', tint:'purple',
+    pool:['in_bruges','parasite','amelie','oldboy','paddington'],
+    rationale:{ in_bruges:'Dark, funny. Pure McDonagh.', parasite:"The funniest thriller you've seen.", amelie:'Wit as warmth. French and pointed.', oldboy:'Twisted comedy of cruelty.', paddington:'Sweetly arch. Hugh Grant alone is worth it.' } },
+];
+
+export const SLOT_LABELS = {
+  tender:["Tonight's pick","Mood match","From your DNA"],
+  thrilled:["Tonight's pick","Highest signal","Director match"],
+  curious:["Tonight's pick","Slow-thinking","From your DNA"],
+  cozy:["A soft choice","Pure comfort","Quietly funny"],
+  melancholy:["Tonight's pick","Earns its silence","Beautifully sad"],
+  witty:["Tonight's pick","Sharp & quick","From your DNA"],
+};
+
+export const CONTINUE = { film:'blade_2049', progress:0.42, timeLeft:'1h 35m left', lastWatched:'Tuesday' };
+export const RECENT = [
+  { key:'parasite',   rating:5, when:'2 days ago',  note:'Held my breath the whole second act.' },
+  { key:'spirited',   rating:4, when:'last Friday', note:null },
+  { key:'paddington', rating:5, when:'last week',   note:'Healed something.' },
+  { key:'whiplash',   rating:4, when:'last week',   note:null },
+];
+export const DNA = {
+  progress:0.23, filmsLogged:7, filmsToNext:3,
+  topMoods:[{label:'Tender',weight:0.84},{label:'Slow-burn',weight:0.71},{label:'Curious',weight:0.52}],
+  directors:['Bong Joon-ho','Patterns forming…'],
+  runtime:{value:'108',unit:'min',note:'shorter than average'},
+  motifs:['Quiet endings','Class tension','Two-handers'],
+};
+export const FRIENDS = [
+  { name:'Marco', match:87, avatarBg:'#A78BFA', last:'Past Lives', lastWhen:'2d', overlap:'Both loved Parasite, Whiplash' },
+  { name:'Priya', match:79, avatarBg:'#F59FA8', last:'Whiplash',   lastWhen:'5d', overlap:'Both loved Spirited Away' },
+  { name:'Theo',  match:64, avatarBg:'#7DD3FC', last:'Drive',      lastWhen:'1w', overlap:'Crime/thriller overlap' },
+];
+export const LISTS = [
+  { id:'silences',         title:'Films that earn their silences',  count:6, cover:'past_lives',     blurb:'When dialogue stops, meaning begins.', palette:['#7C3AED','#1e1b4b'] },
+  { id:'bad-days',         title:'For when the day was a lot',      count:5, cover:'paddington',     blurb:"Soft, kind, no surprises you don't want.", palette:['#F59E0B','#451a03'] },
+  { id:'romance-skeptics', title:'Romance for skeptics',            count:7, cover:'before_sunrise', blurb:'Talky, tender, never saccharine.',     palette:['#EC4899','#831843'] },
+  { id:'made-you-think',   title:"You'll think about for a week",   count:8, cover:'arrival',        blurb:'Big ideas with patience to match.',     palette:['#06B6D4','#164e63'] },
+];
+export const META = { issueNum:'012', volume:'I', edition:`For ${USER.name}` };
+
+// Deterministic poster fallback gradient
+const FILM_GRADIENTS = [
+  ['#7C3AED','#1e1b4b'],['#EC4899','#831843'],['#F59E0B','#451a03'],['#10B981','#064e3b'],
+  ['#3B82F6','#1e3a8a'],['#EF4444','#7f1d1d'],['#A78BFA','#312e81'],['#06B6D4','#164e63'],
+  ['#F472B6','#500724'],['#FBBF24','#78350f'],['#34D399','#14532d'],['#60A5FA','#172554'],
+  ['#C084FC','#581c87'],['#FB923C','#7c2d12'],['#A3E635','#365314'],['#F87171','#7f1d1d'],
+];
+export const gradFor = (key) => FILM_GRADIENTS[(FILMS[key]?.id ?? 0) % FILM_GRADIENTS.length];

--- a/src/app/home-v2/home-v2.css
+++ b/src/app/home-v2/home-v2.css
@@ -1,0 +1,10 @@
+/* FeelFlick — Home v2 scoped styles.
+   Outfit display font, Inter for body. Scoped to .ff-home-v2 to avoid touching the rest of the app. */
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@200;300;400;500;600;700&family=Inter:wght@400;500;600&display=swap');
+
+.ff-home-v2 {
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+.ff-home-v2 ::selection { background: rgba(167,139,250,0.35); color: #fff; }

--- a/src/app/home-v2/sections-bottom.jsx
+++ b/src/app/home-v2/sections-bottom.jsx
@@ -1,0 +1,226 @@
+// Home v2 — bottom sections, wired against data.js exports + handlers from HomeV2.
+import { useState } from 'react';
+import { FILMS, HP, RECENT, CONTINUE, DNA, FRIENDS, LISTS } from './data';
+import { SmartImg, Stars } from './atoms';
+
+const Heading = ({ kicker, title, sub }) => (
+  <header style={{ marginBottom: 36 }}>
+    <div style={{ fontSize: 10, fontWeight: 700, letterSpacing:'0.24em', textTransform:'uppercase', color: HP.purple, marginBottom: 14, display:'inline-flex', alignItems:'center', gap: 10 }}>
+      <span style={{ height: 1, width: 22, background: HP.purple, opacity: 0.6 }} />{kicker}
+    </div>
+    <h2 style={{ fontFamily:'Outfit, Inter, sans-serif', fontSize: 44, lineHeight: 1.0, fontWeight: 500, letterSpacing:'-0.035em', color: HP.text, margin: 0, textWrap:'balance' }}>{title}</h2>
+    {sub && <p style={{ marginTop: 14, fontSize: 14, color: HP.textMuted, maxWidth: 540, fontFamily:'Outfit, Inter, sans-serif', textWrap:'pretty' }}>{sub}</p>}
+  </header>
+);
+
+export function ContinueWatching({ onResume }) {
+  const f = FILMS[CONTINUE.film];
+  return (
+    <section style={{ padding:'56px 88px', borderTop:`1px solid ${HP.border}` }}>
+      <Heading kicker="In Progress" title="Pick up where you paused." />
+      <button
+        type="button"
+        onClick={() => onResume?.(CONTINUE.film)}
+        onMouseEnter={(e)=>e.currentTarget.style.borderColor=HP.purple+'66'} onMouseLeave={(e)=>e.currentTarget.style.borderColor=HP.border}
+        style={{
+          display:'flex', gap: 24, padding: 20, border:`1px solid ${HP.border}`, borderRadius: 6,
+          background:'rgba(255,255,255,0.012)', maxWidth: 720, cursor:'pointer',
+          transition:'border-color 0.3s ease', textAlign: 'left', width: '100%', fontFamily: 'inherit', color: 'inherit',
+        }}
+      >
+        <SmartImg filmKey={CONTINUE.film} style={{ width: 84, height: 126, objectFit:'cover', borderRadius: 4, flex:'none' }} />
+        <div style={{ display:'flex', flexDirection:'column', justifyContent:'space-between', flex: 1, minWidth: 0 }}>
+          <div>
+            <div style={{ fontFamily:'Outfit', fontSize: 19, fontWeight: 500, color: HP.text, letterSpacing:'-0.015em' }}>{f.title}</div>
+            <div style={{ fontSize: 12, color: HP.textMuted, marginTop: 4, fontFamily:'Outfit', letterSpacing:'0.04em' }}>{CONTINUE.timeLeft} · last watched {CONTINUE.lastWatched}</div>
+          </div>
+          <div>
+            <div style={{ height: 2, background: HP.border, borderRadius: 999, overflow:'hidden', marginBottom: 8 }}>
+              <div style={{ height:'100%', width:`${CONTINUE.progress*100}%`, background: HP.purple, borderRadius: 999 }} />
+            </div>
+            <div style={{ fontSize: 10, color: HP.textFaint, fontFamily:'Outfit', letterSpacing:'0.06em', textTransform:'uppercase' }}>{Math.round(CONTINUE.progress*100)}% watched</div>
+          </div>
+        </div>
+        <span style={{ alignSelf:'center', padding:'10px 18px', borderRadius: 4, background: HP.purple, color:'#0A0510', border:'none', fontFamily:'Outfit', fontWeight: 600, fontSize: 12, letterSpacing:'0.04em', cursor:'pointer' }}>Resume →</span>
+      </button>
+    </section>
+  );
+}
+
+export function CinematicDNA() {
+  return (
+    <section style={{ padding:'72px 88px', borderTop:`1px solid ${HP.border}`, background:'rgba(255,255,255,0.008)' }}>
+      <Heading kicker="Cinematic DNA" title="Your taste, taking shape." sub={`A portrait of what you’re drawn to. ${DNA.filmsToNext} more films and your DNA fully tunes.`} />
+      <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap: 64 }}>
+        <div>
+          <div style={{ display:'flex', alignItems:'baseline', justifyContent:'space-between', marginBottom: 24 }}>
+            <div style={{ fontSize: 11, color: HP.textMuted, fontFamily:'Outfit', letterSpacing:'0.12em', textTransform:'uppercase' }}>Confidence</div>
+            <div style={{ fontFamily:'Outfit', fontSize: 56, fontWeight: 200, color: HP.text, letterSpacing:'-0.04em' }}>{Math.round(DNA.progress*100)}<span style={{ fontSize: 24, color: HP.textMuted }}>%</span></div>
+          </div>
+          <div style={{ height: 2, background: HP.border, borderRadius: 999, overflow:'hidden', marginBottom: 28 }}>
+            <div style={{ height:'100%', width:`${DNA.progress*100}%`, background:`linear-gradient(90deg, ${HP.purple}, ${HP.pink})` }} />
+          </div>
+          <div style={{ fontSize: 12, color: HP.textSoft, fontFamily:'Outfit', fontStyle:'italic', marginBottom: 28 }}>{DNA.filmsLogged} films logged · taking shape.</div>
+          <div style={{ fontSize: 11, color: HP.textMuted, fontFamily:'Outfit', letterSpacing:'0.12em', textTransform:'uppercase', marginBottom: 12 }}>Motifs forming</div>
+          <div style={{ display:'flex', flexWrap:'wrap', gap: 8 }}>
+            {DNA.motifs.map(m => (
+              <span key={m} style={{ padding:'6px 12px', borderRadius: 4, background:'rgba(167,139,250,0.06)', border:`1px solid ${HP.purple}33`, fontSize: 12, color: HP.textSoft, fontFamily:'Outfit' }}>{m}</span>
+            ))}
+          </div>
+        </div>
+        <div>
+          <div style={{ fontSize: 11, color: HP.textMuted, fontFamily:'Outfit', letterSpacing:'0.12em', textTransform:'uppercase', marginBottom: 24 }}>Mood weights</div>
+          <div style={{ display:'flex', flexDirection:'column', gap: 18 }}>
+            {DNA.topMoods.map(m => (
+              <div key={m.label}>
+                <div style={{ display:'flex', justifyContent:'space-between', alignItems:'baseline', marginBottom: 6 }}>
+                  <div style={{ fontFamily:'Outfit', fontSize: 14, fontWeight: 500, color: HP.text }}>{m.label}</div>
+                  <div style={{ fontFamily:'Outfit', fontSize: 12, color: HP.textMuted, letterSpacing:'0.04em' }}>{Math.round(m.weight*100)}%</div>
+                </div>
+                <div style={{ height: 2, background: HP.border, borderRadius: 999, overflow:'hidden' }}>
+                  <div style={{ height:'100%', width:`${m.weight*100}%`, background: HP.purple, opacity: 0.6 + m.weight*0.4 }} />
+                </div>
+              </div>
+            ))}
+          </div>
+          <div style={{ marginTop: 32, fontSize: 11, color: HP.textMuted, fontFamily:'Outfit', letterSpacing:'0.12em', textTransform:'uppercase', marginBottom: 12 }}>Runtime preference</div>
+          <div style={{ display:'flex', alignItems:'baseline', gap: 8 }}>
+            <span style={{ fontFamily:'Outfit', fontSize: 36, fontWeight: 200, color: HP.text, letterSpacing:'-0.03em' }}>{DNA.runtime.value}</span>
+            <span style={{ fontSize: 12, color: HP.textMuted, fontFamily:'Outfit' }}>{DNA.runtime.unit} · {DNA.runtime.note}</span>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function RecentlyLogged({ onCardClick }) {
+  return (
+    <section style={{ padding:'72px 88px', borderTop:`1px solid ${HP.border}` }}>
+      <Heading kicker="Diary" title="Recently logged." />
+      <div style={{ display:'grid', gridTemplateColumns:'repeat(4,1fr)', gap: 32 }}>
+        {RECENT.map(l => (
+          <button
+            key={l.key}
+            type="button"
+            onClick={() => onCardClick?.(l.key)}
+            style={{
+              background: 'transparent', border: 'none', padding: 0, cursor: 'pointer',
+              textAlign: 'left', fontFamily: 'inherit', color: 'inherit',
+            }}
+          >
+            <SmartImg filmKey={l.key} style={{ width:'100%', aspectRatio:'2/3', objectFit:'cover', borderRadius: 4, marginBottom: 14 }} />
+            <div style={{ fontFamily:'Outfit', fontSize: 16, fontWeight: 500, color: HP.text, letterSpacing:'-0.015em' }}>{FILMS[l.key].title}</div>
+            <div style={{ display:'flex', alignItems:'center', gap: 10, marginTop: 6 }}>
+              <Stars value={l.rating} size={11} />
+              <div style={{ fontSize: 11, color: HP.textMuted, fontFamily:'Outfit' }}>{l.when}</div>
+            </div>
+            {l.note && <p style={{ fontSize: 13, color: HP.textSoft, marginTop: 10, fontFamily:'Outfit, Inter, sans-serif', fontStyle:'italic', lineHeight: 1.55, textWrap:'pretty' }}>“{l.note}”</p>}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function TasteMatch({ onOpenFriends }) {
+  return (
+    <section style={{ padding:'72px 88px', borderTop:`1px solid ${HP.border}`, background:'rgba(255,255,255,0.008)' }}>
+      <Heading kicker="Taste match" title="People who see what you see." sub="Friends with overlapping taste fingerprints — not just shared genres." />
+      <div style={{ display:'grid', gridTemplateColumns:'repeat(3,1fr)', gap: 24 }}>
+        {FRIENDS.map(fr => (
+          <button
+            key={fr.name}
+            type="button"
+            onClick={onOpenFriends}
+            style={{
+              padding: 28, border:`1px solid ${HP.border}`, borderRadius: 6, background:'rgba(255,255,255,0.02)',
+              cursor: 'pointer', textAlign: 'left', fontFamily: 'inherit', color: 'inherit', width: '100%',
+            }}
+          >
+            <div style={{ display:'flex', justifyContent:'space-between', alignItems:'flex-start', marginBottom: 22 }}>
+              <div style={{ width: 44, height: 44, borderRadius: 999, background: fr.avatarBg, display:'flex', alignItems:'center', justifyContent:'center', color: '#0A0510', fontFamily:'Outfit', fontWeight: 700, fontSize: 16 }}>{fr.name.charAt(0)}</div>
+              <div style={{ textAlign:'right' }}>
+                <div style={{ fontFamily:'Outfit', fontSize: 38, fontWeight: 200, color: HP.text, lineHeight: 1, letterSpacing:'-0.04em' }}>{fr.match}<span style={{ fontSize: 14, color: HP.textMuted, marginLeft: 2 }}>%</span></div>
+                <div style={{ fontSize: 9, color: HP.textMuted, fontFamily:'Outfit', letterSpacing:'0.14em', textTransform:'uppercase', marginTop: 2 }}>match</div>
+              </div>
+            </div>
+            <div style={{ fontFamily:'Outfit', fontSize: 17, fontWeight: 500, color: HP.text, marginBottom: 4 }}>{fr.name}</div>
+            <div style={{ fontSize: 12, color: HP.textMuted, fontFamily:'Outfit', marginBottom: 16, letterSpacing:'0.02em' }}>Watched {fr.last} · {fr.lastWhen} ago</div>
+            <p style={{ fontSize: 13, lineHeight: 1.55, color: HP.textSoft, fontFamily:'Outfit, Inter, sans-serif', fontStyle:'italic', margin: 0, textWrap:'pretty' }}>“{fr.overlap}.”</p>
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function CuratedLists({ onOpenList }) {
+  return (
+    <section style={{ padding:'72px 88px', borderTop:`1px solid ${HP.border}` }}>
+      <Heading kicker="Lists" title="Curated edits." sub="Hand-built collections, not algorithmic dumps." />
+      <div style={{ display:'grid', gridTemplateColumns:'repeat(4,1fr)', gap: 24 }}>
+        {LISTS.map(L => {
+          const [c1, c2] = L.palette;
+          return (
+            <button
+              key={L.id}
+              type="button"
+              onClick={() => onOpenList?.(L.id)}
+              style={{
+                cursor:'pointer', background: 'transparent', border: 'none', padding: 0,
+                textAlign: 'left', fontFamily: 'inherit', color: 'inherit',
+              }}
+            >
+              <div style={{ aspectRatio:'4/5', borderRadius: 6, background:`linear-gradient(135deg, ${c1}33, ${c2}11)`, border:`1px solid ${HP.border}`, position:'relative', overflow:'hidden', marginBottom: 14 }}>
+                <div style={{ position:'absolute', inset: 0, background:`radial-gradient(circle at 70% 30%, ${c1}55, transparent 60%)` }} />
+                <div style={{ position:'absolute', bottom: 16, left: 16, right: 16 }}>
+                  <div style={{ fontSize: 9, color: HP.text, fontFamily:'Outfit', letterSpacing:'0.18em', textTransform:'uppercase', opacity: 0.7, marginBottom: 6 }}>{L.count} films</div>
+                  <div style={{ fontFamily:'Outfit, Inter, sans-serif', fontSize: 19, fontWeight: 500, color: HP.text, lineHeight: 1.1, letterSpacing:'-0.02em', textWrap:'balance' }}>{L.title}</div>
+                </div>
+              </div>
+              <div style={{ fontSize: 12, color: HP.textMuted, fontFamily:'Outfit, Inter, sans-serif', textWrap:'pretty', lineHeight: 1.5 }}>{L.blurb}</div>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+export function QuickLog({ onLog }) {
+  const examples = ['Past Lives', 'Whiplash', 'The Handmaiden', 'Drive'];
+  const [query, setQuery] = useState('');
+  return (
+    <section style={{ padding:'72px 88px 96px', borderTop:`1px solid ${HP.border}`, background:'rgba(255,255,255,0.008)' }}>
+      <div style={{ maxWidth: 720 }}>
+        <Heading kicker="Feed the engine" title="Log a film you’ve seen." sub="Every film you log makes tomorrow’s briefing sharper." />
+        <form
+          onSubmit={(e) => { e.preventDefault(); onLog?.(query); }}
+          style={{ display:'flex', gap: 0, border:`1px solid ${HP.border}`, borderRadius: 8, background:'rgba(255,255,255,0.02)', padding: 4 }}
+        >
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search a film you watched recently…"
+            style={{ flex: 1, background:'transparent', border:'none', outline:'none', padding:'14px 16px', color: HP.text, fontFamily:'Outfit, Inter, sans-serif', fontSize: 15 }}
+          />
+          <button type="submit" style={{ padding:'10px 20px', borderRadius: 6, background: HP.purple, border:'none', color:'#0A0510', fontFamily:'Outfit', fontWeight: 600, fontSize: 13, letterSpacing:'0.02em', cursor:'pointer' }}>Log it →</button>
+        </form>
+        <div style={{ marginTop: 18, display:'flex', alignItems:'center', gap: 10, flexWrap:'wrap', fontSize: 11, color: HP.textMuted, fontFamily:'Outfit' }}>
+          <span style={{ letterSpacing:'0.08em', textTransform:'uppercase' }}>Try</span>
+          {examples.map(e => (
+            <button
+              key={e}
+              type="button"
+              onClick={() => onLog?.(e)}
+              style={{ padding:'5px 11px', borderRadius: 999, background:'transparent', border:`1px solid ${HP.border}`, color: HP.textSoft, fontFamily:'Outfit', fontSize: 12, cursor:'pointer' }}
+            >
+              {e}
+            </button>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/home-v2/sections-top.jsx
+++ b/src/app/home-v2/sections-top.jsx
@@ -1,0 +1,168 @@
+// Home v2 — top sections (Masthead, Mood Reactor, The Briefing 3-up).
+import { useMemo, useState } from 'react';
+import { FILMS, HP, MOODS, SLOT_LABELS, META } from './data';
+import { SmartImg } from './atoms';
+
+export function BriefMasthead({ user }) {
+  const today = new Date();
+  const days = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+  const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+  return (
+    <section style={{ padding:'72px 88px 40px', display:'grid', gridTemplateColumns:'1fr auto', alignItems:'flex-end', gap: 56, borderBottom:`1px solid ${HP.border}` }}>
+      <div>
+        <div style={{ display:'flex', alignItems:'center', gap: 14, marginBottom: 26 }}>
+          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing:'0.28em', textTransform:'uppercase', color: HP.purple }}>The Briefing</div>
+          <div style={{ flex:'none', height: 1, width: 36, background: HP.purple, opacity: 0.5 }} />
+          <div style={{ fontSize: 10, fontWeight: 500, letterSpacing:'0.18em', textTransform:'uppercase', color: HP.textMuted, fontFamily:'Outfit' }}>Issue {META.issueNum} · Vol. {META.volume} · For {user.name}</div>
+        </div>
+        <h1 style={{ fontFamily:'Outfit, Inter, sans-serif', fontSize: 104, lineHeight: 0.92, fontWeight: 600, letterSpacing:'-0.05em', color: HP.text, margin: 0, textWrap:'balance' }}>
+          Tonight’s <em style={{ fontStyle:'italic', fontWeight: 400, color: HP.textSoft }}>edit</em>.
+        </h1>
+        <div style={{ marginTop: 28, fontSize: 15, lineHeight: 1.65, color: HP.textSoft, maxWidth: 580, fontFamily:'Outfit, Inter, sans-serif' }}>
+          Three films, hand-picked from your taste signal. <em>Not a feed</em> — a short list. Pick one and the others rest until tomorrow.
+        </div>
+        <div style={{ marginTop: 32, display:'flex', alignItems:'center', gap: 24, fontSize: 11, color: HP.textMuted, fontFamily:'Outfit', letterSpacing:'0.04em' }}>
+          <span style={{ display:'inline-flex', alignItems:'center', gap: 8 }}>
+            <span style={{ width: 6, height: 6, borderRadius: 999, background:'#10B981', boxShadow:'0 0 8px #10B981' }} />
+            Refreshed 4:00am · next 4:00am
+          </span>
+          <span style={{ width: 1, height: 12, background: HP.border }} />
+          <span>Tuned to <span style={{ color: HP.text }}>your mood</span></span>
+          <span style={{ width: 1, height: 12, background: HP.border }} />
+          <span>{user.watched} films logged</span>
+        </div>
+      </div>
+      <div style={{ textAlign:'right', borderLeft:`1px solid ${HP.border}`, paddingLeft: 40 }}>
+        <div style={{ fontFamily:'Outfit', fontSize: 13, fontWeight: 500, color: HP.textMuted, letterSpacing:'0.12em', textTransform:'uppercase' }}>{days[today.getDay()]}</div>
+        <div style={{ fontFamily:'Outfit', fontSize: 96, fontWeight: 200, color: HP.text, lineHeight: 1, letterSpacing:'-0.05em', marginTop: 4 }}>{today.getDate()}</div>
+        <div style={{ fontFamily:'Outfit', fontSize: 13, fontWeight: 500, color: HP.textMuted, letterSpacing:'0.12em', textTransform:'uppercase', marginTop: 6 }}>{months[today.getMonth()]} · {today.getFullYear()}</div>
+      </div>
+    </section>
+  );
+}
+
+export function MoodReactor({ currentMood, setMood }) {
+  return (
+    <section style={{ padding:'28px 88px', display:'flex', alignItems:'center', gap: 24, borderBottom:`1px solid ${HP.border}`, background:'rgba(255,255,255,0.012)' }}>
+      <div style={{ display:'flex', alignItems:'baseline', gap: 12, flex:'none' }}>
+        <div style={{ fontSize: 10, fontWeight: 600, letterSpacing:'0.22em', textTransform:'uppercase', color: HP.textMuted }}>Tonight I feel</div>
+        <div style={{ fontFamily:'Outfit', fontSize: 22, fontWeight: 500, fontStyle:'italic', color: currentMood.hex, letterSpacing:'-0.015em', transition:'color 0.4s ease' }}>{currentMood.label.toLowerCase()}.</div>
+      </div>
+      <div style={{ flex: 1, display:'flex', gap: 8, justifyContent:'flex-end', flexWrap:'wrap' }}>
+        {MOODS.map(m => {
+          const active = m.id === currentMood.id;
+          return (
+            <button key={m.id} onClick={() => setMood(m)} style={{
+              display:'inline-flex', alignItems:'center', gap: 8,
+              padding:'8px 14px', borderRadius: 999,
+              background: active ? `${m.hex}22` : 'transparent',
+              border: `1px solid ${active ? m.hex : HP.border}`,
+              color: active ? HP.text : HP.textSoft,
+              fontFamily:'Outfit', fontSize: 12, fontWeight: 500,
+              letterSpacing:'-0.005em', cursor:'pointer', transition:'all 0.25s ease',
+            }}>
+              <span style={{ width: 7, height: 7, borderRadius: 999, background: m.hex, boxShadow: active ? `0 0 10px ${m.hex}` : 'none', transition:'box-shadow 0.25s ease' }} />
+              {m.label}
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function BriefingCard({ pick, idx, label, rationale, featured, onWatch, onSave, onSkip }) {
+  const f = FILMS[pick];
+  const [hover, setHover] = useState(false);
+  return (
+    <article onMouseEnter={() => setHover(true)} onMouseLeave={() => setHover(false)}
+      style={{ display:'flex', flexDirection:'column', gap: 22, transition:'transform 0.4s cubic-bezier(0.2,0.8,0.2,1)', transform: hover ? 'translateY(-4px)':'translateY(0)' }}>
+      <button
+        type="button"
+        onClick={() => onWatch?.(pick)}
+        aria-label={`Watch ${f.title}`}
+        style={{
+          position:'relative', borderRadius: 6, overflow:'hidden',
+          boxShadow: hover ? '0 24px 60px -16px rgba(0,0,0,0.8), 0 0 0 1px rgba(167,139,250,0.2)' : '0 16px 40px -12px rgba(0,0,0,0.6)',
+          transition:'box-shadow 0.4s ease',
+          background: 'transparent', border: 'none', padding: 0, cursor: 'pointer',
+        }}
+      >
+        <SmartImg filmKey={pick} big style={{ width:'100%', aspectRatio:'2/3', objectFit:'cover', display:'block' }} />
+        <div style={{ position:'absolute', top: 16, right: 16, padding:'5px 10px', borderRadius: 4, background:'rgba(0,0,0,0.55)', backdropFilter:'blur(10px)', fontSize: 9, fontWeight: 600, color: HP.textSoft, letterSpacing:'0.16em', textTransform:'uppercase', fontFamily:'Outfit' }}>0{idx + 1}</div>
+        <div style={{ position:'absolute', bottom: 16, left: 16, padding:'7px 12px', borderRadius: 4, background:'rgba(0,0,0,0.85)', backdropFilter:'blur(10px)', border:'1px solid rgba(167,139,250,0.4)', display:'inline-flex', alignItems:'center', gap: 8 }}>
+          <span style={{ width: 6, height: 6, borderRadius: 999, background: HP.purple, boxShadow:`0 0 8px ${HP.purple}` }} />
+          <span style={{ fontSize: 11, fontWeight: 700, color: HP.text, fontFamily:'Outfit', letterSpacing:'0.06em' }}>{75 + idx*-5 + (featured?18:8)}% MATCH</span>
+        </div>
+      </button>
+      <div>
+        <div style={{ fontSize: 10, fontWeight: 700, letterSpacing:'0.24em', textTransform:'uppercase', color: HP.purple, marginBottom: 14, display:'inline-flex', alignItems:'center', gap: 8 }}>
+          <span style={{ height: 1, width: 14, background: HP.purple, opacity: 0.7 }} />{label}
+        </div>
+        <h3 style={{ fontFamily:'Outfit, Inter, sans-serif', fontSize: featured?44:32, lineHeight: 0.98, fontWeight: 600, letterSpacing:'-0.03em', color: HP.text, margin:'0 0 14px 0', textWrap:'balance' }}>{f.title}</h3>
+        <div style={{ display:'flex', alignItems:'center', gap: 10, fontSize: 11, color: HP.textMuted, marginBottom: 18, fontFamily:'Outfit', letterSpacing:'0.06em', textTransform:'uppercase' }}>
+          <span>{f.year}</span><span style={{ width: 3, height: 3, borderRadius: 999, background: HP.textFaint }} />
+          <span>{f.runtime} min</span><span style={{ width: 3, height: 3, borderRadius: 999, background: HP.textFaint }} />
+          <span>{f.director}</span>
+        </div>
+        <p style={{ fontSize: 15, lineHeight: 1.6, color: HP.textSoft, margin:'0 0 22px 0', fontFamily:'Outfit, Inter, sans-serif', fontStyle:'italic', textWrap:'pretty' }}>“{rationale}”</p>
+        <div style={{ display:'flex', gap: 0, paddingTop: 18, borderTop:`1px solid ${HP.border}` }}>
+          <button type="button" onClick={() => onWatch?.(pick)} style={{ fontSize: 12, fontWeight: 600, color: HP.text, background:'transparent', border:'none', cursor:'pointer', padding:'4px 16px 4px 0', fontFamily:'Outfit', letterSpacing:'0.04em', display:'inline-flex', alignItems:'center', gap: 8, borderRight:`1px solid ${HP.border}` }}>
+            Watch <span style={{ fontSize: 14, lineHeight: 1, transform: hover?'translateX(2px)':'none', transition:'transform 0.3s ease' }}>→</span>
+          </button>
+          <button type="button" onClick={() => onSave?.(pick)} style={{ fontSize: 12, fontWeight: 500, color: HP.textMuted, background:'transparent', border:'none', cursor:'pointer', padding:'4px 16px', fontFamily:'Outfit', borderRight:`1px solid ${HP.border}` }}>Save</button>
+          <button type="button" onClick={() => onSkip?.(pick)} style={{ fontSize: 12, fontWeight: 500, color: HP.textMuted, background:'transparent', border:'none', cursor:'pointer', padding:'4px 16px', fontFamily:'Outfit' }}>Skip</button>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+// Tiny seeded shuffle so each Reshuffle click reorders deterministically.
+function shuffleByseed(arr, seed) {
+  if (!seed) return arr;
+  const out = arr.slice();
+  let s = seed * 9301 + 49297;
+  for (let i = out.length - 1; i > 0; i--) {
+    s = (s * 9301 + 49297) % 233280;
+    const j = Math.floor((s / 233280) * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+export function TheBriefing({ currentMood, shuffleSeed = 0, onWatch, onSave, onSkip, onReshuffle }) {
+  const picks = useMemo(
+    () => shuffleByseed(currentMood.pool, shuffleSeed).slice(0, 3),
+    [currentMood, shuffleSeed],
+  );
+  const labels = SLOT_LABELS[currentMood.id];
+  return (
+    <section style={{ padding:'64px 88px 80px' }}>
+      <div style={{ display:'grid', gridTemplateColumns:'1.05fr 1fr 1fr', gap: 56 }}>
+        {picks.map((key, i) => (
+          <BriefingCard
+            key={`${currentMood.id}-${key}-${shuffleSeed}`}
+            pick={key} idx={i} label={labels[i]} rationale={currentMood.rationale[key]} featured={i===0}
+            onWatch={onWatch} onSave={onSave} onSkip={onSkip}
+          />
+        ))}
+      </div>
+      <div style={{ marginTop: 40, paddingTop: 24, borderTop:`1px solid ${HP.border}`, display:'flex', alignItems:'center', justifyContent:'space-between', fontSize: 11, color: HP.textMuted, fontFamily:'Outfit', letterSpacing:'0.06em' }}>
+        <div style={{ display:'inline-flex', alignItems:'center', gap: 12 }}>
+          <span>Curated from <span style={{ color: HP.text }}>your taste signal</span></span>
+          <span style={{ width: 3, height: 3, borderRadius: 999, background: HP.textFaint }} />
+          <span>Tuned to <span style={{ color: currentMood.hex, transition:'color 0.4s ease' }}>{currentMood.label}</span></span>
+        </div>
+        <button
+          type="button"
+          onClick={onReshuffle}
+          style={{ background:'transparent', border:'none', cursor:'pointer', fontSize: 11, color: HP.textSoft, fontFamily:'Outfit', letterSpacing:'0.06em', textTransform:'uppercase', fontWeight: 600, display:'inline-flex', alignItems:'center', gap: 6 }}
+        >
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5"><path d="M3 12a9 9 0 1 0 18 0M3 12l3-3M3 12l3 3" strokeLinecap="round"/></svg>
+          Reshuffle
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/app/router.jsx
+++ b/src/app/router.jsx
@@ -18,6 +18,7 @@ const Landing = lazy(() => import('@/features/landing/Landing'))
 
 // App pages (with header/sidebar)
 const HomePage = lazy(() => import('@/app/homepage/HomePage'))
+const HomeV2 = lazy(() => import('@/app/home-v2/HomeV2'))
 const MoviesTab = lazy(() => import('@/app/pages/movies/MoviesTab'))
 const MovieDetail = lazy(() => import('@/app/pages/MovieDetail'))
 import ErrorBoundary from './ErrorBoundary'
@@ -350,6 +351,7 @@ export const router = sentryCreateBrowserRouter([
             errorElement: <ErrorBoundary />,
             children: [
               { path: 'home', element: <HomeRoute />, errorElement: <ErrorBoundary /> },
+              { path: 'home-v2', element: <LazyRoute Component={HomeV2} />, errorElement: <ErrorBoundary /> },
               { path: 'account', element: <LazyRoute Component={Account} />, errorElement: <ErrorBoundary /> },
               { path: 'preferences', element: <LazyRoute Component={Preferences} />, errorElement: <ErrorBoundary /> },
               { path: 'watchlist', element: <LazyRoute Component={Watchlist} />, errorElement: <ErrorBoundary /> },


### PR DESCRIPTION
## Summary

Mounts the v2 "daily edit" homepage prototype at `/home-v2`, in parallel with `/home`. Mood-reactive briefing of 3 hand-picked films + Continue Watching, Cinematic DNA, Recent Diary, Taste Match, Curated Lists, Quick Log.

Behind the existing auth gate + AppShell (signed-in users only).

### Phase 1 wire-up (this PR — every button does something real)
- **HPNav** → real `NavLink`s (`/home-v2`, `/discover`, `/watchlist`, `/watched`); search pill → `/discover`; avatar → `/account`
- **USER** pulled from `useAuthSession` (falls back to prototype default while loading)
- **TMDB ids** added to every FILM entry (matched against Supabase `movies` table) + canonical poster paths
- **BriefingCard**: Watch button + poster click → `/movie/:tmdbId` · Save → toast (`"Saved …"`) with CTA to `/watchlist` · Skip → toast (`"Skipped … we'll learn from this"`)
- **Reshuffle** → deterministic seed-based shuffle of the mood pool
- **Continue Watching Resume** → `/movie/:tmdbId`
- **Recently Logged** cards → `/movie/:tmdbId`
- **Taste Match** friends → `/people`
- **Curated Lists** tiles → `/lists/curated/:slug`
- **Quick Log** input + example chips → `/discover?q=…`

### Deferred to Phase 2
Real backend integrations per the README wire-up checklist:
- Save → real `addToWatchlist` (needs TMDB → internal-UUID lookup per click)
- Skip → real `submitRecommendationFeedback`
- `RECENT` → query `user_history`
- `DNA` → from `user_profiles_computed`
- `MOODS[].pool` + `rationale` → from recommendation engine
- Quick Log search → live TMDB search dropdown + `user_history` write
- Continue Watching service (doesn't currently exist)
- Friends taste-match service (doesn't currently exist)

### Bonus
Cleared 4 pre-existing lint warnings in the dropped-in source (unused `BACKDROP`, `HP_GRAD`, `USER`, `currentMood`).

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run test` — 519/519 pass
- [x] `npm run build` — succeeds
- [ ] Manual `/home-v2` (signed in): nav links navigate, mood pills change page, briefing cards click through to /movie/:id, Save/Skip show toast, Reshuffle reorders briefing, list tiles open `/lists/curated/:slug`
- [ ] `/home` still renders (untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)