### PR TITLE
feat(profile): mobile responsive layer — every grid stacks cleanly under 880px

### DIFF
--- a/src/features/profile-v2/bottom.jsx
+++ b/src/features/profile-v2/bottom.jsx
@@ -19,18 +19,18 @@ function SignatureDirectors() {
   const { directors } = useProfileData();
   if (!directors || directors.length === 0) return null;
   return (
-    <section style={{ padding:'80px 88px', borderTop:`1px solid ${HP.border}` }}>
+    <section className="ff-profile-section" style={{ padding:'80px 88px', borderTop:`1px solid ${HP.border}` }}>
       <div style={{ display:'flex', alignItems:'flex-end', justifyContent:'space-between', marginBottom:40 }}>
         <div>
           <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color:HP.purple, marginBottom:14, display:'inline-flex', alignItems:'center', gap:10 }}>
             <span style={{ height:1, width:22, background:HP.purple, opacity:0.6 }} />Signature directors
           </div>
-          <h2 style={{ fontFamily:'Outfit', fontSize:44, lineHeight:1, fontWeight:500, letterSpacing:'-0.035em', color:HP.text, margin:0 }}>
+          <h2 className="ff-profile-section-h2" style={{ fontFamily:'Outfit', fontSize:44, lineHeight:1, fontWeight:500, letterSpacing:'-0.035em', color:HP.text, margin:0 }}>
             The voices you <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>trust.</em>
           </h2>
         </div>
       </div>
-      <div style={{ display:'grid', gridTemplateColumns:`repeat(${Math.min(directors.length, 5)},1fr)`, gap:20 }}>
+      <div className="ff-profile-directors-grid" style={{ display:'grid', gridTemplateColumns:`repeat(${Math.min(directors.length, 5)},1fr)`, gap:20 }}>
         {directors.map(d => (
           <div key={d.name} style={{ padding:'24px 22px', borderRadius:6, background:'rgba(255,255,255,0.025)', border:`1px solid ${HP.border}`, position:'relative', overflow:'hidden' }}>
             <div style={{ position:'absolute', top:-30, right:-30, width:100, height:100, borderRadius:999, background:`radial-gradient(circle, ${d.accent}33, transparent 70%)` }} />
@@ -62,11 +62,11 @@ function MotifCloud() {
   const { motifs } = useProfileData();
   if (!motifs || motifs.length === 0) return null;
   return (
-    <section style={{ padding:'80px 88px', borderTop:`1px solid ${HP.border}`, background:'rgba(255,255,255,0.012)' }}>
-      <div style={{ display:'grid', gridTemplateColumns:'1fr 2fr', gap:80, alignItems:'flex-start' }}>
+    <section className="ff-profile-section" style={{ padding:'80px 88px', borderTop:`1px solid ${HP.border}`, background:'rgba(255,255,255,0.012)' }}>
+      <div className="ff-profile-motifs-grid" style={{ display:'grid', gridTemplateColumns:'1fr 2fr', gap:80, alignItems:'flex-start' }}>
         <div>
           <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color:HP.purple, marginBottom:18 }}>Recurring motifs</div>
-          <h2 style={{ fontFamily:'Outfit', fontSize:44, lineHeight:1, fontWeight:500, letterSpacing:'-0.035em', color:HP.text, margin:0 }}>What you <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>keep finding.</em></h2>
+          <h2 className="ff-profile-section-h2" style={{ fontFamily:'Outfit', fontSize:44, lineHeight:1, fontWeight:500, letterSpacing:'-0.035em', color:HP.text, margin:0 }}>What you <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>keep finding.</em></h2>
           <p style={{ marginTop:18, fontSize:14, color:HP.textMuted, fontFamily:'Outfit, Inter, sans-serif', lineHeight:1.65, maxWidth:340 }}>Patterns the engine sees across what you&rsquo;ve loved. Bigger means stronger pull.</p>
         </div>
         <div style={{ display:'flex', flexWrap:'wrap', gap:'14px 18px', alignItems:'baseline' }}>
@@ -102,13 +102,13 @@ function Trajectory() {
     ? <>Every <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>year so far.</em></>
     : <>The <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>last twelve.</em></>;
   return (
-    <section style={{ padding:'80px 88px', borderTop:`1px solid ${HP.border}` }}>
+    <section className="ff-profile-section" style={{ padding:'80px 88px', borderTop:`1px solid ${HP.border}` }}>
       <div style={{ display:'flex', alignItems:'flex-end', justifyContent:'space-between', marginBottom:44 }}>
         <div>
           <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color:HP.purple, marginBottom:14, display:'inline-flex', alignItems:'center', gap:10 }}>
             <span style={{ height:1, width:22, background:HP.purple, opacity:0.6 }} />Taste trajectory
           </div>
-          <h2 style={{ fontFamily:'Outfit', fontSize:44, lineHeight:1, fontWeight:500, letterSpacing:'-0.035em', color:HP.text, margin:0 }}>{heading}</h2>
+          <h2 className="ff-profile-section-h2" style={{ fontFamily:'Outfit', fontSize:44, lineHeight:1, fontWeight:500, letterSpacing:'-0.035em', color:HP.text, margin:0 }}>{heading}</h2>
         </div>
         {/* Only render the toggle when "All time" is actually informative
             (≥2 distinct years). Otherwise hide it so users don't tap into
@@ -131,7 +131,7 @@ function Trajectory() {
           </div>
         )}
       </div>
-      <div style={{ display:'flex', alignItems:'flex-end', justifyContent:'space-between', gap:14, height:240 }}>
+      <div className="ff-profile-trajectory-bars" style={{ display:'flex', alignItems:'flex-end', justifyContent:'space-between', gap:14, height:240 }}>
         {series.map((t, i) => {
           const h = (t.count / max) * 100;
           return (
@@ -139,8 +139,8 @@ function Trajectory() {
               <div style={{ width:'100%', display:'flex', alignItems:'flex-end', justifyContent:'center', height:200 }}>
                 <div style={{ width:'100%', maxWidth:48, height:`${h}%`, background:`linear-gradient(180deg, ${t.hex}, ${t.hex}77)`, borderRadius:'4px 4px 0 0', boxShadow:`0 0 16px ${t.hex}33`, transition:'height 1s cubic-bezier(0.2,0.8,0.2,1)' }} />
               </div>
-              <div style={{ fontFamily:'Outfit', fontSize:11, color:HP.textMuted, letterSpacing:'0.08em', textTransform:'uppercase' }}>{t.label}</div>
-              <div style={{ fontFamily:'Outfit', fontSize:11, color:HP.text, fontWeight:600 }}>{t.count}</div>
+              <div className="ff-profile-trajectory-label" style={{ fontFamily:'Outfit', fontSize:11, color:HP.textMuted, letterSpacing:'0.08em', textTransform:'uppercase' }}>{t.label}</div>
+              <div className="ff-profile-trajectory-count" style={{ fontFamily:'Outfit', fontSize:11, color:HP.text, fontWeight:600 }}>{t.count}</div>
             </div>
           );
         })}
@@ -163,8 +163,8 @@ function PatternPanel() {
     return 'Morning person, cinematically.';
   })();
   return (
-    <section style={{ padding:'80px 88px', borderTop:`1px solid ${HP.border}`, background:'rgba(255,255,255,0.012)' }}>
-      <div style={{ display:'grid', gridTemplateColumns:'repeat(3,1fr)', gap:48 }}>
+    <section className="ff-profile-section" style={{ padding:'80px 88px', borderTop:`1px solid ${HP.border}`, background:'rgba(255,255,255,0.012)' }}>
+      <div className="ff-profile-pattern-grid" style={{ display:'grid', gridTemplateColumns:'repeat(3,1fr)', gap:48 }}>
         {/* Decades */}
         {decades && decades.length > 0 && (
           <div>
@@ -233,12 +233,12 @@ function Mixtape() {
   const { mixtape } = useProfileData();
   if (!mixtape || mixtape.length === 0) return null;
   return (
-    <section style={{ padding:'88px 88px', borderTop:`1px solid ${HP.border}` }}>
+    <section className="ff-profile-section" style={{ padding:'88px 88px', borderTop:`1px solid ${HP.border}` }}>
       <div style={{ marginBottom:36 }}>
         <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color:HP.purple, marginBottom:14, display:'inline-flex', alignItems:'center', gap:10 }}>
           <span style={{ height:1, width:22, background:HP.purple, opacity:0.6 }} />Your mixtape
         </div>
-        <h2 style={{ fontFamily:'Outfit', fontSize:52, lineHeight:1, fontWeight:500, letterSpacing:'-0.04em', color:HP.text, margin:0, textWrap:'balance' }}>
+        <h2 className="ff-profile-section-h2" style={{ fontFamily:'Outfit', fontSize:52, lineHeight:1, fontWeight:500, letterSpacing:'-0.04em', color:HP.text, margin:0, textWrap:'balance' }}>
           {mixtape.length === 1 ? (
             <>One film <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>so far.</em></>
           ) : (
@@ -252,7 +252,7 @@ function Mixtape() {
         )}
       </div>
       {/* Always 5 columns — the grid stays consistent, empty slots are placeholders so cards never blow up. */}
-      <div style={{ display:'grid', gridTemplateColumns:'repeat(5,1fr)', gap:18 }}>
+      <div className="ff-profile-mixtape-grid" style={{ display:'grid', gridTemplateColumns:'repeat(5,1fr)', gap:18 }}>
         {mixtape.map((f, i) => (
           <button
             key={f.tmdbId || f.title}
@@ -300,11 +300,11 @@ function Skew() {
   const rows = (skews && skews.length > 0) ? skews : SKEWS;
   const isLive = skews && skews.length > 0;
   return (
-    <section style={{ padding:'80px 88px', borderTop:`1px solid ${HP.border}`, background:'rgba(255,255,255,0.012)' }}>
-      <div style={{ display:'grid', gridTemplateColumns:'1fr 1.4fr', gap:80, alignItems:'flex-start' }}>
+    <section className="ff-profile-section" style={{ padding:'80px 88px', borderTop:`1px solid ${HP.border}`, background:'rgba(255,255,255,0.012)' }}>
+      <div className="ff-profile-skew-grid" style={{ display:'grid', gridTemplateColumns:'1fr 1.4fr', gap:80, alignItems:'flex-start' }}>
         <div>
           <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color:HP.purple, marginBottom:14 }}>Vs everyone else</div>
-          <h2 style={{ fontFamily:'Outfit', fontSize:44, lineHeight:1, fontWeight:500, letterSpacing:'-0.035em', color:HP.text, margin:0, textWrap:'balance' }}>How you <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>skew.</em></h2>
+          <h2 className="ff-profile-section-h2" style={{ fontFamily:'Outfit', fontSize:44, lineHeight:1, fontWeight:500, letterSpacing:'-0.035em', color:HP.text, margin:0, textWrap:'balance' }}>How you <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>skew.</em></h2>
           <p style={{ marginTop:18, fontSize:14, color:HP.textMuted, fontFamily:'Outfit, Inter, sans-serif', lineHeight:1.65, maxWidth:340 }}>{isLive ? 'Versus the median FeelFlick user. Refreshed nightly.' : <>Versus the median FeelFlick user. <em style={{ fontStyle:'italic' }}>Sample values — live comparison ships in a follow-up.</em></>}</p>
         </div>
         <div style={{ display:'flex', flexDirection:'column', gap:16 }}>
@@ -340,15 +340,15 @@ function FriendsRanked() {
   const { friends } = useProfileData();
   const hasFriends = friends && friends.length > 0;
   return (
-    <section style={{ padding:'72px 88px', borderTop:`1px solid ${HP.border}` }}>
+    <section className="ff-profile-section" style={{ padding:'72px 88px', borderTop:`1px solid ${HP.border}` }}>
       <div style={{ marginBottom:32 }}>
         <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color:HP.purple, marginBottom:14, display:'inline-flex', alignItems:'center', gap:10 }}>
           <span style={{ height:1, width:22, background:HP.purple, opacity:0.6 }} />Taste twins
         </div>
-        <h2 style={{ fontFamily:'Outfit', fontSize:36, lineHeight:1.05, fontWeight:500, letterSpacing:'-0.03em', color:HP.text, margin:0 }}>People who <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>get it.</em></h2>
+        <h2 className="ff-profile-section-h2" style={{ fontFamily:'Outfit', fontSize:36, lineHeight:1.05, fontWeight:500, letterSpacing:'-0.03em', color:HP.text, margin:0 }}>People who <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>get it.</em></h2>
       </div>
       {hasFriends ? (
-        <div style={{ display:'grid', gridTemplateColumns:'repeat(4,1fr)', gap:18 }}>
+        <div className="ff-profile-friends-grid" style={{ display:'grid', gridTemplateColumns:'repeat(4,1fr)', gap:18 }}>
           {friends.map(f => (
             <button
               key={f.userId || f.name}
@@ -407,11 +407,11 @@ function ShareCard() {
     } catch { /* silent */ }
   };
   return (
-    <section style={{ padding:'80px 88px', borderTop:`1px solid ${HP.border}`, background:'rgba(255,255,255,0.012)' }}>
-      <div style={{ display:'grid', gridTemplateColumns:'1fr auto', gap:64, alignItems:'center' }}>
+    <section className="ff-profile-section" style={{ padding:'80px 88px', borderTop:`1px solid ${HP.border}`, background:'rgba(255,255,255,0.012)' }}>
+      <div className="ff-profile-share-grid" style={{ display:'grid', gridTemplateColumns:'1fr auto', gap:64, alignItems:'center' }}>
         <div>
           <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color:HP.purple, marginBottom:14 }}>Share your DNA</div>
-          <h2 style={{ fontFamily:'Outfit', fontSize:44, lineHeight:1, fontWeight:500, letterSpacing:'-0.035em', color:HP.text, margin:0, textWrap:'balance' }}>
+          <h2 className="ff-profile-section-h2" style={{ fontFamily:'Outfit', fontSize:44, lineHeight:1, fontWeight:500, letterSpacing:'-0.035em', color:HP.text, margin:0, textWrap:'balance' }}>
             Card for <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>the feed.</em>
           </h2>
           <p style={{ marginTop:18, fontSize:14, color:HP.textMuted, fontFamily:'Outfit, Inter, sans-serif', lineHeight:1.65, maxWidth:380 }}>
@@ -434,7 +434,7 @@ function ShareCard() {
           </div>
         </div>
         {/* Story-shape preview */}
-        <div style={{ width:240, aspectRatio:'9/16', borderRadius:14, padding:'32px 26px', background:'linear-gradient(160deg, #1a0d3a 0%, #06060a 50%, #3a0d1f 100%)', position:'relative', overflow:'hidden', boxShadow:'0 32px 80px -16px rgba(0,0,0,0.7), 0 0 0 1px rgba(255,255,255,0.06)', display:'flex', flexDirection:'column', justifyContent:'space-between' }}>
+        <div className="ff-profile-share-preview" style={{ width:240, aspectRatio:'9/16', borderRadius:14, padding:'32px 26px', background:'linear-gradient(160deg, #1a0d3a 0%, #06060a 50%, #3a0d1f 100%)', position:'relative', overflow:'hidden', boxShadow:'0 32px 80px -16px rgba(0,0,0,0.7), 0 0 0 1px rgba(255,255,255,0.06)', display:'flex', flexDirection:'column', justifyContent:'space-between' }}>
           <div style={{ position:'absolute', top:'-20%', right:'-30%', width:'80%', aspectRatio:1, borderRadius:999, background:`radial-gradient(circle, ${HP.purple}66, transparent 65%)`, filter:'blur(20px)' }} />
           <div style={{ position:'absolute', bottom:'-20%', left:'-30%', width:'80%', aspectRatio:1, borderRadius:999, background:`radial-gradient(circle, ${HP.pink}55, transparent 65%)`, filter:'blur(20px)' }} />
           <div style={{ position:'relative' }}>
@@ -479,8 +479,8 @@ function YIRBanner() {
     banner = { headline: `You binged ${YIR.bingedMonth.count} films in ${YIR.bingedMonth.month}.`, sub: `${YIR.topMoodGrowth.mood} climbed ${YIR.topMoodGrowth.delta} — ${YIR.topMoodGrowth.note}` };
   }
   return (
-    <section style={{ padding:'56px 88px', borderTop:`1px solid ${HP.border}`, background:`linear-gradient(135deg, ${HP.purple}11, ${HP.pink}08)` }}>
-      <div style={{ display:'grid', gridTemplateColumns:'auto 1fr', gap:32, alignItems:'center' }}>
+    <section className="ff-profile-section" style={{ padding:'56px 88px', borderTop:`1px solid ${HP.border}`, background:`linear-gradient(135deg, ${HP.purple}11, ${HP.pink}08)` }}>
+      <div className="ff-profile-yir-grid" style={{ display:'grid', gridTemplateColumns:'auto 1fr', gap:32, alignItems:'center' }}>
         <div style={{ fontFamily:'Outfit', fontSize:64, fontWeight:200, color:HP.text, letterSpacing:'-0.05em', lineHeight:1, background:HP_GRAD, WebkitBackgroundClip:'text', WebkitTextFillColor:'transparent' }}>{new Date().getFullYear()}</div>
         <div>
           <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.22em', textTransform:'uppercase', color:HP.purple, marginBottom:6 }}>Year so far</div>
@@ -495,7 +495,7 @@ function YIRBanner() {
 function ProfileFooter() {
   const linkStyle = { fontSize:12, color:HP.textMuted, letterSpacing:'0.04em', textDecoration:'none', cursor:'pointer' };
   return (
-    <footer style={{ padding:'40px 88px 64px', borderTop:`1px solid ${HP.border}`, display:'flex', alignItems:'center', justifyContent:'space-between', fontFamily:'Outfit', flexWrap:'wrap', gap:20 }}>
+    <footer className="ff-profile-section" style={{ padding:'40px 88px 64px', borderTop:`1px solid ${HP.border}`, display:'flex', alignItems:'center', justifyContent:'space-between', fontFamily:'Outfit', flexWrap:'wrap', gap:20 }}>
       <div style={{ display:'flex', alignItems:'center', gap:14 }}>
         <div style={{ width:28, height:28, borderRadius:6, background:HP_GRAD, display:'inline-flex', alignItems:'center', justifyContent:'center', fontWeight:700, fontSize:13, color:'#fff' }}>FF</div>
         <span style={{ fontSize:13, color:HP.textMuted, letterSpacing:'0.04em' }}>FeelFlick · Cinematic DNA</span>

--- a/src/features/profile-v2/profile-v2.css
+++ b/src/features/profile-v2/profile-v2.css
@@ -9,4 +9,169 @@
 .ff-profile-v2 ::selection { background: rgba(167,139,250,0.4); color: #fff; }
 .ff-profile-v2 em { font-style: italic; }
 .ff-profile-v2 button { font-family: inherit; transition: filter 0.18s ease; }
-.ff-profile-v2 button:hover { filter: brightness(1.12); }
+.ff-profile-v2 button:hover:not(:disabled) { filter: brightness(1.12); }
+
+/* === Responsive overrides ==================================================
+   Same pattern as lists-v2 / watchlist-v2 / history-v2 / people-v2: every
+   section's desktop padding + rigid grid template lives inline on the JSX,
+   and these class-hook + `!important` rules collapse them at narrow widths.
+   The class names are stable contracts — JSX adds them alongside the inline
+   styles; the CSS only kicks in below each breakpoint. */
+
+/* Tablet (≤ 1100px) — trim sidewalls, soften some grids. */
+@media (max-width: 1100px) {
+  .ff-profile-section {
+    padding-left: clamp(28px, 5vw, 60px) !important;
+    padding-right: clamp(28px, 5vw, 60px) !important;
+  }
+  .ff-profile-masthead {
+    padding-top: 56px !important;
+    padding-bottom: 24px !important;
+  }
+  .ff-profile-masthead-h1 {
+    font-size: clamp(56px, 8vw, 80px) !important;
+  }
+  .ff-profile-signature {
+    font-size: clamp(36px, 6vw, 52px) !important;
+  }
+  .ff-profile-directors-grid {
+    grid-template-columns: repeat(3, 1fr) !important;
+  }
+  .ff-profile-stats-grid {
+    gap: 24px !important;
+  }
+}
+
+/* Smaller tablet (≤ 880px) — stack the two-column section layouts. */
+@media (max-width: 880px) {
+  /* Masthead: avatar above, then name + summary, then archetype card. */
+  .ff-profile-masthead-grid {
+    grid-template-columns: 1fr !important;
+    gap: 28px !important;
+    align-items: flex-start !important;
+  }
+  .ff-profile-masthead-h1 {
+    font-size: clamp(48px, 10vw, 72px) !important;
+  }
+  .ff-profile-signature {
+    font-size: clamp(28px, 6vw, 44px) !important;
+    margin-top: 40px !important;
+    padding-top: 32px !important;
+  }
+  .ff-profile-stats-grid {
+    grid-template-columns: repeat(2, 1fr) !important;
+    row-gap: 32px !important;
+  }
+  /* Reset the borderLeft trick — when grid wraps to 2-col it'd put a line
+     halfway across the second row. Drop and use a row gap instead. */
+  .ff-profile-stat-cell {
+    border-left: none !important;
+    padding-left: 0 !important;
+  }
+  .ff-profile-mood-grid,
+  .ff-profile-motifs-grid,
+  .ff-profile-skew-grid,
+  .ff-profile-share-grid {
+    grid-template-columns: 1fr !important;
+    gap: 32px !important;
+  }
+  .ff-profile-mood-radar {
+    width: 100% !important;
+    max-width: 360px !important;
+    height: auto !important;
+    aspect-ratio: 1 !important;
+    margin: 0 auto !important;
+  }
+  .ff-profile-directors-grid {
+    grid-template-columns: repeat(2, 1fr) !important;
+    gap: 14px !important;
+  }
+  .ff-profile-mixtape-grid {
+    grid-template-columns: repeat(3, 1fr) !important;
+    gap: 14px !important;
+  }
+  .ff-profile-friends-grid {
+    grid-template-columns: repeat(2, 1fr) !important;
+    gap: 14px !important;
+  }
+  .ff-profile-pattern-grid {
+    grid-template-columns: 1fr !important;
+    gap: 32px !important;
+  }
+  .ff-profile-yir-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px !important;
+  }
+  .ff-profile-section {
+    padding-top: 56px !important;
+    padding-bottom: 56px !important;
+  }
+  /* Top-row actions wrap below the eyebrow on narrow widths. */
+  .ff-profile-masthead-actions-row {
+    flex-direction: column !important;
+    align-items: flex-start !important;
+    gap: 14px !important;
+  }
+}
+
+/* Phone (≤ 720px). */
+@media (max-width: 720px) {
+  .ff-profile-section {
+    padding-left: clamp(16px, 4vw, 24px) !important;
+    padding-right: clamp(16px, 4vw, 24px) !important;
+    padding-top: 44px !important;
+    padding-bottom: 44px !important;
+  }
+  .ff-profile-masthead {
+    padding-top: 36px !important;
+  }
+  .ff-profile-masthead-h1 {
+    font-size: clamp(42px, 13vw, 60px) !important;
+    letter-spacing: -0.04em !important;
+  }
+  .ff-profile-masthead-summary {
+    font-size: 16px !important;
+  }
+  .ff-profile-signature {
+    font-size: clamp(26px, 7vw, 40px) !important;
+    line-height: 1.1 !important;
+  }
+  .ff-profile-stats-grid {
+    grid-template-columns: 1fr 1fr !important;
+    gap: 24px !important;
+  }
+  .ff-profile-stat-value {
+    font-size: 44px !important;
+  }
+  .ff-profile-mixtape-grid {
+    grid-template-columns: repeat(2, 1fr) !important;
+    gap: 12px !important;
+  }
+  .ff-profile-friends-grid {
+    grid-template-columns: 1fr !important;
+  }
+  .ff-profile-directors-grid {
+    grid-template-columns: 1fr !important;
+  }
+  /* Trajectory: keep 12 bars but tighten spacing + drop the per-bar count
+     label (the bar height already shows it; numbers stack overlap badly
+     at narrow widths). */
+  .ff-profile-trajectory-bars {
+    gap: 6px !important;
+  }
+  .ff-profile-trajectory-count {
+    display: none !important;
+  }
+  .ff-profile-trajectory-label {
+    font-size: 9px !important;
+    letter-spacing: 0.04em !important;
+  }
+  .ff-profile-share-preview {
+    width: 200px !important;
+    margin: 0 auto !important;
+  }
+  /* Section headers in panels — bring h2 down to a phone-readable size. */
+  .ff-profile-section-h2 {
+    font-size: 32px !important;
+  }
+}

--- a/src/features/profile-v2/top.jsx
+++ b/src/features/profile-v2/top.jsx
@@ -64,11 +64,11 @@ function Masthead() {
   };
 
   return (
-    <section style={{ padding:'80px 88px 24px', position:'relative' }}>
+    <section className="ff-profile-section ff-profile-masthead" style={{ padding:'80px 88px 24px', position:'relative' }}>
       <div style={{ position:'absolute', inset:0, pointerEvents:'none', background:'radial-gradient(ellipse 70% 40% at 20% 0%, rgba(167,139,250,0.18), transparent 60%), radial-gradient(ellipse 60% 30% at 90% 0%, rgba(236,72,153,0.12), transparent 60%)' }} />
 
       {/* Top row: eyebrow on left, page actions on right */}
-      <div style={{ position:'relative', display:'flex', alignItems:'center', justifyContent:'space-between', gap:14, marginBottom:30 }}>
+      <div className="ff-profile-masthead-actions-row" style={{ position:'relative', display:'flex', alignItems:'center', justifyContent:'space-between', gap:14, marginBottom:30 }}>
         <div style={{ display:'flex', alignItems:'center', gap:14 }}>
           <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.32em', textTransform:'uppercase', color:HP.purple }}>Cinematic DNA</div>
           {updatedLabel && (
@@ -102,7 +102,7 @@ function Masthead() {
         </div>
       </div>
 
-      <div style={{ display:'grid', gridTemplateColumns:'auto 1fr auto', gap:48, alignItems:'flex-end' }}>
+      <div className="ff-profile-masthead-grid" style={{ display:'grid', gridTemplateColumns:'auto 1fr auto', gap:48, alignItems:'flex-end' }}>
         {/* Avatar — gradient ring with photo or initial fallback */}
         <div style={{ position:'relative', width:120, height:120 }}>
           <div style={{ position:'absolute', inset:-6, borderRadius:999, background:HP_GRAD, opacity:0.5, filter:'blur(18px)' }} />
@@ -116,10 +116,10 @@ function Masthead() {
         </div>
 
         <div>
-          <h1 style={{ fontFamily:'Outfit', fontSize:96, lineHeight:0.92, fontWeight:300, letterSpacing:'-0.055em', color:HP.text, margin:0, textWrap:'balance' }}>
+          <h1 className="ff-profile-masthead-h1" style={{ fontFamily:'Outfit', fontSize:96, lineHeight:0.92, fontWeight:300, letterSpacing:'-0.055em', color:HP.text, margin:0, textWrap:'balance' }}>
             {firstName}{lastName && <> <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>{lastName}</em></>}.
           </h1>
-          <p style={{ marginTop:18, fontFamily:'Outfit, Inter, sans-serif', fontSize:21, fontStyle:'italic', color:HP.textSoft, letterSpacing:'-0.012em', maxWidth:720, textWrap:'pretty' }}>
+          <p className="ff-profile-masthead-summary" style={{ marginTop:18, fontFamily:'Outfit, Inter, sans-serif', fontSize:21, fontStyle:'italic', color:HP.textSoft, letterSpacing:'-0.012em', maxWidth:720, textWrap:'pretty' }}>
             “{summary}”
           </p>
           <div style={{ marginTop:20, display:'flex', alignItems:'center', gap:14, fontSize:11, color:HP.textMuted, fontFamily:'Outfit', letterSpacing:'0.08em', textTransform:'uppercase', flexWrap:'wrap' }}>
@@ -146,7 +146,7 @@ function Masthead() {
 
       {/* Signature — LLM-generated short caption, falls back to USER_DEFAULT */}
       <div style={{ marginTop:64, paddingTop:48, borderTop:`1px solid ${HP.border}` }}>
-        <p style={{ fontFamily:'Outfit', fontSize:64, lineHeight:1.05, fontWeight:300, letterSpacing:'-0.04em', color:HP.text, margin:0, textWrap:'balance', textAlign:'center' }}>
+        <p className="ff-profile-signature" style={{ fontFamily:'Outfit', fontSize:64, lineHeight:1.05, fontWeight:300, letterSpacing:'-0.04em', color:HP.text, margin:0, textWrap:'balance', textAlign:'center' }}>
           <em style={{ fontStyle:'italic', fontWeight:400, background:HP_GRAD, WebkitBackgroundClip:'text', WebkitTextFillColor:'transparent' }}>{signature}</em>
         </p>
       </div>
@@ -166,12 +166,12 @@ function QuickStats() {
     { label:'DNA confidence',  value: `${stats.dnaConfidence}%`, sub: confLabel },
   ];
   return (
-    <section style={{ padding:'40px 88px', borderTop:`1px solid ${HP.border}` }}>
-      <div style={{ display:'grid', gridTemplateColumns:'repeat(4,1fr)', gap:48 }}>
+    <section className="ff-profile-section" style={{ padding:'40px 88px', borderTop:`1px solid ${HP.border}` }}>
+      <div className="ff-profile-stats-grid" style={{ display:'grid', gridTemplateColumns:'repeat(4,1fr)', gap:48 }}>
         {items.map((s, i) => (
-          <div key={s.label} style={{ borderLeft:i===0?'none':`1px solid ${HP.border}`, paddingLeft:i===0?0:32 }}>
+          <div key={s.label} className="ff-profile-stat-cell" style={{ borderLeft:i===0?'none':`1px solid ${HP.border}`, paddingLeft:i===0?0:32 }}>
             <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.18em', textTransform:'uppercase', color:HP.textMuted, fontFamily:'Outfit', marginBottom:10 }}>{s.label}</div>
-            <div style={{ fontFamily:'Outfit', fontSize:56, fontWeight:200, color:HP.text, letterSpacing:'-0.045em', lineHeight:1 }}>{s.value}</div>
+            <div className="ff-profile-stat-value" style={{ fontFamily:'Outfit', fontSize:56, fontWeight:200, color:HP.text, letterSpacing:'-0.045em', lineHeight:1 }}>{s.value}</div>
             <div style={{ marginTop:6, fontSize:11, color:HP.textSoft, fontFamily:'Outfit', fontStyle:'italic', letterSpacing:'0.02em' }}>{s.sub}</div>
           </div>
         ))}
@@ -202,13 +202,13 @@ function MoodRadar() {
   const anim = in_ ? target : moods.map(()=>0);
 
   return (
-    <section ref={ref} style={{ padding:'88px', borderTop:`1px solid ${HP.border}`, background:'rgba(255,255,255,0.012)' }}>
-      <div style={{ display:'grid', gridTemplateColumns:'1fr 1.2fr', gap:80, alignItems:'center' }}>
+    <section ref={ref} className="ff-profile-section" style={{ padding:'88px', borderTop:`1px solid ${HP.border}`, background:'rgba(255,255,255,0.012)' }}>
+      <div className="ff-profile-mood-grid" style={{ display:'grid', gridTemplateColumns:'1fr 1.2fr', gap:80, alignItems:'center' }}>
         <div>
           <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color:HP.purple, marginBottom:18, display:'inline-flex', alignItems:'center', gap:10 }}>
             <span style={{ height:1, width:22, background:HP.purple, opacity:0.6 }} />Mood signature
           </div>
-          <h2 style={{ fontFamily:'Outfit', fontSize:52, lineHeight:1, fontWeight:500, letterSpacing:'-0.04em', color:HP.text, margin:0, textWrap:'balance' }}>
+          <h2 className="ff-profile-section-h2" style={{ fontFamily:'Outfit', fontSize:52, lineHeight:1, fontWeight:500, letterSpacing:'-0.04em', color:HP.text, margin:0, textWrap:'balance' }}>
             How you <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>feel cinema.</em>
           </h2>
           <p style={{ marginTop:18, fontSize:15, lineHeight:1.7, color:HP.textMuted, fontFamily:'Outfit, Inter, sans-serif', maxWidth:380 }}>
@@ -228,7 +228,7 @@ function MoodRadar() {
           </div>
         </div>
 
-        <div style={{ position:'relative', width:420, height:420, margin:'0 auto' }}>
+        <div className="ff-profile-mood-radar" style={{ position:'relative', width:420, height:420, margin:'0 auto' }}>
           <svg viewBox="0 0 400 400" style={{ width:'100%', height:'100%' }}>
             {[0.25,0.5,0.75,1].map((r,i) => {
               const p = moods.map((_,j) => {


### PR DESCRIPTION
## Summary

Stacked on [#87](https://github.com/30adityakumar/feelflick-app/pull/87).

profile-v2.css was 13 lines (just font + selection color). Every grid stayed at desktop layout on phones, plus the 96px masthead H1 + 88px horizontal padding made the whole page unusable below ~1100px. This PR adds the responsive layer using the same pattern shipped on /lists, /watchlist, /history, /people, /preferences: JSX adds class-hook `className` alongside the existing inline styles; CSS uses `!important` overrides at 1100 / 880 / 720 breakpoints.

## Breakpoint behavior

- **≤1100px (tablet)** — trim section padding to `clamp(28px, 5vw, 60px)`, collapse Directors to 3-col, shrink masthead H1.
- **≤880px (small tablet)** — stack every two-column section (Masthead grid, MoodRadar, MotifCloud, Skew, ShareCard, PatternPanel). QuickStats → 2×2 (borderLeft trick disabled). Mixtape 5 → 3. Friends 4 → 2. Directors 3 → 2.
- **≤720px (phone)** — tighter padding, shrink section H2s, Mixtape 3 → 2, Friends 2 → 1, Directors 2 → 1. Trajectory keeps 12 bars but drops the per-bar count label (would stack ugly) and shrinks month labels.

## Files

- `src/features/profile-v2/profile-v2.css` — full responsive layer (was: just fonts)
- `src/features/profile-v2/top.jsx` — className hooks: section, masthead grid/h1/summary/actions-row, signature, stats grid + stat cell + stat value, mood grid + radar, section-h2
- `src/features/profile-v2/bottom.jsx` — className hooks: directors-grid, motifs-grid, pattern-grid, mixtape-grid, skew-grid, friends-grid, share-grid + share-preview, yir-grid, trajectory-bars + label + count, section on every section + footer

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 519/519 pass
- [x] `npm run build` clean
- [x] **Visual checks** at desktop (1440), tablet (1024), mobile (~500):
  - 1440: no regression — full desktop layout intact (4-col stats, side-by-side radar, 5-col mixtape, 3-col directors, etc.)
  - 1024: Directors collapsed to 3-col; padding tightened; everything else holds desktop
  - 500: Masthead stacks (avatar → name → archetype card), QuickStats 2×2, Mixtape 2-col, all wide grids stack cleanly
- [ ] Manual: 880px boundary transition (small tablet) — verify stacking kicks in
- [ ] Manual: 720px boundary transition (phone) — verify trajectory count labels hide

🤖 Generated with [Claude Code](https://claude.com/claude-code)