### PR TITLE
docs(engine): note recommendations.js header changelog stops at v2.7

### DIFF
--- a/src/shared/services/recommendations.js
+++ b/src/shared/services/recommendations.js
@@ -1,6 +1,11 @@
 // src/shared/services/recommendations.js
 /**
- * FeelFlick Recommendation Engine v2.7
+ * FeelFlick Recommendation Engine
+ *
+ * Current version: the `ENGINE_VERSION` const below is the source of truth. The
+ * dated changelog in this header stops at v2.7 — the engine has shipped many
+ * versions since without new header entries; use `git log -S ENGINE_VERSION`
+ * (or git blame on the const) for the changes since.
  *
  * NEW in v2.7:
  * ✅ ff_final_rating >= 7.2 absolute floor added to hero candidate pool alongside genre-norm


### PR DESCRIPTION
Tiny follow-up to #141. The engine file's own header comment is titled **"v2.7"** and changelogs up to v2.7, but `ENGINE_VERSION` is **2.17** — so the header reads ~10 versions behind at a glance.

Drops the stale version from the title and adds a one-line pointer to the `ENGINE_VERSION` const (the source of truth) + `git log -S ENGINE_VERSION` for changes since. **Comment only, no behavior change.** Deliberately did *not* back-fill 10 versions of changelog — git history is the durable record, and a hardcoded number here would just drift again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)