### PR TITLE
chore(shell): close Module 0 — replay privacy, crash polish, cruft

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,6 @@
     </script>
     
     <!-- Security Headers -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="referrer" content="origin-when-cross-origin" />
     
     <!-- PWA Support — mobile-web-app-capable is the W3C spec name;
@@ -106,7 +105,7 @@
     <div id="root" style="background:#06060a;min-height:100vh">
   <!-- Pre-hydration content for crawlers. React replaces this on mount. -->
   <div id="prerender-content" style="position:absolute;left:-99999px;top:0;width:1px;height:1px;overflow:hidden;opacity:0;pointer-events:none" aria-hidden="true">
-    <h1 style="font-size:2.25rem;font-weight:900;margin-bottom:1rem;background:linear-gradient(135deg,#9333ea,#ec4899);-webkit-background-clip:text;-webkit-text-fill-color:transparent">FeelFlick — The right film. Right now.</h1>
+    <h1 style="font-size:2.25rem;font-weight:700;margin-bottom:1rem;background:linear-gradient(135deg,#9333ea,#ec4899);-webkit-background-clip:text;-webkit-text-fill-color:transparent">FeelFlick — The right film. Right now.</h1>
     <p style="font-size:1.125rem;color:#cbd5e1;margin-bottom:1.5rem">Films that know you. Tuned to your mood, your taste, and everything you've ever loved on screen. FeelFlick is a free mood-first movie discovery platform — one pick a night, with the article that makes its case. No ads, no upsells, no algorithm tax.</p>
     <p style="font-size:1rem;color:#94a3b8;margin-bottom:2rem">FeelFlick requires JavaScript. Please enable it to continue, or use one of the links below.</p>
     <nav style="font-size:0.95rem">
@@ -123,7 +122,7 @@
     <!-- Fallback for No JavaScript -->
     <noscript>
   <div style="max-width:720px;margin:0 auto;padding:4rem 1.5rem;background:#06060a;color:#f8fafc;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;line-height:1.6">
-    <h1 style="font-size:2.25rem;font-weight:900;margin-bottom:1rem;background:linear-gradient(135deg,#9333ea,#ec4899);-webkit-background-clip:text;-webkit-text-fill-color:transparent">FeelFlick — The right film. Right now.</h1>
+    <h1 style="font-size:2.25rem;font-weight:700;margin-bottom:1rem;background:linear-gradient(135deg,#9333ea,#ec4899);-webkit-background-clip:text;-webkit-text-fill-color:transparent">FeelFlick — The right film. Right now.</h1>
     <p style="font-size:1.125rem;color:#cbd5e1;margin-bottom:1.5rem">Films that know you. Tuned to your mood, your taste, and everything you've ever loved on screen. FeelFlick is a free mood-first movie discovery platform — one pick a night, with the article that makes its case.</p>
     <p style="font-size:1rem;color:#94a3b8;margin-bottom:2rem">FeelFlick requires JavaScript. Please enable it to continue.</p>
     <nav style="font-size:0.95rem">

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,7 +4,6 @@ Allow: /
 # Disallow authenticated/private routes
 Disallow: /admin
 Disallow: /onboarding
-Disallow: /dev
 
 # Allow movie pages explicitly (for clarity)
 Allow: /movie/

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,15 +11,25 @@ export default function App() {
   useSessionTracking()
   return (
     <Sentry.ErrorBoundary
-      fallback={({ error }) => (
-        <div className="min-h-screen bg-black flex items-center justify-center text-white text-center p-8">
-          <div>
-            <h1 className="text-2xl font-bold mb-2">
+      fallback={() => (
+        // Last-resort outer boundary (the route-level ErrorBoundary handles most
+        // crashes with richer UI). Generic copy — never surface raw error.message
+        // to users — plus a branded reload affordance.
+        <div className="min-h-screen bg-[#06060a] flex items-center justify-center text-white text-center p-8">
+          <div className="max-w-sm">
+            <h1 className="text-2xl font-semibold mb-2" style={{ fontFamily: 'Outfit, Inter, sans-serif' }}>
               Something went wrong
             </h1>
-            <p className="text-white/60 text-sm">
-              {error?.message || 'An unexpected error occurred'}
+            <p className="text-white/60 text-sm mb-6">
+              An unexpected error occurred. Reloading usually fixes it.
             </p>
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              className="rounded-md bg-linear-to-r from-purple-600 to-pink-500 px-4 py-2 text-sm font-medium hover:brightness-110 focus:outline-none focus:ring-2 focus:ring-purple-400/50"
+            >
+              Reload
+            </button>
           </div>
         </div>
       )}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -22,7 +22,10 @@ Sentry.init({
   integrations: [
     Sentry.browserTracingIntegration(),
     Sentry.replayIntegration({
-      maskAllText: false,
+      // Privacy-first: mask all text in session replays so user input (search
+      // queries, names, emails) never leaves the browser. Media (movie posters)
+      // isn't sensitive, so keep it visible for debugging context.
+      maskAllText: true,
       blockAllMedia: false,
     }),
   ],


### PR DESCRIPTION
Closes out the **Module 0** review — the safe P2 trust items + P3 cruft. (The OAuth sign-in double-reload is **deferred to its own PR** — it touches the auth flow and deserves a careful, tested change.)

### P2 — trust
- **Sentry session replay**: `maskAllText` `false → true`. User input (search queries, names, emails) is now masked and never leaves the browser. Media (posters) kept for debugging context. Privacy-first default (Stripe-trust).
- **App-level crash fallback**: stop surfacing raw `error.message` to users; generic copy + a branded **Reload** affordance (was bare + leaked internals).

### P3 — cruft
- Dropped the dead `X-UA-Compatible` / `IE=edge` meta.
- Prerender + noscript fallback `<h1>` `font-weight:900 → 700` (editorial law forbids Inter-black; crawler/no-JS-only, but should still comply).
- `robots.txt`: removed `Disallow: /dev` (route no longer exists).

Lint + build green. Docs/shell only — no behavior change beyond the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)