### PR TITLE
fix(profile): cinematic DNA honesty pass — no fake friends, no dead CTAs

### DIFF
--- a/src/features/profile-v2/bottom.jsx
+++ b/src/features/profile-v2/bottom.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { HP, HP_GRAD, USER as USER_DEFAULT, FRIENDS, SKEWS, YIR } from './data'
+import { HP, HP_GRAD, USER as USER_DEFAULT, SKEWS, YIR } from './data'
 import { useProfileData } from './useProfileData'
 
 // FeelFlick — /profile · Directors, Motifs, Trajectory, Decades+Runtime, Mixtape, Skews, Friends, Share card, Footer.
@@ -84,12 +84,23 @@ function MotifCloud() {
   );
 }
 
-// Trajectory — 12-month bar chart, color by dominant mood
+// Trajectory — bar chart toggling between "Year" (last 12 months) and "All
+// time" (one bar per distinct calendar year). Both series come from the
+// hook as pure-derived arrays of { label, count, mood, hex }.
 function Trajectory() {
-  const { trajectory } = useProfileData();
+  const { trajectory, trajectoryAllTime } = useProfileData();
   const [range, setRange] = useState('Year');
-  if (!trajectory || trajectory.every(t => t.count === 0)) return null;
-  const max = Math.max(1, ...trajectory.map(t => t.count));
+  const yearSeries    = trajectory || [];
+  const allTimeSeries = trajectoryAllTime || [];
+  // "All time" is only meaningful with 2+ distinct years — otherwise it
+  // collapses to a single bar and the toggle adds nothing.
+  const allTimeAvailable = allTimeSeries.length >= 2;
+  const series = (range === 'All time' && allTimeAvailable) ? allTimeSeries : yearSeries;
+  if (!series.length || series.every(t => t.count === 0)) return null;
+  const max = Math.max(1, ...series.map(t => t.count));
+  const heading = range === 'All time'
+    ? <>Every <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>year so far.</em></>
+    : <>The <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>last twelve.</em></>;
   return (
     <section style={{ padding:'80px 88px', borderTop:`1px solid ${HP.border}` }}>
       <div style={{ display:'flex', alignItems:'flex-end', justifyContent:'space-between', marginBottom:44 }}>
@@ -97,33 +108,38 @@ function Trajectory() {
           <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color:HP.purple, marginBottom:14, display:'inline-flex', alignItems:'center', gap:10 }}>
             <span style={{ height:1, width:22, background:HP.purple, opacity:0.6 }} />Taste trajectory
           </div>
-          <h2 style={{ fontFamily:'Outfit', fontSize:44, lineHeight:1, fontWeight:500, letterSpacing:'-0.035em', color:HP.text, margin:0 }}>The <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>last twelve.</em></h2>
+          <h2 style={{ fontFamily:'Outfit', fontSize:44, lineHeight:1, fontWeight:500, letterSpacing:'-0.035em', color:HP.text, margin:0 }}>{heading}</h2>
         </div>
-        <div role="radiogroup" aria-label="Time range" style={{ display:'inline-flex', borderRadius:999, background:'rgba(255,255,255,0.04)', border:`1px solid ${HP.border}`, padding:3 }}>
-          {['Year','All time'].map(p => {
-            const active = range === p;
-            return (
-              <button
-                key={p}
-                type="button"
-                role="radio"
-                aria-checked={active}
-                onClick={() => setRange(p)}
-                style={{ padding:'7px 14px', borderRadius:999, background:active?HP_GRAD:'transparent', color:active?'#fff':HP.textMuted, border:'none', cursor:'pointer', fontFamily:'Outfit', fontSize:11, fontWeight:600, letterSpacing:'0.04em' }}
-              >{p}</button>
-            );
-          })}
-        </div>
+        {/* Only render the toggle when "All time" is actually informative
+            (≥2 distinct years). Otherwise hide it so users don't tap into
+            an identical chart. */}
+        {allTimeAvailable && (
+          <div role="radiogroup" aria-label="Time range" style={{ display:'inline-flex', borderRadius:999, background:'rgba(255,255,255,0.04)', border:`1px solid ${HP.border}`, padding:3 }}>
+            {['Year','All time'].map(p => {
+              const active = range === p;
+              return (
+                <button
+                  key={p}
+                  type="button"
+                  role="radio"
+                  aria-checked={active}
+                  onClick={() => setRange(p)}
+                  style={{ padding:'7px 14px', borderRadius:999, background:active?HP_GRAD:'transparent', color:active?'#fff':HP.textMuted, border:'none', cursor:'pointer', fontFamily:'Outfit', fontSize:11, fontWeight:600, letterSpacing:'0.04em' }}
+                >{p}</button>
+              );
+            })}
+          </div>
+        )}
       </div>
       <div style={{ display:'flex', alignItems:'flex-end', justifyContent:'space-between', gap:14, height:240 }}>
-        {trajectory.map((t, i) => {
+        {series.map((t, i) => {
           const h = (t.count / max) * 100;
           return (
-            <div key={`${t.month}-${i}`} style={{ flex:1, display:'flex', flexDirection:'column', alignItems:'center', gap:10 }}>
+            <div key={`${t.label}-${i}`} style={{ flex:1, display:'flex', flexDirection:'column', alignItems:'center', gap:10 }}>
               <div style={{ width:'100%', display:'flex', alignItems:'flex-end', justifyContent:'center', height:200 }}>
                 <div style={{ width:'100%', maxWidth:48, height:`${h}%`, background:`linear-gradient(180deg, ${t.hex}, ${t.hex}77)`, borderRadius:'4px 4px 0 0', boxShadow:`0 0 16px ${t.hex}33`, transition:'height 1s cubic-bezier(0.2,0.8,0.2,1)' }} />
               </div>
-              <div style={{ fontFamily:'Outfit', fontSize:11, color:HP.textMuted, letterSpacing:'0.08em', textTransform:'uppercase' }}>{t.month}</div>
+              <div style={{ fontFamily:'Outfit', fontSize:11, color:HP.textMuted, letterSpacing:'0.08em', textTransform:'uppercase' }}>{t.label}</div>
               <div style={{ fontFamily:'Outfit', fontSize:11, color:HP.text, fontWeight:600 }}>{t.count}</div>
             </div>
           );
@@ -314,11 +330,15 @@ function Skew() {
   );
 }
 
-// Friends ranked — live from user_similarity (bidirectional). Static FRIENDS
-// stays as cold-start fallback for users with no overlap data yet.
+// Taste twins — real overlap from user_similarity (bidirectional via
+// useProfileData). When the user has no similarity rows yet (new account
+// or thin history), we render an explicit empty state with a /people CTA
+// instead of falling back to fabricated names — fake social proof is
+// explicitly off-limits.
 function FriendsRanked() {
+  const navigate = useNavigate();
   const { friends } = useProfileData();
-  const rows = (friends && friends.length > 0) ? friends : FRIENDS;
+  const hasFriends = friends && friends.length > 0;
   return (
     <section style={{ padding:'72px 88px', borderTop:`1px solid ${HP.border}` }}>
       <div style={{ marginBottom:32 }}>
@@ -327,21 +347,41 @@ function FriendsRanked() {
         </div>
         <h2 style={{ fontFamily:'Outfit', fontSize:36, lineHeight:1.05, fontWeight:500, letterSpacing:'-0.03em', color:HP.text, margin:0 }}>People who <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>get it.</em></h2>
       </div>
-      <div style={{ display:'grid', gridTemplateColumns:'repeat(4,1fr)', gap:18 }}>
-        {rows.map(f => (
-          <div key={f.userId || f.name} style={{ padding:'24px 22px', borderRadius:6, background:'rgba(255,255,255,0.025)', border:`1px solid ${HP.border}` }}>
-            <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginBottom:18 }}>
-              <div style={{ width:44, height:44, borderRadius:999, background:f.avatarBg, display:'flex', alignItems:'center', justifyContent:'center', fontFamily:'Outfit', fontWeight:700, color:'#0a0510', fontSize:18 }}>{f.initial}</div>
-              <div style={{ textAlign:'right' }}>
-                <div style={{ fontFamily:'Outfit', fontSize:30, fontWeight:200, color:HP.text, letterSpacing:'-0.04em', lineHeight:1 }}>{f.match}<span style={{ fontSize:13, color:HP.textMuted, marginLeft:1 }}>%</span></div>
-                <div style={{ fontSize:9, color:HP.textFaint, fontFamily:'Outfit', letterSpacing:'0.14em', textTransform:'uppercase' }}>match</div>
+      {hasFriends ? (
+        <div style={{ display:'grid', gridTemplateColumns:'repeat(4,1fr)', gap:18 }}>
+          {friends.map(f => (
+            <button
+              key={f.userId || f.name}
+              type="button"
+              onClick={() => f.userId && navigate(`/profile/${f.userId}`)}
+              style={{ ...RESET_BTN, padding:'24px 22px', borderRadius:6, background:'rgba(255,255,255,0.025)', border:`1px solid ${HP.border}`, transition:'border-color 0.18s ease, background 0.18s ease' }}
+              onMouseEnter={(e) => { e.currentTarget.style.borderColor = HP.borderStrong; e.currentTarget.style.background = 'rgba(255,255,255,0.04)' }}
+              onMouseLeave={(e) => { e.currentTarget.style.borderColor = HP.border; e.currentTarget.style.background = 'rgba(255,255,255,0.025)' }}
+            >
+              <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginBottom:18 }}>
+                <div style={{ width:44, height:44, borderRadius:999, background:f.avatarBg, display:'flex', alignItems:'center', justifyContent:'center', fontFamily:'Outfit', fontWeight:700, color:'#0a0510', fontSize:18 }}>{f.initial}</div>
+                <div style={{ textAlign:'right' }}>
+                  <div style={{ fontFamily:'Outfit', fontSize:30, fontWeight:200, color:HP.text, letterSpacing:'-0.04em', lineHeight:1 }}>{f.match}<span style={{ fontSize:13, color:HP.textMuted, marginLeft:1 }}>%</span></div>
+                  <div style={{ fontSize:9, color:HP.textFaint, fontFamily:'Outfit', letterSpacing:'0.14em', textTransform:'uppercase' }}>match</div>
+                </div>
               </div>
-            </div>
-            <div style={{ fontFamily:'Outfit', fontSize:16, fontWeight:500, color:HP.text, letterSpacing:'-0.01em' }}>{f.name}</div>
-            <div style={{ fontSize:11, color:HP.textMuted, fontFamily:'Outfit', marginTop:3 }}>{f.films} films logged</div>
-          </div>
-        ))}
-      </div>
+              <div style={{ fontFamily:'Outfit', fontSize:16, fontWeight:500, color:HP.text, letterSpacing:'-0.01em' }}>{f.name}</div>
+              <div style={{ fontSize:11, color:HP.textMuted, fontFamily:'Outfit', marginTop:3 }}>{f.films} film{f.films === 1 ? '' : 's'} logged</div>
+            </button>
+          ))}
+        </div>
+      ) : (
+        <div style={{ padding:'40px 36px', borderRadius:8, background:'rgba(255,255,255,0.025)', border:`1px dashed ${HP.borderStrong}`, display:'flex', flexDirection:'column', alignItems:'flex-start', gap:18 }}>
+          <p style={{ margin:0, fontFamily:'Outfit, Inter, sans-serif', fontSize:16, fontStyle:'italic', color:HP.textSoft, maxWidth:520, lineHeight:1.55 }}>
+            Twins surface here once your taste overlaps with someone else&rsquo;s &mdash; keep logging films and they&rsquo;ll come.
+          </p>
+          <button
+            type="button"
+            onClick={() => navigate('/people')}
+            style={{ padding:'10px 18px', borderRadius:6, background:HP_GRAD, border:'none', color:'#fff', fontFamily:'Outfit', fontSize:12, fontWeight:600, letterSpacing:'0.04em', cursor:'pointer', boxShadow:'0 8px 22px -8px rgba(167,139,250,0.45)' }}
+          >Find people on FeelFlick →</button>
+        </div>
+      )}
     </section>
   );
 }
@@ -440,20 +480,13 @@ function YIRBanner() {
   }
   return (
     <section style={{ padding:'56px 88px', borderTop:`1px solid ${HP.border}`, background:`linear-gradient(135deg, ${HP.purple}11, ${HP.pink}08)` }}>
-      <div style={{ display:'grid', gridTemplateColumns:'auto 1fr auto', gap:32, alignItems:'center' }}>
+      <div style={{ display:'grid', gridTemplateColumns:'auto 1fr', gap:32, alignItems:'center' }}>
         <div style={{ fontFamily:'Outfit', fontSize:64, fontWeight:200, color:HP.text, letterSpacing:'-0.05em', lineHeight:1, background:HP_GRAD, WebkitBackgroundClip:'text', WebkitTextFillColor:'transparent' }}>{new Date().getFullYear()}</div>
         <div>
-          <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.22em', textTransform:'uppercase', color:HP.purple, marginBottom:6 }}>Year in review · draft</div>
+          <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.22em', textTransform:'uppercase', color:HP.purple, marginBottom:6 }}>Year so far</div>
           <div style={{ fontFamily:'Outfit', fontSize:22, fontWeight:500, color:HP.text, letterSpacing:'-0.02em', marginBottom:6 }}>{banner.headline}</div>
           <div style={{ fontSize:13, color:HP.textSoft, fontFamily:'Outfit, Inter, sans-serif', fontStyle:'italic' }}>{banner.sub}</div>
         </div>
-        <button
-          type="button"
-          disabled
-          aria-disabled="true"
-          title="Full Year in Review ships in a follow-up"
-          style={{ padding:'12px 22px', borderRadius:6, background:'rgba(255,255,255,0.06)', border:`1px solid ${HP.borderStrong}`, color:HP.textMuted, fontFamily:'Outfit', fontSize:13, fontWeight:600, cursor:'not-allowed', opacity:0.6 }}
-        >Open the full review →</button>
       </div>
     </section>
   );
@@ -461,7 +494,6 @@ function YIRBanner() {
 
 function ProfileFooter() {
   const linkStyle = { fontSize:12, color:HP.textMuted, letterSpacing:'0.04em', textDecoration:'none', cursor:'pointer' };
-  const disabledStyle = { ...linkStyle, color:HP.textFaint, cursor:'not-allowed', background:'none', border:'none', padding:0, font:'inherit' };
   return (
     <footer style={{ padding:'40px 88px 64px', borderTop:`1px solid ${HP.border}`, display:'flex', alignItems:'center', justifyContent:'space-between', fontFamily:'Outfit', flexWrap:'wrap', gap:20 }}>
       <div style={{ display:'flex', alignItems:'center', gap:14 }}>
@@ -471,13 +503,6 @@ function ProfileFooter() {
       <div style={{ display:'flex', gap:24 }}>
         <a href="/privacy" style={linkStyle}>Privacy</a>
         <a href="/account" style={linkStyle}>Manage data</a>
-        <button
-          type="button"
-          disabled
-          aria-disabled="true"
-          title="Engine-transparency page coming soon"
-          style={disabledStyle}
-        >What the engine sees</button>
       </div>
     </footer>
   );

--- a/src/features/profile-v2/data.js
+++ b/src/features/profile-v2/data.js
@@ -1,18 +1,16 @@
 // FeelFlick — /profile · data layer.
 //
 // What's left here:
-//   - USER editorial fallbacks (summary, archetype, signature) — these are
-//     still hardcoded until a per-user editorial overlay table lands (PR 4).
-//     name/handle/joined/filmsLogged/hoursWatched are all derived live now —
-//     USER_DEFAULT.name is only the placeholder if useAuthSession() has no
-//     user yet.
-//   - Brand tokens (HP, HP_GRAD)
-//   - FRIENDS / SKEWS / YIR — still static until PR 3 (FRIENDS needs real
-//     user_similarity; SKEWS needs an RPC; YIR composes both).
+//   - USER editorial fallbacks (summary, archetype, signature). The real
+//     values come from user_profiles_computed.editorial_* via
+//     useProfileData; USER_DEFAULT.* only renders pre-load or when the
+//     LLM regen hasn't run yet.
+//   - Brand tokens (HP, HP_GRAD).
+//   - SKEWS / YIR cold-start fallbacks — kept because they let the Skew /
+//     YIR sections always render something sensible while data thickens.
 //
-// MOODS, DIRECTORS, MOTIFS, TRAJECTORY, DECADES, RUNTIME, DAYPART, MIXTAPE
-// are now derived in real time from user_history × user_ratings × the taste
-// fingerprint — see ./derive.js and ./useProfileData.jsx.
+// FRIENDS is gone: the Taste Twins section now renders a real empty state
+// when user_similarity has no rows (no more Marco/Priya/Theo/Jules).
 
 export const USER = {
   name: 'You',
@@ -37,14 +35,9 @@ export const HP = {
 };
 export const HP_GRAD = 'linear-gradient(135deg, #A78BFA 0%, #EC4899 100%)';
 
-// Static fallbacks — PR 3 wires these to real Supabase data.
-export const FRIENDS = [
-  { name:'Marco', initial:'M', match:87, films:42, avatarBg:'#A78BFA' },
-  { name:'Priya', initial:'P', match:79, films:64, avatarBg:'#F472B6' },
-  { name:'Theo',  initial:'T', match:64, films:38, avatarBg:'#7DD3FC' },
-  { name:'Jules', initial:'J', match:58, films:91, avatarBg:'#FBBF24' },
-];
-
+// Cold-start fallbacks for sections that always render — Skew + YIR show
+// these neutral values when the user has too little data for a live
+// derivation.
 export const SKEWS = [
   { label:'Darker',         you:73, them:50, delta:+23 },
   { label:'Slower-paced',   you:68, them:50, delta:+18 },

--- a/src/features/profile-v2/derive.js
+++ b/src/features/profile-v2/derive.js
@@ -146,6 +146,14 @@ export function deriveMixtape({ history, ratingsByMovieId }) {
 
 // === TRAJECTORY (last 12 months, count + dominant mood per month) ===
 
+function pickDominantMood(moodCounts) {
+  if (moodCounts.size === 0) return { mood: null, hex: HP.purple }
+  const sorted = [...moodCounts.entries()].sort((a, b) => b[1] - a[1])
+  const mood = capitalize(sorted[0][0])
+  const idx = Math.abs(mood.charCodeAt(0) + mood.length) % MOOD_PALETTE.length
+  return { mood, hex: MOOD_PALETTE[idx] }
+}
+
 export function deriveTrajectory({ history }) {
   if (history.length === 0) return []
   const now = new Date()
@@ -155,7 +163,7 @@ export function deriveTrajectory({ history }) {
     const d = new Date(now.getFullYear(), now.getMonth() - i, 1)
     buckets.push({
       key: `${d.getFullYear()}-${d.getMonth()}`,
-      month: MONTH_LABELS[d.getMonth()],
+      label: MONTH_LABELS[d.getMonth()],
       count: 0,
       moodCounts: new Map(),
     })
@@ -174,17 +182,34 @@ export function deriveTrajectory({ history }) {
     }
   }
   return buckets.map(b => {
-    let dominant = null
-    let dominantHex = HP.purple
-    if (b.moodCounts.size > 0) {
-      const sorted = [...b.moodCounts.entries()].sort((a, b2) => b2[1] - a[1])
-      dominant = capitalize(sorted[0][0])
-      // hash → palette index
-      const idx = Math.abs(dominant.charCodeAt(0) + dominant.length) % MOOD_PALETTE.length
-      dominantHex = MOOD_PALETTE[idx]
-    }
-    return { month: b.month, count: b.count, mood: dominant, hex: dominantHex }
+    const { mood, hex } = pickDominantMood(b.moodCounts)
+    return { label: b.label, count: b.count, mood, hex }
   })
+}
+
+// "All time" view — one bar per distinct calendar year with watch history.
+// Used by the Trajectory toggle's "All time" option.
+export function deriveTrajectoryAllTime({ history }) {
+  if (history.length === 0) return []
+  const byYear = new Map()  // year → { count, moodCounts }
+  for (const h of history) {
+    if (!h.watched_at) continue
+    const y = new Date(h.watched_at).getFullYear()
+    if (!Number.isFinite(y)) continue
+    if (!byYear.has(y)) byYear.set(y, { count: 0, moodCounts: new Map() })
+    const b = byYear.get(y)
+    b.count += 1
+    for (const tag of h.movies?.mood_tags || []) {
+      b.moodCounts.set(tag, (b.moodCounts.get(tag) || 0) + 1)
+    }
+  }
+  if (byYear.size === 0) return []
+  return [...byYear.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([year, b]) => {
+      const { mood, hex } = pickDominantMood(b.moodCounts)
+      return { label: String(year), count: b.count, mood, hex }
+    })
 }
 
 // === DECADES (% of watched films per decade) ===

--- a/src/features/profile-v2/top.jsx
+++ b/src/features/profile-v2/top.jsx
@@ -8,6 +8,27 @@ import { useProfileData } from './useProfileData'
 // Edit profile + Share my DNA actions live in the masthead corner — the page
 // is rendered inside AppShell which already provides the global TopNav.
 
+// "Updated today" / "Updated 5 days ago" / "Updated May 2026" — relative
+// label for the masthead eyebrow, driven by editorial.generatedAt. Returns
+// null when we have no real timestamp so the secondary text just hides
+// instead of lying.
+function formatUpdated(isoString) {
+  if (!isoString) return null
+  const t = new Date(isoString).getTime()
+  if (!Number.isFinite(t)) return null
+  const diffMs = Date.now() - t
+  const day = 24 * 60 * 60 * 1000
+  const days = Math.floor(diffMs / day)
+  if (days <= 0) return 'Updated today'
+  if (days === 1) return 'Updated yesterday'
+  if (days < 7) return `Updated ${days} days ago`
+  if (days < 30) {
+    const weeks = Math.floor(days / 7)
+    return `Updated ${weeks} week${weeks === 1 ? '' : 's'} ago`
+  }
+  return `Updated ${new Date(isoString).toLocaleDateString('en-US', { month: 'short', year: 'numeric' })}`
+}
+
 function Masthead() {
   const navigate = useNavigate();
   const { user, isSelf, viewingUserId, editorial } = useProfileData();
@@ -19,6 +40,9 @@ function Masthead() {
   const archetype  = Array.isArray(editorial?.archetype) && editorial.archetype.length === 3
     ? editorial.archetype
     : USER_DEFAULT.archetype;
+  // "Updated [N days] ago" — driven by the real editorial regen timestamp, not
+  // a hardcoded "Vol. I · Updated today" string.
+  const updatedLabel = formatUpdated(editorial?.generatedAt);
 
   const handleShareDNA = async () => {
     const url = window.location.href;
@@ -47,8 +71,12 @@ function Masthead() {
       <div style={{ position:'relative', display:'flex', alignItems:'center', justifyContent:'space-between', gap:14, marginBottom:30 }}>
         <div style={{ display:'flex', alignItems:'center', gap:14 }}>
           <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.32em', textTransform:'uppercase', color:HP.purple }}>Cinematic DNA</div>
-          <div style={{ height:1, width:38, background:HP.purple, opacity:0.5 }} />
-          <div style={{ fontSize:10, fontWeight:500, letterSpacing:'0.18em', textTransform:'uppercase', color:HP.textMuted, fontFamily:'Outfit' }}>Vol. I · Updated today</div>
+          {updatedLabel && (
+            <>
+              <div style={{ height:1, width:38, background:HP.purple, opacity:0.5 }} />
+              <div style={{ fontSize:10, fontWeight:500, letterSpacing:'0.18em', textTransform:'uppercase', color:HP.textMuted, fontFamily:'Outfit' }}>{updatedLabel}</div>
+            </>
+          )}
         </div>
         <div style={{ display:'flex', gap:10, alignItems:'center' }}>
           {isSelf ? (

--- a/src/features/profile-v2/useProfileData.jsx
+++ b/src/features/profile-v2/useProfileData.jsx
@@ -11,7 +11,8 @@ import { getTasteFingerprint } from '@/shared/services/tasteCache'
 
 import {
   deriveUser, deriveStats, deriveMoods, deriveDirectors, deriveMotifs,
-  deriveMixtape, deriveTrajectory, deriveDecades, deriveRuntime, deriveDaypart,
+  deriveMixtape, deriveTrajectory, deriveTrajectoryAllTime,
+  deriveDecades, deriveRuntime, deriveDaypart,
   deriveFriends, deriveSkews, deriveYIR,
 } from './derive'
 import { archetypeForFingerprint } from './archetype'
@@ -46,6 +47,7 @@ const INITIAL_STATE = {
   motifs: [],
   mixtape: [],
   trajectory: [],
+  trajectoryAllTime: [],
   decades: [],
   runtime: null,
   daypart: [],
@@ -153,6 +155,7 @@ export function useProfileDataFetch({ userId, authUser, isSelf = false }) {
           motifs: deriveMotifs({ history }),
           mixtape: deriveMixtape({ history, ratingsByMovieId }),
           trajectory: deriveTrajectory({ history }),
+          trajectoryAllTime: deriveTrajectoryAllTime({ history }),
           decades: deriveDecades({ history }),
           runtime: deriveRuntime({ history }),
           daypart: deriveDaypart({ history }),


### PR DESCRIPTION
## Summary

The /profile page (Cinematic DNA) is a marquee surface for FeelFlick, but four small things have been undercutting it:

1. **Fake taste twins** — when `user_similarity` is empty (which is most new users), the Taste Twins section rendered hardcoded **Marco / Priya / Theo / Jules** with realistic match percents (87/79/64/58). Direct violation of CLAUDE.md *"Never Do #4 — no fake social proof."*
2. **"Vol. I · Updated today"** in the masthead eyebrow — fake versioning + hardcoded freshness claim.
3. **Trajectory "Year | All time" toggle** that updated React state but never changed the chart. Decorative.
4. **Disabled CTAs** — "Open the full review →" in the YIR banner + "What the engine sees" footer link, both pointing to features that don't exist.

## What ships

- **Taste Twins** — when no `user_similarity` rows exist, render an explicit empty state with a `/people` CTA. Live twin cards now clickable to `/profile/:userId`.
- **Masthead eyebrow** — `editorial.generatedAt` drives a real relative label (`Updated today` / `Updated 3 days ago` / `Updated May 2026`). Hides entirely when no real timestamp.
- **Trajectory toggle** — wired for real. New `deriveTrajectoryAllTime()` groups history by calendar year. Toggle hidden when user has <2 distinct years (otherwise both options would show the same one-bar chart).
- **YIR banner** — drop the disabled "Open the full review →" button. Rename "Year in review · draft" → "Year so far". Stats (binged month, mood growth) stay; they were always real.
- **Footer** — drop the disabled "What the engine sees" link.

## Derive layer refactor

Shared `pickDominantMood()` helper extracted so the year and month derivers don't duplicate the palette-pick logic. Trajectory items use `{ label, count, mood, hex }` so both series share a shape (`label` instead of `month`-or-`year`).

## Files changed

- `src/features/profile-v2/derive.js` — extract helper + add `deriveTrajectoryAllTime`
- `src/features/profile-v2/useProfileData.jsx` — fetch + expose both trajectory series
- `src/features/profile-v2/top.jsx` — `formatUpdated()` helper, real timestamp in masthead
- `src/features/profile-v2/bottom.jsx` — Trajectory toggle rewire, Taste Twins empty state, YIR button drop, Footer link drop
- `src/features/profile-v2/data.js` — drop `FRIENDS` array + comment refresh

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 519/519 pass
- [x] `npm run build` clean
- [x] **Live test as dev user (0 user_similarity rows, editorial regen present):** Taste Twins shows empty state + CTA. Masthead eyebrow reads "UPDATED TODAY". YIR shows clean stat block. Footer shows only Privacy / Manage data. Trajectory toggle hidden (only 1 year of data).
- [ ] Manual: load /profile/:userId for someone with similarity rows → live twin cards render, clicking opens their profile.
- [ ] Manual: user with 2+ years of history → "Year / All time" toggle appears and actually switches the chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)