### PR TITLE
chore(deps): web-vitals 4→5 (drop retired onFID) + defer build-tool majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,12 +11,20 @@ updates:
       minor-and-patch:
         update-types: ["minor", "patch"]
     # Defer breaking majors that need a deliberate, tested migration rather than
-    # an auto-merge. Tailwind 4 (#105, closed 2026-05-29) is a CSS-first rewrite
-    # that requires rewriting tailwind.config.js. Patch/minor still flow; delete
-    # the entry when ready to take that migration on.
-    # (React 19 was completed 2026-05-29, so its major ignore was removed here.)
+    # an auto-merge. Each fails CI as a bare bump and/or rewrites a Hard-Stop
+    # config. Patch/minor still flow; delete an entry when ready to migrate.
+    #   - tailwindcss 4: CSS-first rewrite, rewrites tailwind.config.js (#105)
+    #   - vite 8 + @vitejs/plugin-react 6: coupled build-tool majors, vite.config.js (#116/#118)
+    #   - eslint 10: flat-config/rule breaks, rewrites eslint.config.js (#119)
+    # (React 19 + web-vitals 5 were completed 2026-05-29/30, so they're not here.)
     ignore:
       - dependency-name: "tailwindcss"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "vite"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@vitejs/plugin-react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint"
         update-types: ["version-update:semver-major"]
     labels: ["dependencies"]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "react-router-dom": "^7.16.0",
-        "web-vitals": "^4.2.4"
+        "web-vitals": "^5.3.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -7130,12 +7130,6 @@
         "web-vitals": "^5.1.0"
       }
     },
-    "node_modules/posthog-js/node_modules/web-vitals": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
-      "integrity": "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==",
-      "license": "Apache-2.0"
-    },
     "node_modules/preact": {
       "version": "10.29.1",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
@@ -8693,9 +8687,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
-      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
       "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-router-dom": "^7.16.0",
-    "web-vitals": "^4.2.4"
+    "web-vitals": "^5.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/src/shared/lib/vitals.js
+++ b/src/shared/lib/vitals.js
@@ -1,5 +1,7 @@
 import * as Sentry from '@sentry/react'
-import { onCLS, onFCP, onFID, onINP, onLCP, onTTFB } from 'web-vitals'
+// web-vitals v5 removed onFID — FID was retired as a Core Web Vital in favor of
+// INP (already reported below via onINP). See https://web.dev/articles/inp.
+import { onCLS, onFCP, onINP, onLCP, onTTFB } from 'web-vitals'
 
 function sendToSentry({ name, value, rating, id }) {
   Sentry.metrics.distribution(`web_vitals.${name.toLowerCase()}`, value, {
@@ -14,7 +16,6 @@ function sendToSentry({ name, value, rating, id }) {
 export function reportWebVitals() {
   onCLS(sendToSentry)
   onFCP(sendToSentry)
-  onFID(sendToSentry)
   onINP(sendToSentry)
   onLCP(sendToSentry)
   onTTFB(sendToSentry)


### PR DESCRIPTION
Processes the rest of the fresh Dependabot batch (#112–119).

## web-vitals 4 → 5 (completed)
v5 removed `onFID` — FID was retired as a Core Web Vital in favor of **INP**, which `vitals.js` already reports via `onINP`. Dropped the dead import + call; no metric lost. Replaces Dependabot #117.

## Deferred (major-only Dependabot ignore)
These fail a bare bump and/or require rewriting a Hard-Stop config, so they need deliberate migrations — not a sweep merge. Patch/minor (incl. security) still flow:
- **vite 7→8** + **@vitejs/plugin-react 4→6** — coupled build-tool majors (`vite.config.js`) — #116/#118
- **eslint 9→10** — flat-config/rule breaks (`eslint.config.js`) — #119

Reversible: delete the entry from `.github/dependabot.yml`. The three PRs are being closed.

## Validation
- `lint` 0 errors · `test` 500 passed · `build` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)