### PR TITLE
chore: security migrations + dev tooling (guardrail skills, lint hook, E2E + CI)

### DIFF
--- a/.claude/hooks/lint-on-edit.sh
+++ b/.claude/hooks/lint-on-edit.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Advisory ESLint on edited src JS/JSX files (PostToolUse: Edit|Write).
+# Non-blocking: always exits 0. If ESLint reports problems, the findings are
+# surfaced back to the model via additionalContext so they get fixed before commit.
+set -u
+
+# Read the edited file path from the hook's stdin JSON.
+f="$(jq -r '.tool_input.file_path // empty' 2>/dev/null)"
+
+# Only lint JS/JSX under src/. Skip everything else silently.
+case "$f" in
+  *src/*.js|*src/*.jsx) ;;
+  *) exit 0 ;;
+esac
+[ -f "$f" ] || exit 0
+
+# Run from project root (two levels up from .claude/hooks/) so the flat
+# eslint.config.js resolves. Use the locally-installed eslint, no network.
+root="$(cd "$(dirname "$0")/../.." && pwd)"
+out="$(cd "$root" && npx --no-install eslint "$f" 2>&1)"
+
+# Clean run prints nothing -> stay silent. Any output (warnings or errors) ->
+# surface it back to the model, but never block the workflow (always exit 0).
+if [ -n "$out" ]; then
+  ctx="$(printf 'ESLint findings in %s (advisory — fix before commit):\n%s' "$f" "$out" | jq -Rs .)"
+  printf '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":%s}}\n' "$ctx"
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,6 +30,18 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/lint-on-edit.sh\"",
+            "statusMessage": "Linting edited file…"
+          }
+        ]
+      }
+    ],
     "PreCompact": [
       {
         "hooks": [

--- a/.claude/skills/a11y-audit/SKILL.md
+++ b/.claude/skills/a11y-audit/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: a11y-audit
+description: >
+  Enforce accessibility on any UI work for FeelFlick. Trigger on: "build a
+  component", "modal", "button", "form", "interactive", "is this accessible",
+  "a11y", "keyboard", "screen reader", or after creating/editing any JSX with
+  interactive elements. CLAUDE.md mandates "no a11y regressions" — this is the
+  runtime/semantic check that eslint-plugin-jsx-a11y can't fully cover.
+---
+
+# Accessibility Audit
+
+FeelFlick's bar: Netflix/Apple TV+ polish — which includes accessibility.
+`eslint-plugin-jsx-a11y` catches static issues (run `lint` first); this skill
+covers the semantic + interaction checks it can't.
+
+When invoked, audit changed UI against this checklist. Report each as
+`severity (error/warning) — file:line — fix`.
+
+## Checklist
+### Interactive elements
+- [ ] Every clickable is a real `<button>`/`<a>` — OR has `role`, `tabIndex={0}`,
+      AND key handlers (Enter + Space). ❌ No bare `<div onClick>`.
+- [ ] Icon-only controls have `aria-label` (the play/add/info buttons on cards).
+- [ ] Event-handler naming: `handleX`, never an internal `onClick`.
+
+### Focus
+- [ ] Visible focus ring on every focusable (`focus-visible:` — match the shared
+      primitives' ring). Never `outline: none` without a replacement.
+- [ ] `<Modal>` traps focus, restores it on close, closes on Escape (the shared
+      Modal already does this — use it, don't hand-roll).
+- [ ] Logical tab order; no positive `tabindex`.
+
+### Content & media
+- [ ] Posters/images have meaningful `alt` (e.g. `alt={movie.title}`), or `alt=""`
+      if purely decorative.
+- [ ] Headings nest correctly (one h1 per view; no skipped levels).
+- [ ] Form inputs have associated labels (the `<Input>` primitive has no built-in
+      label — add one or `aria-label`).
+
+### Color & motion
+- [ ] Text contrast ≥ WCAG AA (4.5:1). ⚠️ Watch low-opacity text on dark
+      (`text-white/40` on `#06060a` can fail) for body text.
+- [ ] Respect reduced motion — use `motion-safe:`/`motion-reduce:`; Framer Motion
+      should honor `prefers-reduced-motion` for non-essential animation.
+
+### Structure
+- [ ] Skip-to-content target `#main` stays intact (it's in the route shells).
+- [ ] Live regions (`aria-live`) for toasts / async status (e.g. ToastNotification).
+
+## Output
+End with: ✅ no a11y issues, or ⚠️ N issues (listed). Run `lint` to confirm the
+static jsx-a11y rules also pass.

--- a/.claude/skills/design-system-guard/SKILL.md
+++ b/.claude/skills/design-system-guard/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: design-system-guard
+description: >
+  Enforce FeelFlick's editorial design language on any UI work. Trigger on:
+  "build a component", "style this", "redesign", "new section", "landing",
+  "fix the layout", "make this look good", or whenever generating/editing JSX
+  or CSS in a v2 surface or the v3 landing. Also run as a check after the
+  frontend-design skill produces UI, since that skill pushes bold aesthetics
+  that can violate this system.
+---
+
+# Design System Guard
+
+FeelFlick has a strict, hand-tuned editorial language shared by the public v3
+landing and every authenticated `*-v2` surface. **This system overrides any
+generic design guidance (including the `frontend-design` skill).** When they
+conflict, this wins.
+
+When invoked, audit the proposed/changed UI against the checklist below and
+report each violation as `severity (error/warning) — file:line — fix`.
+
+## Hard rules (errors)
+
+### Fonts
+- [ ] Display/headlines/buttons/eyebrows → **Outfit** (`var(--font-display)`).
+      Body/prose → **Inter** (`var(--font-body)`). Meta → JetBrains Mono (rare).
+- [ ] ❌ FORBIDDEN fonts: Playfair Display, Satoshi, Fraunces — not installed.
+- [ ] ❌ No new font imports without updating CLAUDE.md's font section.
+- [ ] Italic Outfit accent applies to a **single fragment** inside a headline,
+      never a whole sentence.
+
+### Color
+- [ ] Purple + pink **only**. No amber / rose / orange in gradients.
+- [ ] No hardcoded hex outside the `HP` token object (v2) or the `C` palette
+      (v3 landing). Otherwise use Tailwind tokens / CSS custom properties.
+- [ ] ❌ No `text-neutral-*` / `text-gray-*` — use `text-white/<opacity>`.
+- [ ] Brand gradient has ONE source of truth:
+      `linear-gradient(135deg, #9333ea 0%, #ec4899 100%)` via
+      `var(--brand-gradient)` or `bg-gradient-to-r from-purple-600 to-pink-500`.
+      ❌ Never invent per-vibe / per-genre gradients.
+
+### Hero / display typography
+- [ ] Weight **200–300 only** at ≥56px. Below 56px, jump to 400–500.
+- [ ] ❌ Never `font-black` / weight 900 in v2 or v3 surfaces (that's the
+      legacy v1 + landing-v2 signature).
+- [ ] Negative letter-spacing on display: `-0.04em` to `-0.05em`.
+- [ ] `textWrap: 'balance'` on headlines, `textWrap: 'pretty'` on body.
+
+### Patterns & primitives
+- [ ] Section headers use the canonical `@/shared/ui/SectionHeader.jsx` —
+      don't hand-roll the gradient bar.
+- [ ] Kicker = 22px purple rule + ALL-CAPS Outfit 700, 10–11px, 0.22–0.32em.
+- [ ] Empty sections **`return null`** — never render a placeholder or
+      fabricate content to fill a slot.
+- [ ] Loading = `animate-pulse` skeletons matching content shape. ❌ No
+      page/section spinners. (In-button micro-spinners in `Button.jsx` are the
+      one documented exception.)
+
+### MovieCard hover — THE LAW
+- [ ] Pure poster `scale(1.04)` only. ❌ No portal, no floating overlay, no
+      expanding panel, no sibling dim/shift. Below-card title stays static.
+- [ ] Touching hover means reading all three owners first:
+      `useMovieCardHover.js`, `Row/index.jsx`, `Card/index.jsx`.
+
+### Navigation & meta
+- [ ] ❌ Don't navigate to v1 legacy routes from a v2 surface
+      (`/movie/:id` not `/movie-legacy/:id`, `/profile/:id` not
+      `/profile-legacy/:id`, etc.).
+- [ ] Tier 1 surfaces call `usePageMeta({ title: '<X> — FeelFlick' })`.
+
+### Microcopy
+- [ ] Sentence case: "Sign in" (not "Sign In").
+- [ ] Unicode ellipsis `…` in pending states: "Signing in…", "Saving…",
+      "Loading…", "Opening Google…".
+
+## Output
+End with a one-line verdict: ✅ on-system, or ⚠️ N violations (list them).
+If zero violations, say so plainly — don't invent nits.

--- a/.claude/skills/perf-guard/SKILL.md
+++ b/.claude/skills/perf-guard/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: perf-guard
+description: >
+  Protect runtime performance for FeelFlick's media-heavy frontend. Trigger on:
+  "performance", "slow", "LCP", "CLS", "bundle size", "image/poster loading",
+  "lazy load", "Lighthouse", "web-vitals", "optimize", or when adding images,
+  carousels, heavy deps, or large queries.
+---
+
+# Performance Guard
+
+FeelFlick is poster-heavy, personalization-heavy, and dual-deployed to Cloudflare
+Pages + Vercel for edge speed. Protect the metrics users feel. **Measure, don't
+guess** — use chrome-devtools (`performance_start_trace`, `lighthouse_audit`) and
+the existing `web-vitals` wiring (`src/shared/lib/vitals.js`).
+
+## Checklist
+### Images / posters (the biggest lever)
+- [ ] Use `tmdbImg()` with a **sized** variant (e.g. w342/w500), never `original`
+      for grid/card posters.
+- [ ] Below-the-fold posters: `loading="lazy"`. Hero/LCP image: eager +
+      `fetchpriority="high"`.
+- [ ] Always set width/height (or aspect-ratio) on posters → prevents CLS.
+
+### Layout stability (CLS)
+- [ ] Skeletons must match final content shape — `HomeSkeleton`/`RouteSkeleton`
+      exist specifically to prevent carousel/hero pop-in. Don't regress them.
+- [ ] Reserve space for async content; never shift on data arrival.
+
+### JS / bundle
+- [ ] Keep routes code-split (`lazy()` in `router.jsx`) — don't pull heavy modules
+      into the entry chunk.
+- [ ] Framer Motion is heavy — prefer CSS transitions for simple cases; animate
+      transform/opacity only (no layout-triggering properties).
+- [ ] Watch vendor chunk growth on `npm run build` (report sizes if they jump).
+
+### Data / queries (Supabase)
+- [ ] `select()` only needed columns — never `select('*')` on `movies`/`people`.
+- [ ] Avoid N+1; batch with `.in()`. Lean on `user_profiles_computed` (cached)
+      instead of recomputing per request.
+- [ ] RLS perf: `auth.uid()` in policies should be `(select auth.uid())` so it's
+      evaluated once, not per row.
+
+## Output
+State the metric at risk (LCP/CLS/TBT/bundle/query), the fix, and — when feasible —
+a before/after from Lighthouse or a build-size diff. Don't claim a win without a number.

--- a/.claude/skills/recommendation-engine/SKILL.md
+++ b/.claude/skills/recommendation-engine/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: recommendation-engine
+description: >
+  Guide and gate any work on FeelFlick's recommendation engine. Trigger on:
+  "recommendations", "scoring", "ranking", "mood to film", "pgvector",
+  "similarity", "embeddings", "engine tuning", "why this movie", "skip signal",
+  "anti-recency", "decay", "discover", or any change to mood_sessions,
+  recommendation_events/impressions, movie_similarity, movie_mood_scores,
+  user_profiles_computed, or scripts/pipeline/.
+---
+
+# Recommendation Engine
+
+FeelFlick's core: turn a stated mood into the right film. The engine is
+content-based filtering + pgvector cosine similarity + behavioral signals.
+This is the most valuable AND most fragile subsystem — treat changes with care.
+
+## Architecture (what's actually there)
+- **Catalog:** `movies` (~12k), `movie_genres`, `movie_keywords`, `people`,
+  `movie_mood_scores` (~96k pre-computed movie×mood compatibility 0–100).
+- **Vectors:** 3072-dim OpenAI embeddings; `movie_similarity` (~926k pre-computed
+  top-N cosine neighbors, built by `scripts/pipeline/11-build-similarity.js`).
+- **Intent:** `mood_sessions` (mood + context + experience + energy/intensity).
+- **Signals:** `recommendation_events` (mood-session-scoped: click/watch/skip/rate),
+  `recommendation_impressions` (homepage-row-scoped — feeds skip signals into
+  `scoreMovieForUser`), `user_interactions`, `user_ratings`.
+- **Cache:** `user_profiles_computed` (taste profile, TTL — invalidated by
+  `invalidate_user_profile_cache`; cleaned by `cleanup_expired_profile_caches`).
+- **Pipeline:** `scripts/pipeline/` ingest TMDB → embed → score → build similarity.
+- **Service code:** `src/shared/services/recommendations.js`, `interactions.js`.
+- **RPCs:** `get_mood_recommendations(_v2)`, `match_movies`, `get_seed_neighbors`,
+  `match_movies_by_seeds`, `find_top_neighbors`.
+
+## Hard rules
+1. **DB-FIRST — always.** Before changing any filter / score / limit, query the
+   ACTUAL data: catalog distribution (genre/decade/runtime/language), tag & mood
+   coverage, and **candidate pool composition at each pipeline stage**. Never tune
+   from assumptions. (See [[feedback_db_first_analysis]].) Show the numbers that
+   justify the change.
+2. **Anti-recency + decay are intentional.** Don't "fix" the engine by surfacing
+   newest/most-popular — that's the trending behaviour FeelFlick rejects. Preserve
+   signal decay and the anti-recency bias.
+3. **Skips are signal, not noise.** Skip rate (`recommendation_impressions`) feeds
+   scoring. Don't drop or flatten it.
+4. **Validate against real outcomes.** Justify scoring changes against
+   `recommendation_events`/`impressions`, not vibes. State expected effect on
+   skip-rate / watch-rate.
+5. **Cache + DDL safety** → defer to [[supabase-change]]. Re-scoring or schema
+   changes have TTL and pipeline implications; service_role runs the pipeline.
+
+## Output
+Lead with the data (the pool/coverage numbers), then the proposed change, then the
+expected measurable effect. If you're reasoning without having queried the data, stop.

--- a/.claude/skills/supabase-change/SKILL.md
+++ b/.claude/skills/supabase-change/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: supabase-change
+description: >
+  Gate and guide any Supabase backend change for FeelFlick. Trigger on:
+  "migration", "schema", "RLS", "policy", "edge function", "alter table",
+  "add column", "pg_cron", "database change", or any task touching
+  supabase/ — including recommendation-engine filter/scoring/limit tweaks
+  that depend on table data.
+---
+
+# Supabase Change Protocol
+
+FeelFlick's backend is Supabase (PostgreSQL + pgvector + RLS + 4 edge
+functions). Backend changes are a **Hard Stop** in CLAUDE.md. This skill
+enforces the process so nothing irreversible happens on a guess.
+
+## Step 1 — STOP and confirm (mandatory)
+Any of these require **explicit user confirmation before acting**:
+- Schema changes, migrations, `ALTER`/`CREATE`/`DROP`
+- RLS policies
+- Edge Function code (`ai-mood-context`, `generate-movie-overlay`,
+  `generate-reflection-prompt`, `generate-taste-summary`)
+- `pg_cron` jobs (e.g. nightly `refresh_feelflick_stats()`)
+
+State exactly what will change and wait for go-ahead. Do **not** proceed on
+assumption. (The one exception: client-side auth sign-in/out against the dev
+test user for MCP testing — that's allowed without asking.)
+
+## Step 2 — DB-first analysis (before any engine change)
+For recommendation/filter/scoring/limit changes, **query the actual data
+first** — never reason from assumptions about what the tables contain:
+- Catalog distribution (genres, decades, runtime, language spread)
+- Tag / mood coverage and sparsity
+- Candidate **pool composition** at each pipeline stage
+- Embedding coverage in `user_profiles_computed` / movie vectors
+
+Only after seeing real numbers, propose the filter/scoring/limit change.
+Show the query results that justify it.
+
+## Step 3 — Migration safety
+- [ ] ❌ Never delete or edit an existing migration — create a **new** one.
+- [ ] Forward-only. Include a clear, dated migration name.
+- [ ] Confirm RLS still enforces per-user access after the change.
+- [ ] Note any TTL / cache implications (`user_profiles_computed` is cached).
+
+## Step 4 — Verify
+- [ ] If schema changed, confirm the client (`@supabase/supabase-js`) calls
+      still match (null-safety on new/changed columns).
+- [ ] Edge function changes: keep CORS aligned across all functions
+      (hardened in #81/#82 — don't regress it).
+- [ ] State what the user should check in the Supabase dashboard.
+
+## Output
+Lead with the gate result:
+- 🛑 **Needs confirmation** — here's exactly what would change.
+- 📊 **Analysis first** — here's the data, here's what it implies.
+- ✅ **Safe to proceed** — proceeding, here's the new migration / change.

--- a/.github/workflows/app-quality.yml
+++ b/.github/workflows/app-quality.yml
@@ -12,6 +12,8 @@ on:
       - 'package.json'
       - 'package-lock.json'
       - 'vite.config.*'
+      - 'playwright.config.*'
+      - 'e2e/**'
       - '.github/workflows/app-quality.yml'
 
 jobs:
@@ -67,3 +69,79 @@ jobs:
       - name: Audit (prod high+)
         if: steps.changes.outputs.code == 'true'
         run: npm audit --omit=dev --audit-level=high
+
+  e2e:
+    name: E2E (Playwright)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect relevant changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            e2e:
+              - 'src/**'
+              - 'public/**'
+              - 'index.html'
+              - 'e2e/**'
+              - 'playwright.config.*'
+              - 'package.json'
+              - 'package-lock.json'
+              - '.github/workflows/app-quality.yml'
+
+      # Skip cleanly (green) until E2E secrets are configured, so this never
+      # blocks PRs before the repo is set up. Add these repo secrets to enable:
+      #   E2E_TEST_EMAIL, E2E_TEST_PASSWORD  (dev test user)
+      #   VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY, VITE_TMDB_API_KEY  (app env)
+      - name: Preflight — require E2E secrets
+        id: pre
+        if: steps.changes.outputs.e2e == 'true'
+        env:
+          HAVE_CREDS: ${{ secrets.E2E_TEST_EMAIL != '' && secrets.VITE_SUPABASE_URL != '' }}
+        run: |
+          if [ "$HAVE_CREDS" = "true" ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::E2E secrets not configured — skipping. Add E2E_TEST_EMAIL/PASSWORD + VITE_* repo secrets to enable."
+          fi
+
+      - name: Setup Node
+        if: steps.pre.outputs.ready == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        if: steps.pre.outputs.ready == 'true'
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        if: steps.pre.outputs.ready == 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        if: steps.pre.outputs.ready == 'true'
+        env:
+          E2E_TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
+          E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
+          # Vite reads VITE_-prefixed vars from the environment for the dev server
+          # that Playwright auto-starts. If these don't resolve in CI, add a step
+          # that writes them to .env.local (Vite always reads .env files).
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+          VITE_TMDB_API_KEY: ${{ secrets.VITE_TMDB_API_KEY }}
+        run: npm run test:e2e
+
+      - name: Upload Playwright report (on failure)
+        if: ${{ steps.pre.outputs.ready == 'true' && failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -15,11 +15,16 @@ dist/
 .vscode/
 .idea/
 
-# Claude Code local files (screenshots, plans, working notes, secrets)
-# .claude/settings.json is project-level config that SHOULD be tracked.
-.claude/
+# Claude Code files. Project-level config (settings.json), guardrail skills, and
+# hook scripts SHOULD be tracked; screenshots/notes/secrets stay local.
+.claude/*
 !.claude/settings.json
+!.claude/skills/
+!.claude/skills/**
+!.claude/hooks/
+!.claude/hooks/**
 .claude/local-secrets.json
+.claude/settings.local.json
 
 # logs
 npm-debug.log*
@@ -33,3 +38,9 @@ yarn-error.log*
 .tmp-screens/
 audits/
 consistency-audit.md
+
+# Playwright E2E
+/test-results/
+/playwright-report/
+/blob-report/
+/e2e/.auth/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,9 +109,17 @@ Use SIGN_IN when testing authenticated surfaces (/home, /discover, /movie/:id, e
 npm run dev          # Vite dev server (port 5173)
 npm run lint         # ESLint (flat config, eslint.config.js)
 npm run lint:fix     # Auto-fix safe issues
-npm run test         # Vitest
+npm run test         # Vitest (unit/component)
+npm run test:e2e     # Playwright E2E (auto-starts dev server; see note below)
 npm run build        # Production build
 ```
+
+> **E2E (Playwright):** tests live in `e2e/` as `*.e2e.js` (named so Vitest skips
+> them). Auth uses a client-side `window.supabase.signInWithPassword` against the
+> dev test user, so set `E2E_TEST_EMAIL` / `E2E_TEST_PASSWORD` (from
+> `.claude/local-secrets.json` → `feelflickDevUser`) before running:
+> `E2E_TEST_EMAIL=… E2E_TEST_PASSWORD=… npm run test:e2e`. Saved session →
+> `e2e/.auth/` (gitignored). `public/` specs run logged-out; `app/` specs authenticated.
 
 - One component per file *except* in editorial surfaces (e.g. `landing/Landing.jsx`) where sub-components are colocated as a single composition.
 - PascalCase components, camelCase hooks prefixed `use`.
@@ -463,8 +471,34 @@ it silently.
    In-button micro-spinners inside `Button.jsx` are the documented exception.
 10. **No two buttons doing the same thing** on one card.
 
+## Project Guardrails — Claude Code skills & hooks
+
+This repo ships with auto-triggering guardrail skills in `.claude/skills/` and a
+lint hook in `.claude/settings.json`. Lean on them — they encode the rules below
+so they aren't re-derived each session.
+
+**Skills (auto-invoke on matching work):**
+- `design-system-guard` — enforces the editorial language (fonts, palette, brand
+  gradient, hero weights, MovieCard hover law, skeletons, microcopy). Also runs as
+  a check after `frontend-design` (which pushes bold aesthetics that can violate it).
+- `recommendation-engine` — gates engine work (scoring, pgvector similarity,
+  mood→film, decay/anti-recency); mandates DB-first analysis before any tuning.
+- `supabase-change` — gates schema/RLS/edge/cron changes (confirm before DDL) and
+  enforces DB-first analysis.
+- `a11y-audit` — aria/keyboard/contrast checks on UI changes (the runtime layer
+  `eslint-plugin-jsx-a11y` can't cover).
+- `perf-guard` — LCP/CLS, lazy+srcset posters, bundle budget, query hygiene for the
+  media-heavy frontend.
+
+**Hook:** `PostToolUse` runs `.claude/hooks/lint-on-edit.sh` after every Edit/Write
+to a `src/**/*.{js,jsx}` file — advisory ESLint (warnings + errors surfaced, never
+blocks). It enforces the `lint → test → build` discipline automatically.
+
 ## Direction signals (recent shipped roadmap)
 
+- Security hardening pass (2026-05-29): RLS + write lockdown on 18 catalog/engine
+  tables, cron-function + IDOR-function lockdown, pinned function `search_path`
+  (migrations `20260529000000`–`000400`). See memory `project_rls_exposure`.
 - v3 landing replaced v2 landing at `/` (PR #84). landing-v2 preserved at `/v2`.
 - v2 surface family is shipping as the app's canonical direction (#79).
 - Onboarding dropped `V2` suffix (#77). Other `*-v2` folders will follow.

--- a/e2e/app/home.e2e.js
+++ b/e2e/app/home.e2e.js
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test'
+
+// Authenticated (storageState from auth.setup.js).
+
+test('authenticated user reaches /home (not bounced to landing)', async ({ page }) => {
+  await page.goto('/home')
+  // RequireAuth would redirect an unauthenticated visitor to "/"; staying on
+  // /home proves the saved session is honored.
+  await expect(page).toHaveURL(/\/home(?:[/?#]|$)/)
+  // And we're not looking at the logged-out landing hero.
+  await expect(page.getByText(/Films that know/i)).toHaveCount(0)
+})
+
+test('root redirects an authenticated user to /home', async ({ page }) => {
+  await page.goto('/')
+  await expect(page).toHaveURL(/\/home(?:[/?#]|$)/)
+})

--- a/e2e/app/recommendations.e2e.js
+++ b/e2e/app/recommendations.e2e.js
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test'
+
+// Smoke: the authenticated home surfaces recommendation content — real TMDB
+// poster images, which depend on the engine returning candidates and the catalog
+// reads working (the RLS public-read path).
+test('home surfaces recommendation posters', async ({ page }) => {
+  await page.goto('/home')
+  await expect(page).toHaveURL(/\/home(?:[/?#]|$)/)
+
+  // Cards render <img alt={title} src="https://image.tmdb.org/...">. Wait for the
+  // first real poster (home loads async behind skeletons).
+  const poster = page.locator('img[src*="image.tmdb.org"]').first()
+  await expect(poster).toBeVisible({ timeout: 20_000 })
+})
+
+test('a recommended poster opens its film detail page', async ({ page }) => {
+  await page.goto('/home')
+  const poster = page.locator('img[src*="image.tmdb.org"]').first()
+  await expect(poster).toBeVisible({ timeout: 20_000 })
+
+  // Clicking a card navigates to /movie/:tmdbId (cards navigate on click).
+  await poster.click()
+  await expect(page).toHaveURL(/\/movie\/\d+/, { timeout: 15_000 })
+})

--- a/e2e/app/watchlist.e2e.js
+++ b/e2e/app/watchlist.e2e.js
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test'
+
+// Exercises the exact write path the 2026-05-29 RLS migration touched: a movie
+// detail page → toggle Save → user_watchlist write (RLS-protected, self-owned).
+// Self-cleaning (ends un-saved) and idempotent, so it's safe to run repeatedly.
+//
+// The Save toggle is OPTIMISTIC (flips aria-pressed before the network write
+// resolves), so we wait on the actual user_watchlist request to complete before
+// asserting/reloading — otherwise a reload aborts the in-flight write.
+const TMDB_ID = 350 // The Devil Wears Prada — stable catalog title
+const WL = /\/rest\/v1\/user_watchlist/
+const saveButton = (page) => page.getByRole('button', { name: /^Saved?$/ }).first()
+
+test('Save adds a film to the watchlist and the change persists', async ({ page }) => {
+  await page.goto(`/movie/${TMDB_ID}`)
+  const save = saveButton(page)
+  await expect(save).toBeVisible()
+  // Movie data + initial watchlist-status fetch must settle so the toggle is
+  // functional (it no-ops until the internal movie id resolves).
+  await page.waitForLoadState('networkidle')
+
+  // Normalize: ensure we start un-saved (await the DELETE if needed).
+  if ((await save.getAttribute('aria-pressed')) === 'true') {
+    await Promise.all([
+      page.waitForResponse((r) => WL.test(r.url()) && r.request().method() === 'DELETE'),
+      save.click(),
+    ])
+    await expect(save).toHaveAttribute('aria-pressed', 'false')
+  }
+
+  // ADD — wait for the POST to actually complete (not just the optimistic flip).
+  const [addResp] = await Promise.all([
+    page.waitForResponse((r) => WL.test(r.url()) && r.request().method() === 'POST'),
+    save.click(),
+  ])
+  expect(addResp.ok(), 'user_watchlist POST should succeed').toBeTruthy()
+  await expect(save).toHaveAttribute('aria-pressed', 'true')
+  await expect(save).toHaveText(/Saved/)
+
+  // Reload → proves it persisted to the DB, not just optimistic UI. This is the
+  // assertion that fails if an RLS/grant regression blocks user_watchlist writes.
+  await page.reload()
+  await page.waitForLoadState('networkidle')
+  const saveAfter = saveButton(page)
+  await expect(saveAfter).toHaveAttribute('aria-pressed', 'true', { timeout: 15_000 })
+
+  // Cleanup + exercise the remove path (await the DELETE).
+  const [delResp] = await Promise.all([
+    page.waitForResponse((r) => WL.test(r.url()) && r.request().method() === 'DELETE'),
+    saveAfter.click(),
+  ])
+  expect(delResp.ok(), 'user_watchlist DELETE should succeed').toBeTruthy()
+  await expect(saveAfter).toHaveAttribute('aria-pressed', 'false')
+})

--- a/e2e/auth.setup.js
+++ b/e2e/auth.setup.js
@@ -1,0 +1,37 @@
+import { test as setup, expect } from '@playwright/test'
+import fs from 'node:fs'
+import path from 'node:path'
+
+// Saved Supabase session, consumed by the `app` project's storageState.
+const authFile = 'e2e/.auth/user.json'
+
+// Authenticate the dev test user the same way the app does — a client-side
+// signInWithPassword against the exposed window.supabase. Credentials come from
+// env (E2E_TEST_EMAIL / E2E_TEST_PASSWORD); the local dev creds live in
+// .claude/local-secrets.json (gitignored). No Google OAuth popup to automate.
+setup('authenticate dev user', async ({ page }) => {
+  const email = process.env.E2E_TEST_EMAIL
+  const password = process.env.E2E_TEST_PASSWORD
+  if (!email || !password) {
+    throw new Error(
+      'E2E auth requires E2E_TEST_EMAIL and E2E_TEST_PASSWORD env vars (the dev test user).\n' +
+        'Local creds: .claude/local-secrets.json → feelflickDevUser. Example:\n' +
+        '  E2E_TEST_EMAIL=… E2E_TEST_PASSWORD=… npm run test:e2e'
+    )
+  }
+
+  await page.goto('/')
+  await page.waitForFunction(() => Boolean(window.supabase), null, { timeout: 15_000 })
+
+  const result = await page.evaluate(async ([e, p]) => {
+    const { error } = await window.supabase.auth.signInWithPassword({ email: e, password: p })
+    const { data } = await window.supabase.auth.getSession()
+    return { error: error?.message ?? null, hasSession: Boolean(data?.session) }
+  }, [email, password])
+
+  expect(result.error, `sign-in failed: ${result.error}`).toBeNull()
+  expect(result.hasSession, 'no session after sign-in').toBe(true)
+
+  fs.mkdirSync(path.dirname(authFile), { recursive: true })
+  await page.context().storageState({ path: authFile })
+})

--- a/e2e/public/landing.e2e.js
+++ b/e2e/public/landing.e2e.js
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test'
+
+// Logged-out: the canonical v3 editorial landing renders at /.
+test('landing renders for logged-out visitors', async ({ page }) => {
+  await page.goto('/')
+  // Hero headline: "Films that know you." ("you." is an italic accent fragment).
+  await expect(page.getByText(/Films that know/i)).toBeVisible()
+})
+
+test('landing exposes a primary call-to-action', async ({ page }) => {
+  await page.goto('/')
+  // Approved CTA copy: "Start free →" (appears in header, hero, and pricing —
+  // assert the primary one renders).
+  await expect(page.getByRole('button', { name: /start free/i }).first()).toBeVisible()
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,11 +22,11 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^7.14.0",
-        "resend": "^6.6.0",
         "web-vitals": "^4.2.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.60.0",
         "@tailwindcss/container-queries": "^0.1.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -1655,6 +1655,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@posthog/core": {
       "version": "1.29.5",
       "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.29.5.tgz",
@@ -2179,11 +2195,6 @@
       "peerDependencies": {
         "react": "^16.14.0 || 17.x || 18.x || 19.x"
       }
-    },
-    "node_modules/@stablelib/base64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
-      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -3939,11 +3950,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-    },
     "node_modules/esbuild": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
@@ -4419,11 +4425,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-sha256": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
-      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -6500,6 +6501,53 @@
         "node": ">= 6"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -6820,11 +6868,6 @@
       "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
       "license": "MIT"
     },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -7033,30 +7076,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
-    },
-    "node_modules/resend": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/resend/-/resend-6.6.0.tgz",
-      "integrity": "sha512-d1WoOqSxj5x76JtQMrieNAG1kZkh4NU4f+Je1yq4++JsDpLddhEwnJlNfvkCzvUuZy9ZquWmMMAm2mENd2JvRw==",
-      "dependencies": {
-        "svix": "1.76.1"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@react-email/render": "*"
-      },
-      "peerDependenciesMeta": {
-        "@react-email/render": {
-          "optional": true
-        }
       }
     },
     "node_modules/resolve": {
@@ -7762,32 +7781,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/svix": {
-      "version": "1.76.1",
-      "resolved": "https://registry.npmjs.org/svix/-/svix-1.76.1.tgz",
-      "integrity": "sha512-CRuDWBTgYfDnBLRaZdKp9VuoPcNUq9An14c/k+4YJ15Qc5Grvf66vp0jvTltd4t7OIRj+8lM1DAgvSgvf7hdLw==",
-      "dependencies": {
-        "@stablelib/base64": "^1.0.0",
-        "@types/node": "^22.7.5",
-        "es6-promise": "^4.2.8",
-        "fast-sha256": "^1.3.0",
-        "url-parse": "^1.5.10",
-        "uuid": "^10.0.0"
-      }
-    },
-    "node_modules/svix/node_modules/@types/node": {
-      "version": "22.19.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.2.tgz",
-      "integrity": "sha512-LPM2G3Syo1GLzXLGJAKdqoU35XvrWzGJ21/7sgZTUpbkBaOasTj8tjwn6w+hCkqaa1TfJ/w67rJSwYItlJ2mYw==",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/svix/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
-    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -8157,32 +8150,11 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
-    },
-    "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/vite": {
       "version": "7.3.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "lint:fix": "eslint src --fix",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
     "@sentry/react": "^10.48.0",
@@ -32,11 +35,11 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^7.14.0",
-    "resend": "^6.6.0",
     "web-vitals": "^4.2.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/container-queries": "^0.1.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,48 @@
+import { defineConfig, devices } from '@playwright/test'
+
+// E2E config for FeelFlick. Tests live in e2e/ and use the *.e2e.js / *.setup.js
+// naming so Vitest (which scans **/*.{test,spec}.*) never picks them up.
+const baseURL = 'http://localhost:5173'
+
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: /.*\.(e2e|setup)\.js$/,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    // Signs in the dev test user once, saves auth state for the `app` project.
+    { name: 'setup', testMatch: /.*\.setup\.js$/ },
+
+    // Logged-out flows (no stored auth).
+    {
+      name: 'public',
+      testMatch: 'public/**/*.e2e.js',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    // Authenticated flows (reuse the saved Supabase session).
+    {
+      name: 'app',
+      testMatch: 'app/**/*.e2e.js',
+      dependencies: ['setup'],
+      use: { ...devices['Desktop Chrome'], storageState: 'e2e/.auth/user.json' },
+    },
+  ],
+
+  // Auto-start the Vite dev server (reuse one if already running locally).
+  webServer: {
+    command: 'npm run dev',
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+})

--- a/supabase/migrations/20260529000000_secure_catalog_tables_rls.sql
+++ b/supabase/migrations/20260529000000_secure_catalog_tables_rls.sql
@@ -1,0 +1,129 @@
+-- Migration: secure catalog & engine tables (RLS + least-privilege grants)
+--
+-- WHY: 18 public tables had RLS DISABLED while the `anon` and `authenticated`
+-- roles held full DML (INSERT/UPDATE/DELETE/TRUNCATE/REFERENCES/TRIGGER). Because
+-- the anon key ships in the client bundle, anyone could destroy or poison the
+-- catalog + engine data (e.g. `TRUNCATE public.movies`, `public.movie_similarity`).
+--
+-- IMPORTANT: PostgreSQL RLS does NOT gate TRUNCATE, so enabling RLS alone is
+-- insufficient — we must also REVOKE the write privileges. All writes continue to
+-- flow through `service_role` (pipeline scripts in scripts/, edge functions), which
+-- bypasses both RLS and these grants.
+--
+-- Read access preserved:
+--   * 15 catalog/lookup tables  -> public read (anon + authenticated): /movies,
+--     /movie/:id and browse are public routes.
+--   * user_similarity           -> authenticated read only (taste-twins on the
+--     auth-gated /people route; queried by UserSearchPage.jsx / usePeopleData.jsx).
+--   * discovery_cursors, update_runs -> NO public access (0 references in src/;
+--     touched only server-side). SELECT revoked too.
+--
+-- Discovered 2026-05-29. Forward-only.
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- 1) Revoke destructive privileges from the public-facing roles on ALL 18 tables.
+--    (service_role is a separate role and is unaffected.)
+-- ---------------------------------------------------------------------------
+revoke insert, update, delete, truncate, references, trigger on table
+  public.movies, public.genres, public.movie_genres, public.people,
+  public.keywords, public.movie_keywords, public.ratings_external,
+  public.movie_people, public.moods, public.viewing_contexts,
+  public.experience_types, public.movie_mood_scores, public.movie_cast_metadata,
+  public.discover_moods, public.movie_similarity, public.user_similarity,
+  public.discovery_cursors, public.update_runs
+from anon, authenticated;
+
+-- Tables the client never reads -> revoke SELECT as well (least privilege).
+revoke select on table public.discovery_cursors, public.update_runs
+from anon, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 2) Enable Row Level Security on all 18 tables (row-level gate for DML/SELECT).
+-- ---------------------------------------------------------------------------
+alter table public.movies                enable row level security;
+alter table public.genres                enable row level security;
+alter table public.movie_genres          enable row level security;
+alter table public.people                enable row level security;
+alter table public.keywords              enable row level security;
+alter table public.movie_keywords        enable row level security;
+alter table public.ratings_external      enable row level security;
+alter table public.movie_people          enable row level security;
+alter table public.moods                 enable row level security;
+alter table public.viewing_contexts      enable row level security;
+alter table public.experience_types      enable row level security;
+alter table public.movie_mood_scores     enable row level security;
+alter table public.movie_cast_metadata   enable row level security;
+alter table public.discover_moods        enable row level security;
+alter table public.movie_similarity      enable row level security;
+alter table public.user_similarity       enable row level security;
+alter table public.discovery_cursors     enable row level security;
+alter table public.update_runs           enable row level security;
+
+-- ---------------------------------------------------------------------------
+-- 3) Public read policies for catalog/lookup tables (anon + authenticated).
+--    `drop policy if exists` keeps this re-runnable.
+-- ---------------------------------------------------------------------------
+drop policy if exists "catalog public read" on public.movies;
+create policy "catalog public read" on public.movies              for select to anon, authenticated using (true);
+drop policy if exists "catalog public read" on public.genres;
+create policy "catalog public read" on public.genres              for select to anon, authenticated using (true);
+drop policy if exists "catalog public read" on public.movie_genres;
+create policy "catalog public read" on public.movie_genres        for select to anon, authenticated using (true);
+drop policy if exists "catalog public read" on public.people;
+create policy "catalog public read" on public.people              for select to anon, authenticated using (true);
+drop policy if exists "catalog public read" on public.keywords;
+create policy "catalog public read" on public.keywords            for select to anon, authenticated using (true);
+drop policy if exists "catalog public read" on public.movie_keywords;
+create policy "catalog public read" on public.movie_keywords      for select to anon, authenticated using (true);
+drop policy if exists "catalog public read" on public.ratings_external;
+create policy "catalog public read" on public.ratings_external    for select to anon, authenticated using (true);
+drop policy if exists "catalog public read" on public.movie_people;
+create policy "catalog public read" on public.movie_people        for select to anon, authenticated using (true);
+drop policy if exists "catalog public read" on public.moods;
+create policy "catalog public read" on public.moods               for select to anon, authenticated using (true);
+drop policy if exists "catalog public read" on public.viewing_contexts;
+create policy "catalog public read" on public.viewing_contexts    for select to anon, authenticated using (true);
+drop policy if exists "catalog public read" on public.experience_types;
+create policy "catalog public read" on public.experience_types    for select to anon, authenticated using (true);
+drop policy if exists "catalog public read" on public.movie_mood_scores;
+create policy "catalog public read" on public.movie_mood_scores   for select to anon, authenticated using (true);
+drop policy if exists "catalog public read" on public.movie_cast_metadata;
+create policy "catalog public read" on public.movie_cast_metadata for select to anon, authenticated using (true);
+drop policy if exists "catalog public read" on public.discover_moods;
+create policy "catalog public read" on public.discover_moods      for select to anon, authenticated using (true);
+drop policy if exists "catalog public read" on public.movie_similarity;
+create policy "catalog public read" on public.movie_similarity    for select to anon, authenticated using (true);
+
+-- ---------------------------------------------------------------------------
+-- 4) user_similarity: authenticated read only (auth-gated /people feature).
+-- ---------------------------------------------------------------------------
+drop policy if exists "similarity authenticated read" on public.user_similarity;
+create policy "similarity authenticated read" on public.user_similarity for select to authenticated using (true);
+
+-- discovery_cursors & update_runs: intentionally NO policy -> RLS denies all
+-- anon/authenticated access. Reached only via service_role.
+
+commit;
+
+-- ===========================================================================
+-- VERIFICATION (run separately, read-only, after applying):
+--
+-- -- (a) RLS now enabled on all 18?
+-- select tablename, rowsecurity
+-- from pg_tables
+-- where schemaname = 'public'
+--   and tablename in ('movies','genres','movie_genres','people','keywords',
+--     'movie_keywords','ratings_external','movie_people','moods','viewing_contexts',
+--     'experience_types','movie_mood_scores','movie_cast_metadata','discover_moods',
+--     'movie_similarity','user_similarity','discovery_cursors','update_runs')
+-- order by tablename;
+--
+-- -- (b) anon/authenticated should now have only SELECT (catalog) or nothing.
+-- select table_name, grantee, string_agg(privilege_type, ', ' order by privilege_type)
+-- from information_schema.role_table_grants
+-- where table_schema = 'public' and grantee in ('anon','authenticated')
+--   and table_name in ('movies','user_similarity','discovery_cursors','update_runs')
+-- group by table_name, grantee order by table_name, grantee;
+-- ===========================================================================

--- a/supabase/migrations/20260529000100_restore_movies_clientside_upsert_grants.sql
+++ b/supabase/migrations/20260529000100_restore_movies_clientside_upsert_grants.sql
@@ -1,0 +1,22 @@
+-- Migration: restore client-side on-demand catalog upsert on public.movies
+--
+-- WHY: 20260529000000_secure_catalog_tables_rls revoked all writes from anon/
+-- authenticated on 18 tables. That correctly locks 17 read-only tables, but the
+-- client legitimately INSERTs into `movies` (on-demand TMDB caching) via
+-- ensureMovieInDb.js (select-then-insert), onboarding.js, and ResultsGrid.jsx.
+--
+-- This restores writes on `movies` ONLY, scoped to the pre-existing RLS policies:
+--   * movies_write_auth   -> INSERT for public (anon + authenticated)
+--   * movies_update_auth  -> UPDATE for authenticated (qual: auth.role()='authenticated')
+--
+-- DELETE and TRUNCATE remain REVOKED (no policy backs them; TRUNCATE is not
+-- RLS-gated). All writes for the other 17 tables continue via service_role.
+--
+-- Forward-only. Pairs with 20260529000000.
+
+begin;
+
+grant insert on table public.movies to anon, authenticated;
+grant update on table public.movies to authenticated;
+
+commit;

--- a/supabase/migrations/20260529000200_harden_cron_fns_and_dedupe_catalog_policies.sql
+++ b/supabase/migrations/20260529000200_harden_cron_fns_and_dedupe_catalog_policies.sql
@@ -1,0 +1,62 @@
+-- Migration: harden public-executable cron functions + drop redundant catalog policies
+--
+-- PART A — lock down pg_cron-only SECURITY DEFINER functions.
+-- These three have NO internal auth guard and are currently EXECUTE-able by the
+-- public (anon + authenticated inherit EXECUTE via the PUBLIC pseudo-role). Anyone
+-- with the anon key could trigger a real daily-briefing email blast, the account-
+-- deletion queue processor, or an expensive stats recompute.
+--
+-- They are invoked only by pg_cron (as the owning superuser, which can always
+-- execute regardless of grants). We revoke from PUBLIC/anon/authenticated and keep
+-- service_role for safety.
+--
+-- PART B — remove the redundant "catalog public read" SELECT policies that
+-- 20260529000000 added to 7 tables which ALREADY had an equivalent public read
+-- policy ("read all …"). Net read access is unchanged (the pre-existing policy
+-- remains). The other 8 catalog tables keep "catalog public read" — it's their
+-- ONLY read policy.
+--
+-- Forward-only.
+
+begin;
+
+-- ---------- PART A: cron function lockdown ----------
+revoke execute on function public._call_process_account_deletions() from public, anon, authenticated;
+revoke execute on function public._call_send_daily_briefings()      from public, anon, authenticated;
+revoke execute on function public.refresh_feelflick_stats()         from public, anon, authenticated;
+
+-- Keep service_role able to invoke (defensive; cron normally runs as the owner).
+grant execute on function public._call_process_account_deletions() to service_role;
+grant execute on function public._call_send_daily_briefings()      to service_role;
+grant execute on function public.refresh_feelflick_stats()         to service_role;
+
+-- ---------- PART B: drop my redundant catalog read policies ----------
+-- Each of these tables retains its pre-existing "read all …" policy.
+drop policy if exists "catalog public read" on public.genres;            -- keeps "read all genres"
+drop policy if exists "catalog public read" on public.keywords;          -- keeps "read all keywords"
+drop policy if exists "catalog public read" on public.movie_genres;      -- keeps "read all mappings"
+drop policy if exists "catalog public read" on public.movie_keywords;    -- keeps "read all movie_keywords"
+drop policy if exists "catalog public read" on public.people;            -- keeps "read all people"
+drop policy if exists "catalog public read" on public.ratings_external;  -- keeps "read all ratings_external"
+drop policy if exists "catalog public read" on public.movies;            -- keeps "read all movies" (+ 2 other pre-existing dupes)
+
+commit;
+
+-- ===========================================================================
+-- VERIFICATION (run separately, read-only):
+--
+-- -- (a) cron fns no longer public-executable:
+-- select p.proname,
+--        has_function_privilege('anon', p.oid, 'EXECUTE')          as anon_exec,
+--        has_function_privilege('authenticated', p.oid, 'EXECUTE') as authd_exec,
+--        has_function_privilege('service_role', p.oid, 'EXECUTE')  as service_exec
+-- from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+-- where n.nspname='public'
+--   and p.proname in ('_call_process_account_deletions','_call_send_daily_briefings','refresh_feelflick_stats');
+--
+-- -- (b) each of the 7 tables still has >=1 permissive SELECT policy:
+-- select tablename, count(*) filter (where cmd='SELECT') as select_policies
+-- from pg_policies where schemaname='public'
+--   and tablename in ('genres','keywords','movie_genres','movie_keywords','people','ratings_external','movies')
+-- group by tablename order by tablename;
+-- ===========================================================================

--- a/supabase/migrations/20260529000300_pin_function_search_path.sql
+++ b/supabase/migrations/20260529000300_pin_function_search_path.sql
@@ -1,0 +1,57 @@
+-- Migration: pin search_path on app SECURITY DEFINER / plpgsql functions
+--
+-- WHY: 28 functions had no fixed `search_path` (advisor: function_search_path_mutable).
+-- A mutable search_path on a SECURITY DEFINER function is a hijack vector. Pinning the
+-- path removes the vulnerability and silences the lint.
+--
+-- PATH CHOICE — `public, extensions, pg_catalog` (NOT `''`):
+--   * public      -> the app's tables + pg_trgm (installed in public)
+--   * extensions  -> pgvector lives here; match_movies/find_top_neighbors/etc. use
+--                    vector operators (<=>, <->) that would break under `''` or a
+--                    path missing `extensions`.
+--   * pg_catalog  -> built-ins.
+-- Using `''` (full-qualification) would break the unqualified pgvector/pg_trgm
+-- operators these functions rely on, so we pin to the exact schemas they need.
+--
+-- SCOPE: only app functions. pg_trgm's own functions (gtrgm_*, similarity, word_*)
+-- live in public too but are extension-owned and intentionally excluded.
+--
+-- Forward-only. No behavior change (same schemas, just pinned).
+
+begin;
+
+alter function public.check_duplicate_feedback() set search_path = public, extensions, pg_catalog;
+alter function public.check_duplicate_ratings() set search_path = public, extensions, pg_catalog;
+alter function public.check_foreign_keys(p_table_name text) set search_path = public, extensions, pg_catalog;
+alter function public.check_indexes(table_names text[]) set search_path = public, extensions, pg_catalog;
+alter function public.check_invalid_watchlist_statuses() set search_path = public, extensions, pg_catalog;
+alter function public.check_unique_constraints(table_names text[]) set search_path = public, extensions, pg_catalog;
+alter function public.cleanup_expired_profile_caches() set search_path = public, extensions, pg_catalog;
+alter function public.count_brief_candidates(p_mood_id integer, p_energy integer, p_attention text, p_tone text, p_time text, p_era text, p_languages text[]) set search_path = public, extensions, pg_catalog;
+alter function public.database_health_check() set search_path = public, extensions, pg_catalog;
+alter function public.find_top_neighbors(source_embedding vector, exclude_id integer, k integer) set search_path = public, extensions, pg_catalog;
+alter function public.get_high_skip_movies(min_impressions integer, min_skip_rate numeric) set search_path = public, extensions, pg_catalog;
+alter function public.get_mood_recommendations(p_mood_id integer, p_viewing_context_id integer, p_experience_type_id integer, p_energy_level integer, p_intensity_openness integer, p_limit integer) set search_path = public, extensions, pg_catalog;
+alter function public.get_mood_recommendations(p_mood_id integer, p_viewing_context_id integer, p_experience_type_id integer, p_energy_level integer, p_intensity_openness integer, p_limit integer, p_user_id uuid) set search_path = public, extensions, pg_catalog;
+alter function public.get_mood_recommendations_v2(p_mood_id integer, p_viewing_context_id integer, p_experience_type_id integer, p_energy_level integer, p_intensity_openness integer, p_limit integer, p_user_id uuid, p_use_semantic_similarity boolean) set search_path = public, extensions, pg_catalog;
+alter function public.get_positive_feedback_movies(p_user_id uuid) set search_path = public, extensions, pg_catalog;
+alter function public.get_seed_neighbors(seed_ids integer[], exclude_ids integer[], top_n integer, min_ff_rating numeric) set search_path = public, extensions, pg_catalog;
+alter function public.get_watchlist_with_status(p_user_id uuid, p_status text) set search_path = public, extensions, pg_catalog;
+alter function public.handle_new_auth_user() set search_path = public, extensions, pg_catalog;
+alter function public.increment_session_interactions(session_id uuid) set search_path = public, extensions, pg_catalog;
+alter function public.invalidate_user_profile_cache() set search_path = public, extensions, pg_catalog;
+alter function public.match_movies(query_embedding vector, match_threshold double precision, match_count integer) set search_path = public, extensions, pg_catalog;
+alter function public.match_movies_by_seeds(seed_ids integer[], exclude_ids integer[], match_count integer, min_ff_rating numeric) set search_path = public, extensions, pg_catalog;
+alter function public.match_movies_for_seed(seed_movie_id integer, match_count integer, min_release_date date, language text, exclude_ids integer[]) set search_path = public, extensions, pg_catalog;
+alter function public.movies_null_profile(p_schema text, p_table text, p_only_missing boolean) set search_path = public, extensions, pg_catalog;
+alter function public.set_movies_editorial_overlay_updated_at() set search_path = public, extensions, pg_catalog;
+alter function public.set_user_discover_preferences_updated_at() set search_path = public, extensions, pg_catalog;
+alter function public.set_user_settings_updated_at() set search_path = public, extensions, pg_catalog;
+alter function public.update_movie_completion_stats() set search_path = public, extensions, pg_catalog;
+
+commit;
+
+-- VERIFICATION (read-only): expect 0 rows = all app functions now pinned.
+-- select p.proname from pg_proc p join pg_namespace n on n.oid=p.pronamespace
+-- where n.nspname='public' and p.prokind='f' and p.proconfig is null
+--   and not exists (select 1 from pg_depend d where d.objid=p.oid and d.deptype='e');

--- a/supabase/migrations/20260529000400_lock_idor_prone_definer_functions.sql
+++ b/supabase/migrations/20260529000400_lock_idor_prone_definer_functions.sql
@@ -1,0 +1,43 @@
+-- Migration: lock down IDOR-prone SECURITY DEFINER functions
+--
+-- WHY: get_watchlist_with_status(p_user_id, p_status) and
+-- get_positive_feedback_movies(p_user_id) are SECURITY DEFINER (bypass RLS) and
+-- filter by a CALLER-SUPPLIED p_user_id with NO auth.uid() check. They were
+-- executable by anon/authenticated via PostgREST RPC, so anyone could read ANY
+-- user's watchlist / liked movies by passing another user's id (IDOR). User ids
+-- are discoverable via the public leaderboard views + /profile/:userId URLs,
+-- making this chain-exploitable.
+--
+-- SAFE TO REVOKE: neither is called by the client —
+--   * get_positive_feedback_movies : 0 call sites in src/
+--   * get_watchlist_with_status    : only via the exported wrapper
+--     getWatchlistWithStatus(), which itself has 0 callers (dead).
+-- Any future/server-side use runs as service_role (retained below).
+--
+-- If these are wired into a feature later, rebuild them to filter by
+-- auth.uid() (self-access) or gate on a privacy setting — do NOT trust a
+-- caller-supplied user_id in a SECURITY DEFINER function.
+--
+-- NOTE: increment_session_interactions(session_id) is intentionally NOT changed
+-- here — it IS called by the client (interactions.js) and is low-impact. Track
+-- separately: add a check that the session belongs to auth.uid().
+--
+-- Forward-only.
+
+begin;
+
+revoke execute on function public.get_watchlist_with_status(uuid, text) from public, anon, authenticated;
+revoke execute on function public.get_positive_feedback_movies(uuid)    from public, anon, authenticated;
+
+grant execute on function public.get_watchlist_with_status(uuid, text) to service_role;
+grant execute on function public.get_positive_feedback_movies(uuid)    to service_role;
+
+commit;
+
+-- VERIFICATION (read-only):
+-- select p.proname,
+--        has_function_privilege('anon', p.oid, 'EXECUTE')          as anon_exec,
+--        has_function_privilege('authenticated', p.oid, 'EXECUTE') as authd_exec,
+--        has_function_privilege('service_role', p.oid, 'EXECUTE')  as service_exec
+-- from pg_proc p join pg_namespace n on n.oid=p.pronamespace
+-- where n.nspname='public' and p.proname in ('get_watchlist_with_status','get_positive_feedback_movies');


### PR DESCRIPTION
Session infrastructure work, split from the dead-code removal (#92). Two commits:

### 1. `feat(db)` — 2026-05-29 security hardening migrations
Already applied to the live project (via MCP); committed for repo record + dual-CI parity. Closes a critical exposure: 18 catalog/engine tables had RLS disabled with full `anon` write/TRUNCATE grants. Also locks public-executable cron functions, pins function `search_path`, and closes an IDOR on two `SECURITY DEFINER` functions. All verified live (lint/test/build/E2E + grant/policy queries).

### 2. `chore(tooling)` — guardrails + tests + CI
- **Guardrail skills** (`.claude/skills/`): design-system-guard, supabase-change, recommendation-engine, a11y-audit, perf-guard.
- **Lint hook** (`.claude/hooks/lint-on-edit.sh`): advisory ESLint on edited `src` JS/JSX.
- **Playwright E2E** (`e2e/`): auth setup + landing/home/recommendations/watchlist specs (8 tests, all green). `*.e2e.js` naming keeps Vitest out.
- **CI**: `app-quality.yml` gains an `e2e` job (no-ops until secrets are set).
- **Deps**: add `@playwright/test` + `test:e2e` scripts; drop unused `resend`.
- **Docs**: CLAUDE.md guardrails + E2E section.

### To activate E2E in CI
Add repo secrets: `E2E_TEST_EMAIL`, `E2E_TEST_PASSWORD`, `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, `VITE_TMDB_API_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)