### PR TITLE
feat(landing-v3): mount editorial v3 landing at /v3

### DIFF
--- a/src/app/router.jsx
+++ b/src/app/router.jsx
@@ -15,6 +15,7 @@ import AppShell from '@/app/AppShell'
 
 // Public pages (no app chrome)
 const Landing = lazy(() => import('@/features/landing/Landing'))
+const LandingV3 = lazy(() => import('@/features/landing-v3/LandingV3'))
 
 // App pages (with header/sidebar)
 const HomePage = lazy(() => import('@/app/homepage/HomePage'))
@@ -282,6 +283,11 @@ export const router = sentryCreateBrowserRouter([
     children: [
       // Root decides: Landing (anon) or /home (authed)
       { index: true, element: <RootEntry /> },
+
+      // Landing v3 — parallel mount for A/B + preview. Public; authed users
+      // can still load it (useful for previewing). Promote to root once
+      // confident in the new design.
+      { path: 'v3', element: <LazyRoute Component={LandingV3} /> },
 
       // OAuth callback route - MUST come before legacy auth redirects
       { path: 'auth/callback', element: <LazyRoute Component={OAuthCallback} /> },

--- a/src/features/landing-v3/LandingV3.jsx
+++ b/src/features/landing-v3/LandingV3.jsx
@@ -1,0 +1,688 @@
+import { useState, useEffect, useRef, useMemo } from 'react'
+import { useGoogleAuth } from '@/features/landing/utils/useGoogleAuth'
+import './landing-v3.css'
+
+const C={bg:'#06060a',bgPure:'#000',bgLight:'#0d0b14',bgPaper:'#0f0c18',text:'#FAFAFA',textHi:'rgba(250,250,250,0.92)',textMid:'rgba(250,250,250,0.72)',textLow:'rgba(250,250,250,0.45)',textFaint:'rgba(250,250,250,0.28)',hairline:'rgba(255,255,255,0.08)',hairlineStrong:'rgba(255,255,255,0.14)',purple:'#A78BFA',pink:'#EC4899',amber:'#F59E0B',green:'#34D399'};
+const GRAD='linear-gradient(135deg,#9333ea 0%,#ec4899 100%)';
+const TMDB=(p)=>`https://image.tmdb.org/t/p/w780${p}`;
+
+const PICKS=[
+  {title:'Past Lives',year:2023,runtime:'1h 45m',dir:'Celine Song',poster:TMDB('/k3waqVXSnvCZWfJYNtdamTgTtTA.jpg'),mood:'Tender',moodHex:'#F472B6',why:'Two strangers in a New York bar — but they were children once, in Seoul. A slow ache that lives in glances.'},
+  {title:'Parasite',year:2019,runtime:'2h 12m',dir:'Bong Joon-ho',poster:TMDB('/7IiTTgloJzvGI1TAYymCfbfl3vT.jpg'),mood:'Tense',moodHex:'#EF4444',why:'A grift becomes architecture. Bong builds his cage room by room until the gate clicks shut.'},
+  {title:'Her',year:2013,runtime:'2h 6m',dir:'Spike Jonze',poster:TMDB('/eCOtqtfvn7mxGl6nfmq4b1exJRc.jpg'),mood:'Bittersweet',moodHex:'#FB7185',why:'Near-future Los Angeles. A man falls for an operating system. Tender, lonely, alive in every frame — Phoenix at his most undone.'},
+  {title:'Interstellar',year:2014,runtime:'2h 49m',dir:'Christopher Nolan',poster:TMDB('/gEU2QniE6E77NI6lCU6MxlNBvIx.jpg'),mood:'Mythic',moodHex:'#0EA5E9',why:'A father leaves Earth to save it. Time bends around love. Nolan at his largest scale and his most tender.'},
+  {title:'PK',year:2014,runtime:'2h 33m',dir:'Rajkumar Hirani',poster:TMDB('/uqoAHhuKZnWxzXbXSUycgpLPmUW.jpg'),mood:'Thoughtful',moodHex:'#FBBF24',why:'An alien lands in Rajasthan and starts asking questions no priest can answer. Aamir Khan, wide-eyed, dismantling certainty.'},
+  {title:'The Truman Show',year:1998,runtime:'1h 43m',dir:'Peter Weir',poster:TMDB('/vuza0WqY239yBXOadKlGwJsZJFE.jpg'),mood:'Restless',moodHex:'#34D399',why:'A man discovers his entire life is a televised set. Jim Carrey, unsettlingly tender, pushing against the walls of a manufactured world.'},
+];
+
+function Reveal({children,delay=0}){
+  const ref=useRef(null);
+  const [iv,setIv]=useState(false);
+  useEffect(()=>{
+    const obs=new IntersectionObserver(([e])=>{if(e.isIntersecting){setTimeout(()=>setIv(true),delay);obs.disconnect();}},{threshold:0.15});
+    if(ref.current)obs.observe(ref.current);
+    return()=>obs.disconnect();
+  },[delay]);
+  return<div ref={ref} className={`ff-reveal${iv?' in':''}`}>{children}</div>;
+}
+
+// Universal poster with mood-gradient fallback if TMDB image misses
+function Poster({src,title,accent='#A78BFA',style}){
+  const [failed,setFailed]=useState(false);
+  if(failed){
+    return(
+      <div style={{...style,display:'flex',alignItems:'flex-end',padding:'14px 16px',background:`linear-gradient(160deg, ${accent}cc 0%, ${accent}77 45%, ${accent}22 100%)`,overflow:'hidden'}}>
+        <div style={{position:'relative',zIndex:1}}>
+          <div className="ff-eyebrow" style={{fontSize:8,color:'rgba(255,255,255,0.6)',marginBottom:6}}>FeelFlick</div>
+          <div style={{fontFamily:'Outfit',fontWeight:500,fontSize:16,color:'#fff',letterSpacing:'-0.018em',lineHeight:1.1,textShadow:'0 2px 8px rgba(0,0,0,0.5)'}}>{title}</div>
+        </div>
+      </div>
+    );
+  }
+  return <img src={src} alt={title} style={style} onError={()=>setFailed(true)}/>;
+}
+
+function Stars({tint,count=50}){
+  const stars=useMemo(()=>Array.from({length:count},()=>({x:Math.random()*100,y:Math.random()*100,s:Math.random()*1.3+0.3,dly:Math.random()*8,dur:6+Math.random()*8,op:0.15+Math.random()*0.4})),[count]);
+  return(
+    <div aria-hidden style={{position:'absolute',inset:0,overflow:'hidden',pointerEvents:'none'}}>
+      <div style={{position:'absolute',inset:0,background:`radial-gradient(ellipse 80% 50% at 50% 0%,${tint}1c,transparent 60%),radial-gradient(ellipse 60% 40% at 50% 100%,${tint}10,transparent 60%)`}}/>
+      {stars.map((s,i)=><div key={i} style={{position:'absolute',left:`${s.x}%`,top:`${s.y}%`,width:s.s,height:s.s,borderRadius:999,background:'#fff',opacity:s.op,animation:`ff-tw ${s.dur}s ease-in-out ${s.dly}s infinite`}}/>)}
+    </div>
+  );
+}
+
+// ── Header ─────────────────────────────────────────────────
+function Header(){
+  const [s,setS]=useState(false);
+  const { signInWithGoogle, isAuthenticating } = useGoogleAuth();
+  useEffect(()=>{const on=()=>setS(window.scrollY>24);window.addEventListener('scroll',on,{passive:true});return()=>window.removeEventListener('scroll',on);},[]);
+  return(
+    <header style={{position:'fixed',top:0,left:0,right:0,zIndex:50,transition:'all 0.4s ease',background:s?'rgba(6,6,10,0.78)':'transparent',backdropFilter:s?'saturate(140%) blur(20px)':'none',borderBottom:s?`1px solid ${C.hairline}`:'1px solid transparent'}}>
+      <div style={{maxWidth:1280,margin:'0 auto',padding:'0 32px',display:'flex',alignItems:'center',justifyContent:'space-between',height:64}}>
+        <a href="/v3" className="ff-link" style={{fontFamily:'Inter',fontSize:21,fontWeight:900,letterSpacing:'-0.012em',background:GRAD,WebkitBackgroundClip:'text',WebkitTextFillColor:'transparent'}}>FEELFLICK</a>
+        <nav style={{display:'flex',alignItems:'center',gap:32}}>
+          {[{l:'Ritual',h:'#ritual'},{l:'Film File',h:'#file'},{l:'Briefing',h:'#briefing'},{l:'Pricing',h:'#pricing'}].map(n=>
+            <a key={n.l} href={n.h} className="ff-link" style={{fontFamily:'Inter',fontSize:13,fontWeight:500,color:C.textMid}}>{n.l}</a>
+          )}
+        </nav>
+        <div style={{display:'flex',alignItems:'center',gap:18}}>
+          <button type="button" onClick={signInWithGoogle} disabled={isAuthenticating} className="ff-link" style={{fontFamily:'Inter',fontSize:13,fontWeight:500,color:C.textMid,background:'transparent',border:'none',padding:0,cursor:isAuthenticating?'progress':'pointer'}} aria-label="Sign in with Google">Sign in</button>
+          <button type="button" onClick={signInWithGoogle} disabled={isAuthenticating} className="ff-link" style={{display:'inline-flex',alignItems:'center',gap:6,fontFamily:'Inter',fontSize:13,fontWeight:600,color:'#fff',padding:'9px 16px',borderRadius:999,background:GRAD,border:'none',cursor:isAuthenticating?'progress':'pointer',opacity:isAuthenticating?0.7:1}} aria-label="Start free with Google">{isAuthenticating?'Opening Google…':'Start free →'}</button>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+// ── Hero ───────────────────────────────────────────────────
+// Criterion-like: the pick is the hero. Editorial.
+function Hero(){
+  const [idx,setIdx]=useState(0);
+  const { signInWithGoogle, isAuthenticating } = useGoogleAuth();
+  useEffect(()=>{
+    const t=setInterval(()=>setIdx(i=>(i+1)%PICKS.length),5400);
+    return()=>clearInterval(t);
+  },[]);
+  const p=PICKS[idx];
+  const greeting=useMemo(()=>{
+    const d=new Date(),h=d.getHours();
+    const day=['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'][d.getDay()];
+    const part=h<5?'late':h<12?'morning':h<17?'afternoon':h<22?'evening':'night';
+    return`${day} ${part}`;
+  },[]);
+  return(
+    <section style={{position:'relative',minHeight:'100vh',display:'flex',alignItems:'center',overflow:'hidden',padding:'140px 32px 80px'}}>
+      <Stars tint={p.moodHex} count={70}/>
+      <div style={{position:'relative',zIndex:1,maxWidth:1280,margin:'0 auto',width:'100%'}} className="ff-grid-hero">
+        <div>
+          <div className="ff-eyebrow" style={{marginBottom:32}}>
+            <span style={{color:C.textLow}}>FeelFlick · {greeting}</span>
+          </div>
+          <h1 className="ff-d1" style={{fontSize:'clamp(56px,7vw,118px)',color:C.text,margin:0}}>
+            Films that<br/>know <em className="ff-italic" style={{color:C.textMid}}>you.</em>
+          </h1>
+          <p className="ff-body" style={{marginTop:36,fontSize:18,color:C.textMid,maxWidth:480,lineHeight:1.6}}>
+            The right film. Right now. Tuned to your mood, your taste, and everything you’ve ever loved on screen.
+          </p>
+          <div style={{marginTop:48,display:'flex',alignItems:'center',gap:18}}>
+            <button type="button" onClick={signInWithGoogle} disabled={isAuthenticating} className="ff-link" style={{display:'inline-flex',alignItems:'center',gap:8,padding:'15px 28px',borderRadius:999,background:GRAD,color:'#fff',fontFamily:'Inter',fontSize:14,fontWeight:600,boxShadow:'0 14px 32px -10px rgba(236,72,153,0.45)',border:'none',cursor:isAuthenticating?'progress':'pointer',opacity:isAuthenticating?0.7:1}} aria-label="Start free with Google">{isAuthenticating?'Opening Google…':'Start free →'}</button>
+            <a href="#ritual" className="ff-link" style={{fontFamily:'Inter',fontSize:13,fontWeight:500,color:C.textMid,letterSpacing:'0.01em'}}>See how it works</a>
+          </div>
+        </div>
+        <div key={p.title} className="ff-fade-swap" style={{position:'relative',padding:'12px 0'}}>
+          <div className="ff-eyebrow" style={{fontSize:10,color:p.moodHex,marginBottom:18,transition:'color 0.6s'}}>Tonight’s selection · {p.mood}</div>
+          <div style={{display:'grid',gridTemplateColumns:'auto 1fr',gap:32,alignItems:'flex-start'}}>
+            <div style={{position:'relative'}}>
+              <div aria-hidden style={{position:'absolute',inset:-18,borderRadius:14,background:`radial-gradient(ellipse at center,${p.moodHex}55,transparent 70%)`,filter:'blur(40px)',transition:'background 0.8s'}}/>
+              <img key={p.poster} src={p.poster} alt={p.title} onError={(e)=>{e.currentTarget.style.display='none';e.currentTarget.parentNode.style.background=`linear-gradient(160deg, ${p.moodHex}cc 0%, ${p.moodHex}55 50%, ${p.moodHex}1a 100%)`;e.currentTarget.parentNode.dataset.fallback=p.title;}} style={{position:'relative',width:240,aspectRatio:'2/3',objectFit:'cover',borderRadius:5,boxShadow:`0 28px 56px -18px rgba(0,0,0,0.85),0 0 0 1px ${p.moodHex}33`,transition:'all 0.8s cubic-bezier(.2,.7,.2,1)'}}/>
+            </div>
+            <div style={{paddingTop:8}}>
+              <h2 key={p.title+'-t'} className="ff-d2" style={{fontSize:'clamp(32px,3.4vw,46px)',color:C.text,margin:0,animation:'ff-tw 0s'}}>{p.title}</h2>
+              <div style={{marginTop:10,display:'flex',alignItems:'center',gap:11,fontFamily:'Inter',fontSize:12,color:C.textLow}}>
+                <span style={{fontStyle:'italic'}}>{p.dir}</span>
+                <span style={{color:C.textFaint}}>·</span>
+                <span>{p.year}</span>
+                <span style={{color:C.textFaint}}>·</span>
+                <span>{p.runtime}</span>
+              </div>
+              <p className="ff-italic" style={{marginTop:24,fontSize:16,color:C.textMid,fontStyle:'italic',lineHeight:1.55,maxWidth:340,paddingLeft:14,borderLeft:`2px solid ${p.moodHex}55`}}>{p.why}</p>
+              {/* Dots */}
+              <div style={{marginTop:32,display:'flex',gap:8}}>
+                {PICKS.map((_,i)=><button key={i} onClick={()=>setIdx(i)} aria-label={`pick ${i+1}`} style={{width:i===idx?22:6,height:6,borderRadius:999,background:i===idx?p.moodHex:C.textFaint,border:'none',padding:0,cursor:'pointer',transition:'all 0.4s cubic-bezier(.2,.7,.2,1)'}}/>)}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ── The Problem (Apple "vs" split) ─────────────────────────
+function TheProblem(){
+  // Build a fake Netflix-style chaotic wall
+  return(
+    <section style={{position:'relative',padding:'160px 32px',borderTop:`1px solid ${C.hairline}`,background:C.bgPure,overflow:'hidden'}}>
+      <div style={{maxWidth:1280,margin:'0 auto'}}>
+        <Reveal>
+          <div style={{textAlign:'center',marginBottom:80}}>
+            <div className="ff-eyebrow" style={{marginBottom:28,color:C.purple}}>The problem</div>
+            <h2 className="ff-d2" style={{fontSize:'clamp(44px,5.6vw,80px)',color:C.text,margin:'0 auto',textWrap:'balance',maxWidth:880}}>
+              You spent <em className="ff-italic" style={{color:'#EF4444'}}>23 minutes</em> picking.<br/>You watched <em className="ff-italic" style={{color:C.purple}}>thirty.</em>
+            </h2>
+            <p className="ff-body" style={{fontSize:17,color:C.textMid,maxWidth:580,margin:'30px auto 0',lineHeight:1.6}}>
+              Streaming taught us to scroll. Three rivals, twelve rows, four trailers, no decision. Most evenings end without a film — and the few that do, end with a film no-one quite wanted.
+            </p>
+          </div>
+        </Reveal>
+        <Reveal delay={150}>
+          <div style={{maxWidth:1280,margin:'0 auto'}} className="ff-grid-2">
+            {/* Left: chaos */}
+            <div style={{position:'relative',borderRadius:14,overflow:'hidden',background:'#0c0a14',border:`1px solid ${C.hairline}`,padding:'24px 24px 0'}}>
+              <div style={{display:'flex',alignItems:'center',justifyContent:'space-between',marginBottom:18}}>
+                <div className="ff-eyebrow" style={{fontSize:10,color:'#EF4444'}}>Streaming · Tonight</div>
+                <div style={{fontFamily:'Inter',fontSize:11,color:C.textFaint}}>scrolling · 23 min</div>
+              </div>
+              {/* Mocked grid of small posters with shimmer */}
+              {[
+                {label:'Trending today',blur:0,op:1},
+                {label:'Because you watched anything',blur:0.5,op:0.78},
+                {label:'Top 10 in your country',blur:1.2,op:0.55},
+              ].map((row,idx)=>(
+                <div key={idx} style={{marginBottom:10}}>
+                  <div style={{fontFamily:'Inter',fontSize:9.5,color:C.textFaint,marginBottom:5,fontWeight:500,letterSpacing:'0.04em'}}>{row.label}</div>
+                  <div style={{display:'flex',gap:6,filter:`blur(${row.blur}px)`,opacity:row.op}}>
+                    {Array.from({length:8}).map((_,i)=><div key={i} style={{flex:'none',width:72,height:100,borderRadius:3,background:`linear-gradient(135deg,rgba(255,255,255,${0.04+(i%3)*0.02}),rgba(255,255,255,0.02))`,border:`1px solid ${C.hairline}`}}/>)}
+                  </div>
+                </div>
+              ))}
+              <div style={{position:'absolute',inset:0,background:'linear-gradient(180deg,transparent 50%,#0c0a14 95%)',pointerEvents:'none'}}/>
+              <div style={{position:'absolute',bottom:20,left:24,right:24,fontFamily:'Inter',fontSize:13,color:C.textLow,fontStyle:'italic',lineHeight:1.5}}>
+                “Maybe this one… no. What about… no. Let’s see what’s trending…”
+              </div>
+            </div>
+            {/* Right: clarity */}
+            <div style={{position:'relative',borderRadius:14,overflow:'hidden',background:`linear-gradient(160deg,${C.purple}10,transparent 80%)`,border:`1px solid ${C.purple}44`,padding:'32px 32px 36px',display:'flex',flexDirection:'column',justifyContent:'space-between'}}>
+              <div style={{display:'flex',alignItems:'center',justifyContent:'space-between'}}>
+                <div className="ff-eyebrow" style={{fontSize:10,color:C.purple}}>FeelFlick · Tonight</div>
+                <div style={{fontFamily:'Inter',fontSize:11,color:C.textFaint}}>deciding · 47 sec</div>
+              </div>
+              <div style={{margin:'auto',display:'flex',gap:24,alignItems:'flex-end',maxWidth:380}}>
+                <div style={{position:'relative',width:140,aspectRatio:'2/3',borderRadius:4,boxShadow:`0 20px 40px -14px rgba(0,0,0,0.7),0 0 0 1px ${C.purple}33`,overflow:'hidden'}}>
+                <Poster src={PICKS[3].poster} title={PICKS[3].title} accent={PICKS[3].moodHex} style={{width:'100%',height:'100%',objectFit:'cover',display:'block'}}/>
+              </div>
+                <div style={{paddingBottom:6}}>
+                  <h3 style={{fontFamily:'Outfit',fontSize:22,fontWeight:400,color:C.text,margin:0,letterSpacing:'-0.02em'}}>{PICKS[3].title}</h3>
+                  <div style={{fontFamily:'Inter',fontSize:11,color:C.textLow,marginTop:4}}>{PICKS[3].dir} · {PICKS[3].year}</div>
+                  <div className="ff-eyebrow" style={{fontSize:9.5,color:C.purple,marginTop:14}}>94% match</div>
+                </div>
+              </div>
+              <div className="ff-italic" style={{fontFamily:'Outfit',fontSize:13,color:C.textMid,fontStyle:'italic',lineHeight:1.5}}>
+                “Forty-seven seconds. The right film. The rest of the night, yours.”
+              </div>
+            </div>
+          </div>
+        </Reveal>
+      </div>
+    </section>
+  );
+}
+
+// ── The Ritual (single combined section) ─────────────────────
+function Ritual(){
+  const steps=[
+    {n:'01',k:'Read the room',t:'How you feel.',b:'Tap one to three moods from a constellation of eight.',visual:'mood'},
+    {n:'02',k:'Fit the hour',t:'About the night.',b:"Time, company, energy. The engine bends to fit.",visual:'night'},
+    {n:'03',k:'Receive the edition',t:'One film.',b:'Not three options. One pick, with the article that makes its case.',visual:'pick'},
+  ];
+  return(
+    <section id="ritual" style={{padding:'180px 32px',borderTop:`1px solid ${C.hairline}`,background:C.bgLight}}>
+      <div style={{maxWidth:1280,margin:'0 auto'}}>
+        <Reveal>
+          <div style={{textAlign:'center',marginBottom:84}}>
+            <div className="ff-eyebrow" style={{marginBottom:26,color:C.purple}}>The Ritual · Three steps</div>
+            <h2 className="ff-d2" style={{fontSize:'clamp(44px,5.6vw,80px)',color:C.text,margin:0,textWrap:'balance',maxWidth:880,marginLeft:'auto',marginRight:'auto'}}>
+              Three short questions. <em className="ff-italic" style={{color:C.textMid}}>One film.</em>
+            </h2>
+            <p className="ff-body" style={{marginTop:24,fontSize:17,color:C.textMid,maxWidth:560,marginLeft:'auto',marginRight:'auto',lineHeight:1.65}}>
+              The whole flow takes a minute. The night gets back the rest.
+            </p>
+          </div>
+        </Reveal>
+        <div className="ff-grid-3">
+          {steps.map((s,i)=>(
+            <Reveal key={s.n} delay={i*150}>
+              <div style={{position:'relative',padding:'32px 28px',borderRadius:14,background:'rgba(255,255,255,0.022)',border:`1px solid ${C.hairline}`,height:'100%',display:'flex',flexDirection:'column'}}>
+                <div className="ff-eyebrow" style={{fontSize:9.5,marginBottom:18,color:C.purple}}>{s.k} · {s.n}</div>
+                <div style={{flex:'none',marginBottom:24}}>
+                  {s.visual==='mood'&&<MoodVisual/>}
+                  {s.visual==='night'&&<NightVisual/>}
+                  {s.visual==='pick'&&<PickMiniVisual/>}
+                </div>
+                <h3 className="ff-d2" style={{fontSize:'clamp(26px,2.6vw,34px)',color:C.text,margin:0,letterSpacing:'-0.025em'}}>{s.t}</h3>
+                <p className="ff-body" style={{marginTop:10,fontSize:14,color:C.textMid,lineHeight:1.6}}>{s.b}</p>
+              </div>
+            </Reveal>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+function MoodVisual(){
+  const moods=[{n:'Tender',h:'#F472B6'},{n:'Tense',h:'#EF4444'},{n:'Slow-burn',h:'#A78BFA',on:true},{n:'Cerebral',h:'#7DD3FC'},{n:'Cozy',h:'#FBBF24'},{n:'Bittersweet',h:'#FB7185',on:true},{n:'Mythic',h:'#0EA5E9'},{n:'Restless',h:'#34D399'}];
+  return(
+    <div style={{position:'relative',aspectRatio:'4/3',borderRadius:10,background:C.bg,border:`1px solid ${C.hairline}`,padding:'22px 18px',display:'flex',flexDirection:'column',justifyContent:'center',alignItems:'center',gap:14}}>
+      <div className="ff-eyebrow" style={{fontSize:9,color:C.textLow}}>Your constellation</div>
+      <div style={{display:'flex',flexWrap:'wrap',gap:6,justifyContent:'center',maxWidth:260}}>
+        {moods.map(m=><div key={m.n} style={{display:'inline-flex',alignItems:'center',gap:5,padding:'5px 9px',borderRadius:999,background:m.on?`${m.h}1f`:'rgba(255,255,255,0.03)',border:`1px solid ${m.on?m.h+'55':C.hairline}`,color:m.on?C.text:C.textLow,fontFamily:'Inter',fontSize:10,fontWeight:m.on?600:500}}><span style={{width:4,height:4,borderRadius:999,background:m.h}}/>{m.n}</div>)}
+      </div>
+      <div className="ff-italic" style={{fontSize:14,color:C.textHi,fontStyle:'italic'}}>“The Long Goodbye”</div>
+    </div>
+  );
+}
+function NightVisual(){
+  const rows=[{l:'Time',v:'~2 hrs'},{l:'With',v:'Just me'},{l:'Energy',v:'Settled'},{l:'Wanting',v:'To be moved'}];
+  return(
+    <div style={{aspectRatio:'4/3',borderRadius:10,background:C.bg,border:`1px solid ${C.hairline}`,padding:'22px 22px',display:'flex',flexDirection:'column',justifyContent:'center',gap:11}}>
+      <div className="ff-eyebrow" style={{fontSize:9,color:C.textLow,marginBottom:4}}>The night</div>
+      {rows.map(r=><div key={r.l} style={{display:'flex',justifyContent:'space-between',paddingBottom:8,borderBottom:`1px solid ${C.hairline}`,fontFamily:'Inter',fontSize:12}}><span style={{color:C.textLow}}>{r.l}</span><span style={{color:C.textHi,fontWeight:500}}>{r.v}</span></div>)}
+    </div>
+  );
+}
+function PickMiniVisual(){
+  const p=PICKS[0];
+  return(
+    <div style={{aspectRatio:'4/3',borderRadius:10,background:C.bg,border:`1px solid ${C.hairline}`,padding:18,overflow:'hidden',display:'flex',gap:16,alignItems:'center'}}>
+      <div style={{width:80,aspectRatio:'2/3',borderRadius:3,flex:'none',overflow:'hidden'}}>
+        <Poster src={p.poster} title={p.title} accent={p.moodHex} style={{width:'100%',height:'100%',objectFit:'cover',display:'block'}}/>
+      </div>
+      <div style={{minWidth:0}}>
+        <div className="ff-eyebrow" style={{fontSize:8,color:C.textLow,marginBottom:6}}>Edition Nº 142</div>
+        <h4 style={{fontFamily:'Outfit',fontSize:17,fontWeight:300,color:C.text,margin:0,letterSpacing:'-0.022em',lineHeight:1.1}}>{p.title}</h4>
+        <div style={{fontFamily:'Inter',fontSize:10,color:C.textLow,marginTop:3}}>{p.dir} · {p.year}</div>
+        <p className="ff-italic" style={{fontSize:11,color:C.textMid,marginTop:10,fontStyle:'italic',lineHeight:1.4,paddingLeft:8,borderLeft:`1.5px solid ${p.moodHex}55`}}>A slow ache that lives in glances.</p>
+      </div>
+    </div>
+  );
+}
+
+// ── The Film File (what every pick comes with) ────────────────
+function FilmFile(){
+  const motifs=['Class tension','Quiet endings','Slow burn','Two-handers'];
+  return(
+    <section id="file" style={{padding:'200px 32px',borderTop:`1px solid ${C.hairline}`,background:C.bgPure,position:'relative'}}>
+      <div aria-hidden style={{position:'absolute',inset:0,background:`radial-gradient(ellipse 80% 50% at 70% 30%,${C.purple}12,transparent 60%)`,pointerEvents:'none'}}/>
+      <div style={{position:'relative',maxWidth:1180,margin:'0 auto'}}>
+        <Reveal>
+          <div style={{textAlign:'center',marginBottom:84}}>
+            <div className="ff-eyebrow" style={{marginBottom:26,color:C.purple}}>The Film File</div>
+            <h2 className="ff-d2" style={{fontSize:'clamp(44px,5.6vw,80px)',color:C.text,margin:'0 auto',textWrap:'balance',maxWidth:780}}>
+              Every pick comes with <em className="ff-italic" style={{color:C.textMid}}>its case.</em>
+            </h2>
+            <p className="ff-body" style={{fontSize:17,color:C.textMid,maxWidth:560,margin:'24px auto 0',lineHeight:1.65}}>
+              Not just a poster. A short essay, a critic’s line, the mood arc, what to drink, and one film we’d skip tonight — and why.
+            </p>
+          </div>
+        </Reveal>
+        <Reveal delay={150}>
+          <div className="ff-grid-feature" style={{padding:'48px 48px',borderRadius:18,background:'rgba(255,255,255,0.02)',border:`1px solid ${C.hairline}`}}>
+            <div>
+              <div style={{width:'100%',aspectRatio:'2/3',borderRadius:6,boxShadow:'0 28px 56px -18px rgba(0,0,0,0.85)',overflow:'hidden'}}>
+                <Poster src={PICKS[2].poster} title={PICKS[2].title} accent={PICKS[2].moodHex} style={{width:'100%',height:'100%',objectFit:'cover',display:'block'}}/>
+              </div>
+            </div>
+            <div>
+              <div className="ff-eyebrow" style={{color:C.textLow,marginBottom:18}}>The Feature · p. 01</div>
+              <h3 className="ff-d2" style={{fontSize:'clamp(36px,4.4vw,58px)',color:C.text,margin:0}}>{PICKS[2].title}</h3>
+              <div style={{marginTop:10,display:'flex',alignItems:'center',gap:11,fontFamily:'Inter',fontSize:13,color:C.textLow}}>
+                <span style={{fontStyle:'italic'}}>directed by {PICKS[2].dir}</span>
+                <span style={{color:C.textFaint}}>·</span><span>{PICKS[2].year}</span>
+                <span style={{color:C.textFaint}}>·</span><span>{PICKS[2].runtime}</span>
+              </div>
+              <p className="ff-body" style={{marginTop:24,fontSize:16,color:C.textHi,lineHeight:1.65,maxWidth:520}}>
+                <span className="ff-italic" style={{float:'left',fontSize:64,lineHeight:0.85,color:C.purple,marginRight:10,marginTop:6,marginBottom:-4,letterSpacing:'-0.06em',fontWeight:300}}>{PICKS[2].why.charAt(0)}</span>
+                {PICKS[2].why.slice(1)}
+              </p>
+              <blockquote style={{margin:'28px 0 0 0',padding:'14px 0 14px 20px',borderLeft:`2px solid ${C.purple}77`}}>
+                <p style={{margin:0,fontFamily:'Outfit',fontSize:18,fontWeight:300,fontStyle:'italic',color:C.text,lineHeight:1.4,letterSpacing:'-0.012em'}}>“Tender enough to break your composure.”</p>
+                <div className="ff-eyebrow" style={{fontSize:9.5,color:C.textLow,marginTop:8}}>— Manohla Dargis, The New York Times</div>
+              </blockquote>
+              <div style={{marginTop:28,display:'grid',gridTemplateColumns:'1fr 1fr',gap:20}}>
+                <div style={{padding:'14px 16px',borderRadius:8,background:'rgba(255,255,255,0.022)',border:`1px solid ${C.hairline}`}}>
+                  <div className="ff-eyebrow" style={{fontSize:9.5,color:C.purple,marginBottom:8}}>Pairs with</div>
+                  <div style={{fontFamily:'Inter',fontSize:12.5,color:C.textMid,fontStyle:'italic',lineHeight:1.55}}>A glass of red. Ninety minutes of nothing else.</div>
+                </div>
+                <div style={{padding:'14px 16px',borderRadius:8,background:'rgba(255,255,255,0.022)',border:`1px solid ${C.hairline}`}}>
+                  <div className="ff-eyebrow" style={{fontSize:9.5,color:C.purple,marginBottom:8}}>Why for you</div>
+                  <div style={{display:'flex',flexWrap:'wrap',gap:6}}>{motifs.map(t=><span key={t} style={{padding:'3px 9px',borderRadius:999,background:`${C.purple}10`,border:`1px solid ${C.purple}33`,fontFamily:'Inter',fontSize:11,color:C.textMid}}>{t}</span>)}</div>
+                </div>
+              </div>
+              {/* Emotional arc + skip tonight — now below right content */}
+              <div style={{marginTop:28,display:'grid',gridTemplateColumns:'1.4fr 1fr',gap:20,alignItems:'stretch'}}>
+                <div style={{padding:'18px 20px',borderRadius:10,background:'rgba(255,255,255,0.022)',border:`1px solid ${C.hairline}`}}>
+                  <div className="ff-eyebrow" style={{fontSize:10,color:C.textLow,marginBottom:14}}>Emotional arc · 126 min</div>
+                  <svg viewBox="0 0 280 56" width="100%" height="56">
+                    <defs>
+                      <linearGradient id="arc-g" x1="0" x2="1"><stop offset="0%" stopColor={C.purple} stopOpacity="0.6"/><stop offset="100%" stopColor={C.pink} stopOpacity="0.95"/></linearGradient>
+                      <linearGradient id="arc-f" x1="0" x2="0" y1="0" y2="1"><stop offset="0%" stopColor={C.purple} stopOpacity="0.22"/><stop offset="100%" stopColor={C.purple} stopOpacity="0"/></linearGradient>
+                    </defs>
+                    <path d="M4,42 L34,38 L62,32 L92,26 L120,22 L150,18 L178,14 L210,12 L240,18 L276,22 L276,52 L4,52 Z" fill="url(#arc-f)"/>
+                    <path d="M4,42 L34,38 L62,32 L92,26 L120,22 L150,18 L178,14 L210,12 L240,18 L276,22" fill="none" stroke="url(#arc-g)" strokeWidth="1.8" strokeLinecap="round"/>
+                    <circle cx="210" cy="12" r="2.6" fill={C.pink}/>
+                  </svg>
+                  <div style={{display:'flex',justifyContent:'space-between',marginTop:6,fontSize:9.5,color:C.textFaint,fontFamily:'Outfit',letterSpacing:'0.08em',textTransform:'uppercase'}}><span>Quiet</span><span style={{color:C.pink}}>Peak</span><span>Bittersweet</span></div>
+                </div>
+                <div style={{padding:'14px 18px',borderRadius:10,background:`${C.amber}0a`,border:`1px solid ${C.amber}33`,display:'flex',flexDirection:'column',justifyContent:'center'}}>
+                  <div className="ff-eyebrow" style={{fontSize:10,color:C.amber,marginBottom:6}}>Skip tonight</div>
+                  <div style={{fontFamily:'Inter',fontSize:13,color:C.textMid,fontStyle:'italic'}}>Hereditary. Your settled energy will resent it.</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </Reveal>
+      </div>
+    </section>
+  );
+}
+
+// ── The Briefing ──────────────────────────────────────────────
+function Briefing(){
+  return(
+    <section id="briefing" style={{padding:'180px 32px',borderTop:`1px solid ${C.hairline}`,background:C.bgLight}}>
+      <div style={{maxWidth:1180,margin:'0 auto'}}>
+        <Reveal>
+          <div className="ff-grid-2" style={{marginBottom:72}}>
+            <div>
+              <div className="ff-eyebrow" style={{marginBottom:24,color:C.purple}}>The Briefing</div>
+              <h2 className="ff-d2" style={{fontSize:'clamp(40px,5.2vw,72px)',color:C.text,margin:0,textWrap:'balance'}}>
+                Or get it <em className="ff-italic" style={{color:C.textMid}}>served.</em>
+              </h2>
+            </div>
+            <p className="ff-body" style={{fontSize:17,color:C.textMid,lineHeight:1.7,maxWidth:480}}>
+              Some nights you want to ask. Others you want it ready. Turn on the Briefing and three picks arrive every evening — tonight’s selection, a mood-match, and one from deep in your DNA. For the evenings you don’t want to think.
+            </p>
+          </div>
+        </Reveal>
+        <Reveal delay={150}>
+          <div style={{borderRadius:14,background:'rgba(255,255,255,0.022)',border:`1px solid ${C.hairline}`,padding:'40px 48px',position:'relative',overflow:'hidden'}}>
+            <div aria-hidden style={{position:'absolute',inset:0,background:`radial-gradient(ellipse 50% 30% at 20% 0%,${C.purple}14,transparent 60%)`,pointerEvents:'none'}}/>
+            <div style={{position:'relative',display:'flex',alignItems:'center',gap:14,paddingBottom:24,borderBottom:`1px solid ${C.hairline}`}}>
+              <div className="ff-eyebrow" style={{fontSize:10,color:C.purple}}>FeelFlick · The Briefing</div>
+              <div style={{height:1,width:28,background:C.purple,opacity:0.5}}/>
+              <div className="ff-eyebrow" style={{fontSize:9.5,color:C.textLow}}>Edition Nº 142 · Tuesday</div>
+              <div style={{flex:1}}/>
+              <div className="ff-italic" style={{fontSize:13,color:C.textLow,fontStyle:'italic'}}>Curated for you</div>
+            </div>
+            <div style={{position:'relative',marginTop:40}} className="ff-grid-3">
+              {[PICKS[1], PICKS[3], PICKS[5]].map((p,i)=>(
+                <article key={i}>
+                  <div style={{position:'relative',marginBottom:18}}>
+                    <div style={{width:'100%',aspectRatio:'2/3',borderRadius:5,boxShadow:'0 20px 40px -16px rgba(0,0,0,0.7)',overflow:'hidden'}}>
+                      <Poster src={p.poster} title={p.title} accent={p.moodHex} style={{width:'100%',height:'100%',objectFit:'cover',display:'block'}}/>
+                    </div>
+                    <div style={{position:'absolute',top:10,left:10,padding:'4px 8px',borderRadius:3,background:'rgba(0,0,0,0.78)',backdropFilter:'blur(8px)',border:`1px solid ${p.moodHex}44`,fontFamily:'Outfit',fontSize:9.5,fontWeight:700,color:p.moodHex,letterSpacing:'0.06em'}}>{[94,88,82][i]}% MATCH</div>
+                  </div>
+                  <div className="ff-eyebrow" style={{fontSize:9.5,color:p.moodHex,marginBottom:9}}>0{i+1} · {['Tonight\'s pick','Mood match','From your DNA'][i]}</div>
+                  <h3 style={{fontFamily:'Outfit',fontSize:22,fontWeight:400,color:C.text,margin:'0 0 6px 0',letterSpacing:'-0.02em'}}>{p.title}</h3>
+                  <div style={{fontFamily:'Inter',fontSize:11.5,color:C.textLow,marginBottom:14}}>{p.year} · {p.dir}</div>
+                  <p className="ff-italic" style={{margin:0,fontSize:13,color:C.textMid,fontStyle:'italic',lineHeight:1.55}}>{p.why.split('. ')[0]}.</p>
+                </article>
+              ))}
+            </div>
+          </div>
+        </Reveal>
+      </div>
+    </section>
+  );
+}
+
+// ── DNA — your portrait ────────────────────────────────────────
+function DNA(){
+  const ref=useRef(null);
+  const [iv,setIv]=useState(false);
+  useEffect(()=>{const o=new IntersectionObserver(([e])=>{if(e.isIntersecting){setIv(true);o.disconnect();}},{threshold:0.3});if(ref.current)o.observe(ref.current);return()=>o.disconnect();},[]);
+  const weights=[{n:'Tense',v:0.84,h:'#EF4444'},{n:'Slow-burn',v:0.78,h:'#A78BFA'},{n:'Bittersweet',v:0.71,h:'#FB7185'},{n:'Cerebral',v:0.68,h:'#7DD3FC'},{n:'Tender',v:0.62,h:'#F472B6'}];
+  return(
+    <section id="dna" ref={ref} style={{padding:'200px 32px',borderTop:`1px solid ${C.hairline}`}}>
+      <div style={{maxWidth:1180,margin:'0 auto'}}>
+        <Reveal>
+          <div style={{textAlign:'center',marginBottom:80}}>
+            <div className="ff-eyebrow" style={{marginBottom:26,color:C.purple}}>Your Cinematic DNA</div>
+            <h2 className="ff-d2" style={{fontSize:'clamp(44px,5.6vw,80px)',color:C.text,margin:'0 auto',textWrap:'balance',maxWidth:880}}>
+              A portrait you can only get <em className="ff-italic" style={{color:C.textMid}}>by watching.</em>
+            </h2>
+            <p className="ff-body" style={{fontSize:17,color:C.textMid,maxWidth:580,margin:'24px auto 0',lineHeight:1.65}}>
+              Letterboxd has your ratings. Netflix has your watch time. FeelFlick has the shape of you — moods, directors, recurring motifs, the runtime you actually have patience for. Visible only to you.
+            </p>
+          </div>
+        </Reveal>
+        <Reveal delay={150}>
+          <div className="ff-grid-2" style={{padding:'48px 48px',borderRadius:16,background:'rgba(255,255,255,0.018)',border:`1px solid ${C.hairline}`}}>
+            <div>
+              <div style={{display:'flex',alignItems:'baseline',justifyContent:'space-between',marginBottom:28}}>
+                <div className="ff-eyebrow" style={{fontSize:10,color:C.textLow}}>Mood signature</div>
+                <div className="ff-italic" style={{fontSize:11,color:C.textFaint,fontStyle:'italic'}}>Sharper with every watch</div>
+              </div>
+              <div style={{display:'flex',flexDirection:'column',gap:16}}>
+                {weights.map((w,i)=>
+                  <div key={w.n}>
+                    <div style={{display:'flex',justifyContent:'space-between',marginBottom:6}}>
+                      <span style={{fontFamily:'Outfit',fontSize:14,fontWeight:400,color:C.text}}>{w.n}</span>
+                      <span style={{fontFamily:'Inter',fontSize:12,color:C.textLow}}>{Math.round(w.v*100)}</span>
+                    </div>
+                    <div style={{height:2,background:'rgba(255,255,255,0.05)',borderRadius:999,overflow:'hidden'}}>
+                      <div style={{height:'100%',width:iv?`${w.v*100}%`:'0%',background:w.h,opacity:0.85,transition:`width 1.6s cubic-bezier(.2,.7,.2,1) ${i*0.1+0.1}s`}}/>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+            <div style={{display:'flex',flexDirection:'column',gap:28}}>
+              <div>
+                <div className="ff-eyebrow" style={{fontSize:10,color:C.textLow,marginBottom:14}}>Signature directors</div>
+                <div style={{display:'flex',flexWrap:'wrap',gap:10}}>
+                  {['Bong Joon-ho','Wong Kar-wai','Denis Villeneuve','Park Chan-wook'].map(d=>
+                    <span key={d} style={{padding:'7px 13px',borderRadius:999,background:`${C.purple}10`,border:`1px solid ${C.purple}33`,fontFamily:'Inter',fontSize:12.5,color:C.textMid}}>{d}</span>
+                  )}
+                </div>
+              </div>
+              <div>
+                <div className="ff-eyebrow" style={{fontSize:10,color:C.textLow,marginBottom:14}}>Recurring motifs</div>
+                <div style={{display:'flex',flexWrap:'wrap',gap:10}}>
+                  {['Class tension','Quiet endings','Two-handers','Long takes','Rain','Patient ache'].map(t=>
+                    <span key={t} style={{padding:'7px 13px',borderRadius:999,background:'rgba(255,255,255,0.04)',border:`1px solid ${C.hairline}`,fontFamily:'Inter',fontSize:12.5,color:C.textMid}}>{t}</span>
+                  )}
+                </div>
+              </div>
+              <div style={{paddingTop:24,borderTop:`1px solid ${C.hairline}`}}>
+                <div className="ff-eyebrow" style={{fontSize:10,color:C.textLow,marginBottom:10}}>Your signature line</div>
+                <div className="ff-italic" style={{fontSize:21,fontStyle:'italic',color:C.text,letterSpacing:'-0.018em',lineHeight:1.3}}>“Films that earn their silences.”</div>
+              </div>
+            </div>
+          </div>
+        </Reveal>
+      </div>
+    </section>
+  );
+}
+
+// ── Community / Taste twins ────────────────────────────────────
+function Community(){
+  const twins=[
+    {n:'Marco',match:87,h:'#A78BFA',mood:'Slow-burn obsessed',recent:'Rated Past Lives ★★★★★ · 2 days ago'},
+    {n:'Priya',match:79,h:'#F472B6',mood:'Late-night cerebral',recent:'Saved 3 films · last week'},
+    {n:'Theo',match:64,h:'#7DD3FC',mood:'Crime + thriller',recent:'Started a list · "Refn-coded"'},
+  ];
+  return(
+    <section style={{padding:'180px 32px',borderTop:`1px solid ${C.hairline}`,background:C.bgPure}}>
+      <div style={{maxWidth:1180,margin:'0 auto'}}>
+        <Reveal>
+          <div className="ff-grid-2" style={{marginBottom:72}}>
+            <h2 className="ff-d2" style={{fontSize:'clamp(40px,5.2vw,72px)',color:C.text,margin:0,textWrap:'balance'}}>
+              Find the people whose ratings <em className="ff-italic" style={{color:C.textMid}}>actually predict yours.</em>
+            </h2>
+            <p className="ff-body" style={{fontSize:17,color:C.textMid,lineHeight:1.7,maxWidth:440}}>
+              Not popularity. Compatibility. We compute the overlap between your taste graph and theirs — and tell you how reliably their five-star agrees with what you’ll feel.
+            </p>
+          </div>
+        </Reveal>
+        <div className="ff-grid-3">
+          {twins.map((t,i)=>
+            <Reveal key={t.n} delay={i*100}>
+              <article style={{padding:'30px 28px',borderRadius:14,background:'rgba(255,255,255,0.022)',border:`1px solid ${C.hairline}`}}>
+                <div style={{display:'flex',alignItems:'flex-start',justifyContent:'space-between',marginBottom:24}}>
+                  <div style={{position:'relative',width:48,height:48}}>
+                    <div style={{position:'absolute',inset:-3,borderRadius:999,background:`conic-gradient(${t.h},${C.pink},${t.h})`,opacity:0.7}}/>
+                    <div style={{position:'relative',width:48,height:48,borderRadius:999,background:C.bg,padding:2}}>
+                      <div style={{width:'100%',height:'100%',borderRadius:999,background:t.h,display:'flex',alignItems:'center',justifyContent:'center',fontFamily:'Outfit',fontWeight:700,color:C.bg,fontSize:17}}>{t.n.charAt(0)}</div>
+                    </div>
+                  </div>
+                  <div style={{textAlign:'right'}}>
+                    <div style={{fontFamily:'Outfit',fontSize:32,fontWeight:200,color:C.text,letterSpacing:'-0.045em',lineHeight:1}}>{t.match}<span style={{fontSize:13,color:C.textLow}}>%</span></div>
+                    <div className="ff-eyebrow" style={{fontSize:9,color:C.textFaint,marginTop:3}}>Match</div>
+                  </div>
+                </div>
+                <div style={{fontFamily:'Outfit',fontSize:17,fontWeight:500,color:C.text}}>{t.n}</div>
+                <div className="ff-italic" style={{fontFamily:'Outfit',fontSize:12,color:C.textLow,fontStyle:'italic',marginTop:3}}>{t.mood}</div>
+                <div style={{marginTop:16,paddingTop:16,borderTop:`1px solid ${C.hairline}`,fontFamily:'Inter',fontSize:12,color:C.textLow,lineHeight:1.5}}>{t.recent}</div>
+              </article>
+            </Reveal>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ── M.'s letter ────────────────────────────────────────────────
+function MLetter(){
+  return(
+    <section style={{padding:'200px 32px',borderTop:`1px solid ${C.hairline}`,background:C.bgPaper}}>
+      <div style={{maxWidth:760,margin:'0 auto'}}>
+        <Reveal>
+          <div style={{textAlign:'center',marginBottom:48}}>
+            <div className="ff-eyebrow" style={{marginBottom:14,color:C.purple}}>Meet M., your curator</div>
+            <p className="ff-body" style={{fontSize:15,color:C.textMid,maxWidth:520,marginLeft:'auto',marginRight:'auto',lineHeight:1.6}}>
+              The engine has a voice. <em style={{color:C.textHi}}>M.</em> reads your taste, the time of day, and what you logged last week — then writes a short note with the pick.
+            </p>
+          </div>
+        </Reveal>
+        <Reveal delay={150}>
+          <div style={{position:'relative',padding:'56px 56px',borderRadius:6,background:'rgba(15,12,24,0.78)',border:`1px solid ${C.hairline}`,boxShadow:'0 32px 60px -20px rgba(0,0,0,0.7)'}}>
+            <div aria-hidden style={{position:'absolute',top:-26,right:32,width:52,height:52,borderRadius:999,background:GRAD,display:'flex',alignItems:'center',justifyContent:'center',fontFamily:'Outfit',fontWeight:700,fontSize:22,color:'#fff',boxShadow:'0 12px 24px -8px rgba(0,0,0,0.6)'}}>M</div>
+            <div className="ff-italic" style={{fontSize:13,color:C.textLow,fontStyle:'italic',marginBottom:24}}>Tuesday, 5:47 PM</div>
+            <p className="ff-body" style={{fontSize:17,color:C.textMid,lineHeight:1.75,margin:0,fontFamily:'Inter'}}>
+              You leaned <em style={{color:C.textHi}}>slow-burn</em> nine nights running. Tuesday has earned some tenderness, so tonight we go softer.
+            </p>
+            <p className="ff-body" style={{fontSize:17,color:C.textMid,lineHeight:1.75,marginTop:14,fontFamily:'Inter'}}>
+              <em style={{color:C.textHi}}>Past Lives</em> is patient. It won’t ask for your forgiveness; it’ll ask for your attention. Give it both. There’s a moment in the airport — you’ll know.
+            </p>
+            <p className="ff-body" style={{fontSize:17,color:C.textMid,lineHeight:1.75,marginTop:14,fontFamily:'Inter'}}>
+              Have it with a glass of something warm and the phone in another room.
+            </p>
+            <div className="ff-italic" style={{fontSize:17,color:C.textHi,fontStyle:'italic',marginTop:24,letterSpacing:'-0.005em'}}>— M.</div>
+          </div>
+        </Reveal>
+      </div>
+    </section>
+  );
+}
+
+// ── Pricing ────────────────────────────────────────────────────
+function Pricing(){
+  return(
+    <section id="pricing" style={{padding:'180px 32px',borderTop:`1px solid ${C.hairline}`}}>
+      <div style={{maxWidth:560,margin:'0 auto',textAlign:'center'}}>
+        <Reveal>
+          <div className="ff-eyebrow" style={{marginBottom:24,color:C.purple}}>Pricing</div>
+          <h2 className="ff-d2" style={{fontSize:'clamp(40px,5vw,68px)',color:C.text,margin:0}}>
+            <em className="ff-italic" style={{color:C.textMid}}>Free</em> to begin.
+          </h2>
+          <p className="ff-body" style={{marginTop:22,fontSize:16,color:C.textMid,lineHeight:1.65}}>Founding members keep the founding price. Forever.</p>
+        </Reveal>
+        <Reveal delay={150}>
+          <div style={{marginTop:56,padding:'48px 44px',borderRadius:16,background:`linear-gradient(160deg,${C.purple}15,transparent 80%)`,border:`1px solid ${C.purple}55`,position:'relative',overflow:'hidden'}}>
+            <div aria-hidden style={{position:'absolute',top:-40,right:-40,width:200,height:200,borderRadius:999,background:`radial-gradient(circle,${C.purple}30,transparent 70%)`,filter:'blur(30px)'}}/>
+            <div style={{position:'relative'}}>
+              <div className="ff-eyebrow" style={{color:C.textLow,marginBottom:18}}>Founding member</div>
+              <div style={{display:'flex',alignItems:'baseline',justifyContent:'center',gap:8,marginBottom:32}}>
+                <span style={{fontFamily:'Outfit',fontSize:84,fontWeight:200,color:C.text,letterSpacing:'-0.055em',lineHeight:0.9}}>$0</span>
+                <span className="ff-italic" style={{fontSize:14,color:C.textLow,fontStyle:'italic'}}>/ forever</span>
+              </div>
+              <ul style={{margin:0,padding:0,listStyle:'none',display:'flex',flexDirection:'column',gap:14,textAlign:'left',maxWidth:380,marginLeft:'auto',marginRight:'auto'}}>
+                {['Unlimited picks, any hour','Cinematic DNA, forever','The Briefing if you want it','No ads. No upsells. No algorithm tax.'].map(t=>
+                  <li key={t} style={{display:'flex',alignItems:'center',gap:12,fontFamily:'Inter',fontSize:14,color:C.textMid}}>
+                    <span style={{width:18,height:18,borderRadius:999,background:`${C.purple}20`,color:C.purple,display:'inline-flex',alignItems:'center',justifyContent:'center',flexShrink:0}}>
+                      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                    </span>{t}
+                  </li>
+                )}
+              </ul>
+              <a href="#start" className="ff-link" style={{display:'block',textAlign:'center',marginTop:36,padding:'15px 22px',borderRadius:999,background:GRAD,color:'#fff',fontFamily:'Inter',fontSize:14,fontWeight:600}}>Claim founding spot →</a>
+            </div>
+          </div>
+        </Reveal>
+      </div>
+    </section>
+  );
+}
+
+// ── Final CTA ──────────────────────────────────────────────────
+function FinalCTA(){
+  const { signInWithGoogle, isAuthenticating } = useGoogleAuth();
+  return(
+    <section id="start" style={{position:'relative',padding:'200px 32px 220px',borderTop:`1px solid ${C.hairline}`,background:C.bgPure,overflow:'hidden'}}>
+      <Stars tint={C.purple} count={80}/>
+      <div style={{position:'relative',maxWidth:980,margin:'0 auto',textAlign:'center'}}>
+        <Reveal>
+          <div className="ff-eyebrow" style={{color:C.purple,marginBottom:32}}>Stop scrolling. Start watching.</div>
+        </Reveal>
+        <Reveal delay={150}>
+          <h2 className="ff-d1" style={{fontSize:'clamp(72px,11vw,160px)',color:C.text,margin:0}}>
+            Tonight is <em className="ff-italic" style={{color:C.textMid}}>yours.</em>
+          </h2>
+        </Reveal>
+        <Reveal delay={300}>
+          <p className="ff-italic" style={{marginTop:36,fontSize:'clamp(17px,1.9vw,22px)',color:C.textMid,fontStyle:'italic',lineHeight:1.55,maxWidth:540,margin:'36px auto 0'}}>
+            One film, for the way you feel. Open it anytime.
+          </p>
+        </Reveal>
+        <Reveal delay={450}>
+          <button type="button" onClick={signInWithGoogle} disabled={isAuthenticating} className="ff-link" style={{display:'inline-flex',alignItems:'center',gap:10,marginTop:52,padding:'16px 32px',borderRadius:999,background:GRAD,color:'#fff',fontFamily:'Inter',fontSize:14.5,fontWeight:600,boxShadow:'0 18px 40px -10px rgba(236,72,153,0.5)',border:'none',cursor:isAuthenticating?'progress':'pointer',opacity:isAuthenticating?0.7:1}} aria-label="Begin with Google">
+            {isAuthenticating?'Opening Google…':'Begin'} <span>→</span>
+          </button>
+        </Reveal>
+        <Reveal delay={550}>
+          <div className="ff-eyebrow" style={{marginTop:24,color:C.textFaint,fontSize:10}}>Free · No credit card · Cancel anytime</div>
+        </Reveal>
+      </div>
+    </section>
+  );
+}
+
+// ── Footer ─────────────────────────────────────────────────────
+function Footer(){
+  return(
+    <footer style={{padding:'72px 32px 84px',borderTop:`1px solid ${C.hairline}`}}>
+      <div className="ff-grid-footer" style={{maxWidth:1180,margin:'0 auto'}}>
+        <div>
+          <div style={{fontFamily:'Inter',fontSize:20,fontWeight:900,letterSpacing:'-0.012em',background:GRAD,WebkitBackgroundClip:'text',WebkitTextFillColor:'transparent'}}>FEELFLICK</div>
+          <p className="ff-italic" style={{marginTop:14,fontFamily:'Inter',fontSize:13,color:C.textLow,lineHeight:1.6,maxWidth:340,fontStyle:'italic'}}>The right film. Right now.</p>
+        </div>
+        {[{t:'Product',l:['Discover','Browse','The Briefing','Your DNA']},{t:'Company',l:['About','Manifesto','Press','Careers']},{t:'Legal',l:['Privacy','Terms','Contact']}].map(c=>
+          <div key={c.t}>
+            <div className="ff-eyebrow" style={{fontSize:10,color:C.textLow,marginBottom:18}}>{c.t}</div>
+            <ul style={{margin:0,padding:0,listStyle:'none',display:'flex',flexDirection:'column',gap:11}}>
+              {c.l.map(li=><li key={li} style={{fontFamily:'Inter',fontSize:13,color:C.textMid,cursor:'pointer'}}>{li}</li>)}
+            </ul>
+          </div>
+        )}
+      </div>
+      <div style={{maxWidth:1180,margin:'56px auto 0',paddingTop:28,borderTop:`1px solid ${C.hairline}`,display:'flex',justifyContent:'space-between',flexWrap:'wrap',gap:12,fontFamily:'Inter',fontSize:11.5,color:C.textFaint}}>
+        <span>© FeelFlick · {new Date().getFullYear()}</span>
+        <span className="ff-italic" style={{fontStyle:'italic'}}>Made for the patient.</span>
+      </div>
+    </footer>
+  );
+}
+
+export default function LandingV3(){
+  return(
+    <div>
+      <Header/>
+      <Hero/>
+      <TheProblem/>
+      <Ritual/>
+      <FilmFile/>
+      <Briefing/>
+      <DNA/>
+      <Community/>
+      <MLetter/>
+      <Pricing/>
+      <FinalCTA/>
+      <Footer/>
+    </div>
+  );
+}

--- a/src/features/landing-v3/landing-v3.css
+++ b/src/features/landing-v3/landing-v3.css
@@ -1,0 +1,33 @@
+*{box-sizing:border-box;}
+
+
+em{font-style:italic;}
+button,input{font-family:inherit;}
+::selection{background:rgba(167,139,250,0.4);}
+@keyframes ff-tw{0%,100%{opacity:0.12;transform:scale(1);}50%{opacity:0.7;transform:scale(1.3);}}
+@keyframes ff-rot{from{transform:rotate(0deg);}to{transform:rotate(360deg);}}
+.ff-reveal{opacity:0;transform:translateY(32px);transition:opacity 1s cubic-bezier(.2,.7,.2,1),transform 1s cubic-bezier(.2,.7,.2,1);}
+.ff-reveal.in{opacity:1;transform:translateY(0);}
+.ff-link{color:inherit;text-decoration:none;}
+.ff-eyebrow{font-family:'Outfit',sans-serif;font-size:11px;font-weight:600;letter-spacing:0.28em;text-transform:uppercase;color:rgba(250,250,250,0.42);}
+.ff-italic{font-family:'Outfit',sans-serif;font-weight:300;font-style:italic;}
+.ff-d1{font-family:'Outfit',sans-serif;font-weight:200;letter-spacing:-0.055em;line-height:0.92;}
+.ff-d2{font-family:'Outfit',sans-serif;font-weight:200;letter-spacing:-0.045em;line-height:0.96;}
+.ff-
+.ff-fade-swap{animation:ff-fade-swap 0.5s cubic-bezier(.2,.7,.2,1);}
+@keyframes ff-fade-swap{from{opacity:0;transform:translateY(6px);filter:blur(4px);}to{opacity:1;transform:translateY(0);filter:blur(0);}}
+.ff-grid-2{display:grid;grid-template-columns:1fr 1fr;gap:80px;align-items:center;}
+.ff-grid-3{display:grid;grid-template-columns:repeat(3,1fr);gap:28px;}
+.ff-grid-hero{display:grid;grid-template-columns:1fr 1.05fr;gap:96px;align-items:center;}
+.ff-grid-feature{display:grid;grid-template-columns:420px 1fr;gap:64px;}
+.ff-grid-card{display:grid;grid-template-columns:auto 1fr;gap:32px;align-items:flex-start;}
+.ff-grid-footer{display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:64px;}
+@media (max-width: 900px){
+  .ff-grid-2,.ff-grid-3,.ff-grid-hero,.ff-grid-feature,.ff-grid-card{grid-template-columns:1fr !important;gap:48px !important;}
+  .ff-grid-footer{grid-template-columns:1fr 1fr !important;gap:36px !important;}
+  .ff-grid-2 > *,.ff-grid-3 > *,.ff-grid-hero > *,.ff-grid-feature > *{max-width:none !important;}
+}
+@media (max-width: 600px){
+  .ff-grid-footer{grid-template-columns:1fr !important;}
+  section{padding-left:20px !important;padding-right:20px !important;}
+}


### PR DESCRIPTION
## Summary
Drop-in port of the **Landing v11 prototype** mounted at `/v3` alongside the existing landing at `/`. Twelve sections: header → hero (6-film rotation) → the problem → the ritual → the Film File → briefing → DNA → taste twins → M.'s letter → pricing → final CTA → footer.

Files:
- `src/features/landing-v3/LandingV3.jsx` (single-file, ~700 lines, all sections inline)
- `src/features/landing-v3/landing-v3.css` (scoped animations + responsive grid)
- Route: `/v3` (public, parallel to `/`)

## Auth
- Header `Sign in`, header + hero `Start free →`, final CTA `Begin →` all wired to `useGoogleAuth` (same hook the existing landing uses).
- `isAuthenticating` disables buttons + shows `Opening Google…` copy.
- Pricing's `Claim founding spot →` stays as `#start` anchor — scrolls to the final CTA where the actual auth button lives.

## Cleanup applied to the dropped-in prototype
- Removed stray `ReactDOM.createRoot(...)` bootstrap at the bottom of the file.
- Removed unused `useLayoutEffect` import.
- Replaced 3 duplicate `margin` keys in inline styles (silent overrides).
- Replaced ASCII apostrophes/quotes in JSX text with typographic Unicode (`'`, `"`, `"`, `…`) — matches editorial tone + passes `react/no-unescaped-entities`.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run test -- --run` — 519/519 pass
- [x] `npm run build` — prod build OK
- [x] Dev server `/v3` — 11,462px page, no console errors
- [ ] Once deployed, click `Start free →` on /v3 — should hand off to Google OAuth and return to `/onboarding` (new account) or `/home` (returning)

## Follow-ups (optional, deferred)
- Replace static `PICKS` with engine top-6 for an anonymous visitor.
- Replace fake Marco/Priya/Theo taste-twins with real user counts.
- Replace the `Past Lives · 5★` reference in M.'s letter with the visitor's most recent rated film (or remove for anonymous-safe).

## Rollout plan
Mount at `/v3` parallel for A/B. Once confident, swap `/` to LandingV3 and preserve the current one at `/landing-legacy` (same pattern as the v2 surface migrations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)