### PR TITLE
docs: fix the Project section (TV overclaim, OpenAI model, missing deps)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,10 +17,11 @@ layer is core, not garnish — don't let a narrow "mood→film, faster" reading
 de-prioritize it.)
 
 ## Project
-Mood-first, taste-deep movie/TV discovery: users express how they feel → get **one**
+Mood-first, taste-deep movie discovery: users express how they feel → get **one**
 trustworthy, case-made pick tuned to their full taste history (not an endless feed).
+(Movies only today — no TV/series surfaces yet.)
 **Quality bar:** Netflix / Apple TV+ polish. Every surface is production-facing.
-**Stack:** React 19 · React Router 7 · Framer Motion · Tailwind 4 · Vite 8 · Supabase (PostgreSQL + pgvector) · TMDB API · OpenAI (text-embedding-3-small) · Resend · Google OAuth · PostHog · Sentry · Vitest · Playwright
+**Stack:** React 19 · React Router 7 · TanStack Query · Framer Motion · Tailwind 4 · Vite 8 · lucide-react · Supabase (PostgreSQL + pgvector) · TMDB API · OpenAI (text-embedding-3-large, 3072-dim) · Resend (Daily Briefing email) · Google OAuth · PostHog · Sentry · Vitest · Playwright
 **Language:** JavaScript (JSX). No TypeScript yet — avoid patterns that block future migration.
 
 ## Folder Map


### PR DESCRIPTION
Pressure-tested `## Project` against the code (same pass as the engine + north star).

| Claim | Reality | Fix |
|---|---|---|
| "movie/**TV** discovery" | **0** TV/series signals in `src/` (no `media_type:tv`, `first_air_date`, `/tv` routes) | → "movie discovery" + explicit "movies only today" note |
| OpenAI `text-embedding-3-**small**` | Production is `text-embedding-3-**large**` (3072-dim) — current pipeline, openai-client util, a migration comment, **and the live About page** all say large; `-small` only survives in already-run `scripts/phase1` | → `text-embedding-3-large, 3072-dim` |
| (missing) | **TanStack Query** wraps the whole app (`QueryClientProvider` in App.jsx) | → added to stack |
| (missing) | **lucide-react** is the icon system (import-order convention already calls it out) | → added to stack |
| "Resend" | Real but MVP-scoped — `account/data.js`: "only Daily Briefing has real send infra (Resend + pg_cron)" | → kept, scoped to "(Daily Briefing email)" |

Auth-adjacent items (Supabase, TMDB, Google OAuth, Sentry, PostHog, Vitest, Playwright) all re-confirmed. Docs only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)