### PR TITLE
chore(db): schedule nightly refresh_feelflick_stats() via pg_cron

### DIFF
--- a/supabase/migrations/20260519010200_schedule_feelflick_stats_cron.sql
+++ b/supabase/migrations/20260519010200_schedule_feelflick_stats_cron.sql
@@ -1,0 +1,30 @@
+-- 2026-05-19 — nightly cron for refresh_feelflick_stats()
+--
+-- Enables pg_cron (Supabase ships it but it's opt-in) and schedules the
+-- stats refresh once per day at 03:15 UTC. profile-v2's "How you skew"
+-- bars depend on these medians being fresh; we don't want them frozen
+-- the day after launch.
+--
+-- 03:15 UTC keeps the job in a quiet window for most user timezones
+-- (late evening EU, early morning Americas, mid-day APAC) — no overlap
+-- with the morning briefing refresh.
+
+CREATE EXTENSION IF NOT EXISTS pg_cron WITH SCHEMA extensions;
+
+GRANT USAGE ON SCHEMA cron TO postgres;
+
+-- Unschedule any prior job under the same name so the migration is
+-- safely re-runnable. cron.unschedule errors if the job doesn't exist,
+-- so wrap in a DO block.
+DO $$
+BEGIN
+  PERFORM cron.unschedule('refresh_feelflick_stats_nightly');
+EXCEPTION WHEN OTHERS THEN
+  NULL;  -- job didn't exist; that's fine
+END $$;
+
+SELECT cron.schedule(
+  'refresh_feelflick_stats_nightly',
+  '15 3 * * *',
+  $$SELECT public.refresh_feelflick_stats();$$
+);


### PR DESCRIPTION
## Summary
- Enables `pg_cron` and schedules `refresh_feelflick_stats()` at 03:15 UTC daily so profile-v2's "How you skew" medians don't go stale.
- Already applied to prod (cron job `refresh_feelflick_stats_nightly` is active, jobid 1). This commit syncs the migration file to git.

## Test plan
- [x] Migration applied to prod via MCP
- [x] `cron.job` shows the job active with `15 3 * * *`
- [ ] Next morning: verify `feelflick_stats.computed_at` updated (should land between 03:15–03:16 UTC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)