### PR TITLE
fix(a11y): readable footer/legal text + clear a stale TODO

### DIFF
--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -136,13 +136,13 @@ export default function Footer() {
             <p className="text-lg font-black tracking-tight bg-linear-to-r from-purple-500 to-pink-500 bg-clip-text text-transparent select-none">
               FEELFLICK
             </p>
-            <p className="text-xs text-white/20">Films That Know You</p>
+            <p className="text-xs text-white/50">Films That Know You</p>
           </div>
 
           {/* Right — human signal + copyright */}
           <div className="text-center sm:text-right">
-            <p className="text-xs text-white/20">Built by Aditya Kumar in Toronto. One developer, 6,700 films, and a belief that recommendations should feel personal.</p>
-            <p className="text-xs text-white/20">&copy; 2026 FeelFlick</p>
+            <p className="text-xs text-white/50">Built by Aditya Kumar in Toronto. One developer, 6,700 films, and a belief that recommendations should feel personal.</p>
+            <p className="text-xs text-white/50">&copy; 2026 FeelFlick</p>
           </div>
 
         </div>

--- a/src/features/history/History.jsx
+++ b/src/features/history/History.jsx
@@ -60,7 +60,7 @@ function PulseStrip() {
 // page stays a chronological record. The DNA page (/profile) is the home
 // for taste patterns; deriveTrajectory + the mood radar there already cover
 // monthly volume + mood share. The streak heatmap is a follow-up port to
-// /profile-v2 (TODO).
+// /profile (TODO).
 
 function FilterBar({ filter, setFilter, sort, setSort, query, setQuery }) {
   // "Favorites" was redundant with "Loved (5★)" — both filtered on the same

--- a/src/features/legal/About.jsx
+++ b/src/features/legal/About.jsx
@@ -458,7 +458,7 @@ export default function About() {
                   </>
                 )}
               </Button>
-              <p className="text-xs text-white/20">
+              <p className="text-xs text-white/50">
                 Free forever · No credit card · No ads
               </p>
             </motion.div>


### PR DESCRIPTION
The safe half of the remaining list — clear a11y bugs + a TODO sweep. (The borderline editorial-de-emphasis contrast and the `@tailwindcss/vite` swap are held for your call.)

## Contrast — clear bugs only
Two spots had readable **content** at `text-white/20` (~1.66:1 — effectively invisible), well below even the design's own faint tier:
- **`Footer.jsx`** — the tagline, the "Built by Aditya…" attribution, and **`© 2026 FeelFlick`** (the one I flagged).
- **`About.jsx`** — the "Free forever · No credit card · No ads" value-prop under the CTA.

→ `text-white/50` (~5:1, **AA-readable**, still quiet). Both land **within the 2% visual tolerance**, so no baseline churn. `/about` contrast advisories dropped 13 → 10.

*Left alone (intentional editorial de-emphasis — your design call):* muted eyebrows/captions, modal char-counters, sentiment micro-text, decorative icons/empty-stars.

## TODO sweep (7 markers)
Resolved the **one stale** comment: `History.jsx` pointed at `/profile-v2` (old name — it's `/profile` now, and it even contradicted line 60 of the same comment). The other **6 are legitimate pending work** and read as clear notes already: 4× DB placement-enum migrations, the soundtrack-score feature gate, and the gradient→token refactor.

## Validation
`lint` 0 · `test` 408 · `build` OK · visual within tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)