### PR TITLE
User-journey pass: auth → onboarding → home → discover → movie + a11y/perf cleanup

### DIFF
--- a/src/features/auth/OAuthCallback.jsx
+++ b/src/features/auth/OAuthCallback.jsx
@@ -8,6 +8,7 @@ import {
   consumeOAuthCallbackNonce,
   readOAuthNonceFromUrl,
 } from '@/shared/lib/auth/oauthNonce'
+import { deriveOnboardingStatus } from '@/shared/lib/auth/onboardingStatus'
 
 /**
  * OAuth Callback Handler
@@ -114,12 +115,8 @@ export default function OAuthCallback() {
           return
         }
 
-        // Check onboarding status from user metadata
-        const meta = session.user.user_metadata || {}
-        const isOnboarded =
-          meta.onboarding_complete === true ||
-          meta.has_onboarded === true ||
-          meta.onboarded === true
+        // Check onboarding status from user metadata (same derivation as PostAuthGate)
+        const { isComplete: isOnboarded } = deriveOnboardingStatus(session.user)
 
         // Route to appropriate page
         const destination = isOnboarded ? '/home' : '/onboarding'

--- a/src/features/auth/PostAuthGate.jsx
+++ b/src/features/auth/PostAuthGate.jsx
@@ -2,36 +2,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Navigate, Outlet, useLocation } from 'react-router-dom'
 import { supabase } from '@/shared/lib/supabase/client'
-
-function AuthGatePlaceholder() {
-  return <div className="fixed inset-0 z-9999 bg-black" />
-}
-
-function isTruthyFlag(v) {
-  return v === true || v === 'true' || v === 1 || v === '1'
-}
-
-function deriveOnboardingFromMetadata(user) {
-  const meta = { ...(user?.app_metadata ?? {}), ...(user?.user_metadata ?? {}) }
-
-  // If any of these keys exist, we treat metadata as “present”
-  const hasAny =
-    meta.onboarding_complete !== undefined ||
-    meta.onboardingComplete !== undefined ||
-    meta.has_onboarded !== undefined ||
-    meta.hasOnboarded !== undefined ||
-    meta.onboarded !== undefined ||
-    meta.onboarding_completed_at !== undefined
-
-  const isComplete =
-    isTruthyFlag(meta.onboarding_complete) ||
-    isTruthyFlag(meta.onboardingComplete) ||
-    isTruthyFlag(meta.has_onboarded) ||
-    isTruthyFlag(meta.hasOnboarded) ||
-    isTruthyFlag(meta.onboarded)
-
-  return { hasAny, isComplete }
-}
+import BrandSplash from '@/shared/ui/BrandSplash'
+import { deriveOnboardingStatus, isTruthyFlag } from '@/shared/lib/auth/onboardingStatus'
 
 /**
  * Post-Auth Gate
@@ -89,7 +61,7 @@ export default function PostAuthGate() {
     }
 
     // Fast path: trust onboarding flags in auth metadata (very fast, no DB round trip)
-    const meta = deriveOnboardingFromMetadata(user)
+    const meta = deriveOnboardingStatus(user)
     if (!forceDbCheck && meta.hasAny) {
       setIsOnboarded(meta.isComplete)
       setPhase('ready')
@@ -165,7 +137,7 @@ export default function PostAuthGate() {
 
   // While determining session/onboarding (rarely more than 1–2 round-trips), block route render
   if (phase !== 'ready' || hasUser === null || isOnboarded === null) {
-    return <AuthGatePlaceholder />
+    return <BrandSplash />
   }
 
   // Not authenticated → redirect to landing

--- a/src/features/discover/Discover.jsx
+++ b/src/features/discover/Discover.jsx
@@ -84,7 +84,7 @@ function AudioToggle() {
   );
 }
 
-// ── Original v4 imports below ──
+// ── imports below ──
 
 // Discover keeps a deeper accent purple + two surface tints; spread the shared
 // core and override only those (explicit divergence, not copy-paste drift).
@@ -109,7 +109,7 @@ const MOODS = [
 // (cozy/wired/tender/fun/tense/mythic — see src/features/onboarding/data.js).
 // /discover uses an 8-axis vocabulary above (the constellation map). This
 // bridge translates baseline-mood keys → Discover mood ids for the
-// first-visit pre-selection in DiscoverV5Body. Four are direct (cozy,
+// first-visit pre-selection in DiscoverBody. Four are direct (cozy,
 // tender, tense, mythic); 'wired' ("cerebral, plot-y, reward focus") maps
 // to the closest Discover hint ("big idea, quiet pace") = cerebral;
 // 'fun' ("light, plot-driven, escapist") maps to restless (the energetic /
@@ -348,7 +348,7 @@ function StageMood({ selected, setSelected, onNext, onBack, blendHex, bursts, fi
 // (from predictDiscoverDefaults) are pre-highlighted so users who agree
 // with the prediction just tap once per step.
 //
-// stepIndex is lifted to DiscoverV5Body so that "Tweak inputs" from
+// stepIndex is lifted to DiscoverBody so that "Tweak inputs" from
 // Stage 3 returns straight to the summary view (all 4 chips visible)
 // rather than re-asking from step 0.
 function StageNightStacked({ stepIndex, setStepIndex, time, setTime, who, setWho, energy, setEnergy, intention, setIntention, onNext, onBack, blendHex }) {
@@ -1642,7 +1642,7 @@ async function commitDiscoverPreferences({ userId, intention, time, who, energy 
   }
 }
 
-function DiscoverV5Body() {
+function DiscoverBody() {
   const [stage, setStage]       = useState(0);
   const [selected, setSelected] = useState([]);
   const [time, setTime]         = useState('std');
@@ -1918,7 +1918,7 @@ export default function Discover() {
   )
   return (
     <DiscoverDataProvider>
-      <DiscoverV5Body />
+      <DiscoverBody />
       {handoffOverlayVisible && (
         <motion.div
           aria-hidden="true"

--- a/src/features/discover/discover.css
+++ b/src/features/discover/discover.css
@@ -1,5 +1,5 @@
-/* Discover v5 — scoped animations + base */
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@200;300;400;500;600;700&family=Inter:wght@400;500;600&display=swap');
+/* Discover — scoped animations + base. Outfit + Inter load globally via index.html
+   (no per-page @import — it's render-blocking + slower than the global <link>). */
 
 * { box-sizing: border-box; }
 html, body, #root { margin:0; padding:0; min-height:100%; background:#06060a; }

--- a/src/features/discover/useDiscoverData.jsx
+++ b/src/features/discover/useDiscoverData.jsx
@@ -1,5 +1,5 @@
 // src/features/discover/useDiscoverData.jsx
-// FeelFlick — Discover v5 data layer.
+// FeelFlick — Discover data layer.
 //
 // Two live sources replace the prototype's hardcoded arrays:
 //   • FILMS         → top-quality candidates from `movies` (capped at 60),
@@ -191,7 +191,7 @@ function shapeFilm(m) {
     arcPoints: arcPointsFrom(fit),
     twin: null, // populated below if we find a follow who rated this film
     criticLine: null, // no real critic source yet — page hides this section when null
-    // Raw Supabase row preserved for scoreMovieForUser — DiscoverV5 does the
+    // Raw Supabase row preserved for scoreMovieForUser — Discover does the
     // engine call inline because the magazine flow applies UI-driven
     // intention/energy modifiers on top of the engine score.
     _raw: m,
@@ -203,7 +203,7 @@ function shapeFilm(m) {
 const INITIAL = {
   films: [],
   diaryQuotes: {},
-  profile: null, // computeUserProfile(userId) result — DiscoverV5 calls scoreMovieForUser inline
+  profile: null, // computeUserProfile(userId) result — Discover calls scoreMovieForUser inline
   baselineMoods: [], // users.taste_baseline_moods (onboarding mood keys)
   // Learned Stage 2 filter counts (intention/time/who/energy) from
   // user_discover_preferences. Used by predictDiscoverDefaults to blend
@@ -211,7 +211,7 @@ const INITIAL = {
   // the row doesn't exist yet (cold-start user).
   learnedPrefs: null,
   // Recent user_watchlist saves (last 90d) with director + genre metadata.
-  // Used by DiscoverV5 allResults to add a saveBoost — films sharing a
+  // Used by Discover allResults to add a saveBoost — films sharing a
   // director or genre with the user's saved films get a small score
   // bonus, so the engine actually rewards positive signals not just
   // demotes negative ones. {director, genre, moodTags}[].
@@ -400,11 +400,11 @@ export function DiscoverDataProvider({ children }) {
                 .maybeSingle()
             : Promise.resolve({ data: null }),
           // Recent watchlist saves (last 90d) — used as a POSITIVE signal
-          // by DiscoverV5 allResults. Films matching the director or
+          // by Discover allResults. Films matching the director or
           // primary_genre of these saves get a saveBoost in scoring.
           // Joined to movies for the metadata we need without extra
           // round-trips. Limited to 50 most recent saves so the .map()
-          // / Set construction in DiscoverV5 stays O(50) per render.
+          // / Set construction in Discover stays O(50) per render.
           userId
             ? supabase
                 .from('user_watchlist')
@@ -582,7 +582,7 @@ export function DiscoverDataProvider({ children }) {
         const diaryQuotes = { ...FALLBACK_DIARY, ...diaryByAxis }
 
         // baselineMoods: array of onboarding mood keys (cozy/wired/tender/
-        // fun/tense/mythic). DiscoverV5Body maps these into Discover's
+        // fun/tense/mythic). DiscoverBody maps these into Discover's
         // 8-axis vocabulary for first-visit pre-selection. Null when the
         // user hasn't completed Onboarding Step 1 (legacy account).
         const baselineMoods = Array.isArray(userRowRes?.data?.taste_baseline_moods)

--- a/src/features/home/Home.jsx
+++ b/src/features/home/Home.jsx
@@ -1,10 +1,9 @@
-// FeelFlick — Home v2 (Briefing edition).
-// Mounted at /home-v2 in parallel with /home.
+// FeelFlick — Home (the Briefing edition). Mounted at /home.
 //
-// Drops the internal HPNav (AppShell owns TopNav). All data flows through
-// the HomeDataProvider (live Supabase reads for user/films/recent/DNA/
-// friends/lists). Action handlers write to real tables and navigate to v2
-// surfaces (/movie/:tmdbId, /profile/:userId, /lists/curated/:slug).
+// AppShell owns the global TopNav. All data flows through the HomeDataProvider
+// (live Supabase reads for user/films/recent/DNA/friends/lists). Action handlers
+// write to real tables and navigate to /movie/:tmdbId, /profile/:userId,
+// /lists/curated/:slug.
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
@@ -24,7 +23,7 @@ import {
 import { HomeDataProvider, useHomeData } from './useHomeData'
 import './home.css'
 
-function HomeV2Body() {
+function HomeBody() {
   usePageMeta({ title: 'Home — FeelFlick' })
   const navigate = useNavigate()
   const location = useLocation()
@@ -150,7 +149,7 @@ function HomeV2Body() {
   }, [navigate])
 
   return (
-    <div className="ff-home-v2" style={{ minHeight: '100vh', background: HP.bg, color: HP.text, position: 'relative', overflowX: 'hidden' }}>
+    <div className="ff-home" style={{ minHeight: '100vh', background: HP.bg, color: HP.text, position: 'relative', overflowX: 'hidden' }}>
       {/* Mood-tuned ambient gradient — reactive */}
       <div aria-hidden style={{
         position: 'fixed', inset: 0, pointerEvents: 'none', zIndex: 0,
@@ -208,7 +207,7 @@ function HomeV2Body() {
 export default function Home() {
   return (
     <HomeDataProvider>
-      <HomeV2Body />
+      <HomeBody />
     </HomeDataProvider>
   )
 }

--- a/src/features/home/atoms.jsx
+++ b/src/features/home/atoms.jsx
@@ -1,4 +1,4 @@
-// FeelFlick — Home v2 atoms / primitives.
+// FeelFlick — Home atoms / primitives.
 // SmartImg now takes a film object (not a key) since runtime films come
 // from useHomeData. HPNav is removed — AppShell owns the global TopNav.
 

--- a/src/features/home/data.js
+++ b/src/features/home/data.js
@@ -1,4 +1,4 @@
-// FeelFlick — Home v2 static design tokens.
+// FeelFlick — Home static design tokens.
 // All runtime data (films, moods.pool, recent, DNA, friends, lists, user counts)
 // now lives in useHomeData.jsx. This file only owns visual tokens + the static
 // MOOD metadata (id/label/hex/tint).

--- a/src/features/home/home.css
+++ b/src/features/home/home.css
@@ -1,10 +1,11 @@
-/* FeelFlick — Home v2 scoped styles.
-   Outfit display font, Inter for body. Scoped to .ff-home-v2 to avoid touching the rest of the app. */
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@200;300;400;500;600;700&family=Inter:wght@400;500;600&display=swap');
+/* FeelFlick — Home scoped styles.
+   Inter for body; Outfit display + Inter both load globally via index.html, so
+   no per-page font @import here (an @import is render-blocking + slower than the
+   global <link>). Scoped to .ff-home so it doesn't touch the rest of the app. */
 
-.ff-home-v2 {
+.ff-home {
   font-family: 'Inter', system-ui, -apple-system, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
-.ff-home-v2 ::selection { background: rgba(167,139,250,0.35); color: #fff; }
+.ff-home ::selection { background: rgba(167,139,250,0.35); color: #fff; }

--- a/src/features/home/sections-bottom.jsx
+++ b/src/features/home/sections-bottom.jsx
@@ -1,4 +1,4 @@
-// Home v2 — bottom sections, wired to useHomeData.
+// Home — bottom sections, wired to useHomeData.
 // All hardcoded RECENT / CONTINUE / DNA / FRIENDS / LISTS imports gone.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'

--- a/src/features/home/sections-top.jsx
+++ b/src/features/home/sections-top.jsx
@@ -1,4 +1,4 @@
-// Home v2 — top sections (Masthead, Mood Reactor, The Briefing 3-up).
+// Home — top sections (Masthead, Mood Reactor, The Briefing 3-up).
 // All film data comes from useHomeData (no more imports from data.js for FILMS).
 
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
@@ -90,7 +90,7 @@ export function MoodReactor({ currentMood, setMood, onReshuffle }) {
   )
 }
 
-// Animated match ring — mirrors MatchRing from movie-v2/sections-top.jsx.
+// Animated match ring — mirrors MatchRing from movie/sections-top.jsx.
 // SVG with a gradient circle stroke that fills from 0 → pct over 1.4s
 // (stroke-dasharray transition), and the percentage number tweens from 0
 // → pct via setTimeout(setV). Unique gradient id per instance via useId
@@ -133,7 +133,7 @@ function MatchRing({ pct, size = 72 }) {
   )
 }
 
-// Action buttons sized + styled to match movie-v2 detail page actions:
+// Action buttons sized + styled to match movie detail page actions:
 // 14/22 padding, rounded-8, 14px Outfit semibold, gradient bg for primary,
 // outline + active-state tint for Watched/Save, smaller quiet pill for Skip.
 // Same shapes the user sees on /movie/:id so the briefing card actions

--- a/src/features/home/useHomeData.jsx
+++ b/src/features/home/useHomeData.jsx
@@ -1,5 +1,5 @@
 // src/features/home/useHomeData.jsx
-// FeelFlick — Home v2 ("The Briefing") data layer.
+// FeelFlick — Home ("The Briefing") data layer.
 //
 // Replaces the prototype's hardcoded FILMS / MOODS.pool / RECENT / DNA /
 // FRIENDS / LISTS arrays with live Supabase reads:
@@ -364,7 +364,7 @@ export function HomeDataProvider({ children }) {
           const bridgeTags = new Set(MOOD_BRIDGE[moodId])
           const otherTags = allOtherMoodTagsByMood[moodId]
           // Only score candidates that match the mood's bridge tags. Keeps
-          // per-mood pools coherent; the engine doesn't know about home-v2's
+          // per-mood pools coherent; the engine doesn't know about home's
           // editorial mood vocabulary.
           const moodPool = rawCandidates.filter(m =>
             Array.isArray(m.mood_tags) && m.mood_tags.some(t => bridgeTags.has(t))

--- a/src/features/movie/MovieDetail.jsx
+++ b/src/features/movie/MovieDetail.jsx
@@ -1,10 +1,9 @@
 // src/features/movie/MovieDetail.jsx
-// FeelFlick — Movie Detail v2 ("Film File" editorial direction).
-// Route: /movie-v2/:id (parallel to existing /movie/:id)
+// FeelFlick — Movie Detail (the "Film File" editorial direction). Route: /movie/:id.
 //
-// Per-id TMDB + Supabase fetch lives in ./useMovieData. PR 1 makes Mood Radar,
-// Why-for-you, Friends Loved, Taste Twin dynamic for every film from existing
-// data. TheTake + CriticQuotes remain Parasite-only until PR 4 (LLM endpoint).
+// Per-id TMDB + Supabase fetch lives in ./useMovieData. Mood Radar, Why-for-you,
+// Friends Loved, and Taste Twin derive dynamically for every film; TheTake +
+// CriticQuotes render from a curated `overlay` when present, else stay hidden.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
@@ -75,8 +74,7 @@ export default function MovieDetail() {
     user,
     movie: mv ? { id: mv.id, title: mv.title, poster_path: null, overview: mv.overview } : null,
     // 'movie_detail' is the canonical source string the user_watchlist.source
-    // check constraint allows. The folder is named -v2 internally but the DB
-    // doesn't care which version of the UI surface logged the action.
+    // check constraint allows.
     source: 'movie_detail',
   })
 
@@ -176,7 +174,7 @@ export default function MovieDetail() {
 
   return (
     <MovieDataProvider value={data}>
-      <div className="ff-movie-v2" style={{
+      <div className="ff-movie" style={{
         minHeight: '100vh', background: '#06060a', color: '#FAFAFA',
         fontFamily: 'Inter, sans-serif', overflow: 'hidden', position: 'relative',
       }}>
@@ -261,7 +259,7 @@ export default function MovieDetail() {
 function PageSkeleton() {
   const pulse = { background: 'rgba(255,255,255,0.04)' };
   return (
-    <div className="ff-movie-v2" style={{
+    <div className="ff-movie" style={{
       minHeight: '100vh', background: '#06060a', color: '#FAFAFA',
       fontFamily: 'Inter, sans-serif', overflow: 'hidden',
     }}>
@@ -287,7 +285,7 @@ function PageSkeleton() {
 
 function PageError({ error, onBack }) {
   return (
-    <div className="ff-movie-v2" style={{
+    <div className="ff-movie" style={{
       minHeight: '100vh', background: '#06060a', color: '#FAFAFA',
       display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24,
       fontFamily: 'Inter, sans-serif',

--- a/src/features/movie/movie.css
+++ b/src/features/movie/movie.css
@@ -1,20 +1,19 @@
-/* src/features/movie-v2/movie.css
- * Scoped keyframes for the v2 Movie Detail page.
+/* src/features/movie/movie.css
+ * Scoped keyframes for the Movie Detail page.
  * Outfit display font, Inter for body.
  * All animations are prefixed `mv-` to avoid colliding with your existing styles.
  */
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@200;300;400;500;600;700&family=Inter:wght@400;500;600&display=swap');
 
-.ff-movie-v2 {
+.ff-movie {
   font-family: 'Inter', system-ui, -apple-system, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
-.ff-movie-v2 ::selection { background: rgba(167,139,250,0.4); color: #fff; }
-.ff-movie-v2 em { font-style: italic; }
-.ff-movie-v2 button { font-family: inherit; transition: filter 0.18s ease; }
-.ff-movie-v2 button:hover:not(:disabled) { filter: brightness(1.12); }
-.ff-movie-v2 textarea { font-family: inherit; }
+.ff-movie ::selection { background: rgba(167,139,250,0.4); color: #fff; }
+.ff-movie em { font-style: italic; }
+.ff-movie button { font-family: inherit; transition: filter 0.18s ease; }
+.ff-movie button:hover:not(:disabled) { filter: brightness(1.12); }
+.ff-movie textarea { font-family: inherit; }
 
 @keyframes mv-fade-in { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: translateY(0); } }
 @keyframes mv-zoom-in { from { opacity: 0; transform: scale(0.94); } to { opacity: 1; transform: scale(1); } }

--- a/src/features/movie/useMovieData.jsx
+++ b/src/features/movie/useMovieData.jsx
@@ -1,5 +1,5 @@
 // src/features/movie/useMovieData.jsx
-// FeelFlick — Movie Detail v2 data layer.
+// FeelFlick — Movie Detail data layer.
 // Fetches TMDB by id, maps to the shape sections expect, and provides via context.
 // FeelFlick-engine fields (mood fingerprint, why-for-you reasons, editorial take,
 // critic pull-quotes, taste twin) live in ./data and are NOT replaced here —

--- a/src/features/onboarding/Onboarding.jsx
+++ b/src/features/onboarding/Onboarding.jsx
@@ -1,11 +1,12 @@
 // src/features/onboarding/Onboarding.jsx
 // FeelFlick — Onboarding V2 (mood-reactive). Mounted at /onboarding.
 //
-// Flow (4 steps, NO step 5 — lands on /home directly):
-//   1. Mood baseline   (NEW)
-//   2. Genres          (restyled)
-//   3. Films           (legacy step, reused)
-//   4. Quick rate      (restyled) → completeOnboarding → /home
+// Flow (4 steps): on completion the FIRST landing is /discover — cold-start, since
+// /home needs watch history to feel personal; returning users route to /home.
+//   1. Mood baseline
+//   2. Genres
+//   3. Films
+//   4. Quick rate → completeOnboarding → /discover
 //
 // Auth + completion logic mirrors the legacy Onboarding.jsx exactly so existing Supabase
 // metadata + PostAuthGate continue to work.
@@ -17,6 +18,7 @@ import { Sparkles } from 'lucide-react'
 
 import { supabase } from '@/shared/lib/supabase/client'
 import { useAuthSession } from '@/shared/hooks/useAuthSession'
+import { deriveOnboardingStatus } from '@/shared/lib/auth/onboardingStatus'
 import { usePageMeta } from '@/shared/hooks/usePageMeta'
 import { tmdbImg } from '@/shared/api/tmdb'
 import { completeOnboarding, markOnboardingAuthComplete } from '@/shared/services/onboarding'
@@ -57,7 +59,7 @@ export default function Onboarding() {
 
   const [checking, setChecking] = useState(true)
   const [celebrate, setCelebrate] = useState(false)
-  // Drives the celebration → /home exit animation. When flipped to true, the
+  // Drives the celebration → /discover exit animation. When flipped to true, the
   // celebration content fades to opacity 0; the black backdrop remains until
   // navigate fires. Smooths what was previously a hard cut.
   const [fadingOut, setFadingOut] = useState(false)
@@ -94,8 +96,7 @@ export default function Onboarding() {
 
     ;(async () => {
       try {
-        const meta = session.user.user_metadata || {}
-        if (meta.onboarding_complete || meta.has_onboarded || meta.onboarded) {
+        if (deriveOnboardingStatus(session.user).isComplete) {
           navigate('/home', { replace: true })
           return
         }
@@ -251,7 +252,7 @@ export default function Onboarding() {
     return <BrandSplash />
   }
 
-  // Celebration → /home. Staggered reveals double as cover for the Supabase
+  // Celebration → /discover. Staggered reveals double as cover for the Supabase
   // writes happening underneath (~1-3s) so the wait feels intentional.
   if (celebrate) {
     return (
@@ -616,7 +617,7 @@ function CelebrationReveal({ moods, selectedGenres, favoriteMovies, ratings, fad
             style={{ textWrap: 'balance', letterSpacing: '-0.02em' }}
           >
             Tonight is{' '}
-            <em className="bg-linear-to-r from-purple-400 to-pink-400 bg-clip-text not-italic italic text-transparent">
+            <em className="bg-linear-to-r from-purple-400 to-pink-400 bg-clip-text italic text-transparent">
               yours.
             </em>
           </h1>

--- a/src/features/onboarding/steps/GenresStep.jsx
+++ b/src/features/onboarding/steps/GenresStep.jsx
@@ -59,7 +59,7 @@ export default function GenresStep({ selectedGenres, toggleGenre, onBack, onNext
           style={{ textWrap: 'balance' }}
         >
           Which{' '}
-          <em className="not-italic bg-linear-to-r from-purple-500 to-pink-500 bg-clip-text text-transparent italic">
+          <em className="bg-linear-to-r from-purple-500 to-pink-500 bg-clip-text text-transparent italic">
             territories
           </em>
           {' '}do you live in?

--- a/src/features/onboarding/steps/MoodStep.jsx
+++ b/src/features/onboarding/steps/MoodStep.jsx
@@ -31,7 +31,7 @@ export default function MoodStep({ moods, setMoods, onNext, firstName }) {
           style={{ textWrap: 'balance' }}
         >
           The vibe you{' '}
-          <em className="not-italic bg-linear-to-r from-purple-500 to-pink-500 bg-clip-text text-transparent italic">
+          <em className="bg-linear-to-r from-purple-500 to-pink-500 bg-clip-text text-transparent italic">
             live in.
           </em>
         </h2>

--- a/src/features/onboarding/steps/MoviesStep.jsx
+++ b/src/features/onboarding/steps/MoviesStep.jsx
@@ -418,7 +418,7 @@ export default function MoviesStep({
           style={{ textWrap: 'balance' }}
         >
           What have you{' '}
-          <em className="bg-linear-to-r from-purple-500 to-pink-500 bg-clip-text not-italic italic text-transparent">
+          <em className="bg-linear-to-r from-purple-500 to-pink-500 bg-clip-text italic text-transparent">
             loved?
           </em>
         </h2>

--- a/src/features/onboarding/steps/RatingStep.jsx
+++ b/src/features/onboarding/steps/RatingStep.jsx
@@ -118,14 +118,14 @@ export default function RatingStep({ favoriteMovies, ratings, onRate, onBack, on
           {allRated ? (
             <>
               Nice — all{' '}
-              <em className="bg-linear-to-r from-purple-500 to-pink-500 bg-clip-text not-italic italic text-transparent">
+              <em className="bg-linear-to-r from-purple-500 to-pink-500 bg-clip-text italic text-transparent">
                 rated.
               </em>
             </>
           ) : (
             <>
               How did this one{' '}
-              <em className="bg-linear-to-r from-purple-500 to-pink-500 bg-clip-text not-italic italic text-transparent">
+              <em className="bg-linear-to-r from-purple-500 to-pink-500 bg-clip-text italic text-transparent">
                 land?
               </em>
             </>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -62,11 +62,13 @@ async function handleOAuthHash() {
           access_token: accessToken,
           refresh_token: refreshToken,
         })
-        
-        // Clean up the URL and redirect to callback route
+
+        // Strip the tokens out of the URL, then mount the app directly — no full
+        // document reload. OAuthCallback reads the now-set session and routes from
+        // there. (Previously this did window.location.replace('/auth/callback'),
+        // forcing a full reload + re-boot at the highest-stakes moment in the funnel.)
         window.history.replaceState(null, '', '/auth/callback')
-        window.location.replace('/auth/callback')
-        return true // Prevent normal app mount
+        return false // fall through to mount; OAuthCallback handles routing
       }
     } catch {
       clearOAuthCallbackNonce()

--- a/src/shared/lib/auth/__tests__/onboardingStatus.test.js
+++ b/src/shared/lib/auth/__tests__/onboardingStatus.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { isTruthyFlag, deriveOnboardingStatus } from '../onboardingStatus'
+
+describe('isTruthyFlag', () => {
+  it('accepts boolean, string, and numeric truthy forms', () => {
+    expect(isTruthyFlag(true)).toBe(true)
+    expect(isTruthyFlag('true')).toBe(true)
+    expect(isTruthyFlag(1)).toBe(true)
+    expect(isTruthyFlag('1')).toBe(true)
+  })
+
+  it('rejects everything else', () => {
+    expect(isTruthyFlag(false)).toBe(false)
+    expect(isTruthyFlag('false')).toBe(false)
+    expect(isTruthyFlag(0)).toBe(false)
+    expect(isTruthyFlag(undefined)).toBe(false)
+    expect(isTruthyFlag(null)).toBe(false)
+    expect(isTruthyFlag('yes')).toBe(false)
+  })
+})
+
+describe('deriveOnboardingStatus', () => {
+  it('handles a missing user', () => {
+    expect(deriveOnboardingStatus(null)).toEqual({ hasAny: false, isComplete: false })
+    expect(deriveOnboardingStatus(undefined)).toEqual({ hasAny: false, isComplete: false })
+  })
+
+  it('reads onboarding_complete from user_metadata', () => {
+    const user = { user_metadata: { onboarding_complete: true } }
+    expect(deriveOnboardingStatus(user)).toEqual({ hasAny: true, isComplete: true })
+  })
+
+  it('reads flags from app_metadata too', () => {
+    const user = { app_metadata: { onboarded: '1' } }
+    expect(deriveOnboardingStatus(user)).toEqual({ hasAny: true, isComplete: true })
+  })
+
+  // The bug the consolidation fixes: the callback used to miss camelCase, so a
+  // user with onboardingComplete would be sent to /onboarding then bounced back.
+  it('recognises the camelCase variant (the redirect-flicker bug)', () => {
+    const user = { user_metadata: { onboardingComplete: true } }
+    expect(deriveOnboardingStatus(user)).toEqual({ hasAny: true, isComplete: true })
+  })
+
+  it('treats a present-but-falsey flag as incomplete (hasAny true)', () => {
+    const user = { user_metadata: { onboarding_complete: false } }
+    expect(deriveOnboardingStatus(user)).toEqual({ hasAny: true, isComplete: false })
+  })
+
+  it('treats a timestamp key as "metadata present" without marking complete', () => {
+    const user = { user_metadata: { onboarding_completed_at: '2026-05-30T00:00:00Z' } }
+    expect(deriveOnboardingStatus(user)).toEqual({ hasAny: true, isComplete: false })
+  })
+
+  it('user_metadata wins over app_metadata on key overlap', () => {
+    const user = {
+      app_metadata: { onboarding_complete: false },
+      user_metadata: { onboarding_complete: true },
+    }
+    expect(deriveOnboardingStatus(user).isComplete).toBe(true)
+  })
+})

--- a/src/shared/lib/auth/onboardingStatus.js
+++ b/src/shared/lib/auth/onboardingStatus.js
@@ -1,0 +1,42 @@
+// Onboarding-status detection from Supabase auth metadata.
+//
+// WHY: this logic was duplicated — PostAuthGate checked 6 flags (+ camelCase, + a
+// DB fallback) while OAuthCallback checked only 3. A user with `onboardingComplete`
+// (camelCase) but not `onboarding_complete` would be routed to /onboarding by the
+// callback, then bounced to /home by the gate — a redirect flicker. One source of
+// truth removes that.
+
+/** Coerce a loosely-typed onboarding flag (bool / 'true' / 1 / '1') to a boolean. */
+export function isTruthyFlag(v) {
+  return v === true || v === 'true' || v === 1 || v === '1'
+}
+
+/**
+ * Derive onboarding status from a Supabase user's metadata (no DB round-trip).
+ *
+ * @param {object|null} user - Supabase auth user (merges app_metadata + user_metadata)
+ * @returns {{ hasAny: boolean, isComplete: boolean }}
+ *   - `hasAny`: any known onboarding flag is present (lets callers decide whether a
+ *     DB fallback is worth a round-trip when metadata is silent).
+ *   - `isComplete`: onboarding is marked complete.
+ */
+export function deriveOnboardingStatus(user) {
+  const meta = { ...(user?.app_metadata ?? {}), ...(user?.user_metadata ?? {}) }
+
+  const hasAny =
+    meta.onboarding_complete !== undefined ||
+    meta.onboardingComplete !== undefined ||
+    meta.has_onboarded !== undefined ||
+    meta.hasOnboarded !== undefined ||
+    meta.onboarded !== undefined ||
+    meta.onboarding_completed_at !== undefined
+
+  const isComplete =
+    isTruthyFlag(meta.onboarding_complete) ||
+    isTruthyFlag(meta.onboardingComplete) ||
+    isTruthyFlag(meta.has_onboarded) ||
+    isTruthyFlag(meta.hasOnboarded) ||
+    isTruthyFlag(meta.onboarded)
+
+  return { hasAny, isComplete }
+}

--- a/src/shared/lib/tokens.js
+++ b/src/shared/lib/tokens.js
@@ -21,7 +21,9 @@ export const HP = {
   text: '#FAFAFA',
   textSoft: 'rgba(250,250,250,0.72)',
   textMuted: 'rgba(250,250,250,0.45)',
-  textFaint: 'rgba(250,250,250,0.28)',
+  // AA-large floor (~3.3:1). Was 0.28 ≈ 2.4:1, which failed AA outright across
+  // every feature surface's faint labels. Matches the landing's C.textFaint.
+  textFaint: 'rgba(250,250,250,0.40)',
   purple: '#A78BFA',
   purpleDeep: '#7C3AED',
   pink: '#EC4899',


### PR DESCRIPTION
A module-by-module pass down the user journey (visit → onboard → Discover → home → explore). Each surface was reviewed read-only first; this bundles the **safe** fixes. Subjective-feel + risky changes were **held for a preview eyeball** (listed at the bottom).

## ⚠️ Before merging — verify ONE thing on the preview
The **OAuth no-reload** change (`c6727c7f`) can't be exercised in CI (the dev test user is password-based, not Google). **Please sign in with a real Google account on this PR's preview deploy** and confirm it lands on `/home` (or `/onboarding` for a new user) smoothly — no blank flash, no loop. Everything else is CI-covered.

## Commits
- **`c6727c7f` auth** — sign-in no longer hard-reloads (`main.jsx` mounts directly after `setSession` instead of `window.location.replace`); one shared `deriveOnboardingStatus` helper for the callback + gate + onboarding (+9 unit tests, kills a camelCase redirect-flicker); `PostAuthGate` shows `<BrandSplash>` not a black flash.
- **`17bfbca6` onboarding** — onboarding gate uses the shared helper; 6 contradictory `not-italic … italic` accents fixed; stale "/home" docs corrected to `/discover`.
- **`2f3e2692` home** — removed a redundant render-blocking font `@import`; de-suffixed `HomeV2Body`→`HomeBody`, `.ff-home-v2`→`.ff-home`, swept v2 comments.
- **`6081e965` discover** — removed the redundant font `@import`; `DiscoverV5Body`→`DiscoverBody` + v5/v4 comment sweep.
- **`ab8b3b58` movie** — removed the redundant font `@import`; `.ff-movie-v2`→`.ff-movie` + stale comments. **Preserved** `movie_detail_v2` analytics labels (renaming would split metrics).
- **`01bb0056` a11y** — raised the shared `HP.textFaint` faint tier 0.28 → 0.40 (was 2.4:1, failed AA) to an AA-large floor across 23 files. Visual-tested surfaces don't use it, so the gate's unaffected.

## What the review found (no fix needed)
The Briefing, the Film File (schema.org/Movie JSON-LD), Discover's mood→pick flow, and `useHomeData` perf are all genuinely strong. The recurring debt (font `@import` + version-suffix leftovers) was localised to home/discover/movie — the remaining surfaces (lists/profile/people/watchlist/history/account/preferences) were already clean.

## Held for your call (on the preview — not in this PR)
- Onboarding **12s celebration** hold (esp. reduced-motion) · onboarding **headline weights** (Inter-extrabold vs Outfit-light)
- Discover **CSS global leak** (scope to `.ff-discover`) · Discover **audio defaults ON** (recommend default-muted + persist)
- Hardcoded-hex sprawl in lists/people jsx

Gate: lint 0 · 417 tests · build · visual green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)