### PR TITLE
refactor: fold mood markers (lists/history/watchlist) into MoodPill

### DIFF
--- a/src/features/history/History.jsx
+++ b/src/features/history/History.jsx
@@ -6,6 +6,7 @@
 import { useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { usePageMeta } from '@/shared/hooks/usePageMeta'
+import MoodPill from '@/shared/components/MoodPill'
 import { HP, HP_GRAD } from './data'
 import { HistoryDataProvider, useHistoryData } from './useHistoryData'
 import './history.css'
@@ -207,11 +208,7 @@ function DiaryGroup({ month, entries }) {
                     </div>
                     <div style={{ marginTop:8, display:'flex', alignItems:'center', gap:12, flexWrap:'wrap' }}>
                       <Stars n={e.rating} />
-                      {e.mood && e.mood !== 'Mixed' && (
-                        <span style={{ display:'inline-flex', alignItems:'center', gap:6, padding:'3px 9px', borderRadius:999, background:`${e.moodHex}1a`, border:`1px solid ${e.moodHex}44`, fontFamily:'Outfit', fontSize:11, color:e.moodHex }}>
-                          <span style={{ width:6, height:6, borderRadius:999, background:e.moodHex }} />{e.mood}
-                        </span>
-                      )}
+                      {e.mood && e.mood !== 'Mixed' && <MoodPill label={e.mood} color={e.moodHex} dot />}
                     </div>
                     {e.note && (
                       <p style={{ margin:'14px 0 0 0', fontSize:14, lineHeight:1.55, color:HP.textSoft, fontFamily:'Outfit, Inter, sans-serif', fontStyle:'italic', borderLeft:`2px solid ${e.moodHex}55`, paddingLeft:14, textWrap:'pretty' }}>

--- a/src/features/lists/ListDetail.jsx
+++ b/src/features/lists/ListDetail.jsx
@@ -11,6 +11,7 @@ import { useAuthSession } from '@/shared/hooks/useAuthSession'
 import { usePageMeta } from '@/shared/hooks/usePageMeta'
 import { tmdbImg } from '@/shared/api/tmdb'
 import CreateListModal from '@/features/lists/CreateListModal'
+import MoodPill from '@/shared/components/MoodPill'
 import './lists.css'
 
 import { HP, HP_GRAD } from '@/shared/lib/tokens'
@@ -410,11 +411,7 @@ export default function ListDetail() {
                       <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
                         <span style={{ fontFamily: 'Outfit', fontSize: 18, fontWeight: 500, color: HP.text, letterSpacing: '-0.015em' }}>{f.title}</span>
                         <span style={{ fontSize: 11, color: HP.textMuted, fontFamily: 'Outfit' }}>{f.year}{f.year && f.dir && ' · '}{f.dir}</span>
-                        {f.mood && (
-                          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '2px 8px', borderRadius: 999, background: 'rgba(167,139,250,0.10)', border: '1px solid rgba(167,139,250,0.30)', fontSize: 10, color: HP.purple, fontFamily: 'Outfit' }}>
-                            <span style={{ width: 5, height: 5, borderRadius: 999, background: HP.purple }} />{f.mood}
-                          </span>
-                        )}
+                        {f.mood && <MoodPill label={f.mood} dot />}
                       </div>
                       {f.note && (
                         <p style={{ margin: '6px 0 0 0', fontSize: 13, lineHeight: 1.55, color: HP.textSoft, fontFamily: 'Outfit, Inter, sans-serif', fontStyle: 'italic', textWrap: 'pretty' }}>

--- a/src/features/lists/Lists.jsx
+++ b/src/features/lists/Lists.jsx
@@ -10,6 +10,7 @@ import { usePageMeta } from '@/shared/hooks/usePageMeta'
 import { useAuthSession } from '@/shared/hooks/useAuthSession'
 import CreateListModal from '@/features/lists/CreateListModal'
 import { ActionButton } from '@/shared/components/ActionButton'
+import MoodPill from '@/shared/components/MoodPill'
 import './lists.css'
 import { ListsDataProvider, useListsData } from './useListsData'
 
@@ -330,11 +331,7 @@ function FeaturedOpen() {
                 <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
                   <span style={{ fontFamily: 'Outfit', fontSize: 18, fontWeight: 500, color: HP.text, letterSpacing: '-0.015em' }}>{f.title}</span>
                   <span style={{ fontSize: 11, color: HP.textMuted, fontFamily: 'Outfit' }}>{f.year}{f.year && ' · '}{f.dir}</span>
-                  {f.mood && f.mood !== 'Mixed' && (
-                    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '2px 8px', borderRadius: 999, background: 'rgba(167,139,250,0.10)', border: '1px solid rgba(167,139,250,0.30)', fontSize: 10, color: HP.purple, fontFamily: 'Outfit' }}>
-                      <span style={{ width: 5, height: 5, borderRadius: 999, background: HP.purple }} />{f.mood}
-                    </span>
-                  )}
+                  {f.mood && f.mood !== 'Mixed' && <MoodPill label={f.mood} dot />}
                 </div>
                 {f.note && (
                   <p style={{ margin: '6px 0 0 0', fontSize: 13, lineHeight: 1.55, color: HP.textSoft, fontFamily: 'Outfit, Inter, sans-serif', fontStyle: 'italic', textWrap: 'pretty' }}>&ldquo;{f.note}&rdquo;</p>

--- a/src/features/watchlist/Watchlist.jsx
+++ b/src/features/watchlist/Watchlist.jsx
@@ -8,6 +8,7 @@
 import { useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { usePageMeta } from '@/shared/hooks/usePageMeta'
+import MoodPill from '@/shared/components/MoodPill'
 import { HP, HP_GRAD } from './data'
 import { WatchlistDataProvider, useWatchlistData } from './useWatchlistData'
 import './watchlist.css'
@@ -299,9 +300,7 @@ function List({ items }) {
                 {f.year || '—'}{f.runtime ? ` · ${f.runtime}m` : ''}{f.dir && f.dir !== '—' ? ` · ${f.dir}` : ''} · added {f.addedDaysAgo}d ago
               </div>
             </div>
-            <div style={{ display:'inline-flex', alignItems:'center', gap:6, padding:'4px 10px', borderRadius:999, background:`${f.hex}1a`, border:`1px solid ${f.hex}44`, fontFamily:'Outfit', fontSize:11, fontWeight:500, color:f.hex }}>
-              <span style={{ width:6, height:6, borderRadius:999, background:f.hex }} />{f.mood}
-            </div>
+            <MoodPill label={f.mood} color={f.hex} dot />
             <div style={{ fontFamily:'Outfit', fontSize:18, fontWeight:300, color:HP.text, letterSpacing:'-0.03em' }}>{f.match}<span style={{ fontSize:10, color:HP.textMuted, marginLeft:1 }}>%</span></div>
             <button
               type="button"

--- a/src/shared/components/MoodPill.jsx
+++ b/src/shared/components/MoodPill.jsx
@@ -15,10 +15,12 @@ import { HP } from '@/shared/lib/tokens'
  * @param {'solid'|'overlay'} [props.variant='solid']
  *   • solid   — tinted pill (`${color}1a` bg / `${color}44` border / color text).
  *   • overlay — same pill on a dark blurred bg, for legibility over a poster.
+ * @param {boolean} [props.dot=false]       Prefix a small colour dot inside the pill
+ *   (the lists / history / watchlist "diary" marker style).
  * @param {object} [props.style]            Merged onto the root (positioning / margins).
  * @returns {JSX.Element|null}
  */
-export default function MoodPill({ label, color = HP.purple, variant = 'solid', style, ...props }) {
+export default function MoodPill({ label, color = HP.purple, variant = 'solid', dot = false, style, ...props }) {
   if (!label) return null
 
   const overlay = variant === 'overlay'
@@ -35,6 +37,7 @@ export default function MoodPill({ label, color = HP.purple, variant = 'solid', 
       }}
       {...props}
     >
+      {dot && <span style={{ width: 6, height: 6, borderRadius: 999, background: color, flex: 'none' }} />}
       {label}
     </span>
   )


### PR DESCRIPTION
## What
Completes the **MoodPill** consolidation (follow-up to #160). The lists / list-detail / history / watchlist diary rows each hand-rolled a tinted pill with a leading colour dot (Outfit) — the same indicator, drifted four ways (5px vs 6px dot, 2-8 vs 4-10 padding, 10 vs 11px, w500 vs w600, always-purple vs mood-hex).

Added a `dot` prop to the canonical `MoodPill` and routed all four through it:
- **lists / list-detail** → `<MoodPill label={f.mood} dot />` (brand purple)
- **history** → `<MoodPill label color={e.moodHex} dot />` (mood hex)
- **watchlist** → `<MoodPill label color={f.hex} dot />` (mood hex)

They adopt the canonical 3px-9px / 11px / 600 sizing and **Inter** face — Inter is the design-system face for micro-labels, so this also fixes four off-spec Outfit usages.

## Verify
- lint clean · test 417 ✓ · build ✓
- Authed: red "● Tense" on `/history` (mood-hex), purple "● Tense" on a `/lists/:id` detail (default purple), both with the leading dot. Watchlist shares history's exact code path.

Gated surfaces — not in the `/` + `/about` visual set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)