### PR TITLE
docs: make the recommendation-engine description match the engine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,33 @@ src/
 
 Auth initialises in `main.jsx` before React mounts: parses OAuth hash → sets Supabase session → `/auth/callback`. `RootEntry` routes authenticated → `/home`, unauthenticated → Landing. `RequireAuth` guards protected routes. `PostAuthGate` redirects new users to `/onboarding`.
 
-Recommendation pipeline: content-based filtering + pgvector cosine similarity + behavioral signals (skips, re-watches, ratings). Anti-recency bias, signal decay. Tracked via `recommendation_impressions` + `mood_sessions`. User profiles cached in `user_profiles_computed` with TTL.
+Recommendation pipeline (`shared/services/recommendations.js`; an `ENGINE_VERSION`
+bump invalidates cached profiles — see `CLAUDE-REFERENCE.md`). Mood-first at the
+door, taste-deep underneath — a blend, not one signal:
+
+- **Taste** — content-based affinity (genre/director/actor) + pgvector cosine
+  similarity over OpenAI embeddings (seeded from your recent + top-rated watches).
+- **Quality gating** — `ff_final_rating` (critic rating blended with community
+  votes) floors + TMDB `vote_count` thresholds + quality tiers; nothing mediocre
+  surfaces regardless of fit.
+- **Behavioral** — a layered skip system (48h hard-exclude → 7-day de-rate →
+  permanent learning for repeat skippers), ratings, re-watches, and a thumbs
+  feedback loop (`user_movie_feedback` → amplifies/dampens affinity).
+- **Mood** — a per-session mood signature (`computeMoodSignature` over
+  `mood_tags`/`tone_tags`/`fit_profile`) + `moodWeights`; this powers the
+  "Mood match" Briefing slot.
+- **Anti-bias** — anti-recency (older masterpieces aren't penalised), signal
+  decay, diversity de-clustering, and a language anti-bubble (STRICT/STRONG modes
+  inject a discovery slot so you're never trapped in one language).
+
+Centrepiece: **the Briefing / hero** — a weighted-random single "tonight's pick"
+(#1 wins ~65%), tuned by a **DNA-confidence** score and shipped with a
+`heroReason`-generated "why this is the one." The engine literally makes its case.
+
+Tracked via `recommendation_impressions` + `mood_sessions`; the computed profile
+is cached in `user_profiles_computed` (plus a `taste_fingerprint` cache, 24h TTL).
+The `recommendation-engine` skill gates any tuning — DB-first analysis is mandatory
+before touching scoring, limits, or filters.
 
 ## Environment Variables
 


### PR DESCRIPTION
Continuing the doc-vs-code pass into the **Auth + Recommendation Engine** section.

**Auth paragraph + table names** (`recommendation_impressions`, `mood_sessions`, `user_profiles_computed`) — verified accurate, left untouched.

**Engine paragraph** was accurate-but-thin: "content-based + pgvector + behavioral, anti-recency, decay." It omitted the mechanisms that actually define FeelFlick — and, ironically for a mood-first product, **never mentioned mood**. Rewrote it to name the real, verified pillars:

- **Taste** — genre/director/actor affinity + pgvector cosine over OpenAI embeddings
- **Quality gating** — `ff_final_rating` floors, `vote_count`, quality tiers
- **Behavioral** — layered skip system (48h → 7d → permanent) + thumbs loop (`user_movie_feedback`)
- **Mood** — `computeMoodSignature` over `mood_tags`/`tone_tags`/`fit_profile` → the "Mood match" Briefing slot
- **Anti-bias** — anti-recency, decay, diversity de-clustering, language anti-bubble
- **The Briefing/hero centrepiece** — weighted-random single "tonight's pick," DNA-confidence tuned, with a `heroReason` "why this one." This is the engine *making its case* — directly ties the pipeline to the north star's editorial moat.

### Out of scope (flagged, not touched)
`recommendations.js`'s own header comment is stale — it changelogs up to "v2.7" while `ENGINE_VERSION` is `2.17`. Engine-file edit, gated by the `recommendation-engine` skill — happy to fix on request, but not silently.

Docs only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)