### PR TITLE
feat(preferences): wire content boundaries; mark subscriptions Coming soon

### DIFF
--- a/src/features/discover-v5/DiscoverV5.jsx
+++ b/src/features/discover-v5/DiscoverV5.jsx
@@ -846,8 +846,13 @@ function DiscoverV5Body() {
     const moodIds = selected.length > 0 ? selected : ['slow','tender'];
     const scored = films.map(f => {
       // === Base score: real engine when we have a profile, mood-tag overlap as cold-start fallback ===
-      const baseScore = (profile && f._raw)
-        ? scoreMovieForUser(f._raw, profile, 'default').score
+      // scoreMovieForUser returns null when a content-boundary hard filter
+      // hits. Discover already applied prefs.avoidGenres at fetch time; for
+      // boundary-filtered films we drop to the mood-overlap score (low
+      // score → film sinks to the back).
+      const engineScored = (profile && f._raw) ? scoreMovieForUser(f._raw, profile, 'default') : null
+      const baseScore = engineScored
+        ? engineScored.score
         : (moodIds.reduce((a, id) => a + (f.fit[id] || 0), 0) / moodIds.length) * 100;
 
       // === UI modifiers layered on top of the engine score ===

--- a/src/features/home-v2/useHomeData.jsx
+++ b/src/features/home-v2/useHomeData.jsx
@@ -200,11 +200,13 @@ export function HomeDataProvider({ children }) {
           )
           const scored = profile
             ? moodPool.map(m => {
-                const { score, pickReason } = scoreMovieForUser(m, profile, 'default')
+                const result = scoreMovieForUser(m, profile, 'default')
+                if (!result) return null  // boundary filter dropped this film
+                const { score, pickReason } = result
                 // pickReason is { label, type, ... } — unwrap to the
                 // user-facing string the briefing card renders.
                 return { raw: m, score, reason: pickReason?.label || null }
-              })
+              }).filter(Boolean)
             // Cold-start: no user profile yet. Fall back to mood-tag overlap
             // count + ff_audience_rating tiebreak.
             : moodPool.map(m => {

--- a/src/features/movie-v2/sections-top.jsx
+++ b/src/features/movie-v2/sections-top.jsx
@@ -137,7 +137,7 @@ function MovieHero({
   onPlayTrailer, onBack, onShare,
   isInWatchlist, isWatched, onToggleWatchlist, onToggleWatched, loading, canAct,
 }) {
-  const { mv } = useMovieData();
+  const { mv, boundaryWarnings } = useMovieData();
   const [scrollY, setScrollY] = useState(0);
   const [tilt, setTilt] = useState({ x:0, y:0 });
 
@@ -249,6 +249,15 @@ function MovieHero({
             <div style={{ display:'inline-flex', alignItems:'center', gap:10, marginTop:22, padding:'8px 14px', borderRadius:999, background:'rgba(167,139,250,0.08)', border:`1px solid ${HP.purple}33`, color: HP.purple }}>
               <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>
               <span style={{ fontFamily:'Outfit', fontSize:11, fontWeight:600, letterSpacing:'0.06em', textTransform:'uppercase' }}>Best watched · {mv.daypartFit}</span>
+            </div>
+          )}
+
+          {boundaryWarnings?.length > 0 && (
+            <div style={{ display:'inline-flex', alignItems:'center', gap:10, marginTop:14, padding:'8px 14px', borderRadius:999, background:'rgba(245,158,11,0.10)', border:'1px solid rgba(245,158,11,0.33)', color:'#F59E0B' }} role="note">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M12 9v4"/><path d="M12 17h.01"/><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/></svg>
+              <span style={{ fontFamily:'Outfit', fontSize:11, fontWeight:600, letterSpacing:'0.06em', textTransform:'uppercase' }}>
+                Heads up · {boundaryWarnings.map(w => w.label).join(' · ')}
+              </span>
             </div>
           )}
 

--- a/src/features/movie-v2/useMovieData.jsx
+++ b/src/features/movie-v2/useMovieData.jsx
@@ -10,13 +10,16 @@ import { backdropImg, fetchJson, getMovieDetails, tmdbImg } from '@/shared/api/t
 import { supabase } from '@/shared/lib/supabase/client'
 import { useAuthSession } from '@/shared/hooks/useAuthSession'
 import { computeUserProfile, scoreMovieForUser } from '@/shared/services/recommendations'
+import { activeMovieBoundaries, BOUNDARY_LABEL } from '@/shared/services/boundaries'
 import { deriveMoodAxes } from './derive/moodRadar'
 
 // Columns from the internal movies row needed by the editorial sections AND
 // every dimension scoreMovieForUser reads (so the match ring isn't hardcoded).
+// keywords + certification feed the content-boundary detector used below.
 const MOVIE_DB_COLS = `
   id, tmdb_id, title, release_date, release_year, runtime,
   director_name, primary_genre, poster_path, original_language,
+  keywords, certification,
   mood_tags, tone_tags, fit_profile,
   ff_audience_rating, ff_audience_confidence, ff_critic_rating,
   ff_final_rating, ff_rating, ff_rating_genre_normalized,
@@ -208,6 +211,7 @@ const INITIAL_STATE = {
   moodAxes: null,      // derived 6-axis radar; null when no LLM signal
   overlay: null,       // curated editorial overlay (movies_editorial_overlay) when present
   hasOverlay: false,
+  boundaryWarnings: [], // [{ id, label }] for /preferences boundaries the user has on AND this film matches
   loading: true,
   error: null,
 }
@@ -223,11 +227,15 @@ export function useMovieDataFetch(id) {
 
     ;(async () => {
       try {
-        const [details, releaseDates, providers, filmDbResult] = await Promise.all([
+        const [details, releaseDates, providers, filmDbResult, userSettingsResult] = await Promise.all([
           getMovieDetails(id),
           fetchJson(`/movie/${id}/release_dates`).catch(() => null),
           fetchJson(`/movie/${id}/watch/providers`).catch(() => null),
           supabase.from('movies').select(MOVIE_DB_COLS).eq('tmdb_id', id).maybeSingle(),
+          // user's content-boundary toggles (anonymous viewers get [])
+          user?.id
+            ? supabase.from('user_settings').select('settings').eq('user_id', user.id).maybeSingle()
+            : Promise.resolve({ data: null }),
         ])
         if (abort) return
         if (!details || details?.success === false || details?.status_code) {
@@ -253,11 +261,27 @@ export function useMovieDataFetch(id) {
           const profile = await computeUserProfile(user.id).catch(() => null)
           if (abort) return
           if (profile) {
-            const { score } = scoreMovieForUser(filmDbRow, profile, 'default')
-            const pct = engineToPercent(score)
-            if (pct != null) mv.ffMatch = pct
+            // scoreMovieForUser returns null when a hard-filter triggers
+            // (muted director or active content boundary). In that case we
+            // intentionally skip the match % — the film still loads, the
+            // warning line below tells the user why we wouldn't have picked it.
+            const result = scoreMovieForUser(filmDbRow, profile, 'default')
+            if (result) {
+              const pct = engineToPercent(result.score)
+              if (pct != null) mv.ffMatch = pct
+            }
           }
         }
+
+        // Content boundary warnings — only the boundaries the user has on
+        // AND this film matches. Empty when anonymous or when no toggles are
+        // on. Computed off filmDbRow which has the engine-shaped keywords +
+        // certification columns; falls back to empty if film isn't in our
+        // catalog.
+        const userBoundaries = userSettingsResult?.data?.settings?.prefs?.boundaries
+        const boundaryWarnings = filmDbRow && userBoundaries
+          ? activeMovieBoundaries(filmDbRow, userBoundaries).map(b => ({ id: b, label: BOUNDARY_LABEL[b] }))
+          : []
 
         // Editorial overlay — admin-curated per-film fields. Keyed by internal
         // movies.id (filmDbRow.id), not tmdb_id. Skip the query if the film
@@ -284,6 +308,7 @@ export function useMovieDataFetch(id) {
           moodAxes,
           overlay,
           hasOverlay: Boolean(overlay),
+          boundaryWarnings,
           loading: false,
           error: null,
         })

--- a/src/features/preferences-v2/PreferencesV2.jsx
+++ b/src/features/preferences-v2/PreferencesV2.jsx
@@ -329,35 +329,42 @@ function Daypart() {
 }
 
 function Subscriptions() {
-  const { draft, toggleSubscription, catalogs } = usePreferencesData()
+  const { catalogs } = usePreferencesData()
+  // Section is disabled — we don't track streamer availability per film yet.
+  // Toggling can't move the engine until movies.watch_providers ships, so
+  // the section is presented read-only with a "Coming soon" badge.
   return (
     <section style={{ padding: '56px 88px', borderTop: `1px solid ${HP.border}`, background: 'rgba(255,255,255,0.012)' }}>
-      <H kicker="Subscriptions" title="What you have access to." sub="We bias recommendations toward what you can actually watch tonight." />
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 14 }}>
-        {catalogs.STREAMERS.map(s => {
-          const on = !!draft.subscriptions[s.id]
-          return (
-            <button
-              key={s.id}
-              type="button"
-              onClick={() => toggleSubscription(s.id)}
-              aria-pressed={on}
-              style={{
-                padding: '18px 20px', borderRadius: 8,
-                background: on ? 'rgba(167,139,250,0.06)' : 'rgba(255,255,255,0.025)',
-                border: `1px solid ${on ? HP.purple + '55' : HP.border}`,
-                cursor: 'pointer',
-                display: 'grid', gridTemplateColumns: 'auto 1fr auto', gap: 14, alignItems: 'center',
-              }}
-            >
-              <div style={{ width: 36, height: 36, borderRadius: 6, background: `linear-gradient(135deg, ${s.tint}33, ${s.tint}11)`, border: `1px solid ${s.tint}55`, display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: 'Outfit', fontWeight: 700, fontSize: 15, color: s.tint }}>{s.logo}</div>
-              <div style={{ fontFamily: 'Outfit', fontSize: 14, fontWeight: 500, color: on ? HP.text : HP.textSoft, letterSpacing: '-0.01em' }}>{s.name}</div>
-              <div style={{ width: 38, height: 22, borderRadius: 999, background: on ? HP_GRAD : 'rgba(255,255,255,0.08)', position: 'relative' }}>
-                <span style={{ position: 'absolute', top: 2, left: on ? 18 : 2, width: 18, height: 18, borderRadius: 999, background: '#fff', transition: 'left 0.25s ease' }} />
-              </div>
-            </button>
-          )
-        })}
+      <header style={{ marginBottom: 24 }}>
+        <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.28em', textTransform: 'uppercase', color: HP.purple, marginBottom: 12, display: 'inline-flex', alignItems: 'center', gap: 10 }}>
+          <span style={{ height: 1, width: 22, background: HP.purple, opacity: 0.6 }} />Subscriptions
+        </div>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 14, flexWrap: 'wrap' }}>
+          <h2 style={{ fontFamily: 'Outfit', fontSize: 36, lineHeight: 1, fontWeight: 500, letterSpacing: '-0.03em', color: HP.text, margin: 0 }}>What you have access to.</h2>
+          <span style={{ padding: '4px 10px', borderRadius: 999, border: `1px solid ${HP.borderStrong}`, background: 'rgba(255,255,255,0.04)', fontFamily: 'Outfit', fontSize: 10, fontWeight: 600, letterSpacing: '0.18em', textTransform: 'uppercase', color: HP.textMuted }}>Coming soon</span>
+        </div>
+        <p style={{ marginTop: 12, fontSize: 14, color: HP.textMuted, fontFamily: 'Outfit, Inter, sans-serif', lineHeight: 1.6, maxWidth: 560, fontStyle: 'italic' }}>
+          We&rsquo;ll bias recommendations toward what you can actually watch tonight &mdash; once we wire up streamer-availability data.
+        </p>
+      </header>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 14, opacity: 0.45, pointerEvents: 'none' }} aria-disabled="true">
+        {catalogs.STREAMERS.map(s => (
+          <div
+            key={s.id}
+            style={{
+              padding: '18px 20px', borderRadius: 8,
+              background: 'rgba(255,255,255,0.025)',
+              border: `1px solid ${HP.border}`,
+              display: 'grid', gridTemplateColumns: 'auto 1fr auto', gap: 14, alignItems: 'center',
+            }}
+          >
+            <div style={{ width: 36, height: 36, borderRadius: 6, background: `linear-gradient(135deg, ${s.tint}33, ${s.tint}11)`, border: `1px solid ${s.tint}55`, display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: 'Outfit', fontWeight: 700, fontSize: 15, color: s.tint }}>{s.logo}</div>
+            <div style={{ fontFamily: 'Outfit', fontSize: 14, fontWeight: 500, color: HP.textSoft, letterSpacing: '-0.01em' }}>{s.name}</div>
+            <div style={{ width: 38, height: 22, borderRadius: 999, background: 'rgba(255,255,255,0.08)', position: 'relative' }}>
+              <span style={{ position: 'absolute', top: 2, left: 2, width: 18, height: 18, borderRadius: 999, background: '#fff' }} />
+            </div>
+          </div>
+        ))}
       </div>
     </section>
   )

--- a/src/features/preferences-v2/usePreferencesData.jsx
+++ b/src/features/preferences-v2/usePreferencesData.jsx
@@ -231,7 +231,6 @@ export function PreferencesDataProvider({ children }) {
   }, [userId])
 
   // === Draft mutations (don't persist) ===
-  const update = useCallback((patch) => setDraft(d => ({ ...d, ...patch })), [])
   const setMoodWeight   = useCallback((id, w) => setDraft(d => ({ ...d, moodWeights: { ...d.moodWeights, [id]: w } })), [])
   const addDrawnGenre   = useCallback((id) => setDraft(d => d.drawnGenreIds.includes(id) || d.avoidGenreIds.includes(id) ? d : ({ ...d, drawnGenreIds: [...d.drawnGenreIds, id] })), [])
   const removeDrawnGenre = useCallback((id) => setDraft(d => ({ ...d, drawnGenreIds: d.drawnGenreIds.filter(x => x !== id) })), [])
@@ -311,9 +310,8 @@ export function PreferencesDataProvider({ children }) {
           subtitles: draft.subtitles,
           spoilerTier: draft.spoilerTier,
           languages: draft.languages,
-          // Genre labels — kept in JSONB as a denormalised mirror of
-          // user_preferences (which is what the engine actually reads).
-          drawnGenres: draft.drawnGenreIds.map(genreLabelOf),
+          // Avoid genres — Discover engine reads names from here. Drawn-to
+          // lives in user_preferences (no need to mirror).
           avoidGenres: draft.avoidGenreIds.map(genreLabelOf),
         },
       }
@@ -350,7 +348,7 @@ export function PreferencesDataProvider({ children }) {
     directorSuggestions,
     catalogs: { MOODS, GENRES, STREAMERS, DAYPARTS, BOUNDARIES, LANGUAGES, SUBTITLE_MODES, SPOILER_TIERS },
     // setters
-    update, setMoodWeight,
+    setMoodWeight,
     addDrawnGenre, removeDrawnGenre,
     addAvoidGenre, removeAvoidGenre,
     addTrustedDirector, removeTrustedDirector,
@@ -361,7 +359,7 @@ export function PreferencesDataProvider({ children }) {
     discard, save,
   }), [
     loading, saving, savedAt, dirty, draft, baseline, directorSuggestions,
-    update, setMoodWeight,
+    setMoodWeight,
     addDrawnGenre, removeDrawnGenre, addAvoidGenre, removeAvoidGenre,
     addTrustedDirector, removeTrustedDirector,
     addMutedDirector, removeMutedDirector,

--- a/src/features/watchlist-v2/useWatchlistData.jsx
+++ b/src/features/watchlist-v2/useWatchlistData.jsx
@@ -89,8 +89,12 @@ function deriveItems({ rows, fingerprint, profile }) {
     const m = r.movies || {}
     const mood = pickPrimaryMood(m.mood_tags)
     // Engine when we have a profile; cold-start fallback otherwise.
-    const match = profile
-      ? engineToPercent(scoreMovieForUser(m, profile, 'default').score)
+    // scoreMovieForUser returns null when a content-boundary hard filter
+    // hits (graphic/sexual + matching keywords/cert); fall back to
+    // approxMatch so the film still has a displayed percent.
+    const engineScored = profile ? scoreMovieForUser(m, profile, 'default') : null
+    const match = engineScored
+      ? engineToPercent(engineScored.score)
       : approxMatch({ movie: m, fingerprint })
     const addedDaysAgo = daysAgo(r.added_at)
     const stale = addedDaysAgo > STALE_DAYS

--- a/src/shared/services/boundaries.js
+++ b/src/shared/services/boundaries.js
@@ -1,0 +1,108 @@
+// Content boundary detection.
+//
+// Maps the 4 toggles on /preferences ("Hard rules") to TMDB keyword sets and
+// certification signals so the engine can act on them and MovieDetail can
+// surface a heads-up line.
+//
+// Semantics (mirror the on-page copy):
+//   • graphic — FILTER: hide from recommendations when toggle is on.
+//   • sexual  — FILTER: hide from recommendations when toggle is on.
+//   • animals — FLAG: don't filter; surface a warning on MovieDetail.
+//   • noise   — FLAG: don't filter; surface a warning on MovieDetail.
+
+const KW = (...names) => new Set(names.map((s) => s.toLowerCase()))
+
+// Curated against actual catalog coverage (queried 2026-05-24). Generic terms
+// like "violence" / "murder" are excluded — they appear on too many films to
+// be a useful "explicit / gore" signal.
+export const BOUNDARY_KEYWORDS = {
+  graphic: KW(
+    'gore', 'torture', 'brutality', 'brutal violence',
+    'extreme violence', 'gun violence', 'police brutality',
+    'mass murder', 'killing spree', 'massacre',
+    'dismemberment', 'decapitation', 'mutilation',
+    'axe murder',
+  ),
+  sexual: KW(
+    'sex scene', 'explicit sex', 'eroticism', 'erotic movie',
+    'erotic thriller', 'nudity', 'graphic nudity', 'female nudity',
+    'male nudity', 'sexual violence', 'sexual abuse', 'sexual assault',
+    'rape', 'rape and revenge', 'child sexual abuse',
+  ),
+  animals: KW(
+    'animal cruelty', 'animal death', 'animal abuse', 'animal slaughter',
+    'animal horror', 'animal attack',
+    'dog death', 'horse death', 'cat death',
+  ),
+  noise: KW(
+    'found footage', 'hybrid found footage', 'shaky cam', 'shaky camera',
+    'flashing lights', 'strobe lighting', 'strobe', 'epilepsy warning',
+    'flicker effect',
+  ),
+}
+
+// Per-boundary user-facing label. Matches /preferences exactly.
+export const BOUNDARY_LABEL = {
+  graphic: 'Graphic violence',
+  sexual:  'Explicit sexual content',
+  animals: 'Harm to animals',
+  noise:   'Sensory-heavy content',
+}
+
+// Boundaries that hide the film outright when toggled on.
+const FILTER_BOUNDARIES = new Set(['graphic', 'sexual'])
+// Boundaries that only surface a heads-up on MovieDetail.
+// (kept for symmetry; computed inline below)
+
+/**
+ * Returns the set of boundary IDs that a film matches, regardless of which
+ * toggles the user has on. Used for "always compute, conditionally show".
+ *
+ * @param {Object} movie - row with .keywords (jsonb [{id,name}]) + .certification
+ * @returns {string[]} subset of ['graphic','sexual','animals','noise']
+ */
+export function detectMovieBoundaries(movie) {
+  if (!movie) return []
+  const flags = []
+  const keywordSet = new Set(
+    (movie.keywords || [])
+      .map((k) => (typeof k === 'string' ? k : k?.name))
+      .filter(Boolean)
+      .map((s) => String(s).toLowerCase()),
+  )
+  const cert = String(movie.certification || '').trim().toUpperCase()
+
+  for (const [boundary, kws] of Object.entries(BOUNDARY_KEYWORDS)) {
+    let matched = false
+    for (const k of keywordSet) {
+      if (kws.has(k)) { matched = true; break }
+    }
+    if (!matched && boundary === 'sexual' && cert === 'NC-17') matched = true
+    if (matched) flags.push(boundary)
+  }
+  return flags
+}
+
+/**
+ * Returns true if the user's toggles + the film's content mean we should
+ * hide the film from recommendations. Only graphic/sexual filter; the
+ * others flag but don't filter.
+ *
+ * @param {Object} movie
+ * @param {Object} enabledBoundaries - shape { graphic, sexual, animals, noise }
+ */
+export function shouldFilterByBoundaries(movie, enabledBoundaries) {
+  if (!movie || !enabledBoundaries) return false
+  const flags = detectMovieBoundaries(movie)
+  return flags.some((b) => FILTER_BOUNDARIES.has(b) && enabledBoundaries[b])
+}
+
+/**
+ * Returns the subset of flags that the user has toggled on AND the film
+ * matches. Drives the "Heads up: X, Y" line on MovieDetail.
+ */
+export function activeMovieBoundaries(movie, enabledBoundaries) {
+  if (!enabledBoundaries) return []
+  const flags = detectMovieBoundaries(movie)
+  return flags.filter((b) => !!enabledBoundaries[b])
+}

--- a/src/shared/services/personalRating.js
+++ b/src/shared/services/personalRating.js
@@ -124,6 +124,10 @@ async function computePersonalRating(userId, movie, { profile } = {}) {
   // 2. Taste match from scoreMovieForUser
   const userProfile = profile ?? await computeUserProfile(userId)
   const scoreResult = scoreMovieForUser(movie, userProfile, 'personal')
+  // scoreMovieForUser returns null when a content-boundary hard filter
+  // triggers — we have no taste signal for those films, so skip the
+  // personal rating entirely (caller treats null as "no rating").
+  if (!scoreResult) return null
   // scoreMovieForUser returns 0-~200 raw; normalize to 0-100
   const tasteMatch = Math.max(0, Math.min(100, scoreResult.score / 2))
 

--- a/src/shared/services/recommendations.js
+++ b/src/shared/services/recommendations.js
@@ -76,6 +76,7 @@ import { buildSkipWeightMap, buildCooldownSet } from './skip-signals'
 import { selectHeroCandidates, dayHashIndex } from './diversity'
 import { heroEraFloor, generateHeroReason, tieBreakSort } from './hero-reason'
 import { briefHardFilters, scoreMovieForBrief, buildBriefSeeds, generateBriefReason } from './brief-scoring'
+import { shouldFilterByBoundaries } from './boundaries'
 
 // ============================================================================
 // VERSION
@@ -2835,6 +2836,14 @@ export function scoreMovieForUser(movie, profile, rowType = 'default', seedFilms
     }
   }
 
+  // Hard-filter on content boundaries (graphic violence / sexual content)
+  // when the user has the corresponding toggle ON in /preferences. Callers
+  // already handle null returns elsewhere in this pipeline. Animals/noise
+  // are flag-only (surfaced on MovieDetail) and don't drop the film.
+  if (userPrefs?.boundaries && shouldFilterByBoundaries(movie, userPrefs.boundaries)) {
+    return null
+  }
+
   // 1) BASE QUALITY (normalized when available, ff_audience_rating as fallback)
   const effectiveRating = movie.ff_audience_rating != null
     ? movie.ff_audience_rating / 10
@@ -4151,6 +4160,7 @@ export async function getGenreBasedRecommendations(userId, options = {}) {
       // 6. Score with GENRE-SPECIFIC weights
       const scored = eligible.map(movie => {
         const result = scoreMovieForUser(movie, profile, 'favorite_genres', seedFilms)
+        if (!result) return null  // boundary filter dropped this film
 
         // Embedding similarity boost
         let embeddingBoost = 0
@@ -4205,11 +4215,12 @@ export async function getGenreBasedRecommendations(userId, options = {}) {
         }
       })
 
-      // 7. Sort by score
-      scored.sort((a, b) => b.score - a.score)
+      // 7. Drop boundary-filtered nulls, then sort by score
+      const scoredKept = scored.filter(Boolean)
+      scoredKept.sort((a, b) => b.score - a.score)
 
       // 8. Apply diversity filter
-      const diverse = applyRowDiversityFilter(scored, limit)
+      const diverse = applyRowDiversityFilter(scoredKept, limit)
 
       // 9. Log impressions (async, don't await)
       logRowImpressions(userId, diverse, 'favorite_genres').catch(err =>
@@ -5414,6 +5425,7 @@ export async function getTrendingForUser(userId, options = {}) {
       // 6. Score with TRENDING-SPECIFIC weights
       const scored = eligible.map(movie => {
         const result = scoreMovieForUser(movie, profile, 'trending', seedFilms)
+        if (!result) return null  // boundary filter dropped this film
 
         // Embedding similarity boost
         let embeddingBoost = 0
@@ -5469,11 +5481,12 @@ export async function getTrendingForUser(userId, options = {}) {
         }
       })
 
-      // 7. Sort by score
-      scored.sort((a, b) => b.score - a.score)
+      // 7. Drop boundary-filtered nulls, then sort
+      const scoredKept = scored.filter(Boolean)
+      scoredKept.sort((a, b) => b.score - a.score)
 
       // 8. Apply diversity filter
-      const diverse = applyRowDiversityFilter(scored, limit)
+      const diverse = applyRowDiversityFilter(scoredKept, limit)
 
       // 9. Log impressions
       logRowImpressions(userId, diverse, 'trending').catch(err =>
@@ -5720,6 +5733,7 @@ export async function getHiddenGemsForUser(userId, options = {}) {
       // 6. Score with HIDDEN GEM-SPECIFIC weights
       const scored = eligible.map(movie => {
         const result = scoreMovieForUser(movie, profile, 'hidden_gems', seedFilms)
+        if (!result) return null  // boundary filter dropped this film
 
         // Embedding similarity boost
         let embeddingBoost = 0
@@ -5780,11 +5794,12 @@ export async function getHiddenGemsForUser(userId, options = {}) {
         }
       })
 
-      // 7. Sort by score
-      scored.sort((a, b) => b.score - a.score)
+      // 7. Drop boundary-filtered nulls, then sort
+      const scoredKept = scored.filter(Boolean)
+      scoredKept.sort((a, b) => b.score - a.score)
 
       // 8. Apply diversity filter
-      const diverse = applyRowDiversityFilter(scored, limit)
+      const diverse = applyRowDiversityFilter(scoredKept, limit)
 
       console.log(
         '[getHiddenGemsForUser] Final selection:',
@@ -5966,8 +5981,10 @@ export async function getMoodCoherenceRow(userId, profile, limit = 20) {
       const scored = candidates
         .map(movie => {
           const result = scoreMovieForUser(movie, profile, 'home')
+          if (!result) return null  // boundary filter dropped this film
           return { movie, score: result.score }
         })
+        .filter(Boolean)
         .sort((a, b) => b.score - a.score)
         .slice(0, limit)
 
@@ -6025,12 +6042,14 @@ export async function getYourGenresRow(userId, profile, limit = 20) {
       return candidates
         .map(movie => {
           const result = scoreMovieForUser(movie, profile, 'home')
+          if (!result) return null  // boundary filter dropped this film
           return {
             ...movie,
             _score: result.score,
             _pickReason: { label: `${genreName} pick`, type: 'your_genre' },
           }
         })
+        .filter(Boolean)
         .sort((a, b) => b._score - a._score)
         .slice(0, limit)
     } catch (error) {
@@ -6193,8 +6212,9 @@ export async function getSlowContemplativeRow(userId, limit = 20) {
       const candidates = (data || []).filter(m => m?.id && !watchedIds.includes(m.id))
       const scored = candidates.map(movie => {
         const result = scoreMovieForUser(movie, profile, 'default', seedFilms)
+        if (!result) return null  // boundary filter dropped this film
         return { ...movie, _score: result.score, _pickReason: { label: 'A moment of quiet', type: 'slow_contemplative' } }
-      })
+      }).filter(Boolean)
       scored.sort((a, b) => b._score - a._score)
       return scored.slice(0, limit)
     } catch (error) {
@@ -6250,8 +6270,9 @@ export async function getQuickWatchesRow(userId, limit = 20) {
 
       const scored = candidates.map(movie => {
         const result = scoreMovieForUser(movie, profile, 'default', seedFilms)
+        if (!result) return null  // boundary filter dropped this film
         return { ...movie, _score: result.score, _pickReason: { label: 'Under 90 minutes', type: 'quick_watch' } }
-      })
+      }).filter(Boolean)
       scored.sort((a, b) => b._score - a._score)
       return scored.slice(0, limit)
     } catch (error) {


### PR DESCRIPTION
## Summary

Stacked on [#85](https://github.com/30adityakumar/feelflick-app/pull/85). Boundaries section now actually does what the page promises; Subscriptions becomes an honest "Coming soon" instead of theater.

**Boundaries** — split by per-toggle copy:
- **Graphic / Sexual** (`Filter explicit / gore content` / `Filter NC-17 / unrated explicit`) → engine hard-filter. `scoreMovieForUser` returns `null` when film matches; every caller now defensive against null (favorite_genres, trending, hidden_gems, mood-coherence, your-genres, slow-contemplative, quick-watch, watchlist match%, Discover engine score, Home briefing, personal rating).
- **Animals / Noise** (`Flag depictions` / `Flicker, jump-cuts, strobe`) → MovieDetail surfaces an amber `Heads up · …` pill listing the boundaries the user has on AND the film matches.

**Keyword sets** curated against actual catalog coverage — queried against the 11k film catalog (graphic: gore/torture/brutality/extreme violence/etc. — 200+ films; sexual: sex scene/explicit/nudity/rape/NC-17 cert; animals: animal cruelty/death/horse death/dog death; noise: found footage/shaky cam/strobe). Generic "violence" / "murder" deliberately excluded — too many films to be a useful "explicit" signal.

**Subscriptions** — section visible but disabled (opacity + pointer-events) with "Coming soon" badge. Honest copy: "We'll bias recommendations toward what you can actually watch tonight — once we wire up streamer-availability data." Wiring it for real needs a `movies.watch_providers` JSONB column + TMDB ETL extension + region awareness — out of scope for this PR.

**Trivial cleanups bundled** (no-op for behavior):
- Drop write-only `settings.prefs.drawnGenres` mirror (nothing read it; engine pulls from `user_preferences` directly).
- Drop orphan `update()` setter on `usePreferencesData` provider (no UI consumer).

## Files

- `src/shared/services/boundaries.js` (new) — BOUNDARY_KEYWORDS + detect/filter helpers
- `src/shared/services/recommendations.js` — `shouldFilterByBoundaries` gate in `scoreMovieForUser`; 7 internal callers + null-guards
- `src/shared/services/personalRating.js` — null guard (returns null when boundary hits → caller treats as "no rating")
- `src/features/movie-v2/useMovieData.jsx` — parallel-fetch user_settings, compute `boundaryWarnings`, add `keywords + certification` to `MOVIE_DB_COLS`, null-safe match%
- `src/features/movie-v2/sections-top.jsx` — amber "Heads up" pill under daypart line
- `src/features/preferences-v2/PreferencesV2.jsx` — Subscriptions "Coming soon" UI
- `src/features/preferences-v2/usePreferencesData.jsx` — drop `drawnGenres` write + orphan `update` setter
- `src/features/discover-v5/DiscoverV5.jsx` — null-safe engine score
- `src/features/watchlist-v2/useWatchlistData.jsx` — null-safe match% (falls back to approxMatch)
- `src/features/home-v2/useHomeData.jsx` — null-safe + `.filter(Boolean)` on mood-coherence row

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 519/519 pass
- [x] `npm run build` clean
- [x] **Live test**: toggled `Graphic violence` ON in /preferences → saved → navigated to `/movie/769` (GoodFellas, has "gore" keyword) → "Heads up · Graphic violence" pill renders. Toggled OFF → reloaded → pill gone.
- [x] DB sanity: dev user `settings.prefs.boundaries` round-trips correctly through save/load
- [ ] Manual: toggle Sexual ON → `/movie/{NC-17 film}` should show pill
- [ ] Manual: toggle Animals/Noise ON → should NOT filter from recommendations, only show pill on MovieDetail
- [ ] Manual: /home, /discover, /watchlist still load when graphic ON (no crashes on null engine score)

🤖 Generated with [Claude Code](https://claude.com/claude-code)