### PR TITLE
refactor(ui): action-button canonical — separate look from layout (Phase 1b·2)

### DIFF
--- a/src/features/home/sections-top.jsx
+++ b/src/features/home/sections-top.jsx
@@ -100,6 +100,7 @@ export function MoodReactor({ currentMood, setMood, onReshuffle }) {
 function WatchedButton({ isWatched, loading, onClick }) {
   return (
     <SecondaryActionButton
+      collapse
       active={isWatched}
       loading={loading}
       onClick={onClick}
@@ -113,6 +114,7 @@ function WatchedButton({ isWatched, loading, onClick }) {
 function SaveButton({ isInWatchlist, loading, onClick }) {
   return (
     <SecondaryActionButton
+      collapse
       active={isInWatchlist}
       loading={loading}
       onClick={onClick}
@@ -128,6 +130,7 @@ function SaveButton({ isInWatchlist, loading, onClick }) {
 function SkipButton({ onClick }) {
   return (
     <SecondaryActionButton
+      collapse
       onClick={onClick}
       title="Skip — not tonight"
       label="Skip Tonight"
@@ -309,7 +312,7 @@ function BriefingSlide({ film, idx, matchPct, user, onWatch, onSkip, onMarkedWat
               hidden, icon only).
             • lg+: wrap row of four labeled pills (movie-detail style). */}
         <div className="flex flex-wrap items-center justify-center gap-2.5 pt-4 lg:justify-start" style={{ borderTop: `1px solid ${HP.border}` }}>
-          <ActionButton onClick={() => onWatch?.(film)}>
+          <ActionButton className="h-11 flex-1 lg:h-auto lg:flex-none" onClick={() => onWatch?.(film)}>
             <span>See More</span>
             <ChevronRight className="h-3.5 w-3.5" />
           </ActionButton>

--- a/src/shared/components/ActionButton.jsx
+++ b/src/shared/components/ActionButton.jsx
@@ -3,30 +3,32 @@ import { Loader2 } from 'lucide-react'
 import { HP, HP_GRAD } from '@/shared/lib/tokens'
 
 /**
- * Canonical in-card action buttons (rounded-8, Outfit) — the family used on the
- * /home Briefing and the /movie Film File, previously reimplemented inline on
- * each. Distinct from the shared <Button> (rounded-full CTA pill) by design:
- * this is the "act on this card" family, not the marketing CTA.
+ * Canonical in-card action buttons (rounded-8, Outfit 14) — the "act on this card"
+ * family shared by the /home Briefing and the /movie Film File. Distinct from the
+ * shared <Button> (rounded-full CTA pill) by design.
  *
- * <ActionButton>          — the gradient primary ("See More" / "Play trailer").
- * <SecondaryActionButton> — the equal-weight outline taps (Watched / Save / Skip)
- *                           that tint when `active`, show a spinner when `loading`,
- *                           and collapse to a 44×44 icon-only target on mobile.
+ * The component owns the LOOK (shape, font, colors, the active tint, states); each
+ * surface owns its LAYOUT (flex / width / mobile arrangement) via `className`, since
+ * the Briefing's 4-in-a-row and the Film File's 3-stack are legitimately different.
+ *
+ * <ActionButton>          — gradient primary ("See More" / "Play Trailer").
+ * <SecondaryActionButton> — outline Watched/Save/Skip taps. `active` tints to
+ *   `accent` (purple by default; /movie passes its film-palette colour); `collapse`
+ *   makes it a 44×44 icon-only target on mobile (for tight rows) → labeled on lg+.
  */
 
-// Secondary: 44×44 round icon-only on mobile → labeled rounded-8 pill on lg+.
-const SECONDARY_CLS =
-  'inline-flex h-11 w-11 flex-none items-center justify-center rounded-full transition-all duration-200 active:scale-[0.98] lg:h-auto lg:w-auto lg:flex-initial lg:gap-2.5 lg:whitespace-nowrap lg:rounded-lg lg:px-[22px] lg:py-[14px]'
+const BASE = 'inline-flex items-center justify-center gap-2.5 transition-all duration-200 active:scale-[0.98] disabled:cursor-not-allowed'
 
-export function ActionButton({ children, style, ...props }) {
+export function ActionButton({ className = '', style, children, ...props }) {
   return (
     <button
       type="button"
-      className="inline-flex h-11 flex-1 items-center justify-center gap-2.5 whitespace-nowrap rounded-lg px-4 transition-transform duration-200 active:scale-[0.98] lg:h-auto lg:flex-none lg:px-[22px] lg:py-[14px]"
+      className={`${BASE} rounded-lg ${className}`.trim()}
       style={{
         background: HP_GRAD, border: 'none', color: '#fff',
-        fontFamily: 'Outfit', fontSize: 13, fontWeight: 600, letterSpacing: '0.02em',
-        cursor: 'pointer', boxShadow: '0 12px 28px -8px rgba(236,72,153,0.5)',
+        fontFamily: 'Outfit', fontSize: 14, fontWeight: 600, letterSpacing: '0.02em',
+        padding: '14px 22px', cursor: 'pointer',
+        boxShadow: '0 12px 28px -8px rgba(236,72,153,0.5)',
         ...style,
       }}
       {...props}
@@ -36,26 +38,39 @@ export function ActionButton({ children, style, ...props }) {
   )
 }
 
-export function SecondaryActionButton({ active, loading = false, icon, label, style, ...props }) {
+export function SecondaryActionButton({
+  active,
+  loading = false,
+  icon,
+  label,
+  accent = HP.purple,
+  collapse = false,
+  className = '',
+  style,
+  ...props
+}) {
   const isActive = Boolean(active)
+  const layout = collapse
+    ? 'h-11 w-11 flex-none rounded-full lg:h-auto lg:w-auto lg:flex-initial lg:rounded-lg lg:px-[22px] lg:py-[14px]'
+    : 'rounded-lg px-[22px] py-[14px]'
   return (
     <button
       type="button"
       disabled={loading}
-      // Only a toggle (Watched/Save pass `active`); Skip omits it, so no aria-pressed.
+      // Only a toggle (Watched/Save pass `active`); Skip omits it → no aria-pressed.
       aria-pressed={active === undefined ? undefined : isActive}
-      className={SECONDARY_CLS}
+      className={`${BASE} ${layout} ${className}`.trim()}
       style={{
-        background: isActive ? 'rgba(167,139,250,0.18)' : 'rgba(255,255,255,0.06)',
-        border: `1px solid ${isActive ? HP.purple + '66' : HP.border}`,
-        color: HP.textSoft, fontFamily: 'Outfit', fontSize: 13, fontWeight: 500,
+        fontFamily: 'Outfit', fontSize: 14, fontWeight: 500, color: HP.textSoft,
+        background: isActive ? `${accent}2e` : 'rgba(255,255,255,0.06)',
+        border: `1px solid ${isActive ? `${accent}66` : HP.border}`,
         cursor: loading ? 'default' : 'pointer', opacity: loading ? 0.65 : 1,
         ...style,
       }}
       {...props}
     >
       {loading ? <Loader2 className="h-4 w-4 animate-spin lg:h-3.5 lg:w-3.5" /> : icon}
-      {label && <span className="hidden lg:inline">{label}</span>}
+      {label && <span className={collapse ? 'hidden lg:inline' : undefined}>{label}</span>}
     </button>
   )
 }


### PR DESCRIPTION
You confirmed the canonical action button (rounded-8 · Outfit 14 · gradient primary + outline secondaries · accent-as-prop). This adopts it.

**Re-architected `ActionButton`** so the component owns the **look** (shape, font, colors, active tint, states) and each surface owns its **layout** via `className` — the Briefing's 4-in-a-row collapse and the Film File's 3-stack are legit layout, not look.
- `<ActionButton>` — gradient primary; layout via `className`.
- `<SecondaryActionButton>` — outline Watched/Save/Skip; `active` tints to **`accent`** (purple default; movie will pass its film-palette colour), `collapse` = the 44×44 icon-only-on-mobile → labeled-on-lg behavior.

**Re-migrated `/home`** onto it (font 13 → canonical 14 — the unification). **Verified on a real dev server desktop *and* mobile** (collapse confirmed). `/movie` adopts the same canonical next, keeping its film-palette tint via `accent`.

Gate: lint 0 · 417 tests · build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)