### PR TITLE
docs: sync CLAUDE.md + CLAUDE-REFERENCE.md to current reality

### DIFF
--- a/CLAUDE-REFERENCE.md
+++ b/CLAUDE-REFERENCE.md
@@ -6,50 +6,60 @@
 
 ## Tuneable Constants
 
-Located in `src/shared/services/recommendations.js` and `src/shared/api/tmdb.js`.
-Change deliberately — these affect recommendation quality and API budgets.
+Located in `src/shared/services/recommendations.js`, `src/shared/api/tmdb.js`,
+and the two cache modules. Change deliberately — these affect recommendation
+quality and API budgets.
 
-> Line numbers reflect the codebase as of 2026-05-20. They drift; trust the
+> Line numbers reflect the codebase as of 2026-05-30. They drift; trust the
 > constant names and re-grep when in doubt.
 
 | Constant | File | Value | Meaning |
 |---|---|---|---|
-| `ENGINE_VERSION` | recommendations.js:83 | `'2.16'` | Bump when algorithm changes; invalidates cached profiles |
-| `THRESHOLDS.MIN_FF_RATING` | recommendations.js:319 | `6.5` | Min FeelFlick score to surface a title |
-| `THRESHOLDS.MIN_FF_CONFIDENCE` | recommendations.js:320 | `50` | Min confidence before showing a recommendation |
-| `THRESHOLDS.MIN_FILMS_FOR_LANGUAGE_PREF` | recommendations.js:321 | `3` | Films needed to infer language preference |
-| `THRESHOLDS.MIN_FILMS_FOR_AFFINITY` | recommendations.js:322 | `2` | Films needed before genre/director affinity applies |
-| `THRESHOLDS.MIN_VOTE_COUNT` | recommendations.js:328 | `150` | Min TMDB vote count for main pools (hidden-gems pool uses its own lower floor of 50) |
-| `LIKELY_SEEN_WEIGHTS` | recommendations.js:308 | All `0` | Intentionally disabled — kept for backward compat |
+| `ENGINE_VERSION` | recommendations.js:84 | `'2.17'` | Bump when algorithm changes; invalidates cached profiles |
+| `THRESHOLDS.MIN_FF_RATING` | recommendations.js:320 | `6.5` | Min FeelFlick score to surface a title |
+| `THRESHOLDS.MIN_FF_CONFIDENCE` | recommendations.js:321 | `50` | Min confidence before showing a recommendation |
+| `THRESHOLDS.MIN_FILMS_FOR_LANGUAGE_PREF` | recommendations.js:322 | `3` | Films needed to infer language preference |
+| `THRESHOLDS.MIN_FILMS_FOR_AFFINITY` | recommendations.js:323 | `2` | Films needed before genre/director affinity applies |
+| `THRESHOLDS.MIN_VOTE_COUNT` | recommendations.js:329 | `150` | Min TMDB vote count for main pools (hidden-gems pool uses its own lower floor of 50) |
+| `LIKELY_SEEN_WEIGHTS` | recommendations.js:309 | All `0` | Intentionally disabled — kept for backward compat |
 | `TTL.FAST` | tmdb.js:41 | `60_000` (1m) | Dynamic endpoints (search, trending) |
 | `TTL.NORMAL` | tmdb.js:42 | `5 * 60_000` (5m) | Discover & lists |
 | `TTL.SLOW` | tmdb.js:43 | `12 * 60 * 60_000` (12h) | Stable data (movie details, credits) |
 | `rateLimiter.maxRequests` | tmdb.js:35 | `40` | TMDB rate limit per 10s window |
-| `CACHE_TTL` | recommendation-cache.js:10 | `5 * 60 * 1000` (5m) | In-memory recommendation cache TTL |
-| `defaultTTL` | lib/cache.js:10 | `5 * 60 * 1000` (5m) | RecommendationCache default TTL |
+| `defaultTTL` | shared/lib/cache.js:10 | `5 * 60 * 1000` (5m) | In-memory recommendation-cache default TTL |
+| `CACHE_TTL_MS` | shared/services/tasteCache.js:14 | `24 * 60 * 60 * 1000` (24h) | Taste-fingerprint cache TTL (gates `taste_fingerprint_computed_at` re-derivation) |
 
-## Dev Environment (VS Code Remote Tunnels / Codespaces)
+> The old `recommendation-cache.js` row is gone — that file never existed under
+> that name; the in-memory cache lives in `shared/lib/cache.js`, and the
+> taste-fingerprint cache in `shared/services/tasteCache.js`.
 
-Node.js v20.20.2 via nvm · npm v10.8.2 · gh CLI v2.71.0 · Claude Code v2.1.87
-nvm sourced in `~/.zshrc` — available in every terminal.
+## Dev Environment
+
+Primary environment is **local macOS**. Node.js v20.20.2 via nvm (no Homebrew;
+`gh` + `claude` live in the nvm bin). nvm is sourced in `~/.zshrc`, so the
+toolchain is on PATH in every terminal.
 
 ```bash
 npm install
-npm run dev           # binds to all interfaces, port 5173
+npm run dev           # Vite dev server, port 5173
 ```
 
-Vite configured with `host: true`, `hmr.clientPort: 443` for Codespaces compatibility.
+`vite.config.js` keeps `host: true` (bind all interfaces) and
+`hmr.clientPort: 443` for Codespaces / remote-tunnel compatibility. Both are
+harmless on plain localhost — leave them unless you're actually debugging HMR
+over a tunnel.
 
 ## Known Codebase Issues
 
-> Run `npm run lint` and `npm audit` for current state — do not treat the
-> numbers below as durable.
+> Run `npm run lint`, `npm run test`, `npm run build`, and `npm audit` for the
+> current state — don't treat the snapshot below as durable.
 
-**ESLint (verified 2026-05-20):** Clean. `npm run lint` returns 0 errors.
+**Snapshot (2026-05-30):** `npm run lint` clean (0 warnings) · `npm run test`
+green (408 tests / 32 files) · `npm run build` succeeds · `npm audit` last seen
+clean.
 
-**npm audit (verified 2026-05-20):** Clean. 0 vulnerabilities.
-
-**Tests:** `recommendations.helpers.test.js` historically crashed on import
-without `VITE_SUPABASE_URL` in env. Verify before relying on the suite in a
-fresh shell. `Error: always broken` output is expected (SectionErrorBoundary
-test exercising error boundaries).
+`recommendations.helpers.test.js` historically crashed on import without
+`VITE_SUPABASE_URL` in env; it now passes in the standard suite. The
+`Error: always broken` line in console output is **expected** — a
+`SectionErrorBoundary` test deliberately exercising the error boundary, not a
+real failure.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ it's not the priority.
 ## Project
 Mood-first movie/TV discovery. Users express how they feel → get curated recommendations.
 **Quality bar:** Netflix / Apple TV+ polish. Every surface is production-facing.
-**Stack:** React 18 · React Router v7 · Framer Motion · Tailwind CSS · Vite · Supabase (PostgreSQL + pgvector) · TMDB API · OpenAI (text-embedding-3-small) · Resend · Google OAuth · Vitest · Sentry
+**Stack:** React 19 · React Router 7 · Framer Motion · Tailwind 4 · Vite 8 · Supabase (PostgreSQL + pgvector) · TMDB API · OpenAI (text-embedding-3-small) · Resend · Google OAuth · PostHog · Sentry · Vitest · Playwright
 **Language:** JavaScript (JSX). No TypeScript yet — avoid patterns that block future migration.
 
 ## Folder Map
@@ -89,6 +89,8 @@ VITE_SUPABASE_ANON_KEY # Supabase anon key (RLS enforces access)
 VITE_TMDB_API_KEY      # TMDB read-only key (rate-limited 40 req/10s)
 VITE_ADMIN_EMAILS      # Comma-separated admin emails for AdminOnly guard
 VITE_SENTRY_DSN        # Sentry DSN (optional; defaults to prod DSN)
+VITE_POSTHOG_KEY       # PostHog project API key (product analytics; optional)
+VITE_POSTHOG_HOST      # PostHog ingest host (optional; defaults to PostHog cloud)
 ```
 
 `import.meta.env.DEV` / `.PROD` and `process.env.NODE_ENV` are automatic.
@@ -157,9 +159,15 @@ every authenticated feature surface. The two families look related on purpose.
 
 - **Outfit** — display headlines, kickers, numbers, buttons, eyebrows. Weights
   200–300 for hero scale (≥56px), 400–500 for section headers, 600 for buttons.
-- **Inter** — body prose, italic blurbs, micro labels. Weights 400–600.
-- **JetBrains Mono** — meta labels (rarely used today).
+- **Inter** — body prose, italic blurbs, micro labels. Weights 300–900.
 - **Forbidden**: Playfair Display, Satoshi, Fraunces — not installed; do not reference.
+
+Both faces load from a **single Google Fonts `<link>` in `index.html`** — Inter
+300–900 + Outfit 200–700. (Until #138 Outfit was referenced everywhere but never
+actually loaded — `git log -S "Outfit" -- index.html` was empty — so it silently
+fell back to Inter; it now renders for real.) For rare monospace bits (e.g. a
+keyboard key-cap) use a system stack `ui-monospace, SFMono-Regular, Menlo,
+monospace` — **JetBrains Mono is not loaded**.
 
 Inline `fontFamily:` should reference the CSS variables:
 
@@ -169,7 +177,9 @@ Inline `fontFamily:` should reference the CSS variables:
 ```
 
 Italic Outfit is the brand's accent face — apply it to *single fragments*
-inside a headline, never to whole sentences:
+inside a headline, never to whole sentences. **Outfit has no italic axis on
+Google Fonts**, so `fontStyle:'italic'` renders as synthesized oblique — fine for
+the short accent fragments it's used on, but never set whole lines italic:
 
 ```jsx
 <h1>Your <em style={{ fontStyle:'italic', color: HP.textSoft }}>taste twins.</em></h1>
@@ -188,10 +198,12 @@ CSS vars in `src/index.css :root` are the authoritative source:
 --bg-base (#06060a), --bg-elevated (#0d0b14)
 ```
 
-Inline-style feature surfaces use the `HP` object (defined per `<feature>/data.js`), and
-the v3 landing uses a local `C` object. Both align with the same hex values —
-just named differently. Eventually these will collapse into one shared
-`shared/lib/tokens.js`.
+The canonical palette now lives in **`src/shared/lib/tokens.js`** — it exports
+`HP` (feature-surface palette), `HP_GRAD` (the one brand gradient), and `C` (the
+v3 landing's same hexes under landing-specific key names). Inline-style surfaces
+import `HP`/`HP_GRAD` from there; the landing imports `C`. (One holdout:
+`features/browse/data.js` still declares a local `HP` — fold it into the shared
+token module when you next touch browse.)
 
 ### Brand gradient — single source of truth
 
@@ -391,6 +403,7 @@ and motion language.
 - `<Checkbox id checked onChange label />` — toggle switch.
 - `<EmptyState icon title description action />` — canonical empty state.
 - `<SectionHeader title subtitle? seeAllTo? eyebrow? />` — carousel row header (matches the section header pattern above).
+- `<Tooltip label>{children}</Tooltip>` — hover/focus tooltip primitive.
 - `<BrandSplash label? error? />` — full-screen brand splash (200ms delayed visibility; errors immediate).
 
 ## Planning Behaviour (never skip)
@@ -511,6 +524,10 @@ so they aren't re-derived each session.
   `eslint-plugin-jsx-a11y` can't cover).
 - `perf-guard` — LCP/CLS, lazy+srcset posters, bundle budget, query hygiene for the
   media-heavy frontend.
+- `code-review` — structured review checklist (severity · file:line · concrete fix).
+  Triggers on "review", "audit", "check this code", "look for issues", "is this safe".
+- `refactor` — guided clean-up process (simplify, extract, de-duplicate) that stays
+  scoped to what's asked. Triggers on "refactor", "clean up", "simplify", "tidy up".
 
 **Hook:** `PostToolUse` runs `.claude/hooks/lint-on-edit.sh` after every Edit/Write
 to a `src/**/*.{js,jsx}` file — advisory ESLint (warnings + errors surfaced, never
@@ -534,5 +551,15 @@ blocks). It enforces the `lint → test → build` discipline automatically.
 - Sentry wired in `main.jsx` + `ErrorBoundary.jsx` (#67).
 - Edge function CORS hardened (#81, #82).
 - Nightly `refresh_feelflick_stats()` via pg_cron (#80).
+- Major-version migrations landed (2026-05-30): React 19, Vite 8, Tailwind 4,
+  web-vitals 5, `@vitejs/plugin-react` 6. ESLint 10 stays deferred (plugins lack
+  peer support). See memory `project_deferred_major_upgrades`.
+- Design tokens consolidated into `shared/lib/tokens.js` (`HP`/`HP_GRAD`/`C`);
+  feature surfaces import from it (one `browse/data.js` holdout remains).
+- Brand display font fixed (#138): Outfit had never been loaded and was silently
+  falling back to Inter everywhere — now loaded for real via `index.html`.
+- CI gates added: Playwright visual-regression (`e2e/visual/`, per-platform
+  baselines) + runtime a11y (`@axe-core/playwright`, serious/critical WCAG ex.
+  color-contrast) — `.github/workflows/visual-regression.yml`.
 
 > For tuneable constants, dev environment setup, and known codebase issues — see `CLAUDE-REFERENCE.md`.


### PR DESCRIPTION
Truth-up of the two guide files against the actual codebase — **docs only, no behavior change**. This is the cleanup that surfaced the Outfit bug (fixed separately in #138).

### CLAUDE.md
- **Stack**: React 18 → **19**; name **Tailwind 4** / **Vite 8**; add **PostHog** + **Playwright**.
- **Env vars**: document `VITE_POSTHOG_KEY` / `VITE_POSTHOG_HOST` — used in code, were undocumented.
- **Fonts**: Outfit is now actually loaded (#138) — note the single Google Fonts `<link>`, Outfit's lack of an italic axis (→ synthesized oblique), and that JetBrains Mono isn't loaded (kbd-caps use a system mono stack).
- **Color tokens**: `shared/lib/tokens.js` is the *adopted* source (`HP`/`HP_GRAD`/`C`), not a future "eventually"; flag the lone `browse/data.js` holdout.
- **Shared UI**: add `<Tooltip>`.
- **Guardrail skills**: 5 → **7** (add `code-review`, `refactor`).
- **Direction signals**: add the React19/Vite8/Tailwind4 migrations, token consolidation, the Outfit fix, and the visual + a11y CI gates.

### CLAUDE-REFERENCE.md
- **Constants**: `ENGINE_VERSION` 2.16 → **2.17**; corrected every `recommendations.js` line number (all +1); replaced the non-existent `recommendation-cache.js` row with the real `lib/cache.js` (5m) + `tasteCache.js` (24h) caches. (`tmdb.js` TTLs were already correct.)
- **Dev environment**: reframed from Codespaces to **local-macOS primary** (the `host:true` / `hmr.clientPort:443` settings stay, for tunnel compat).
- **Known issues**: refreshed snapshot/date — lint clean, 408 tests, build OK.

### What was already correct (left alone)
Folder map (no `legacy/`, de-suffixed features, feed/challenges as "parked"), the editorial-language patterns, hover law, Hard Stops, and the `*-legacy`-routes-are-gone warnings were all accurate — no churn there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)