### PR TITLE
fix: the held items — discover CSS leak, onboarding type, lists token

### DIFF
--- a/src/features/discover/Discover.jsx
+++ b/src/features/discover/Discover.jsx
@@ -1887,7 +1887,7 @@ function DiscoverBody() {
   }, [selected, time, who, energy, intention, films, profile, recentSaves]);
 
   return (
-    <div style={{ minHeight:'100vh', background:HP.bgDeep, color:HP.text, fontFamily:'Inter, sans-serif', position:'relative', overflow:'hidden' }}>
+    <div className="ff-discover" style={{ minHeight:'100vh', background:HP.bgDeep, color:HP.text, fontFamily:'Inter, sans-serif', position:'relative', overflow:'hidden' }}>
       <Starfield tint={blendHex} />
       <div style={{ position:'relative', zIndex:1, maxWidth:1440, margin:'0 auto' }}>
         {stage === 0   && <StageHero onBegin={()=>setStage(1)} onSurprise={()=>{ setSelected(['slow','tender']); FFAudio.whoom(); setStage(2.3); }} />}

--- a/src/features/discover/discover.css
+++ b/src/features/discover/discover.css
@@ -1,14 +1,17 @@
 /* Discover — scoped animations + base. Outfit + Inter load globally via index.html
-   (no per-page @import — it's render-blocking + slower than the global <link>). */
+   (no per-page @import — it's render-blocking + slower than the global <link>).
+ *
+ * Base/button/selection rules are SCOPED to .ff-discover (the DiscoverBody root)
+ * so this lazy chunk no longer leaks globals app-wide once /discover is visited.
+ * The page base (dark bg, Inter, box-sizing) already comes from index.css +
+ * Tailwind preflight + the DiscoverBody root's own inline styles — no global
+ * resets needed here. */
 
-* { box-sizing: border-box; }
-html, body, #root { margin:0; padding:0; min-height:100%; background:#06060a; }
-body { font-family:'Inter', sans-serif; color:#fafafa; -webkit-font-smoothing:antialiased; }
-em { font-style: italic; }
-button { font-family: inherit; transition: filter 0.18s ease; }
-button:hover:not(:disabled) { filter: brightness(1.12); }
-blockquote { quotes: "\201C" "\201D"; }
-::selection { background: rgba(167,139,250,0.4); }
+.ff-discover em { font-style: italic; }
+.ff-discover button { font-family: inherit; transition: filter 0.18s ease; }
+.ff-discover button:hover:not(:disabled) { filter: brightness(1.12); }
+.ff-discover blockquote { quotes: "\201C" "\201D"; }
+.ff-discover ::selection { background: rgba(167,139,250,0.4); }
 
 @keyframes ff-fade { from { opacity:0; transform: translateY(8px); } to { opacity:1; transform: translateY(0); } }
 @keyframes ff-fade-late { 0%, 30% { opacity:0; } 100% { opacity:0.9; } }

--- a/src/features/lists/Lists.jsx
+++ b/src/features/lists/Lists.jsx
@@ -138,7 +138,7 @@ function ListCard({ list, kind, onOpen }) {
               </div>
             )}
             {kind === 'followed' && list.by && (
-              <div style={{ width: 30, height: 30, borderRadius: 999, background: list.byBg, display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: 'Outfit', fontWeight: 700, color: '#0a0510', fontSize: 13, border: '2px solid #06060a' }}>
+              <div style={{ width: 30, height: 30, borderRadius: 999, background: list.byBg, display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: 'Outfit', fontWeight: 700, color: '#0a0510', fontSize: 13, border: `2px solid ${HP.bgDeep}` }}>
                 {list.by.charAt(0).toUpperCase()}
               </div>
             )}

--- a/src/features/onboarding/Onboarding.jsx
+++ b/src/features/onboarding/Onboarding.jsx
@@ -613,7 +613,7 @@ function CelebrationReveal({ moods, selectedGenres, favoriteMovies, ratings, fad
           className="mt-12"
         >
           <h1
-            className="ob-display text-4xl font-extrabold leading-[1.05] text-white sm:text-5xl md:text-6xl"
+            className="ob-display text-4xl font-normal leading-[1.05] text-white sm:text-5xl md:text-6xl"
             style={{ textWrap: 'balance', letterSpacing: '-0.02em' }}
           >
             Tonight is{' '}

--- a/src/features/onboarding/onboarding.css
+++ b/src/features/onboarding/onboarding.css
@@ -1,9 +1,9 @@
 /* src/features/onboarding/onboarding.css
- * Scoped to .onboarding — Outfit display font + a tidy custom scrollbar.
- * Tailwind utilities still apply; this file only adds what Tailwind can't express tersely.
+ * Scoped to .onboarding — the Outfit display family + a tidy custom scrollbar.
+ * Outfit + Inter load globally via index.html (no per-page @import — it's
+ * render-blocking + slower than the global <link>). Tailwind utilities still
+ * apply; this file only adds what Tailwind can't express tersely.
  */
-
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&display=swap');
 
 .onboarding .ob-display {
   font-family: 'Outfit', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;

--- a/src/features/onboarding/steps/GenresStep.jsx
+++ b/src/features/onboarding/steps/GenresStep.jsx
@@ -55,7 +55,7 @@ export default function GenresStep({ selectedGenres, toggleGenre, onBack, onNext
           Genres · 2 of 4
         </p>
         <h2
-          className="ob-display text-[32px] sm:text-4xl md:text-5xl font-extrabold text-white leading-[1.05]"
+          className="ob-display text-[32px] sm:text-4xl md:text-5xl font-normal text-white leading-[1.05]"
           style={{ textWrap: 'balance' }}
         >
           Which{' '}

--- a/src/features/onboarding/steps/MoodStep.jsx
+++ b/src/features/onboarding/steps/MoodStep.jsx
@@ -27,7 +27,7 @@ export default function MoodStep({ moods, setMoods, onNext, firstName }) {
           {firstName ? `Hey ${firstName} —` : 'Mood baseline · 1 of 4'}
         </p>
         <h2
-          className="ob-display text-[32px] sm:text-4xl md:text-5xl font-extrabold text-white leading-[1.05]"
+          className="ob-display text-[32px] sm:text-4xl md:text-5xl font-normal text-white leading-[1.05]"
           style={{ textWrap: 'balance' }}
         >
           The vibe you{' '}

--- a/src/features/onboarding/steps/MoviesStep.jsx
+++ b/src/features/onboarding/steps/MoviesStep.jsx
@@ -414,7 +414,7 @@ export default function MoviesStep({
           Films · 3 of 4
         </p>
         <h2
-          className="ob-display text-[32px] sm:text-4xl md:text-5xl font-extrabold leading-[1.05] text-white"
+          className="ob-display text-[32px] sm:text-4xl md:text-5xl font-normal leading-[1.05] text-white"
           style={{ textWrap: 'balance' }}
         >
           What have you{' '}

--- a/src/features/onboarding/steps/RatingStep.jsx
+++ b/src/features/onboarding/steps/RatingStep.jsx
@@ -112,7 +112,7 @@ export default function RatingStep({ favoriteMovies, ratings, onRate, onBack, on
           Rate · 4 of 4 · {allRated ? 'all done' : `${remaining} to go`}
         </p>
         <h2
-          className="ob-display text-[30px] font-extrabold leading-[1.05] text-white sm:text-4xl md:text-5xl"
+          className="ob-display text-[30px] font-normal leading-[1.05] text-white sm:text-4xl md:text-5xl"
           style={{ textWrap: 'balance' }}
         >
           {allRated ? (
@@ -356,7 +356,7 @@ function FilmCard({ movie }) {
       />
       <div className="pointer-events-none absolute inset-x-0 bottom-0 h-32 bg-linear-to-t from-black/90 via-black/50 to-transparent" />
       <div className="pointer-events-none absolute inset-x-5 bottom-4">
-        <div className="ob-display text-xl font-extrabold tracking-tight text-white drop-shadow-[0_2px_8px_rgba(0,0,0,0.6)] sm:text-2xl">
+        <div className="ob-display text-xl font-semibold tracking-tight text-white drop-shadow-[0_2px_8px_rgba(0,0,0,0.6)] sm:text-2xl">
           {movie.title}
         </div>
         {year && <div className="text-xs text-white/75 drop-shadow-[0_1px_4px_rgba(0,0,0,0.6)]">{year}</div>}


### PR DESCRIPTION
Worked through the three held items — now that I can verify surfaces via a real FeelFlick dev server + screenshots, the "can't check blind" blocker is gone.

### 1. Discover CSS global leak → scoped (`8a…` commit)
`discover.css` declared unscoped `*` / `body` / `button:hover{filter:brightness}` / `::selection` that leaked app-wide once `/discover` lazy-loaded. Removed the redundant resets (page base already comes from index.css + Tailwind + the DiscoverBody root) and **scoped the rest to `.ff-discover`**. **Verified `/discover` renders pixel-identically** before/after (only the randomized starfield differs); the leak's gone since the selectors now need the `.ff-discover` ancestor.

### 2. Onboarding type → editorial
Headlines went `font-extrabold` (Outfit 800 — generic-bold, a different brand than the airy landing) → **`font-normal` (Outfit 400)**. **Verified side-by-side**: 400 is clearly more on-brand, italic gradient accent popping against the light roman. Targeted only the `ob-display` headlines (badges keep their weight; the movie-title-over-poster → `font-semibold` for legibility). Also removed onboarding.css's **redundant font `@import`**.
*Left the 12s celebration hold unchanged — the comment shows it's an a11y decision (coaching-beat reading time for dyslexic users); trimming would regress it. A skip affordance is the right enhancement, as a focused follow-up.*

### 3. Lists hex → token
Mostly a non-issue: the lists hex is legitimate **data** (gradient-cover pairs + avatar palette, which the design system allows). The single token-literal — a `#06060a` avatar ring — is now **`HP.bgDeep`**. Value-preserving.

Gate: lint 0 · 417 tests · build green. Discover + onboarding verified visually on a real dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)