### PR TITLE
chore(dependabot): defer React 19 + Tailwind 4 majors (major-only ignore)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,21 @@ updates:
       # Collapse routine minor/patch bumps into one PR to cut noise.
       minor-and-patch:
         update-types: ["minor", "patch"]
+    # Defer breaking majors that need deliberate, tested migrations rather than
+    # an auto-merge: React 19 (#104/#106) and Tailwind 4 (#105), all closed
+    # 2026-05-29. Patch/minor updates for these still flow. Delete an entry when
+    # you're ready to take that migration on.
+    ignore:
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "tailwindcss"
+        update-types: ["version-update:semver-major"]
     labels: ["dependencies"]
 
   # Pipeline scripts have their own lockfile.


### PR DESCRIPTION
Resolves the 3 remaining Dependabot PRs from the backlog sweep that can't be auto-merged:

- **#104 + #106** — React 18 → **19** (core framework major; needs a code migration)
- **#105** — Tailwind 3 → **4** (CSS-first rewrite; requires rewriting `tailwind.config.js` + re-tuning the design system)

These need deliberate, tested migrations, not a dependency-bump merge. This adds a **major-only** ignore in `.github/dependabot.yml` so:

- Dependabot stops re-opening these failing major PRs every run (no recurring clutter), and
- **patch/minor updates (including security) for react/react-dom/tailwindcss keep flowing.**

Reversible: delete the relevant `ignore` entry when you're ready to take a migration on. The three PRs themselves are being closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)