### PR TITLE
fix(edge): align CORS defaults across all 3 edge functions

### DIFF
--- a/supabase/functions/ai-mood-context/index.ts
+++ b/supabase/functions/ai-mood-context/index.ts
@@ -2,7 +2,14 @@ import OpenAI from 'npm:openai@4'
 
 const openai = new OpenAI({ apiKey: Deno.env.get('OPENAI_API_KEY') })
 
-const rawOrigins = Deno.env.get('ALLOWED_ORIGINS') ?? 'https://feelflick.app'
+// Default CORS allowlist — overridden by the ALLOWED_ORIGINS env var if set.
+//   app.feelflick.com           — production app (Cloudflare Pages, current)
+//   feelflick.com / www.        — apex (used today for marketing; will host the app
+//                                 once the planned subdomain → apex migration lands)
+//   feelflick-app.pages.dev     — canonical CF Pages preview
+//   localhost:5173              — Vite dev server
+const rawOrigins = Deno.env.get('ALLOWED_ORIGINS')
+  ?? 'https://app.feelflick.com,https://feelflick.com,https://www.feelflick.com,https://feelflick-app.pages.dev,http://localhost:5173'
 const ALLOWED_ORIGINS = rawOrigins.split(',').map((s) => s.trim())
 
 function corsHeaders(origin: string): Record<string, string> {

--- a/supabase/functions/generate-reflection-prompt/index.ts
+++ b/supabase/functions/generate-reflection-prompt/index.ts
@@ -3,7 +3,14 @@ import { createClient } from 'npm:@supabase/supabase-js@2'
 
 const openai = new OpenAI({ apiKey: Deno.env.get('OPENAI_API_KEY') })
 
-const rawOrigins = Deno.env.get('ALLOWED_ORIGINS') ?? 'https://feelflick.app'
+// Default CORS allowlist — overridden by the ALLOWED_ORIGINS env var if set.
+//   app.feelflick.com           — production app (Cloudflare Pages, current)
+//   feelflick.com / www.        — apex (used today for marketing; will host the app
+//                                 once the planned subdomain → apex migration lands)
+//   feelflick-app.pages.dev     — canonical CF Pages preview
+//   localhost:5173              — Vite dev server
+const rawOrigins = Deno.env.get('ALLOWED_ORIGINS')
+  ?? 'https://app.feelflick.com,https://feelflick.com,https://www.feelflick.com,https://feelflick-app.pages.dev,http://localhost:5173'
 const ALLOWED_ORIGINS = rawOrigins.split(',').map((s) => s.trim())
 
 const FALLBACK_PROMPT = 'What stayed with you after the credits?'

--- a/supabase/functions/generate-taste-summary/index.ts
+++ b/supabase/functions/generate-taste-summary/index.ts
@@ -3,8 +3,9 @@ import OpenAI from 'npm:openai@4'
 const openai = new OpenAI({ apiKey: Deno.env.get('OPENAI_API_KEY') })
 
 // Default CORS allowlist — overridden by the ALLOWED_ORIGINS env var if set.
-//   app.feelflick.com           — production app (Cloudflare Pages)
-//   feelflick.com / www.        — marketing apex
+//   app.feelflick.com           — production app (Cloudflare Pages, current)
+//   feelflick.com / www.        — apex (used today for marketing; will host the app
+//                                 once the planned subdomain → apex migration lands)
 //   feelflick-app.pages.dev     — canonical CF Pages preview
 //   localhost:5173              — Vite dev server
 const rawOrigins = Deno.env.get('ALLOWED_ORIGINS')


### PR DESCRIPTION
## Summary
Two edge functions still fell back to `https://feelflick.app` (unregistered). Updates them to match the corrected allowlist that `generate-taste-summary` now uses, and refines the inline comment in all three so they document the same future-state plan (`feelflick.com` apex will host the app once the planned subdomain → apex migration lands).

## Deployed
- `ai-mood-context` → v12 ACTIVE
- `generate-reflection-prompt` → v9 ACTIVE
- `generate-taste-summary` → unchanged (v15) — comment-only diff here

🤖 Generated with [Claude Code](https://claude.com/claude-code)