### PR TITLE
refactor(tokens): fold the v3 landing C palette into shared tokens

### DIFF
--- a/src/features/landing/Landing.jsx
+++ b/src/features/landing/Landing.jsx
@@ -2,10 +2,8 @@ import { useState, useEffect, useRef, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { useGoogleAuth } from '@/shared/hooks/useGoogleAuth'
 import { usePageMeta } from '@/shared/hooks/usePageMeta'
+import { C, HP_GRAD as GRAD } from '@/shared/lib/tokens'
 import './landing.css'
-
-const C={bg:'#06060a',bgPure:'#000',bgLight:'#0d0b14',bgPaper:'#0f0c18',text:'#FAFAFA',textHi:'rgba(250,250,250,0.92)',textMid:'rgba(250,250,250,0.72)',textLow:'rgba(250,250,250,0.55)',textFaint:'rgba(250,250,250,0.28)',hairline:'rgba(255,255,255,0.08)',hairlineStrong:'rgba(255,255,255,0.14)',purple:'#A78BFA',pink:'#EC4899',amber:'#F59E0B',green:'#34D399'};
-const GRAD='linear-gradient(135deg,#9333ea 0%,#ec4899 100%)';
 // Posters render at <=240px wide on the landing — w342 is the right TMDB size.
 const TMDB=(p)=>`https://image.tmdb.org/t/p/w342${p}`;
 

--- a/src/shared/lib/tokens.js
+++ b/src/shared/lib/tokens.js
@@ -32,3 +32,26 @@ export const HP = {
 
 /** The one brand gradient — purple-600 → pink-500. Never invent per-vibe variants. */
 export const HP_GRAD = 'linear-gradient(135deg, #9333ea 0%, #ec4899 100%)'
+
+/**
+ * v3 landing palette. Same hexes as `HP`, different key names (hairline≈border,
+ * textMid≈textSoft, bgPure≈bg) plus a few landing-only surface tints. Aliased to
+ * `HP` where they align so the shared colors live in exactly one place.
+ */
+export const C = {
+  bg: HP.bgDeep,
+  bgPure: HP.bg,
+  bgLight: '#0d0b14',
+  bgPaper: '#0f0c18',
+  text: HP.text,
+  textHi: 'rgba(250,250,250,0.92)',
+  textMid: HP.textSoft,
+  textLow: 'rgba(250,250,250,0.55)',
+  textFaint: HP.textFaint,
+  hairline: HP.border,
+  hairlineStrong: HP.borderStrong,
+  purple: HP.purple,
+  pink: HP.pink,
+  amber: HP.amber,
+  green: HP.green,
+}


### PR DESCRIPTION
Follow-up to #126 — finishes "collapse HP + C".

The v3 landing declared its own `C` palette (same hexes as `HP`, different key names: `hairline`≈`border`, `textMid`≈`textSoft`, `bgPure`≈`bg`) plus a few landing-only tints (`bgLight`, `bgPaper`, `textHi`, `textLow:0.55`). It now lives in `src/shared/lib/tokens.js` and **aliases `HP`** where the values align, so the shared brand colors have one home. The local `GRAD` collapses into `HP_GRAD`.

**Zero rendered change** — every value is byte-identical; only `bgPure` `'#000'`→`'#000000'` and the gradient's internal whitespace differ, both of which render identically.

Gate: `lint` 0 errors · `test` 500 passed · `build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)