### PR TITLE
feat(profile): engine signal upgrades — smarter confidence, real motifs, no theater

### DIFF
--- a/src/features/profile-v2/bottom.jsx
+++ b/src/features/profile-v2/bottom.jsx
@@ -42,6 +42,11 @@ function SignatureDirectors() {
                     <span style={{ fontFamily:'Outfit', fontSize:30, fontWeight:200, color:d.accent, letterSpacing:'-0.04em', lineHeight:1 }}>{d.avg}</span>
                     <span style={{ fontSize:11, color:HP.textMuted, fontFamily:'Outfit' }}>★ avg</span>
                   </>
+                ) : d.firstWatchedYear ? (
+                  <>
+                    <span style={{ fontFamily:'Outfit', fontSize:30, fontWeight:200, color:d.accent, letterSpacing:'-0.04em', lineHeight:1 }}>{d.firstWatchedYear}</span>
+                    <span style={{ fontSize:11, color:HP.textMuted, fontFamily:'Outfit', letterSpacing:'0.04em' }}>since</span>
+                  </>
                 ) : (
                   <span style={{ fontSize:11, color:HP.textMuted, fontFamily:'Outfit', letterSpacing:'0.06em', textTransform:'uppercase' }}>unrated</span>
                 )}
@@ -68,7 +73,7 @@ function MotifCloud() {
         <div>
           <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color:HP.purple, marginBottom:18 }}>Recurring motifs</div>
           <h2 className="ff-profile-section-h2" style={{ fontFamily:'Outfit', fontSize:44, lineHeight:1, fontWeight:500, letterSpacing:'-0.035em', color:HP.text, margin:0 }}>What you <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>keep finding.</em></h2>
-          <p style={{ marginTop:18, fontSize:14, color:HP.textMuted, fontFamily:'Outfit, Inter, sans-serif', lineHeight:1.65, maxWidth:340 }}>Patterns the engine sees across what you&rsquo;ve loved. Bigger means stronger pull.</p>
+          <p style={{ marginTop:18, fontSize:14, color:HP.textMuted, fontFamily:'Outfit, Inter, sans-serif', lineHeight:1.65, maxWidth:340 }}>Tonal qualities that show up across what you&rsquo;ve watched &mdash; not how films feel, but how they&rsquo;re made. Bigger means stronger pull.</p>
         </div>
         <div style={{ display:'flex', flexWrap:'wrap', gap:'14px 18px', alignItems:'baseline' }}>
           {motifs.map(m => {
@@ -297,7 +302,7 @@ function Mixtape() {
 
 // How you skew vs FF median — live from feelflick_stats; static SKEWS stays as cold-start fallback.
 function Skew() {
-  const { skews } = useProfileData();
+  const { skews, communityMood } = useProfileData();
   const rows = (skews && skews.length > 0) ? skews : SKEWS;
   const isLive = skews && skews.length > 0;
   return (
@@ -307,6 +312,12 @@ function Skew() {
           <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color:HP.purple, marginBottom:14 }}>Vs everyone else</div>
           <h2 className="ff-profile-section-h2" style={{ fontFamily:'Outfit', fontSize:44, lineHeight:1, fontWeight:500, letterSpacing:'-0.035em', color:HP.text, margin:0, textWrap:'balance' }}>How you <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>skew.</em></h2>
           <p style={{ marginTop:18, fontSize:14, color:HP.textMuted, fontFamily:'Outfit, Inter, sans-serif', lineHeight:1.65, maxWidth:340 }}>{isLive ? 'Versus the median FeelFlick user. Refreshed nightly.' : <>Versus the median FeelFlick user. <em style={{ fontStyle:'italic' }}>Sample values — live comparison ships in a follow-up.</em></>}</p>
+          {communityMood?.tag && (
+            <div style={{ marginTop:24, paddingTop:18, borderTop:`1px solid ${HP.border}`, maxWidth:340 }}>
+              <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.18em', textTransform:'uppercase', color:HP.textMuted, fontFamily:'Outfit', marginBottom:6 }}>This week the room is into</div>
+              <div style={{ fontFamily:'Outfit', fontSize:24, fontWeight:500, color:HP.text, letterSpacing:'-0.02em' }}>{communityMood.tag}<span style={{ fontSize:14, color:HP.textMuted, fontStyle:'italic', marginLeft:8 }}>films.</span></div>
+            </div>
+          )}
         </div>
         <div style={{ display:'flex', flexDirection:'column', gap:16 }}>
           {rows.map(s => (

--- a/src/features/profile-v2/derive.js
+++ b/src/features/profile-v2/derive.js
@@ -45,15 +45,30 @@ export function deriveUser({ authUser, dbUser, history }) {
 
 // === Stats (quick-stats grid) ===
 
-export function deriveStats({ history, ratings }) {
+// DNA confidence — blends three signals so the score reflects how much we
+// can actually trust the user's derived DNA, not just one metric:
+//   • watch history (breadth, caps at 100 films)         — 30%
+//   • ratings count (taste calibration, caps at 30)      — 50%
+//   • fingerprint richness (distinct mood tags, cap 12)  — 20%
+// At 100/30/12 the score saturates at 100. The old formula only looked at
+// ratings, so a 200-film viewer with no ratings showed up as 0% confident
+// even though we had a rich mood fingerprint for them.
+function computeDnaConfidence({ filmsLogged, filmsRated, distinctMoodTags }) {
+  const history     = Math.min(filmsLogged / 100, 1) * 30
+  const ratings     = Math.min(filmsRated / 30, 1) * 50
+  const fingerprint = Math.min((distinctMoodTags || 0) / 12, 1) * 20
+  return Math.min(100, Math.round(history + ratings + fingerprint))
+}
+
+export function deriveStats({ history, ratings, fingerprint }) {
   const filmsLogged = history.length
   const hoursWatched = Math.round((history.reduce((s, h) => s + (h.movies?.runtime || 0), 0) / 60))
   const now = new Date()
   const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1)
   const filmsThisMonth = history.filter(h => h.watched_at && new Date(h.watched_at) >= startOfMonth).length
   const filmsRated = ratings.length
-  // DNA confidence: simple bucket from rated count; saturates at 50 ratings.
-  const conf = Math.min(100, Math.round((filmsRated / 50) * 100))
+  const distinctMoodTags = fingerprint?.topMoodTags?.length || 0
+  const conf = computeDnaConfidence({ filmsLogged, filmsRated, distinctMoodTags })
   return { filmsLogged, hoursWatched, filmsThisMonth, filmsRated, dnaConfidence: conf }
 }
 
@@ -71,18 +86,27 @@ export function deriveMoods(fingerprint) {
   }))
 }
 
-// === DIRECTORS (top 5 by watch count, with avg rating) ===
+// === DIRECTORS (top 5 by watch count, with avg rating + first-watched year) ===
 
 export function deriveDirectors({ history, ratingsByMovieId }) {
   const buckets = new Map()
   for (const h of history) {
     const dir = h.movies?.director_name
     if (!dir) continue
-    if (!buckets.has(dir)) buckets.set(dir, { films: 0, ratingSum: 0, ratingN: 0, signature: '' })
+    if (!buckets.has(dir)) buckets.set(dir, { films: 0, ratingSum: 0, ratingN: 0, firstWatchedT: null, signature: '' })
     const b = buckets.get(dir)
     b.films += 1
     const r = ratingsByMovieId.get(h.movie_id)?.rating
     if (r != null) { b.ratingSum += r; b.ratingN += 1 }
+    // Track the earliest watched_at timestamp per director so we can show
+    // "Since 2023" on the card when the user hasn't rated their films yet —
+    // a "first watched" year beats a bare "unrated" label.
+    if (h.watched_at) {
+      const t = new Date(h.watched_at).getTime()
+      if (Number.isFinite(t) && (b.firstWatchedT == null || t < b.firstWatchedT)) {
+        b.firstWatchedT = t
+      }
+    }
   }
   const list = [...buckets.entries()]
     .map(([name, b]) => ({
@@ -90,6 +114,7 @@ export function deriveDirectors({ history, ratingsByMovieId }) {
       films: b.films,
       // Convert 1-10 → 1-5 for "★ avg" display
       avg: b.ratingN > 0 ? Math.round((b.ratingSum / b.ratingN / 2) * 10) / 10 : null,
+      firstWatchedYear: b.firstWatchedT ? new Date(b.firstWatchedT).getFullYear() : null,
       signature: '',  // editorial — populated by overlay/LLM in a later PR
     }))
     .filter(d => d.films >= 2)  // need at least 2 films to call it "signature"
@@ -99,17 +124,29 @@ export function deriveDirectors({ history, ratingsByMovieId }) {
   return list.map((d, i) => ({ ...d, accent: MOOD_PALETTE[i % MOOD_PALETTE.length] }))
 }
 
-// === MOTIFS (chip cloud) — derived from mood_tags frequency ===
+// === MOTIFS (chip cloud) ===
+// We pull from movies.tone_tags first — they describe HOW films feel
+// stylistically (earnest, ornate, restrained, kinetic, brooding…), which
+// is a different signal than mood_tags (how films feel emotionally).
+// MoodRadar already covers mood; motifs cover tone so the two sections
+// say different things instead of restating the same fingerprint twice.
+// Falls back to mood_tags when a user has no tone coverage yet so the
+// cloud isn't empty in cold-start.
 
 export function deriveMotifs({ history }) {
-  const counts = new Map()
+  const tone = new Map()
+  const mood = new Map()
   for (const h of history) {
+    for (const tag of h.movies?.tone_tags || []) {
+      tone.set(tag, (tone.get(tag) || 0) + 1)
+    }
     for (const tag of h.movies?.mood_tags || []) {
-      counts.set(tag, (counts.get(tag) || 0) + 1)
+      mood.set(tag, (mood.get(tag) || 0) + 1)
     }
   }
-  if (counts.size === 0) return []
-  const sorted = [...counts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 12)
+  const source = tone.size > 0 ? tone : mood
+  if (source.size === 0) return []
+  const sorted = [...source.entries()].sort((a, b) => b[1] - a[1]).slice(0, 12)
   const max = sorted[0][1]
   return sorted.map(([tag, count]) => ({
     tag: capitalize(tag),
@@ -254,7 +291,25 @@ export function deriveRuntime({ history }) {
 
 // === DAYPART (% of watches by time-of-day bin) ===
 
+const ONE_DAY_MS = 24 * 60 * 60 * 1000
+
+// Returns true if 10+ history rows have watched_at timestamps that all sit
+// within a 24h window — the signature of a bulk import or onboarding seed.
+// In that case the "time of day" bin is meaningless (every row shares the
+// import timestamp) and we'd surface a misleading "you're a morning person"
+// claim. Better to hide the section than lie.
+function looksLikeBulkImport(history) {
+  const ts = history
+    .map(h => h.watched_at ? new Date(h.watched_at).getTime() : null)
+    .filter(Number.isFinite)
+  if (ts.length < 10) return false
+  let min = ts[0], max = ts[0]
+  for (const t of ts) { if (t < min) min = t; if (t > max) max = t }
+  return (max - min) < ONE_DAY_MS
+}
+
 export function deriveDaypart({ history }) {
+  if (looksLikeBulkImport(history)) return []
   const buckets = { Morning: 0, Afternoon: 0, Evening: 0, Late: 0 }
   let total = 0
   for (const h of history) {
@@ -367,6 +422,25 @@ function buildSkewRow(label, you, them, band, unit) {
     youRaw: round1(you),
     themRaw: round1(them),
     unit,
+  }
+}
+
+// === COMMUNITY MOOD (from feelflick_stats.top_mood, refreshed nightly) ===
+// Exposes the mood the rest of FeelFlick has been leaning into this week.
+// Tiny editorial caption above /profile's Skew section so the section
+// contextualises the user's skew against a live community signal instead
+// of a frozen "FF median" abstraction.
+export function deriveCommunityMood(feelflickStats) {
+  if (!Array.isArray(feelflickStats)) return null
+  const row = feelflickStats.find(r => r.stat_key === 'top_mood')
+  if (!row) return null
+  const v = row.stat_value
+  if (!v || typeof v !== 'object') return null
+  const tag = v.tag || v.key || null
+  if (!tag) return null
+  return {
+    tag: capitalize(tag),
+    share: typeof v.share === 'number' ? v.share : null,
   }
 }
 

--- a/src/features/profile-v2/useProfileData.jsx
+++ b/src/features/profile-v2/useProfileData.jsx
@@ -13,7 +13,7 @@ import {
   deriveUser, deriveStats, deriveMoods, deriveDirectors, deriveMotifs,
   deriveMixtape, deriveTrajectory, deriveTrajectoryAllTime,
   deriveDecades, deriveRuntime, deriveDaypart,
-  deriveFriends, deriveSkews, deriveYIR,
+  deriveFriends, deriveSkews, deriveYIR, deriveCommunityMood,
 } from './derive'
 import { archetypeForFingerprint } from './archetype'
 import { aggregateWatchHistorySignals, buildSummaryRequestBody } from './buildSummaryRequest'
@@ -54,6 +54,7 @@ const INITIAL_STATE = {
   editorial: null,
   friends: [],
   skews: [],
+  communityMood: null,
   yir: null,
   loading: true,
   error: null,
@@ -146,7 +147,7 @@ export function useProfileDataFetch({ userId, authUser, isSelf = false }) {
           }
         }
 
-        const statsDerived = deriveStats({ history, ratings })
+        const statsDerived = deriveStats({ history, ratings, fingerprint })
         setState({
           user: deriveUser({ authUser, dbUser, history }),
           stats: statsDerived,
@@ -166,6 +167,7 @@ export function useProfileDataFetch({ userId, authUser, isSelf = false }) {
             filmsByFriendId,
           }),
           skews: deriveSkews({ stats: statsDerived, history, ratings, feelflickStats }),
+          communityMood: deriveCommunityMood(feelflickStats),
           yir: deriveYIR({ history }),
           loading: false,
           error: null,


### PR DESCRIPTION
## Summary

Stacked on [#89](https://github.com/30adityakumar/feelflick-app/pull/89). Five compounding quality fixes for the DNA derivation layer. Most of /profile already runs on real data; these change what that real data is allowed to say.

## Changes

### 1. DNA confidence formula (was: 1 signal, now: 3 weighted)
Old: `Math.min(100, Math.round((filmsRated / 50) * 100))` — one input.
New: blend of history breadth (30%), ratings count (50%), fingerprint richness via distinct mood-tag count (20%).

For dev user (34 films, 5 rated, 12 mood tags): **10% → 39%**. A 200-film viewer with no ratings used to show 0% confidence despite a rich mood fingerprint — now reflects the actual signal strength.

### 2. MotifCloud pulls from `tone_tags`, not `mood_tags`
MoodRadar already shows top emotional moods (Uplifting, Bittersweet, Tense…). MotifCloud was a second visualization of the same data. Now it surfaces TONAL qualities (Earnest, Warm, Sentimental, Polished, Intimate, Poetic…) — different signal, different vocabulary. Two sections say two different things.

Falls back to `mood_tags` for users with no tone coverage yet.

### 3. SignatureDirector `firstWatchedYear` fallback
When a user hasn't rated a director's films, the card showed bare `UNRATED`. Now shows `2023 · since` — implies a relationship rather than a gap. Fits the editorial DNA frame.

### 4. Daypart bulk-import guard
When 10+ history rows all sit within a 24h window (the signature of a CSV/seed import), the time-of-day binning is meaningless. We now return `[]` instead of surfacing a misleading "You're a morning person, cinematically" claim. Real users with spread-out timestamps unaffected.

### 5. Surface `feelflick_stats.top_mood` (was: unused)
That stat is refreshed nightly by pg_cron but had no reader. Now appears as a small caption below the Skew description: **"This week the room is into Tense films."** Pairs personal skew with a live community signal.

## Files

- `src/features/profile-v2/derive.js` — new `computeDnaConfidence`, refactored `deriveMotifs` (tone-first), `deriveDirectors` (gain `firstWatchedYear`), `deriveDaypart` (bulk-import guard), new `deriveCommunityMood`
- `src/features/profile-v2/useProfileData.jsx` — pass `fingerprint` to `deriveStats`, expose `communityMood` on context
- `src/features/profile-v2/bottom.jsx` — director "since" fallback, motif copy tweak, Skew section community caption

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 519/519 pass
- [x] `npm run build` clean
- [x] **Live test (dev user):**
  - DNA confidence: 10% → 39% (medium label, accurate)
  - SignatureDirectors: Nitesh Tiwari / Rajkumar Hirani / Frank Darabont show `2026 · since` (not "UNRATED")
  - Recurring motifs: tone words (Earnest, Warm, Sentimental, Polished, Intimate, Poetic, Satirical, Urgent, Whimsical, Grandiose, Cold, Ironic) — distinct from MoodRadar's moods
  - Skew section: "This week the room is into Tense films." below description
  - Daypart bulk-import guard doesn't trigger for dev user (timestamps span >24h)
- [ ] Manual: rate 30+ films → confidence should jump toward 80%+
- [ ] Manual: user with NO `tone_tags` coverage → motifs falls back to mood_tags
- [ ] Manual: user with all watches on same day → daypart section self-hides

🤖 Generated with [Claude Code](https://claude.com/claude-code)