### PR TITLE
refactor(tokens): single source of truth for HP design tokens

### DIFF
--- a/src/features/account/data.js
+++ b/src/features/account/data.js
@@ -14,13 +14,7 @@
 // USER + stats are now live. They're fetched via useAccountData() against
 // auth.getUser() + the users table + user_history/user_ratings counts.
 
-export const HP = {
-  bg:'#000000', bgDeep:'#06060a',
-  border:'rgba(255,255,255,0.08)', borderStrong:'rgba(255,255,255,0.14)',
-  text:'#FAFAFA', textSoft:'rgba(250,250,250,0.72)', textMuted:'rgba(250,250,250,0.45)', textFaint:'rgba(250,250,250,0.28)',
-  purple:'#A78BFA', purpleDeep:'#7C3AED', pink:'#EC4899', amber:'#F59E0B', red:'#EF4444', green:'#34D399',
-};
-export const HP_GRAD = 'linear-gradient(135deg, #9333ea 0%, #ec4899 100%)';
+export { HP, HP_GRAD } from '@/shared/lib/tokens'
 
 export const SETTINGS = {
   notifications: [

--- a/src/features/browse/data.js
+++ b/src/features/browse/data.js
@@ -1,15 +1,19 @@
 // FeelFlick — Browse v3 data layer.
 // /browse v5 — data layer.
 
+import { HP as baseHP, HP_GRAD } from '@/shared/lib/tokens'
+
+// Browse keeps a deeper page bg, extra text tiers, and a couple of accents;
+// spread the shared core and override only those (explicit, not drift).
 export const HP = {
-  bg:'#06060a', surface:'#0e0b18',
-  border:'rgba(255,255,255,0.07)', borderStrong:'rgba(255,255,255,0.14)',
-  text:'#FAFAFA', textHi:'rgba(250,250,250,0.92)', textMid:'rgba(250,250,250,0.72)',
-  textLow:'rgba(250,250,250,0.5)', textFaint:'rgba(250,250,250,0.32)',
-  purple:'#A78BFA', purpleDeep:'#9333ea', pink:'#EC4899',
-  amber:'#F59E0B', green:'#34D399', red:'#EF4444', blue:'#7DD3FC',
-};
-export const HP_GRAD = 'linear-gradient(135deg, #9333ea 0%, #ec4899 100%)';
+  ...baseHP,
+  bg: '#06060a', surface: '#0e0b18',
+  border: 'rgba(255,255,255,0.07)', textFaint: 'rgba(250,250,250,0.32)',
+  purpleDeep: '#9333ea',
+  textHi: 'rgba(250,250,250,0.92)', textMid: 'rgba(250,250,250,0.72)', textLow: 'rgba(250,250,250,0.5)',
+  blue: '#7DD3FC',
+}
+export { HP_GRAD }
 export const TMDB = (p) => `https://image.tmdb.org/t/p/w500${p}`;
 
 export const MOODS = [

--- a/src/features/discover/Discover.jsx
+++ b/src/features/discover/Discover.jsx
@@ -9,6 +9,7 @@ import { scoreMovieForUser, logSurfaceImpressions, updateImpression } from '@/sh
 import { computeMatchPercent } from '@/shared/services/matchScore'
 import { trackInteraction } from '@/shared/services/interactions'
 import { getMovieWatchProviders } from '@/shared/api/tmdb'
+import { HP as baseHP, HP_GRAD } from '@/shared/lib/tokens'
 import { Play, SkipForward, X, Check, Bookmark } from 'lucide-react'
 import { DiscoverDataProvider, useDiscoverData } from './useDiscoverData'
 import './discover.css'
@@ -85,13 +86,9 @@ function AudioToggle() {
 
 // ── Original v4 imports below ──
 
-const HP = {
-  bgDeep:'#06060a', surface:'#120d1c', paper:'#0d0b13',
-  border:'rgba(255,255,255,0.08)', borderStrong:'rgba(255,255,255,0.14)',
-  text:'#FAFAFA', textSoft:'rgba(250,250,250,0.72)', textMuted:'rgba(250,250,250,0.45)', textFaint:'rgba(250,250,250,0.28)',
-  purple:'#A78BFA', purpleDeep:'#9333ea', pink:'#EC4899', amber:'#F59E0B', red:'#EF4444', green:'#34D399',
-};
-const HP_GRAD = 'linear-gradient(135deg, #9333ea 0%, #ec4899 100%)';
+// Discover keeps a deeper accent purple + two surface tints; spread the shared
+// core and override only those (explicit divergence, not copy-paste drift).
+const HP = { ...baseHP, purpleDeep: '#9333ea', surface: '#120d1c', paper: '#0d0b13' }
 const TMDB = (p) => `https://image.tmdb.org/t/p/w500${p}`;
 
 // Hints harmonized to noun-phrase voice — the other 6 already use this

--- a/src/features/history/data.js
+++ b/src/features/history/data.js
@@ -3,13 +3,7 @@
 // USER + ENTRIES + HEATMAP + TIMELINE + MOOD_SHARE are now derived live in
 // useHistoryData.jsx from user_history × movies × user_ratings.
 
-export const HP = {
-  bgDeep:'#06060a',
-  border:'rgba(255,255,255,0.08)', borderStrong:'rgba(255,255,255,0.14)',
-  text:'#FAFAFA', textSoft:'rgba(250,250,250,0.72)', textMuted:'rgba(250,250,250,0.45)', textFaint:'rgba(250,250,250,0.28)',
-  purple:'#A78BFA', purpleDeep:'#7C3AED', pink:'#EC4899', amber:'#F59E0B', red:'#EF4444', green:'#34D399',
-};
-export const HP_GRAD = 'linear-gradient(135deg, #9333ea 0%, #ec4899 100%)';
+export { HP, HP_GRAD } from '@/shared/lib/tokens'
 
 const TMDB_IMG = 'https://image.tmdb.org/t/p';
 export const tmdbImg = (path, size = 'w500') =>

--- a/src/features/home/data.js
+++ b/src/features/home/data.js
@@ -7,15 +7,7 @@ const TMDB_BASE = 'https://image.tmdb.org/t/p'
 export const TMDB = (path, size = 'w500') => path ? `${TMDB_BASE}/${size}${path}` : null
 export const POSTER = (path) => TMDB(path)
 
-export const HP = {
-  bg: '#000000', bgDeep: '#06060a',
-  panel: 'rgba(255,255,255,0.04)',
-  border: 'rgba(255,255,255,0.08)', borderStrong: 'rgba(255,255,255,0.14)',
-  text: '#FAFAFA', textSoft: 'rgba(250,250,250,0.72)', textMuted: 'rgba(250,250,250,0.45)', textFaint: 'rgba(250,250,250,0.28)',
-  purple: '#A78BFA', purpleDeep: '#7C3AED', pink: '#EC4899', amber: '#F59E0B',
-}
-export const HP_GRAD = 'linear-gradient(135deg, #9333ea 0%, #ec4899 100%)'
-
+export { HP, HP_GRAD } from '@/shared/lib/tokens'
 // Mood UI metadata only. Pool + rationale come from useHomeData.
 export const MOOD_META = [
   { id: 'tender',     label: 'Tender',     hex: '#F59FA8', tint: 'pink' },

--- a/src/features/lists/CuratedList.jsx
+++ b/src/features/lists/CuratedList.jsx
@@ -9,13 +9,7 @@ import { usePageMeta } from '@/shared/hooks/usePageMeta'
 import { CURATED_LISTS } from '@/shared/lib/curatedLists'
 import './lists.css'
 
-const HP = {
-  bgDeep: '#06060a',
-  border: 'rgba(255,255,255,0.08)', borderStrong: 'rgba(255,255,255,0.14)',
-  text: '#FAFAFA', textSoft: 'rgba(250,250,250,0.72)', textMuted: 'rgba(250,250,250,0.45)', textFaint: 'rgba(250,250,250,0.28)',
-  purple: '#A78BFA', pink: '#EC4899',
-}
-const HP_GRAD = 'linear-gradient(135deg, #9333ea 0%, #ec4899 100%)'
+import { HP, HP_GRAD } from '@/shared/lib/tokens'
 const RESET_BTN = { background: 'none', border: 'none', padding: 0, margin: 0, font: 'inherit', color: 'inherit', cursor: 'pointer', textAlign: 'left' }
 
 const TMDB_IMG = (path, size = 'w342') => path ? `https://image.tmdb.org/t/p/${size}${path}` : null

--- a/src/features/lists/ListDetail.jsx
+++ b/src/features/lists/ListDetail.jsx
@@ -13,13 +13,7 @@ import { tmdbImg } from '@/shared/api/tmdb'
 import CreateListModal from '@/features/lists/CreateListModal'
 import './lists.css'
 
-const HP = {
-  bgDeep: '#06060a',
-  border: 'rgba(255,255,255,0.08)', borderStrong: 'rgba(255,255,255,0.14)',
-  text: '#FAFAFA', textSoft: 'rgba(250,250,250,0.72)', textMuted: 'rgba(250,250,250,0.45)', textFaint: 'rgba(250,250,250,0.28)',
-  purple: '#A78BFA', purpleDeep: '#7C3AED', pink: '#EC4899', amber: '#F59E0B', red: '#EF4444', green: '#34D399',
-}
-const HP_GRAD = 'linear-gradient(135deg, #9333ea 0%, #ec4899 100%)'
+import { HP, HP_GRAD } from '@/shared/lib/tokens'
 const RESET_BTN = { background: 'none', border: 'none', padding: 0, margin: 0, font: 'inherit', color: 'inherit', cursor: 'pointer', textAlign: 'left' }
 
 function capitalize(s) {

--- a/src/features/lists/Lists.jsx
+++ b/src/features/lists/Lists.jsx
@@ -12,14 +12,7 @@ import CreateListModal from '@/features/lists/CreateListModal'
 import './lists.css'
 import { ListsDataProvider, useListsData } from './useListsData'
 
-const HP = {
-  bgDeep: '#06060a',
-  border: 'rgba(255,255,255,0.08)', borderStrong: 'rgba(255,255,255,0.14)',
-  text: '#FAFAFA', textSoft: 'rgba(250,250,250,0.72)', textMuted: 'rgba(250,250,250,0.45)', textFaint: 'rgba(250,250,250,0.28)',
-  purple: '#A78BFA', purpleDeep: '#7C3AED', pink: '#EC4899', amber: '#F59E0B', red: '#EF4444', green: '#34D399',
-}
-const HP_GRAD = 'linear-gradient(135deg, #9333ea 0%, #ec4899 100%)'
-
+import { HP, HP_GRAD } from '@/shared/lib/tokens'
 const RESET_BTN = { background: 'none', border: 'none', padding: 0, margin: 0, font: 'inherit', color: 'inherit', cursor: 'pointer', textAlign: 'left' }
 
 // === Masthead ============================================================

--- a/src/features/lists/PersonalListPage.jsx
+++ b/src/features/lists/PersonalListPage.jsx
@@ -37,13 +37,7 @@ function applyExcludeIds(query, ids) {
   return query.not('id', 'in', `(${ids.join(',')})`)
 }
 
-const HP = {
-  bgDeep: '#06060a',
-  border: 'rgba(255,255,255,0.08)', borderStrong: 'rgba(255,255,255,0.14)',
-  text: '#FAFAFA', textSoft: 'rgba(250,250,250,0.72)', textMuted: 'rgba(250,250,250,0.45)', textFaint: 'rgba(250,250,250,0.28)',
-  purple: '#A78BFA', pink: '#EC4899',
-}
-const HP_GRAD = 'linear-gradient(135deg, #9333ea 0%, #ec4899 100%)'
+import { HP, HP_GRAD } from '@/shared/lib/tokens'
 const RESET_BTN = { background: 'none', border: 'none', padding: 0, margin: 0, font: 'inherit', color: 'inherit', cursor: 'pointer', textAlign: 'left' }
 const TMDB_IMG = (path, size = 'w342') => path ? `https://image.tmdb.org/t/p/${size}${path}` : null
 

--- a/src/features/movie/data.js
+++ b/src/features/movie/data.js
@@ -49,20 +49,5 @@ const DNA_DELTA = [
 ]
 
 // === Brand tokens ===
-const HP = {
-  bg:           '#000000',
-  bgDeep:       '#06060a',
-  border:       'rgba(255,255,255,0.08)',
-  borderStrong: 'rgba(255,255,255,0.14)',
-  text:         '#FAFAFA',
-  textSoft:     'rgba(250,250,250,0.72)',
-  textMuted:    'rgba(250,250,250,0.45)',
-  textFaint:    'rgba(250,250,250,0.28)',
-  purple:       '#A78BFA',
-  purpleDeep:   '#7C3AED',
-  pink:         '#EC4899',
-  amber:        '#F59E0B',
-}
-const HP_GRAD = 'linear-gradient(135deg, #9333ea 0%, #ec4899 100%)'
-
-export { FILM_PALETTE, TIMELINE, DNA_DELTA, HP, HP_GRAD }
+export { HP, HP_GRAD } from '@/shared/lib/tokens'
+export { FILM_PALETTE, TIMELINE, DNA_DELTA }

--- a/src/features/people/data.js
+++ b/src/features/people/data.js
@@ -1,12 +1,6 @@
 // /people v2 — data.
 
-export const HP = {
-  bgDeep:'#06060a',
-  border:'rgba(255,255,255,0.08)', borderStrong:'rgba(255,255,255,0.14)',
-  text:'#FAFAFA', textSoft:'rgba(250,250,250,0.72)', textMuted:'rgba(250,250,250,0.45)', textFaint:'rgba(250,250,250,0.28)',
-  purple:'#A78BFA', purpleDeep:'#7C3AED', pink:'#EC4899', amber:'#F59E0B', red:'#EF4444', green:'#34D399',
-};
-export const HP_GRAD = 'linear-gradient(135deg, #9333ea 0%, #ec4899 100%)';
+export { HP, HP_GRAD } from '@/shared/lib/tokens'
 
 export const USER = { name:'Aditya', following:24, followers:31, taste:'Patient class-coded thrillers' };
 

--- a/src/features/preferences/Preferences.jsx
+++ b/src/features/preferences/Preferences.jsx
@@ -9,13 +9,7 @@ import { usePageMeta } from '@/shared/hooks/usePageMeta'
 import { PreferencesDataProvider, usePreferencesData, genreLabelOf } from './usePreferencesData'
 import './preferences.css'
 
-const HP = {
-  bgDeep: '#06060a',
-  border: 'rgba(255,255,255,0.08)', borderStrong: 'rgba(255,255,255,0.14)',
-  text: '#FAFAFA', textSoft: 'rgba(250,250,250,0.72)', textMuted: 'rgba(250,250,250,0.45)', textFaint: 'rgba(250,250,250,0.28)',
-  purple: '#A78BFA', purpleDeep: '#7C3AED', pink: '#EC4899', amber: '#F59E0B', red: '#EF4444', green: '#34D399',
-}
-const HP_GRAD = 'linear-gradient(135deg, #9333ea 0%, #ec4899 100%)'
+import { HP, HP_GRAD } from '@/shared/lib/tokens'
 const RESET_BTN = { background: 'none', border: 'none', padding: 0, margin: 0, font: 'inherit', color: 'inherit', cursor: 'pointer', textAlign: 'left' }
 
 // === Atoms ===============================================================

--- a/src/features/profile/data.js
+++ b/src/features/profile/data.js
@@ -27,13 +27,7 @@ export const USER = {
 };
 
 // Brand tokens
-export const HP = {
-  bg:'#000000', bgDeep:'#06060a',
-  border:'rgba(255,255,255,0.08)', borderStrong:'rgba(255,255,255,0.14)',
-  text:'#FAFAFA', textSoft:'rgba(250,250,250,0.72)', textMuted:'rgba(250,250,250,0.45)', textFaint:'rgba(250,250,250,0.28)',
-  purple:'#A78BFA', purpleDeep:'#7C3AED', pink:'#EC4899', amber:'#F59E0B',
-};
-export const HP_GRAD = 'linear-gradient(135deg, #9333ea 0%, #ec4899 100%)';
+export { HP, HP_GRAD } from '@/shared/lib/tokens'
 
 // Cold-start fallbacks for sections that always render — Skew + YIR show
 // these neutral values when the user has too little data for a live

--- a/src/features/watchlist/data.js
+++ b/src/features/watchlist/data.js
@@ -3,13 +3,7 @@
 // USER + ITEMS are now derived live in useWatchlistData.jsx from
 // user_watchlist (joined with movies) + the user's taste_fingerprint.
 
-export const HP = {
-  bgDeep:'#06060a',
-  border:'rgba(255,255,255,0.08)', borderStrong:'rgba(255,255,255,0.14)',
-  text:'#FAFAFA', textSoft:'rgba(250,250,250,0.72)', textMuted:'rgba(250,250,250,0.45)', textFaint:'rgba(250,250,250,0.28)',
-  purple:'#A78BFA', purpleDeep:'#7C3AED', pink:'#EC4899', amber:'#F59E0B', red:'#EF4444', green:'#34D399',
-};
-export const HP_GRAD = 'linear-gradient(135deg, #9333ea 0%, #ec4899 100%)';
+export { HP, HP_GRAD } from '@/shared/lib/tokens'
 
 const TMDB_IMG = 'https://image.tmdb.org/t/p';
 export const tmdbImg = (path, size = 'w500') =>

--- a/src/shared/lib/tokens.js
+++ b/src/shared/lib/tokens.js
@@ -1,0 +1,34 @@
+// === FeelFlick design tokens — single source of truth ======================
+//
+// The canonical values behind CLAUDE.md's "Editorial Language". The inline-style
+// feature surfaces used to each declare their own near-identical `HP` object
+// (14 copies that had quietly drifted); they now import from here.
+//
+// `HP` is the shared core. A surface that genuinely needs an extra/overridden
+// value spreads this and adds it locally (see features/browse, features/discover)
+// so any divergence is explicit rather than a silent copy-paste drift.
+//
+// WHY: one place to tune the palette; no more hunting 14 files. The v3 landing's
+// `C` palette aligns with these same hexes and is a candidate to fold in next.
+
+/** Core editorial palette for inline-style feature surfaces. */
+export const HP = {
+  bg: '#000000',
+  bgDeep: '#06060a',
+  panel: 'rgba(255,255,255,0.04)',
+  border: 'rgba(255,255,255,0.08)',
+  borderStrong: 'rgba(255,255,255,0.14)',
+  text: '#FAFAFA',
+  textSoft: 'rgba(250,250,250,0.72)',
+  textMuted: 'rgba(250,250,250,0.45)',
+  textFaint: 'rgba(250,250,250,0.28)',
+  purple: '#A78BFA',
+  purpleDeep: '#7C3AED',
+  pink: '#EC4899',
+  amber: '#F59E0B',
+  red: '#EF4444',
+  green: '#34D399',
+}
+
+/** The one brand gradient — purple-600 → pink-500. Never invent per-vibe variants. */
+export const HP_GRAD = 'linear-gradient(135deg, #9333ea 0%, #ec4899 100%)'


### PR DESCRIPTION
First of the two "strengthen the spine" moves from the UI-workflow discussion (instead of bolting on 5 generative tools). CLAUDE.md already flagged this: *"Eventually these will collapse into one shared `shared/lib/tokens.js`."*

## Problem
The inline-style feature surfaces each declared their own `HP` palette — **14 near-identical copies** that had quietly drifted (e.g. 2 surfaces used `purpleDeep:#9333ea` vs the other 12's `#7C3AED`; browse had a one-off `border:0.07` and `textFaint:0.32`).

## Change
- **New `src/shared/lib/tokens.js`** — the canonical `HP` core + the single `HP_GRAD`.
- **12 surfaces** were exact canonical subsets → clean `import` / re-export.
- **2 surfaces** genuinely diverge (`browse`, `discover`) → they now spread the shared core and override **only** their deltas, so divergence is **explicit** rather than buried in a copy. (A follow-up can decide whether to normalize those ~5 values away.)

## Zero rendered change — by construction
Every value each surface actually *uses* is preserved byte-for-byte; surfaces just gain unused canonical keys. No normalization was applied.

## Validation
- `lint` 0 errors · `test` 500 passed · `build` OK

## Next
- Fold the v3 landing's `C` palette into the same module.
- Widen visual-regression coverage to the deterministic editorial surfaces (the other spine move).

🤖 Generated with [Claude Code](https://claude.com/claude-code)