### PR TITLE
test(a11y): runtime accessibility gate via @axe-core/playwright

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -1,4 +1,4 @@
-name: Visual Regression
+name: Visual & A11y Regression
 
 on:
   pull_request:
@@ -59,6 +59,18 @@ jobs:
           else
             npm run test:visual
           fi
+
+      # Runtime a11y on the logged-out surfaces (same dummy env). Fails on
+      # serious/critical WCAG violations excluding color-contrast, which is a
+      # deliberate editorial-design choice tracked separately. Authenticated
+      # a11y (/home, /movie) runs via the secret-gated E2E job + locally.
+      - name: Accessibility (logged-out surfaces)
+        if: ${{ !startsWith(github.ref, 'refs/heads/visual-baselines/') }}
+        env:
+          VITE_SUPABASE_URL: https://dummy.supabase.co
+          VITE_SUPABASE_ANON_KEY: dummy-anon-key
+          VITE_TMDB_API_KEY: dummy
+        run: npx playwright test --project=public e2e/public/a11y.e2e.js
 
       - name: Commit regenerated baselines
         if: ${{ startsWith(github.ref, 'refs/heads/visual-baselines/') }}

--- a/e2e/app/a11y.e2e.js
+++ b/e2e/app/a11y.e2e.js
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test'
+import AxeBuilder from '@axe-core/playwright'
+
+// Runtime a11y on the authenticated surfaces (uses the saved session). Diagnostic
+// for now — prints all violations; the blocking assertion excludes color-contrast
+// (a deliberate editorial-design tension tracked separately).
+
+const BLOCKING = ['serious', 'critical']
+const TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']
+
+function summarize(violations) {
+  if (!violations.length) return '(none)'
+  return violations
+    .map(
+      (v) =>
+        `  [${v.impact}] ${v.id} — ${v.help} (${v.nodes.length} node(s), e.g. \`${v.nodes[0]?.target?.join(' ')}\`)`
+    )
+    .join('\n')
+}
+
+async function audit(page, label) {
+  const { violations } = await new AxeBuilder({ page }).withTags(TAGS).analyze()
+  const blocking = violations.filter((v) => BLOCKING.includes(v.impact))
+  const nonContrast = blocking.filter((v) => v.id !== 'color-contrast')
+  console.log(
+    `\n[a11y] ${label}: ${violations.length} total, ${blocking.length} blocking ` +
+      `(${nonContrast.length} excluding contrast)\n${summarize(violations)}`
+  )
+  expect(nonContrast, `${label} — non-contrast serious/critical:\n${summarize(nonContrast)}`).toEqual([])
+}
+
+test('a11y — home (/home)', async ({ page }) => {
+  await page.goto('/home')
+  await page.waitForLoadState('networkidle')
+  await audit(page, '/home')
+})
+
+test('a11y — film detail (/movie/:id)', async ({ page }) => {
+  await page.goto('/home')
+  // Cards navigate on click (onClick, not <a href>) — match the recommendations e2e.
+  const poster = page.locator('img[src*="image.tmdb.org"]').first()
+  await expect(poster).toBeVisible({ timeout: 20_000 })
+  await poster.click()
+  await expect(page).toHaveURL(/\/movie\/\d+/, { timeout: 15_000 })
+  await page.waitForLoadState('networkidle')
+  await audit(page, '/movie/:id')
+})

--- a/e2e/public/a11y.e2e.js
+++ b/e2e/public/a11y.e2e.js
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test'
+import AxeBuilder from '@axe-core/playwright'
+
+// Runtime accessibility gate — the layer eslint-plugin-jsx-a11y (static) can't
+// see: focus order, ARIA validity, computed contrast in the live DOM. Fails on
+// serious/critical WCAG 2.1 A/AA violations on the public (logged-out) surfaces.
+//
+// `color-contrast` is intentionally NOT blocking: the editorial design uses
+// deliberate low-opacity text for hierarchy (eyebrows, muted labels), which is a
+// design decision tracked separately — not a code regression. Everything else
+// (labels, roles, names, focus) IS gated, and currently passes clean.
+
+const BLOCKING = ['serious', 'critical']
+const NON_BLOCKING_RULES = ['color-contrast']
+const TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']
+
+function summarize(violations) {
+  if (!violations.length) return '(none)'
+  return violations
+    .map(
+      (v) =>
+        `  [${v.impact}] ${v.id} — ${v.help}\n` +
+        `    ${v.nodes.length} node(s), e.g. \`${v.nodes[0]?.target?.join(' ')}\`\n` +
+        `    ${v.helpUrl}`
+    )
+    .join('\n\n')
+}
+
+async function audit(page, label) {
+  const { violations } = await new AxeBuilder({ page }).withTags(TAGS).analyze()
+  const blocking = violations.filter(
+    (v) => BLOCKING.includes(v.impact) && !NON_BLOCKING_RULES.includes(v.id)
+  )
+  const contrast = violations.find((v) => v.id === 'color-contrast')
+  // Surface contrast as an advisory (not a failure) so regressions are visible.
+  console.log(
+    `\n[a11y] ${label}: ${blocking.length} blocking` +
+      (contrast ? `, ${contrast.nodes.length} color-contrast (advisory)` : '')
+  )
+  if (violations.length) console.log(summarize(violations))
+  expect(blocking, `${label} — serious/critical a11y violations:\n${summarize(blocking)}`).toEqual([])
+}
+
+test('a11y — landing (/)', async ({ page }) => {
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+  await audit(page, 'landing /')
+})
+
+test('a11y — about (/about)', async ({ page }) => {
+  await page.goto('/about')
+  await page.waitForLoadState('networkidle')
+  await audit(page, '/about')
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "web-vitals": "^5.3.0"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.3",
         "@eslint/js": "^9.39.4",
         "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4.3.0",
@@ -131,6 +132,19 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -3628,9 +3642,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
-      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "web-vitals": "^5.3.0"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
     "@eslint/js": "^9.39.4",
     "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4.3.0",


### PR DESCRIPTION
The one high-value add from the consistency-tooling discussion: runtime a11y. `eslint-plugin-jsx-a11y` only sees static JSX — it can't compute contrast, focus order, ARIA validity, or accessible names on a *rendered* page. `@axe-core/playwright` does, reusing the Playwright infra we already have.

## What it checks
- **`e2e/public/a11y.e2e.js`** — landing (`/`) + `/about` (logged-out)
- **`e2e/app/a11y.e2e.js`** — `/home` + `/movie/:id` (authenticated, saved session)
- Fails on **serious/critical** WCAG 2.1 A/AA violations.

## Key finding: structurally clean
Across all four surfaces, the **only** violation type is `color-contrast` (~180 nodes) — **zero** missing labels, ARIA misuse, focus, or naming issues. So the structural a11y is in great shape, and that's what's gated (currently green).

## Contrast = a design decision, not a code bug
Every contrast hit is the editorial design's **intentional** low-opacity text (eyebrows at `rgba(…,0.28)`, muted labels, `text-white/20` footer). Forcing AA there would materially change the look. So contrast is **logged as an advisory, not a failure** — surfaced for a deliberate design pass rather than auto-blocking. (A few are quite low, e.g. the footer © at 1.66:1, worth a look.)

## CI
The logged-out audit runs on **every PR** via the renamed **Visual & A11y Regression** workflow (dummy `VITE_*` env — no secrets needed). Authenticated a11y runs via the secret-gated E2E job + locally.

Gate: `lint` 0 errors · `test` 500 passed · `build` OK · all 4 a11y surfaces pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)