### PR TITLE
docs: archive stale historical docs + add docs index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,23 @@
+# docs/
+
+Long-form project documentation. For *how to work in this repo* (conventions,
+guardrails, workflows), the source of truth is **`CLAUDE.md`** at the root, plus
+`CLAUDE-REFERENCE.md`. This folder holds the deeper references.
+
+## Current references
+| File | What it is |
+|---|---|
+| [`architecture.md`](architecture.md) | System architecture overview |
+| [`FeelFlick_Overview.md`](FeelFlick_Overview.md) | Product overview — what FeelFlick is + the engine |
+| [`DESIGN_SYSTEM.md`](DESIGN_SYSTEM.md) | The editorial design language |
+| [`user-journey.md`](user-journey.md) | End-to-end user journey |
+| [`SUPABASE_SCHEMA.md`](SUPABASE_SCHEMA.md) | DB schema reference — ⚠️ auto-generated; see its staleness note, the live DB is source of truth |
+| [`PLANNING.md`](PLANNING.md) | Active planning notes |
+
+## Structured
+- [`decisions/`](decisions/) — Architecture Decision Records (ADRs) + `DECISIONS.md` index.
+- [`audits/`](audits/) — point-in-time audit write-ups.
+- [`runbooks/`](runbooks/) — operational runbooks (dev setup, debugging).
+
+## archive/
+Historical / superseded docs — see [`archive/README.md`](archive/README.md). Not current.

--- a/docs/SUPABASE_SCHEMA.md
+++ b/docs/SUPABASE_SCHEMA.md
@@ -1,6 +1,8 @@
 # FeelFlick Supabase Schema Reference
 
 > Auto-generated from live DB introspection on 2026-04-19.
+
+> ⚠️ **Stale:** generated before the 2026-05-29 RLS-hardening + perf-index migrations. The live Supabase DB is the source of truth — regenerate from introspection when you need current detail.
 > 36 tables, 1 view in `public` schema. PostgreSQL 15.8 + pgvector.
 
 ---

--- a/docs/archive/AUDIT_RECOMMENDATIONS.md
+++ b/docs/archive/AUDIT_RECOMMENDATIONS.md
@@ -1,3 +1,5 @@
+
+> 📦 **Archived — historical snapshot, not current.** Kept for reference; see `docs/archive/README.md`.
 # FeelFlick Recommendation Engine Audit
 
 **Date:** 2026-04-19

--- a/docs/archive/LANDING_BLUEPRINT.md
+++ b/docs/archive/LANDING_BLUEPRINT.md
@@ -1,3 +1,5 @@
+
+> 📦 **Archived — historical snapshot, not current.** Kept for reference; see `docs/archive/README.md`.
 # FeelFlick Landing Page Blueprint
 *Last updated: April 2026 — approved architecture before implementation*
 

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -1,0 +1,12 @@
+# docs/archive/
+
+Point-in-time documents kept for historical reference — **not current**. They
+describe the product / engine / design at a past moment and may reference code
+that has since changed or been removed. Don't treat anything here as a current spec.
+
+- **`AUDIT_RECOMMENDATIONS.md`** — recommendation-engine audit (2026-04-19), scoped
+  to the since-removed v1 `/home` (`HomePage.jsx`) + `/discover` (`DiscoverPage.jsx`).
+  Its findings are largely addressed; the engine has moved on.
+- **`LANDING_BLUEPRINT.md`** — the v3 landing's pre-build architecture spec. The
+  landing is now shipped (`src/features/landing/Landing.jsx`), so this is a design
+  record, not a build target.


### PR DESCRIPTION
Newcomer-clarity pass on `docs/` — same spirit as the naming cleanup. Stale docs that describe the *old* structure mislead a new engineer worse than no docs.

## Changes
- **Archived 2 historical docs** → `docs/archive/` (neither is referenced anywhere):
  - `AUDIT_RECOMMENDATIONS.md` — an Apr-19 engine audit scoped to the **removed** v1 `/home` (`HomePage.jsx`) + `/discover` (`DiscoverPage.jsx`).
  - `LANDING_BLUEPRINT.md` — a *pre-build* landing spec; the landing is shipped.
  - Each got a "historical snapshot" banner + a `docs/archive/README.md` explaining the folder.
- **`SUPABASE_SCHEMA.md`** — added a staleness banner: auto-generated Apr-19, **predates the May RLS-hardening + perf-index migrations**; the live DB is the source of truth.
- **Added `docs/README.md`** — an index of the current docs + the `decisions/` `audits/` `runbooks/` subfolders, so a newcomer can navigate `docs/` at a glance (there was no index before).

## Kept (assessed, current)
`FeelFlick_Overview.md` (evergreen product overview), `architecture.md` (12 days old).

Docs-only — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)