### PR TITLE
fix(edge): allow real prod origins in generate-taste-summary CORS

### DIFF
--- a/supabase/functions/generate-taste-summary/index.ts
+++ b/supabase/functions/generate-taste-summary/index.ts
@@ -2,7 +2,13 @@ import OpenAI from 'npm:openai@4'
 
 const openai = new OpenAI({ apiKey: Deno.env.get('OPENAI_API_KEY') })
 
-const rawOrigins = Deno.env.get('ALLOWED_ORIGINS') ?? 'https://feelflick.app'
+// Default CORS allowlist — overridden by the ALLOWED_ORIGINS env var if set.
+//   app.feelflick.com           — production app (Cloudflare Pages)
+//   feelflick.com / www.        — marketing apex
+//   feelflick-app.pages.dev     — canonical CF Pages preview
+//   localhost:5173              — Vite dev server
+const rawOrigins = Deno.env.get('ALLOWED_ORIGINS')
+  ?? 'https://app.feelflick.com,https://feelflick.com,https://www.feelflick.com,https://feelflick-app.pages.dev,http://localhost:5173'
 const ALLOWED_ORIGINS = rawOrigins.split(',').map((s) => s.trim())
 
 function corsHeaders(origin: string): Record<string, string> {


### PR DESCRIPTION
## Summary
Default `ALLOWED_ORIGINS` previously fell back to `https://feelflick.app` — an **unregistered domain**. The actual prod app is `app.feelflick.com` (Cloudflare Pages). This commit syncs the function source to git; the edge function has already been redeployed.

New default allowlist:
- `https://app.feelflick.com` — production app
- `https://feelflick.com` / `https://www.feelflick.com` — marketing apex
- `https://feelflick-app.pages.dev` — canonical CF Pages preview URL
- `http://localhost:5173` — Vite dev server

`ALLOWED_ORIGINS` env var still overrides the default when set in Supabase Functions secrets.

## Test plan
- [x] Edge function `generate-taste-summary` redeployed (now v15 ACTIVE)
- [ ] After Cloudflare Pages picks up this commit, hit `app.feelflick.com/profile` (signed in) → editorial regen call should succeed (currently it would have CORS-blocked from `feelflick.app`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)