### PR TITLE
docs: enshrine the wedge — FeelFlick's North Star + anti-drift test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,36 @@ the priority. (Note the third clause: the Film File / Briefing "makes its case"
 layer is core, not garnish — don't let a narrow "mood→film, faster" reading
 de-prioritize it.)
 
+## The wedge — why FeelFlick wins
+
+The whole product defends one sentence:
+
+> **Mood-first, taste-deep — a single justified nightly pick that makes its case. Anti-scroll.**
+
+Nobody else does this one thing, and that gap *is* the strategy:
+
+- **TMDB** has the data but doesn't recommend.
+- **Netflix** recommends but buries you in an endless grid.
+- **Letterboxd** logs the past beautifully — but it doesn't pick *tonight* for you.
+- **Apple / Stripe** are craft + trust benchmarks, not movie pickers.
+
+So we don't match them feature-for-feature — we become **undeniably the best in the
+world at the one thing none of them do**, and borrow their disciplines to support
+it: craft from Apple, measurement from Netflix, trust from Stripe, and let
+Letterboxd-style community compound once there are users.
+
+**Anti-drift test** — reject anything that turns us into a *worse* version of one
+of them:
+
+- An infinite / endless feed → betrays *anti-scroll*. ❌
+- A wall of carousels as the primary surface → betrays *the single pick*. ❌
+- Making the user do the curation work → betrays *it picks for you*. ❌
+- A pick shown without its case → betrays *makes its case*. ❌
+- Recs that ignore mood, or ignore taste → betrays *mood-first* / *taste-deep*. ❌
+
+When a feature request arrives, the first question isn't "can we build it?" — it's
+"does this **sharpen the wedge**, or blunt it toward someone else's product?"
+
 ## Project
 Mood-first, taste-deep movie discovery: users express how they feel → get **one**
 trustworthy, case-made pick tuned to their full taste history (not an endless feed).


### PR DESCRIPTION
The founder committed to the competitive thesis we pinned down this session as FeelFlick's definitive identity — *"I want FeelFlick to be exactly like this."* This makes it the official, defended North Star in CLAUDE.md (new **"## The wedge — why FeelFlick wins"** section) so neither a human nor a future session drifts.

**The sentence the whole product defends:**
> Mood-first, taste-deep — a single justified nightly pick that makes its case. Anti-scroll.

**Why it wins** (the gap *is* the strategy): TMDB has data but doesn't recommend · Netflix recommends but buries you in an endless grid · Letterboxd logs the past but doesn't pick *tonight* · Apple/Stripe are craft/trust benchmarks, not pickers. → Be best in the world at the one thing none of them do; borrow craft (Apple), measurement (Netflix), trust (Stripe); let community (Letterboxd) compound once there are users.

**Anti-drift test** — reject anything that makes us a worse version of one of them: infinite feeds, carousel-walls as the primary surface, user-does-the-curation, case-less picks, mood/taste-blind recs.

Also saved to project memory so it survives across sessions. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)