### PR TITLE
feat: world-class pass — DB perf, SEO structured data, CI hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  # App dependencies (root)
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      # Collapse routine minor/patch bumps into one PR to cut noise.
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+    labels: ["dependencies"]
+
+  # Pipeline scripts have their own lockfile.
+  - package-ecosystem: npm
+    directory: "/scripts/pipeline"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels: ["dependencies", "pipeline"]
+
+  # Keep GitHub Actions pinned versions current.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels: ["ci"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: CodeQL
+
+# Static security analysis (complements GitGuardian secret scanning).
+# Free on public repos; results appear under Security → Code scanning alerts.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          queries: security-and-quality
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,63 @@
+name: Lighthouse CI
+
+# Perf / a11y / SEO budgets on the public landing. Builds the app and runs
+# Lighthouse against the static bundle. Gated to no-op (green) until the VITE_*
+# build secrets are configured, so it never blocks PRs before setup.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "public/**"
+      - "index.html"
+      - "package.json"
+      - "package-lock.json"
+      - "vite.config.*"
+      - "lighthouserc.json"
+      - ".github/workflows/lighthouse.yml"
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Build secrets gate — skip cleanly until configured.
+      - name: Preflight
+        id: pre
+        env:
+          HAVE: ${{ secrets.VITE_SUPABASE_URL != '' }}
+        run: |
+          if [ "$HAVE" = "true" ]; then echo "ready=true" >> "$GITHUB_OUTPUT";
+          else echo "ready=false" >> "$GITHUB_OUTPUT"; echo "::notice::VITE_* build secrets not set — skipping Lighthouse."; fi
+
+      - name: Setup Node
+        if: steps.pre.outputs.ready == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install
+        if: steps.pre.outputs.ready == 'true'
+        run: npm ci
+
+      - name: Build
+        if: steps.pre.outputs.ready == 'true'
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+          VITE_TMDB_API_KEY: ${{ secrets.VITE_TMDB_API_KEY }}
+        run: npm run build
+
+      - name: Lighthouse CI
+        if: steps.pre.outputs.ready == 'true'
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          configPath: ./lighthouserc.json
+          uploadArtifacts: true
+          temporaryPublicStorage: true

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,25 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./dist",
+      "numberOfRuns": 3,
+      "settings": {
+        "preset": "desktop"
+      }
+    },
+    "assert": {
+      "assertions": {
+        "categories:accessibility": ["error", { "minScore": 0.9 }],
+        "categories:performance": ["warn", { "minScore": 0.85 }],
+        "categories:seo": ["warn", { "minScore": 0.9 }],
+        "categories:best-practices": ["warn", { "minScore": 0.9 }],
+        "largest-contentful-paint": ["warn", { "maxNumericValue": 3000 }],
+        "cumulative-layout-shift": ["warn", { "maxNumericValue": 0.1 }],
+        "total-blocking-time": ["warn", { "maxNumericValue": 400 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/src/features/movie-v2/MovieDetailV2.jsx
+++ b/src/features/movie-v2/MovieDetailV2.jsx
@@ -42,10 +42,30 @@ export default function MovieDetailV2() {
 
   const movieTitle = mv?.title
   const movieYear = mv?.year ? ` (${mv.year})` : ''
+  const movieUrl = `https://app.feelflick.com/movie/${id}`
+  // schema.org/Movie structured data → rich Google results for film pages.
+  const movieJsonLd = mv
+    ? {
+        '@context': 'https://schema.org',
+        '@type': 'Movie',
+        name: mv.title,
+        url: movieUrl,
+        ...(mv.overview ? { description: mv.overview } : {}),
+        ...(mv.poster || mv.backdrop ? { image: mv.poster || mv.backdrop } : {}),
+        ...(mv.genres?.length ? { genre: mv.genres } : {}),
+        ...(mv.director && mv.director !== '—'
+          ? { director: { '@type': 'Person', name: mv.director } }
+          : {}),
+        ...(mv.runtime ? { duration: `PT${mv.runtime}M` } : {}),
+        ...(mv.year ? { datePublished: String(mv.year) } : {}),
+      }
+    : null
   usePageMeta({
     title: movieTitle ? `${movieTitle}${movieYear} — FeelFlick` : 'Movie — FeelFlick',
     description: mv?.tagline || mv?.overview || undefined,
     image: mv?.backdrop || undefined,
+    url: movieUrl,
+    jsonLd: movieJsonLd,
   })
 
   const {

--- a/src/shared/hooks/usePageMeta.js
+++ b/src/shared/hooks/usePageMeta.js
@@ -32,6 +32,23 @@ function setCanonical(url) {
   el.setAttribute('href', url)
 }
 
+// Inject/replace a single page-level JSON-LD <script>. Pass null to remove it.
+function setJsonLd(json) {
+  const id = 'page-ld-json'
+  let el = document.getElementById(id)
+  if (!json) {
+    if (el) el.remove()
+    return
+  }
+  if (!el) {
+    el = document.createElement('script')
+    el.type = 'application/ld+json'
+    el.id = id
+    document.head.appendChild(el)
+  }
+  el.textContent = json
+}
+
 /**
  * Sets page-level SEO tags from runtime route data and restores FeelFlick defaults on cleanup.
  *
@@ -40,9 +57,12 @@ function setCanonical(url) {
  * @param {string|null} params.description - Meta description.
  * @param {string|null} params.image - OG/Twitter image URL.
  * @param {string|null} params.url - Canonical/OG/Twitter URL.
+ * @param {Object|null} [params.jsonLd] - schema.org structured data injected as JSON-LD; removed on cleanup.
  * @returns {void}
  */
-export function usePageMeta({ title, description, image, url }) {
+export function usePageMeta({ title, description, image, url, jsonLd }) {
+  // Serialize so the effect re-runs only when the structured data actually changes.
+  const ldString = jsonLd ? JSON.stringify(jsonLd) : null
   useEffect(() => {
     const prevTitle = document.title
 
@@ -57,6 +77,7 @@ export function usePageMeta({ title, description, image, url }) {
     setMeta('twitter:image', image || DEFAULT_IMAGE, true)
     setMeta('twitter:url', url || BASE_URL, true)
     setCanonical(url || BASE_URL)
+    setJsonLd(ldString)
 
     return () => {
       document.title = prevTitle
@@ -70,6 +91,7 @@ export function usePageMeta({ title, description, image, url }) {
       setMeta('twitter:image', DEFAULT_IMAGE, true)
       setMeta('twitter:url', BASE_URL, true)
       setCanonical(BASE_URL)
+      setJsonLd(null)
     }
-  }, [title, description, image, url])
+  }, [title, description, image, url, ldString])
 }

--- a/supabase/migrations/20260529000500_perf_rls_initplan_fk_indexes_dedupe.sql
+++ b/supabase/migrations/20260529000500_perf_rls_initplan_fk_indexes_dedupe.sql
@@ -1,0 +1,82 @@
+-- Migration: performance pass (RLS initplan + FK indexes + duplicate index cleanup)
+-- Source: Supabase performance advisor. No access-control semantics change.
+--
+-- PART A — wrap auth.uid()/role()/jwt() in (select ...) across all RLS policies.
+--   Today these are re-evaluated PER ROW (auth_rls_initplan, 85 policies / 23 tables);
+--   wrapping makes Postgres evaluate them ONCE per statement (initplan). Done via an
+--   idempotent DO block (normalize-then-wrap) using expression-only ALTER POLICY, so
+--   each policy's command/roles/permissive flags are preserved exactly.
+-- PART B — add covering indexes for 12 unindexed foreign keys (faster joins/cascades).
+-- PART C — drop 10 duplicate indexes (8 plain dupes; 2 redundant unique/PK-backed
+--   constraints dropped via ALTER TABLE so we keep the canonical one).
+--
+-- Forward-only. Atomic (begin/commit) — a failure rolls back cleanly.
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- PART A: pin auth.* in RLS policy expressions (idempotent)
+-- ---------------------------------------------------------------------------
+do $$
+declare r record; q text; c text;
+begin
+  for r in
+    select tablename, policyname, qual, with_check
+    from pg_policies
+    where schemaname = 'public'
+      and (qual ~ 'auth\.(uid|role|jwt)\(\)' or with_check ~ 'auth\.(uid|role|jwt)\(\)')
+  loop
+    q := r.qual;
+    c := r.with_check;
+    if q is not null then
+      q := replace(replace(replace(q, '(select auth.uid())','auth.uid()'), '(select auth.role())','auth.role()'), '(select auth.jwt())','auth.jwt()');
+      q := replace(replace(replace(q, 'auth.uid()','(select auth.uid())'), 'auth.role()','(select auth.role())'), 'auth.jwt()','(select auth.jwt())');
+    end if;
+    if c is not null then
+      c := replace(replace(replace(c, '(select auth.uid())','auth.uid()'), '(select auth.role())','auth.role()'), '(select auth.jwt())','auth.jwt()');
+      c := replace(replace(replace(c, 'auth.uid()','(select auth.uid())'), 'auth.role()','(select auth.role())'), 'auth.jwt()','(select auth.jwt())');
+    end if;
+    execute 'alter policy ' || quote_ident(r.policyname) || ' on public.' || quote_ident(r.tablename)
+      || coalesce(' using (' || q || ')', '')
+      || coalesce(' with check (' || c || ')', '');
+  end loop;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- PART B: covering indexes for unindexed foreign keys
+-- ---------------------------------------------------------------------------
+create index if not exists idx_list_movies_movie_id on public.list_movies (movie_id);
+create index if not exists idx_mood_session_abandoned_user_id on public.mood_session_abandoned (user_id);
+create index if not exists idx_mood_sessions_experience_type_id on public.mood_sessions (experience_type_id);
+create index if not exists idx_mood_sessions_viewing_context_id on public.mood_sessions (viewing_context_id);
+create index if not exists idx_movies_editorial_overlay_curated_by on public.movies_editorial_overlay (curated_by);
+create index if not exists idx_recommendation_impressions_movie_id on public.recommendation_impressions (movie_id);
+create index if not exists idx_recommendation_impressions_seed_movie_id on public.recommendation_impressions (seed_movie_id);
+create index if not exists idx_user_history_mood_session_id on public.user_history (mood_session_id);
+create index if not exists idx_user_preferences_genre_id on public.user_preferences (genre_id);
+create index if not exists idx_user_watchlist_mood_session_id on public.user_watchlist (mood_session_id);
+create index if not exists idx_user_watchlist_movie_id on public.user_watchlist (movie_id);
+create index if not exists idx_users_default_viewing_context_id on public.users (default_viewing_context_id);
+
+-- ---------------------------------------------------------------------------
+-- PART C: drop duplicate indexes (keep one of each identical pair)
+-- ---------------------------------------------------------------------------
+-- Plain (non-constraint) duplicates:
+drop index if exists public.idx_movie_mood_scores_movie_score;
+drop index if exists public.idx_recommendation_events_user_shown_at;
+drop index if exists public.idx_user_history_movie_id;
+drop index if exists public.idx_user_history_user_watched_at;
+drop index if exists public.idx_user_movie_feedback_user_created;
+drop index if exists public.user_preferences_user_id_idx;
+drop index if exists public.idx_user_ratings_user_rated;
+drop index if exists public.idx_watchlist_user_status;
+-- Redundant unique constraints (keep movies_tmdb_id_key / ratings_external_pkey):
+alter table public.movies drop constraint if exists unique_tmdb_id;
+alter table public.ratings_external drop constraint if exists ratings_external_movie_id_unique;
+
+commit;
+
+-- VERIFICATION (read-only, run after): expect 0 unwrapped auth.* policies.
+-- select count(*) from pg_policies where schemaname='public'
+--   and (qual ~ 'auth\.(uid|role|jwt)\(\)' or with_check ~ 'auth\.(uid|role|jwt)\(\)')
+--   and not (coalesce(qual,'')||coalesce(with_check,'')) ~ '\(select auth\.';


### PR DESCRIPTION
Three focused commits toward world-class polish. The DB migration is already applied to the live project (committed here for repo + dual-CI parity).

### `perf(db)` — RLS initplan + indexes
- Wrap `auth.uid()/role()/jwt()` in `(select …)` across **85 RLS policies / 23 tables** → evaluated once per statement instead of per row (the dominant RLS cost on `recommendation_impressions`/`events`/`user_*`). Expression-only `ALTER POLICY`; semantics preserved (verified: 0 unwrapped remaining, 8/8 E2E green incl. watchlist write-path).
- Add **12 covering indexes** for unindexed foreign keys.
- Drop **10 duplicate indexes** (8 plain; 2 redundant unique/PK constraints).

### `feat(seo)` — Movie structured data
- `usePageMeta` gains a `jsonLd` param; `/movie/:id` emits a schema.org `Movie` object + a per-movie canonical URL → rich Google results for film pages.

### `chore(ci)` — repo hardening
- **Dependabot** (npm root + `scripts/pipeline` + github-actions), **CodeQL** scanning (public repo), **Lighthouse CI** perf/a11y/SEO budgets (a11y gated ≥0.9).

### To activate
Lighthouse CI no-ops until `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY`/`VITE_TMDB_API_KEY` repo secrets are set (same as the E2E job). CodeQL/Dependabot are automatic.

Validated locally: lint (0 errors) · 500 unit tests · build · 8 E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)