### PR TITLE
docs: clarify feed/challenges are parked features, not delete candidates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ src/
 │   ├── profile/          # /profile/:userId — taste profile
 │   ├── people/           # /people — taste twins
 │   ├── lists/            # /lists + curated detail (+ Create/AddToList modals)
-│   └── feed/, challenges/ # ⚠️ unwired stubs (routes redirect to /home) — delete candidates
+│   └── feed/, challenges/ # parked features — built but unrouted (redirect to /home until shipped)
 ├── components/           # canonical app-wide UI
 │   ├── carousel/         # the MovieCard hover LAW (Card, Row, hooks)
 │   ├── layout/           # TopNav, Footer (shared chrome)


### PR DESCRIPTION
Follow-up to #109. During the post-refactor cleanup recon I found that the two items the Folder Map flagged as "delete candidates" are **not** dead code:

- **`features/feed` + `features/challenges`** — `FeedPage.jsx` is built and uses a live `useUnreadFeed` hook; `Header.jsx` scaffolds the bell *"Restore alongside the FeedPage route when /feed ships."* They're **parked planned work**, deliberately routed to `/home` until ready.
- **`legacy/` + `/v2` + `*-legacy`** — deliberate rollback/comparison nets (no current surface links to them). PostHog shows ~0 real traffic, but analytics is only ~5 weeks old, so that can't *confirm* "unused", and zero traffic is the expected state for a safety net anyway.

This PR only rewords the Folder Map comment so the intent is unambiguous. **No code or routes change.** Per the decision, nothing is deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)