### PR TITLE
docs: refocus the FeelFlick north star to match the built product

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,15 +2,23 @@
 
 ## What is FeelFlick
 
-Mood-first movie discovery. Users say how they feel. We return films —
-not what's trending, what's right for them right now.
+FeelFlick turns *how you feel* into one considered film for tonight — tuned to
+your mood and everything you've ever loved on screen, and it tells you why it's
+the one. A pick you can trust, not a feed to scroll.
 
-Every surface, every doc, every feature serves this one sentence. If a
-change doesn't make mood-to-film clearer, faster, or more personal —
-it's not the priority.
+Mood is the front door; your taste (your "Cinematic DNA") is the house; the
+editorial case for each pick is the moat. One film a night — made for the
+patient, not the scrollers.
+
+Every surface, every doc, every feature serves this. If a change doesn't make
+tonight's one pick **land faster, fit better, or earn more trust** — it's not
+the priority. (Note the third clause: the Film File / Briefing "makes its case"
+layer is core, not garnish — don't let a narrow "mood→film, faster" reading
+de-prioritize it.)
 
 ## Project
-Mood-first movie/TV discovery. Users express how they feel → get curated recommendations.
+Mood-first, taste-deep movie/TV discovery: users express how they feel → get **one**
+trustworthy, case-made pick tuned to their full taste history (not an endless feed).
 **Quality bar:** Netflix / Apple TV+ polish. Every surface is production-facing.
 **Stack:** React 19 · React Router 7 · Framer Motion · Tailwind 4 · Vite 8 · Supabase (PostgreSQL + pgvector) · TMDB API · OpenAI (text-embedding-3-small) · Resend · Google OAuth · PostHog · Sentry · Vitest · Playwright
 **Language:** JavaScript (JSX). No TypeScript yet — avoid patterns that block future migration.


### PR DESCRIPTION
Follow-up to #139. The doc-vs-code review surfaced a deeper gap than stale versions: the **"What is FeelFlick" north star itself** under-described the product.

### The finding
- `/home` opens with a literal **"TONIGHT I FEEL"** picker over a single **Briefing** whose three slots are **"Tonight's pick / Mood match / From your DNA"** — mood is *one of three* lenses.
- The engine weighs **taste/behavioral signals above mood** (genre 532 · rating 364 · skip 263 · mood 258 refs in `recommendations.js`).
- Every pick ships with an **editorial case** (Briefing / Film File) — the real differentiator vs. a feed.
- The site's own SEO copy already says it: *"one pick a night, with the article that makes its case. No algorithm tax."*

### The problem it caused
The old filter — *"if a change doesn't make mood-to-film faster, it's not the priority"* — would actively **de-prioritize the Film File, taste twins, and the one-pick ritual**, three of FeelFlick's most distinctive surfaces. The north star was mis-pointed.

### The change
Rewrites the definition to keep **mood as the entry gesture** while naming the moat: *one trustworthy, case-made pick tuned to mood + full taste, not a feed.* Refocuses the priority filter on **land faster / fit better / earn more trust** so it stops excluding the editorial layer. Also updates the Project one-liner to match. **Docs only, no behavior change.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)