### PR TITLE
fix(discover): default the audio layer to muted + persist the choice

### DIFF
--- a/src/features/discover/Discover.jsx
+++ b/src/features/discover/Discover.jsx
@@ -22,7 +22,15 @@ import './discover.css'
 const FFAudio = (() => {
   let ctx = null;
   let masterGain = null;
-  let muted = false;
+  // Audio defaults to MUTED. Auto-playing sound on a web app is jarring (quiet or
+  // public settings) and off-brand for a calm, considered pick — users opt in via
+  // the AudioToggle, and the choice persists across visits.
+  const MUTED_KEY = 'ff_discover_muted';
+  const readMutedPref = () => {
+    try { const v = localStorage.getItem(MUTED_KEY); return v === null ? true : v === '1'; }
+    catch { return true; }
+  };
+  let muted = readMutedPref();
   function ensure() {
     if (ctx) return ctx;
     try {
@@ -65,7 +73,11 @@ const FFAudio = (() => {
       osc.connect(g); g.connect(masterGain); osc.start(t + i*0.06); osc.stop(t + 2.7);
     });
   }
-  function setMuted(v) { muted = v; if (masterGain) masterGain.gain.value = v ? 0 : 0.45; }
+  function setMuted(v) {
+    muted = v;
+    if (masterGain) masterGain.gain.value = v ? 0 : 0.45;
+    try { localStorage.setItem(MUTED_KEY, v ? '1' : '0'); } catch { /* private mode — non-fatal */ }
+  }
   function isMuted() { return muted; }
   return { pluck, whoom, chord, setMuted, isMuted };
 })();


### PR DESCRIPTION
Acting on the held Discover-audio item. The web-audio cue layer defaulted **ON** (`muted = false`) and wasn't remembered — after a user clicked *Begin*, the first stage transition played sound at 0.45 gain they never opted into (jarring in quiet/public settings, off-brand for a *calm, considered pick*), and every visit reset to unmuted.

→ Defaults to **muted**, opt-in via the existing toggle, and **persists** the choice (`localStorage 'ff_discover_muted'`). The immersive sound is one tap away for anyone who wants it.

*Held the other Discover item — the CSS global leak — deliberately: fixing it right means scoping styles to a `.ff-discover` wrapper, and Discover has no visual baseline to verify against. Not worth gambling on the app's most hand-tuned surface for a minor leak; it stays flagged for a preview-verified follow-up.*

lint 0 · 417 tests · build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)