### PR TITLE
refactor(ui): canonical MatchBadge — consolidate the match % indicator (Phase 1a)

### DIFF
--- a/src/features/home/sections-top.jsx
+++ b/src/features/home/sections-top.jsx
@@ -1,15 +1,16 @@
 // Home — top sections (Masthead, Mood Reactor, The Briefing 3-up).
 // All film data comes from useHomeData (no more imports from data.js for FILMS).
 
-import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { ChevronLeft, ChevronRight, SkipForward, Loader2, RefreshCw } from 'lucide-react'
-import { HP, HP_GRAD, MOOD_META } from './data'
-import { SmartImg } from './atoms'
-import { useHomeData } from './useHomeData'
+import MatchBadge from '@/shared/components/MatchBadge'
 import { useUserMovieStatus } from '@/shared/hooks/useUserMovieStatus'
 import { getMovieWatchProviders } from '@/shared/api/tmdb'
 import { logSurfaceImpressions } from '@/shared/services/recommendations'
+import { HP, HP_GRAD, MOOD_META } from './data'
+import { SmartImg } from './atoms'
+import { useHomeData } from './useHomeData'
 
 // Static slot labels — one per position in the 3-card briefing row.
 // Same across moods (functional, not flavor): position 0 is the engine's
@@ -87,49 +88,6 @@ export function MoodReactor({ currentMood, setMood, onReshuffle }) {
         </div>
       </div>
     </section>
-  )
-}
-
-// Animated match ring — mirrors MatchRing from movie/sections-top.jsx.
-// SVG with a gradient circle stroke that fills from 0 → pct over 1.4s
-// (stroke-dasharray transition), and the percentage number tweens from 0
-// → pct via setTimeout(setV). Unique gradient id per instance via useId
-// so multiple rings on the same page don't share `id="ring"`.
-function MatchRing({ pct, size = 72 }) {
-  const id = useId()
-  const gradId = `match-ring-${id.replace(/:/g, '')}`
-  const [v, setV] = useState(0)
-  useEffect(() => {
-    const t = setTimeout(() => setV(pct || 0), 250)
-    return () => clearTimeout(t)
-  }, [pct])
-  const dash = v * 0.943  // 0..100 → 0..94.3, matching SVG circle r=15 circumference
-  return (
-    <div
-      style={{
-        position: 'absolute', bottom: 14, right: 14,
-        width: size, height: size, borderRadius: 999,
-        background: 'rgba(0,0,0,0.85)', backdropFilter: 'blur(12px)',
-        boxShadow: '0 12px 28px -6px rgba(0,0,0,0.6)',
-      }}
-    >
-      <svg viewBox="0 0 36 36" style={{ width: '100%', height: '100%', transform: 'rotate(-90deg)' }}>
-        <circle cx="18" cy="18" r="15" fill="none" stroke="rgba(255,255,255,0.08)" strokeWidth="2.5" />
-        <circle cx="18" cy="18" r="15" fill="none" stroke={`url(#${gradId})`} strokeWidth="2.5" strokeDasharray={`${dash} 100`} strokeLinecap="round" style={{ transition: 'stroke-dasharray 1.4s cubic-bezier(0.2,0.8,0.2,1)' }} />
-        <defs>
-          <linearGradient id={gradId} x1="0" y1="0" x2="1" y2="0">
-            <stop offset="0%" stopColor={HP.purple} />
-            <stop offset="100%" stopColor={HP.pink} />
-          </linearGradient>
-        </defs>
-      </svg>
-      <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
-        <span style={{ fontFamily: 'Outfit', fontSize: Math.round(size * 0.31), fontWeight: 300, color: HP.text, letterSpacing: '-0.04em', lineHeight: 1 }}>
-          {v}<span style={{ fontSize: Math.round(size * 0.16), color: HP.textMuted, marginLeft: 1 }}>%</span>
-        </span>
-        <span style={{ fontSize: Math.round(size * 0.095), fontWeight: 700, color: HP.purple, letterSpacing: '0.18em', textTransform: 'uppercase', marginTop: 2 }}>Match</span>
-      </div>
-    </div>
   )
 }
 
@@ -343,10 +301,10 @@ function BriefingSlide({ film, idx, matchPct, user, onWatch, onSkip, onMarkedWat
         <div style={{ position: 'absolute', top: 14, right: 14, padding: '4px 9px', borderRadius: 4, background: 'rgba(0,0,0,0.55)', backdropFilter: 'blur(10px)', fontSize: 10, fontWeight: 600, color: HP.textSoft, letterSpacing: '0.16em', textTransform: 'uppercase', fontFamily: 'Outfit' }}>
           0{idx + 1}
         </div>
-        {/* Animated MatchRing — sized to feel proportionate against the
+        {/* Animated match ring — sized to feel proportionate against the
             smallest poster width (200px mobile); still reads at lg (340px). */}
         {Number.isFinite(matchPct) && matchPct > 0 && (
-          <MatchRing pct={matchPct} size={60} />
+          <MatchBadge variant="ring" pct={matchPct} size={60} style={{ bottom: 14, right: 14 }} />
         )}
       </button>
 

--- a/src/features/landing/Landing.jsx
+++ b/src/features/landing/Landing.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { useGoogleAuth } from '@/shared/hooks/useGoogleAuth'
 import { usePageMeta } from '@/shared/hooks/usePageMeta'
+import MatchBadge from '@/shared/components/MatchBadge'
 import { C, HP_GRAD as GRAD } from '@/shared/lib/tokens'
 import './landing.css'
 // Posters render at <=240px wide on the landing — w342 is the right TMDB size.
@@ -524,7 +525,7 @@ function Briefing(){
                     <div style={{width:'100%',aspectRatio:'2/3',borderRadius:5,boxShadow:'0 20px 40px -16px rgba(0,0,0,0.7)',overflow:'hidden'}}>
                       <Poster src={p.poster} title={p.title} accent={p.moodHex} style={{width:'100%',height:'100%',objectFit:'cover',display:'block'}}/>
                     </div>
-                    <div style={{position:'absolute',top:10,left:10,padding:'4px 8px',borderRadius:3,background:'rgba(0,0,0,0.78)',backdropFilter:'blur(8px)',border:`1px solid ${p.moodHex}44`,fontFamily:'Outfit',fontSize:9.5,fontWeight:700,color:p.moodHex,letterSpacing:'0.06em'}}>{[94,88,82][i]}% MATCH</div>
+                    <MatchBadge variant="pill" pct={[94,88,82][i]} accent={p.moodHex} />
                   </div>
                   <div className="ff-eyebrow" style={{color:p.moodHex,marginBottom:9}}>0{i+1} · {['Tonight\'s pick','Mood match','From your DNA'][i]}</div>
                   <h3 style={{fontFamily:'Outfit',fontSize:22,fontWeight:400,color:C.text,margin:'0 0 6px 0',letterSpacing:'-0.02em'}}>{p.title}</h3>

--- a/src/features/movie/sections-bottom.jsx
+++ b/src/features/movie/sections-bottom.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { tmdbImg } from '@/shared/api/tmdb'
+import MatchBadge from '@/shared/components/MatchBadge'
 import { FILM_PALETTE, TIMELINE, DNA_DELTA, HP, HP_GRAD } from './data'
 import { useMovieData } from './useMovieData'
 import { useUserRating } from './hooks/useUserRating'
@@ -259,9 +260,7 @@ function PairsWith({ goToMovie }) {
                   is in our catalog AND the engine produced a score. Films
                   off-catalog show no badge (instead of a fabricated number). */}
               {Number.isFinite(s.match) && (
-                <div style={{ position:'absolute', top:10, left:10, padding:'4px 8px', borderRadius:3, background:'rgba(0,0,0,0.85)', backdropFilter:'blur(8px)', border:'1px solid rgba(167,139,250,0.35)', fontSize:9, fontWeight:700, color: HP.purple, fontFamily:'Outfit', letterSpacing:'0.08em' }}>
-                  {s.match}% MATCH
-                </div>
+                <MatchBadge variant="pill" pct={s.match} />
               )}
             </div>
             <div style={{ fontFamily:'Outfit', fontSize:17, fontWeight:500, color: HP.text, letterSpacing:'-0.015em' }}>{s.title}</div>

--- a/src/features/movie/sections-top.jsx
+++ b/src/features/movie/sections-top.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import Tooltip from '@/shared/ui/Tooltip'
+import MatchBadge from '@/shared/components/MatchBadge'
 import { FILM_PALETTE, HP, HP_GRAD } from './data'
 import { useMovieData } from './useMovieData'
 
@@ -214,7 +215,15 @@ function MovieHero({
               ? <img src={mv.poster} alt={mv.title} style={{ width:'100%', display:'block', borderRadius:8, boxShadow:`0 36px 100px -20px rgba(0,0,0,0.95), 0 0 0 1px rgba(255,255,255,0.06), 0 0 60px ${FILM_PALETTE.primary}44` }} />
               : <div style={{ width:'100%', aspectRatio:'2/3', borderRadius:8, background:`linear-gradient(155deg, ${FILM_PALETTE.primary}55, ${FILM_PALETTE.glow}33)`, display:'flex', alignItems:'center', justifyContent:'center', color:HP.text, fontFamily:'Outfit', fontSize:24, padding:24, textAlign:'center', boxShadow:`0 36px 100px -20px rgba(0,0,0,0.95), 0 0 0 1px rgba(255,255,255,0.06)` }}>{mv.title}</div>
             }
-            {Number.isFinite(mv.ffMatch) && <MatchRing pct={mv.ffMatch} />}
+            {Number.isFinite(mv.ffMatch) && (
+              <MatchBadge
+                variant="ring"
+                pct={mv.ffMatch}
+                size={96}
+                style={{ bottom: -22, right: -22, boxShadow: '0 16px 40px -8px rgba(0,0,0,0.7)' }}
+                classes={{ root: 'ff-movie-match-ring', num: 'ff-movie-match-ring-num', pct: 'ff-movie-match-ring-pct', label: 'ff-movie-match-ring-label' }}
+              />
+            )}
           </div>
         </div>
 
@@ -335,27 +344,6 @@ function MovieHero({
   );
 }
 
-function MatchRing({ pct }) {
-  const [v, setV] = useState(0);
-  useEffect(() => {
-    const t = setTimeout(() => setV(pct), 250);
-    return () => clearTimeout(t);
-  }, [pct]);
-  const dash = v * 0.943;
-  return (
-    <div className="ff-movie-match-ring" style={{ position:'absolute', bottom:-22, right:-22, width:96, height:96, borderRadius:999, background:'rgba(0,0,0,0.85)', backdropFilter:'blur(12px)', boxShadow:'0 16px 40px -8px rgba(0,0,0,0.7)' }}>
-      <svg viewBox="0 0 36 36" style={{ width:'100%', height:'100%', transform:'rotate(-90deg)' }}>
-        <circle cx="18" cy="18" r="15" fill="none" stroke="rgba(255,255,255,0.08)" strokeWidth="2.5" />
-        <circle cx="18" cy="18" r="15" fill="none" stroke="url(#ring)" strokeWidth="2.5" strokeDasharray={`${dash} 100`} strokeLinecap="round" style={{ transition:'stroke-dasharray 1.4s cubic-bezier(0.2,0.8,0.2,1)' }} />
-        <defs><linearGradient id="ring" x1="0" y1="0" x2="1" y2="0"><stop offset="0%" stopColor={HP.purple}/><stop offset="100%" stopColor={HP.pink}/></linearGradient></defs>
-      </svg>
-      <div style={{ position:'absolute', inset:0, display:'flex', flexDirection:'column', alignItems:'center', justifyContent:'center' }}>
-        <span className="ff-movie-match-ring-num" style={{ fontFamily:'Outfit', fontSize:30, fontWeight:300, color: HP.text, letterSpacing:'-0.04em', lineHeight:1 }}>{v}<span className="ff-movie-match-ring-pct" style={{ fontSize:13, color: HP.textMuted, marginLeft:1 }}>%</span></span>
-        <span className="ff-movie-match-ring-label" style={{ fontSize:8, fontWeight:700, color: HP.purple, letterSpacing:'0.18em', textTransform:'uppercase', marginTop:2 }}>Match</span>
-      </div>
-    </div>
-  );
-}
 
 function MarkWatchedButton({ isWatched, onToggleWatched, loading, canAct }) {
   const wasWatchedRef = useRef(isWatched);

--- a/src/shared/components/MatchBadge.jsx
+++ b/src/shared/components/MatchBadge.jsx
@@ -1,0 +1,96 @@
+// src/shared/components/MatchBadge.jsx
+import { useEffect, useId, useState } from 'react'
+import { HP } from '@/shared/lib/tokens'
+
+/**
+ * Canonical "% match" indicator — ONE source of truth for what was previously
+ * reimplemented as two near-identical `MatchRing` copies (home + movie) plus
+ * inline "X% MATCH" overlay pills (landing + movie/similar). Extracted in the
+ * consistency refactor so the match indicator can be perfected in one place.
+ *
+ * Variants:
+ *   • `ring`  — animated SVG progress ring (the corner medallion on a poster).
+ *   • `pill`  — compact "X% MATCH" overlay chip (top-left of a poster).
+ *
+ * The accent stays a prop because it's legitimately contextual (brand purple on
+ * /movie + /home; the mood hex on the landing's mood-tinted example cards).
+ *
+ * @param {object}  props
+ * @param {number}  props.pct      0–100 match percentage.
+ * @param {'ring'|'pill'} [props.variant='ring']
+ * @param {number}  [props.size=72]        Ring diameter in px (ring only).
+ * @param {string}  [props.accent]         Primary accent (gradient start + label / pill text+border).
+ * @param {string}  [props.accent2]        Gradient end (ring only).
+ * @param {object}  [props.style]          Merged onto the root — use for positioning + shadow overrides.
+ * @param {object}  [props.classes]        Optional { root, num, pct, label } class hooks for responsive CSS (ring only).
+ * @returns {JSX.Element|null}
+ */
+export default function MatchBadge({ variant = 'ring', ...props }) {
+  if (variant === 'pill') return <MatchPill {...props} />
+  return <MatchRing {...props} />
+}
+
+function MatchRing({
+  pct,
+  size = 72,
+  accent = HP.purple,
+  accent2 = HP.pink,
+  style,
+  classes = {},
+}) {
+  const id = useId()
+  const gradId = `match-ring-${id.replace(/:/g, '')}` // unique per instance — no #ring collisions
+  const [v, setV] = useState(0)
+  useEffect(() => {
+    const t = setTimeout(() => setV(pct || 0), 250)
+    return () => clearTimeout(t)
+  }, [pct])
+  const dash = v * 0.943 // 0..100 → 0..94.3, matching the SVG circle r=15 circumference
+
+  return (
+    <div
+      className={classes.root}
+      style={{
+        position: 'absolute', width: size, height: size, borderRadius: 999,
+        background: 'rgba(0,0,0,0.85)', backdropFilter: 'blur(12px)',
+        boxShadow: '0 12px 28px -6px rgba(0,0,0,0.6)',
+        ...style,
+      }}
+    >
+      <svg viewBox="0 0 36 36" style={{ width: '100%', height: '100%', transform: 'rotate(-90deg)' }}>
+        <circle cx="18" cy="18" r="15" fill="none" stroke="rgba(255,255,255,0.08)" strokeWidth="2.5" />
+        <circle cx="18" cy="18" r="15" fill="none" stroke={`url(#${gradId})`} strokeWidth="2.5" strokeDasharray={`${dash} 100`} strokeLinecap="round" style={{ transition: 'stroke-dasharray 1.4s cubic-bezier(0.2,0.8,0.2,1)' }} />
+        <defs>
+          <linearGradient id={gradId} x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0%" stopColor={accent} />
+            <stop offset="100%" stopColor={accent2} />
+          </linearGradient>
+        </defs>
+      </svg>
+      <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
+        <span className={classes.num} style={{ fontFamily: 'Outfit', fontSize: Math.round(size * 0.31), fontWeight: 300, color: HP.text, letterSpacing: '-0.04em', lineHeight: 1 }}>
+          {v}<span className={classes.pct} style={{ fontSize: Math.round(size * 0.16), color: HP.textMuted, marginLeft: 1 }}>%</span>
+        </span>
+        <span className={classes.label} style={{ fontSize: Math.round(size * 0.095), fontWeight: 700, color: accent, letterSpacing: '0.18em', textTransform: 'uppercase', marginTop: 2 }}>Match</span>
+      </div>
+    </div>
+  )
+}
+
+function MatchPill({ pct, accent = HP.purple, style }) {
+  return (
+    <div
+      style={{
+        position: 'absolute', top: 10, left: 10,
+        padding: '4px 8px', borderRadius: 3,
+        background: 'rgba(0,0,0,0.78)', backdropFilter: 'blur(8px)',
+        border: `1px solid ${accent}44`,
+        fontFamily: 'Outfit', fontSize: 9.5, fontWeight: 700,
+        color: accent, letterSpacing: '0.06em',
+        ...style,
+      }}
+    >
+      {pct}% MATCH
+    </div>
+  )
+}


### PR DESCRIPTION
**Phase 1a of the consistency refactor** — first extracted block, proving the extract→migrate→verify pattern.

### The duplication (from the audit)
The "% match" indicator existed **~6 ways**: `MatchRing` defined **twice** (home + movie, near-identical) + inline "X% MATCH" pills (landing + movie/similar).

### The fix — one component, two variants
`shared/components/MatchBadge.jsx`:
- **`ring`** — the robust home version (size-proportional fonts, `accent` props, a per-instance gradient id via `useId` that **fixes the movie copy's hardcoded `id="ring"` collision bug**). Movie keeps its responsive mobile sizing through the `classes` prop (movie.css's `.ff-movie-match-ring-*` still apply).
- **`pill`** — one canonical, set to the **landing's exact values** so the landing visual-regression gate stays **pixel-identical**; movie/similar unifies onto it. `accent` stays a prop (brand purple on home/movie, the mood hex on the landing).

### Faithful, per the plan
This is a *faithful* extraction (no intended visual change) — consolidation now, canonical-look perfection later in Phase 3. **Verified on a real dev server**: the ring on /home's Briefing (authed), the pill on the landing's Briefing cards (anon) — both render unchanged.

### Next in Phase 1
`Button` (19 inline + 3 bespoke → shared `Button`), then `MoodPill` (~9), then the hover law.

Gate: lint 0 · 417 tests · build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)