### PR TITLE
chore: drop dead scripts + vestigial deps + clear lint warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,6 @@
         "@supabase/supabase-js": "^2.106.2",
         "@tanstack/react-query": "^5.100.14",
         "@vercel/edge": "^1.3.1",
-        "axios": "^1.16.1",
-        "dotenv": "^17.4.2",
         "framer-motion": "^12.40.0",
         "html-to-image": "^1.11.13",
         "lucide-react": "^1.17.0",
@@ -3620,11 +3618,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -3649,43 +3642,6 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
-        "https-proxy-agent": "^5.0.1",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
-    "node_modules/axios/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/axios/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -3784,6 +3740,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -3900,17 +3857,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -4070,6 +4016,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -4132,14 +4079,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -4190,22 +4129,11 @@
         "@types/trusted-types": "^2.0.7"
       }
     },
-    "node_modules/dotenv": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
-      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -4328,6 +4256,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -4336,6 +4265,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -4380,6 +4310,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -4391,6 +4322,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -4957,26 +4889,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -4991,21 +4903,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/framer-motion": {
@@ -5053,6 +4950,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5111,6 +5009,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -5134,6 +5033,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -5206,6 +5106,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -5276,6 +5177,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -5287,6 +5189,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -5301,6 +5204,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -6449,6 +6353,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -6459,25 +6364,6 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
@@ -6507,7 +6393,8 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "node_modules/nanoid": {
       "version": "3.3.12",
@@ -7057,15 +6944,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/punycode": {

--- a/package.json
+++ b/package.json
@@ -28,8 +28,6 @@
     "@supabase/supabase-js": "^2.106.2",
     "@tanstack/react-query": "^5.100.14",
     "@vercel/edge": "^1.3.1",
-    "axios": "^1.16.1",
-    "dotenv": "^17.4.2",
     "framer-motion": "^12.40.0",
     "html-to-image": "^1.11.13",
     "lucide-react": "^1.17.0",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,7 +25,10 @@ deleted**, because they're ambiguous and harmless in place:
 | `spot-check.js`, `test-status-flow.js` | Dev/debug helpers (import `./utils/supabase`). Left in place to avoid breaking their relative paths; move into `maintenance/` only with the import fixed. |
 | `test-recommendation-cache-final.js` | Debug script (the `-final` name is a smell). **Review / archive.** |
 | `fix-complete-movies-missing-embeddings.js`, `fix-limits.js` | **Spent** one-time data fixes — already run. **Review / archive.** |
-| `run-fix-keywords.sh`, `run-health-check.sh` | ⚠️ **Dead** — they invoke `scripts/monitoring/*.js`, a directory that does not exist. Either restore the monitoring scripts or delete these. |
+
+> `run-fix-keywords.sh` + `run-health-check.sh` were **deleted** — they invoked a
+> non-existent `scripts/monitoring/`. Restore from git history if those monitoring
+> scripts ever return.
 
 > Run logs were previously committed under `../logs/`; those are now gitignored
 > (regenerated each cron run, uploaded as CI artifacts). The dir is kept via

--- a/scripts/run-fix-keywords.sh
+++ b/scripts/run-fix-keywords.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-cd "$(dirname "$0")/.."
-set -a
-source .env
-set +a
-node scripts/monitoring/fix-missing-keywords.js

--- a/scripts/run-health-check.sh
+++ b/scripts/run-health-check.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-cd "$(dirname "$0")/.."
-set -a
-source .env
-set +a
-node scripts/monitoring/check-pipeline-health.js

--- a/src/features/browse/components.jsx
+++ b/src/features/browse/components.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect, useRef } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { HP, HP_GRAD, MOODS, SORT_OPTIONS, DECADE_OPTIONS, LANG_OPTIONS, GENRE_OPTIONS, RUNTIME_OPTIONS, PACING_OPTIONS, INTENSITY_OPTIONS, DEPTH_OPTIONS, DIALOGUE_OPTIONS, ATTENTION_OPTIONS, GAP_OPTIONS, VIBE_OPTIONS, PRESETS } from './data'
 
 // FeelFlick — Browse v3 components.
@@ -30,7 +30,6 @@ const IcZap    = (p) => <Ic {...p} d={<polygon points="13 2 3 14 12 14 11 22 21 
 const IcGlobe  = (p) => <Ic {...p} d={<><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3a14.7 14.7 0 0 1 0 18 14.7 14.7 0 0 1 0-18z"/></>} />;
 const IcFlame  = (p) => <Ic {...p} d={<path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z"/>} />;
 const IcSmile  = (p) => <Ic {...p} d={<><circle cx="12" cy="12" r="9"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" y1="9" x2="9.01" y2="9"/><line x1="15" y1="9" x2="15.01" y2="9"/></>} />;
-const IcInfo   = (p) => <Ic {...p} d={<><circle cx="12" cy="12" r="9"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></>} />;
 const PRESET_ICONS = { gem:IcGem, moon:IcMoon, brain:IcBrain, zap:IcZap, globe:IcGlobe, flame:IcFlame, smile:IcSmile, clock:IcClock, spark:IcSpark };
 
 // ── Mood tag helper ──
@@ -67,7 +66,7 @@ function Nav() {
 // ╭───────────────────────────────────────╮
 // │ Editorial header + mood reactor       │
 // ╰───────────────────────────────────────╯
-function EditorialHeader({ mood, setMood, total }) {
+function EditorialHeader({ mood }) {
   const m = MOODS.find(x => x.id === mood) || MOODS[0];
   const tint = m.hex;
   return (
@@ -119,26 +118,6 @@ function MoodRow({ mood, setMood, sortBy, setSortBy, view, setView }) {
             );
           })}
         </div>
-      </div>
-    </section>
-  );
-}
-
-// ╭───────────────────────────────────────╮
-// │ Tonight CTA                           │
-// ╰───────────────────────────────────────╯
-function TonightRow({ on, set }) {
-  return (
-    <section style={{ padding:'4px 56px 18px' }}>
-      <div style={{ display:'grid', gridTemplateColumns:'auto 1fr auto', gap:18, alignItems:'center', padding:'14px 18px', borderRadius:10, background: on ? 'rgba(167,139,250,0.10)' : 'rgba(255,255,255,0.025)', border:`1px solid ${on ? HP.purple+'55' : HP.border}`, transition:'all 0.2s ease' }}>
-        <div style={{ width:34, height:34, borderRadius:999, background: on ? HP_GRAD : 'rgba(167,139,250,0.13)', color: on ? '#fff' : HP.purple, display:'flex', alignItems:'center', justifyContent:'center' }}>
-          <IcClock s={16} />
-        </div>
-        <div>
-          <div style={{ fontFamily:'Outfit', fontSize:15, fontWeight:500, color:HP.text, letterSpacing:'-0.005em' }}>{on ? 'Tonight mode on' : 'Pick for tonight'}</div>
-          <div style={{ fontFamily:'Inter', fontSize:12.5, color:HP.textMid, marginTop:2, lineHeight:1.5 }}>{on ? 'Slow-burn, under 2h 15m, available on your streamers.' : 'One tap: tune the catalogue to your evening.'}</div>
-        </div>
-        <button onClick={()=>set(!on)} style={{ padding:'10px 18px', borderRadius:999, background: on ? 'rgba(255,255,255,0.06)' : HP_GRAD, border: on ? `1px solid ${HP.borderStrong}` : 'none', color: on ? HP.textMid : '#fff', fontFamily:'Inter', fontSize:12.5, fontWeight:600, cursor:'pointer' }}>{on ? 'Clear' : 'Tonight →'}</button>
       </div>
     </section>
   );
@@ -288,14 +267,6 @@ function ToggleSwitch({ on, onClick, label, disabled = false, title }) {
   );
 }
 
-function ToggleDot({ on }) {
-  return (
-    <span aria-hidden style={{ display:'inline-flex', alignItems:'center', justifyContent:'center', width:14, height:14, borderRadius:999, background: on ? HP.purple : 'transparent', border:`1.5px solid ${on ? HP.purple : 'rgba(255,255,255,0.25)'}`, transition:'all 0.18s ease', flex:'none' }}>
-      {on && <span style={{ width:5, height:5, borderRadius:999, background:'#fff' }}/>}
-    </span>
-  );
-}
-
 function SegGroup({ label, value, options, onChange }) {
   return (
     <div>
@@ -333,7 +304,7 @@ function RatingSlider({ label, value, onChange }) {
 // │ Toolbar — search, sort, view, filters │
 // ╰───────────────────────────────────────╯
 function Toolbar(props) {
-  const { query, setQuery, draftQuery, setDraftQuery, hideWatched, setHide, panelOpen, setPanel, advancedCount, availableTonight, setAvailableTonight, availableTonightDisabled, availableTonightTitle, twinsLoved, setTwinsLoved, twinsLovedDisabled, twinsLovedTitle, onSurprise } = props;
+  const { setQuery, draftQuery, setDraftQuery, hideWatched, setHide, panelOpen, setPanel, advancedCount, availableTonight, setAvailableTonight, availableTonightDisabled, availableTonightTitle, twinsLoved, setTwinsLoved, twinsLovedDisabled, twinsLovedTitle, onSurprise } = props;
   const searchRef = useRef(null);
   useEffect(() => {
     const onKey = (e) => {
@@ -425,6 +396,9 @@ function RefinePanel(props) {
     document.addEventListener('keydown', esc);
     document.body.style.overflow = 'hidden';
     return () => { document.removeEventListener('keydown', esc); document.body.style.overflow = ''; };
+    // Intentionally [open]-only: bind the Escape handler + scroll-lock when the
+    // panel opens; props.onClose is stable for the panel's lifetime.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
   if (!open) return null;
   return (

--- a/src/features/browse/immersive.jsx
+++ b/src/features/browse/immersive.jsx
@@ -1,11 +1,11 @@
-import React, { useState, useEffect } from 'react'
+import React, { useEffect } from 'react'
 import { HP, HP_GRAD, MOODS, LANG_OPTIONS } from './data'
 import { getMoodTag } from './components'
 
 // FeelFlick — Browse v3 immersive: MoodBackdrop + QuickLook slide-over.
 
 // Hooks aliases
-const useS = useState; const useE = useEffect;
+const useE = useEffect;
 
 // Local icons
 const Ic = ({ d, s=16, fill='none' }) => (
@@ -15,7 +15,6 @@ const IcX     = (p) => <Ic {...p} d={<><path d="M18 6 6 18M6 6l12 12"/></>} />;
 const IcPlus  = (p) => <Ic {...p} d={<><path d="M12 5v14M5 12h14"/></>} />;
 const IcCheck = (p) => <Ic {...p} d={<path d="M20 6 9 17l-5-5"/>} />;
 const IcEye   = (p) => <Ic {...p} d={<><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></>} />;
-const IcEyeOff= (p) => <Ic {...p} d={<><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><path d="m2 2 20 20"/></>} />;
 
 // /browse v5 — immersive additions: ambient mood backdrop, hero spotlight rail, quick-look panel.
 
@@ -31,70 +30,6 @@ function MoodBackdrop({ tint }) {
       `,
       transition:'background 0.7s cubic-bezier(.2,.7,.2,1)',
     }} />
-  );
-}
-
-// ── Hero spotlight strip — 3 big cinematic cards (mood-aware) ─
-function Spotlight({ mood, items, watched, watchlist, onTW, onTWL, onOpen }) {
-  // Top 3 films by current match
-  const top3 = items.slice(0, 3);
-  const m = MOODS.find(x => x.id === mood) || MOODS[0];
-  const tint = m.hex;
-  if (top3.length < 3) return null;
-  return (
-    <section style={{ position:'relative', padding:'4px 56px 36px' }}>
-      <div style={{ marginBottom:14, display:'flex', alignItems:'center', gap:14 }}>
-        <span style={{ fontFamily:'Outfit', fontSize:11, fontWeight:600, letterSpacing:'0.28em', textTransform:'uppercase', color:tint }}>
-          {mood==='all' ? "Tonight's shortlist" : `Tonight · ${m.label}`}
-        </span>
-        <span style={{ height:1, flex:1, background:`linear-gradient(90deg, ${tint}55, transparent)` }} />
-        <span style={{ fontFamily:'Inter', fontSize:11.5, color:HP.textFaint }}>Top {top3.length} by match</span>
-      </div>
-      <div style={{ display:'grid', gridTemplateColumns:'repeat(3, 1fr)', gap:18 }}>
-        {top3.map((f, i) => {
-          const matchScore = mood==='all' ? f.ff : Math.round(0.6*(f.fit[mood]*100) + 0.25*f.ff + 0.15*(100 - Math.abs(115 - f.runtime)));
-          const isWatched = watched.has(f.id);
-          const isWL = watchlist.has(f.id);
-          return <SpotlightCard key={f.id} f={f} mood={mood} matchScore={matchScore} idx={i+1} watched={isWatched} inWatchlist={isWL} onTW={()=>onTW(f.id)} onTWL={()=>onTWL(f.id)} onOpen={()=>onOpen(f)} />;
-        })}
-      </div>
-    </section>
-  );
-}
-
-function SpotlightCard({ f, mood, matchScore, idx, watched, inWatchlist, onTW, onTWL, onOpen }) {
-  const [h, setH] = useS(false);
-  const why = mood==='all' ? `${f.dir} · FF ${f.ff}%` : f.rationale[mood];
-  return (
-    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events
-    <article onClick={onOpen} onMouseEnter={()=>setH(true)} onMouseLeave={()=>setH(false)} style={{ position:'relative', borderRadius:14, overflow:'hidden', cursor:'pointer', border:`1px solid ${h?'rgba(216,180,254,0.32)':HP.border}`, transition:'all 0.25s ease', boxShadow: h?'0 30px 60px -18px rgba(0,0,0,0.75)':'0 16px 36px -16px rgba(0,0,0,0.6)' }}>
-      <div style={{ position:'relative', aspectRatio:'16/10' }}>
-        {/* Backdrop poster blurred */}
-        <div style={{ position:'absolute', inset:0, backgroundImage:`url(${f.poster})`, backgroundSize:'cover', backgroundPosition:'center 20%', filter: h ? 'blur(14px) saturate(140%) brightness(0.55)' : 'blur(20px) saturate(120%) brightness(0.45)', transition:'filter 0.4s ease', transform:'scale(1.1)' }} />
-        <div style={{ position:'absolute', inset:0, background:`linear-gradient(115deg, rgba(6,6,10,0.85) 0%, rgba(6,6,10,0.55) 45%, rgba(6,6,10,0.85) 100%)` }} />
-
-        {/* Foreground content */}
-        <div style={{ position:'relative', height:'100%', padding:'18px', display:'flex', gap:18, alignItems:'flex-end' }}>
-          <img src={f.poster} alt={f.title} loading="lazy" style={{ width:90, aspectRatio:'2/3', objectFit:'cover', borderRadius:5, boxShadow:'0 12px 28px -8px rgba(0,0,0,0.7)' }} />
-          <div style={{ flex:1, minWidth:0, color:'#fff' }}>
-            <div style={{ display:'flex', alignItems:'center', gap:10, marginBottom:8 }}>
-              <span style={{ fontFamily:'Outfit', fontSize:9.5, fontWeight:700, letterSpacing:'0.22em', textTransform:'uppercase', color:HP.purple }}>0{idx} · Pick of the night</span>
-            </div>
-            <h3 style={{ fontFamily:'Outfit', fontSize:22, fontWeight:500, color:'#fff', margin:0, letterSpacing:'-0.018em', lineHeight:1.15 }}>{f.title}</h3>
-            <div style={{ marginTop:4, fontFamily:'Inter', fontSize:12, color:'rgba(255,255,255,0.65)' }}>{f.year} · {f.dir} · {f.runtime}m</div>
-            <div style={{ marginTop:10, fontFamily:'Inter', fontSize:12, color:HP.purple, lineHeight:1.45 }}>{why}</div>
-          </div>
-          <div style={{ position:'absolute', top:14, right:14, display:'flex', alignItems:'center', gap:6 }}>
-            <span style={{ fontFamily:'Outfit', fontSize:24, fontWeight:300, color:'#fff', letterSpacing:'-0.025em', lineHeight:1 }}>{matchScore}<span style={{ fontSize:11, color:'rgba(255,255,255,0.55)' }}>%</span></span>
-          </div>
-          {/* Action row — appears on hover */}
-          <div style={{ position:'absolute', bottom:14, right:14, display:'flex', gap:6, opacity: h?1:0, transform: h?'translateY(0)':'translateY(6px)', transition:'all 0.2s ease' }}>
-            <button onClick={e=>{e.stopPropagation(); onTWL();}} title={inWatchlist?'In watchlist':'Add to watchlist'} style={{ display:'inline-flex', alignItems:'center', justifyContent:'center', width:32, height:32, borderRadius:999, border:`1px solid ${inWatchlist?'rgba(216,180,254,0.5)':'rgba(255,255,255,0.2)'}`, background: inWatchlist?'rgba(168,85,247,0.85)':'rgba(0,0,0,0.55)', color:'#fff', cursor:'pointer' }}>{inWatchlist ? <IcCheck s={13}/> : <IcPlus s={13}/>}</button>
-            <button onClick={e=>{e.stopPropagation(); onTW();}}  title={watched?'Mark unwatched':'Mark watched'} style={{ display:'inline-flex', alignItems:'center', justifyContent:'center', width:32, height:32, borderRadius:999, border:`1px solid ${watched?'rgba(110,231,183,0.5)':'rgba(255,255,255,0.2)'}`, background: watched?'rgba(16,185,129,0.85)':'rgba(0,0,0,0.55)', color:'#fff', cursor:'pointer' }}>{watched ? <IcEye s={13}/> : <IcEyeOff s={13}/>}</button>
-          </div>
-        </div>
-      </div>
-    </article>
   );
 }
 


### PR DESCRIPTION
Final tidy pass — the small polish items after the legacy removal.

## Dead scripts (2)
Deleted `scripts/run-fix-keywords.sh` + `run-health-check.sh` — both invoked a non-existent `scripts/monitoring/`.

## Vestigial root deps (2)
Removed `axios` + `dotenv` from the **root** app manifest — they're never imported by the app; only `scripts/pipeline` uses them, and it has its own `package.json`. **Kept `openai`** (the Supabase edge functions import it via `npm:openai@4`).

## Lint: 9 warnings → 0
All in `features/browse/`:
- Removed dead, unexported components: `TonightRow`, `ToggleDot` (`components.jsx`), `Spotlight` + `SpotlightCard` (`immersive.jsx`) — and the helpers they orphaned (`IcInfo`, `IcEyeOff`, the `useS` alias + its `useState` import).
- Dropped unused imports/args/destructures (`useMemo`, `setMood`, `total`, `query`).
- Scoped the one intentional `[open]`-only `useEffect` (`RefinePanel`) with an `eslint-disable-next-line` — consistent with the file's existing disables.

**No behavior change** — every removed item was unexported and unused.

## Validation
`lint` **0 warnings** (was 9) · `test` 408 passed · `build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)