### PR TITLE
refactor(lists): canonical ChipButton for the standalone gradient chips

### DIFF
--- a/src/features/lists/CuratedList.jsx
+++ b/src/features/lists/CuratedList.jsx
@@ -7,9 +7,10 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { supabase } from '@/shared/lib/supabase/client'
 import { usePageMeta } from '@/shared/hooks/usePageMeta'
 import { CURATED_LISTS } from '@/shared/lib/curatedLists'
+import { ChipButton } from '@/shared/components/ActionButton'
 import './lists.css'
 
-import { HP, HP_GRAD } from '@/shared/lib/tokens'
+import { HP } from '@/shared/lib/tokens'
 const RESET_BTN = { background: 'none', border: 'none', padding: 0, margin: 0, font: 'inherit', color: 'inherit', cursor: 'pointer', textAlign: 'left' }
 
 const TMDB_IMG = (path, size = 'w342') => path ? `https://image.tmdb.org/t/p/${size}${path}` : null
@@ -131,13 +132,9 @@ function NotFound({ onBack }) {
       <div style={{ textAlign: 'center', maxWidth: 520 }}>
         <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.28em', textTransform: 'uppercase', color: HP.purple, marginBottom: 18 }}>Curated · 404</div>
         <h1 style={{ fontFamily: 'Outfit', fontSize: 40, fontWeight: 500, color: HP.text, margin: '0 0 18px 0', letterSpacing: '-0.025em' }}>That shelf doesn&rsquo;t exist.</h1>
-        <button
-          type="button"
-          onClick={onBack}
-          style={{ padding: '10px 18px', borderRadius: 6, background: HP_GRAD, border: 'none', color: '#fff', fontFamily: 'Outfit', fontSize: 11, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', cursor: 'pointer' }}
-        >
+        <ChipButton onClick={onBack}>
           Back to shelves →
-        </button>
+        </ChipButton>
       </div>
     </div>
   )

--- a/src/features/lists/ListDetail.jsx
+++ b/src/features/lists/ListDetail.jsx
@@ -12,6 +12,7 @@ import { usePageMeta } from '@/shared/hooks/usePageMeta'
 import { tmdbImg } from '@/shared/api/tmdb'
 import CreateListModal from '@/features/lists/CreateListModal'
 import MoodPill from '@/shared/components/MoodPill'
+import { ChipButton } from '@/shared/components/ActionButton'
 import './lists.css'
 
 import { HP, HP_GRAD } from '@/shared/lib/tokens'
@@ -499,13 +500,9 @@ function NotFound({ onBack }) {
         <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.28em', textTransform: 'uppercase', color: HP.purple, marginBottom: 18 }}>List · 404</div>
         <h1 style={{ fontFamily: 'Outfit', fontSize: 40, fontWeight: 500, color: HP.text, margin: '0 0 18px 0', letterSpacing: '-0.025em' }}>This shelf isn&rsquo;t here.</h1>
         <p style={{ margin: '0 0 24px 0', color: 'rgba(250,250,250,0.6)', fontSize: 14, lineHeight: 1.6 }}>It may have been deleted, made private, or it never existed.</p>
-        <button
-          type="button"
-          onClick={onBack}
-          style={{ padding: '10px 18px', borderRadius: 6, background: HP_GRAD, border: 'none', color: '#fff', fontFamily: 'Outfit', fontSize: 11, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', cursor: 'pointer' }}
-        >
+        <ChipButton onClick={onBack}>
           Back to shelves →
-        </button>
+        </ChipButton>
       </div>
     </div>
   )

--- a/src/features/lists/Lists.jsx
+++ b/src/features/lists/Lists.jsx
@@ -9,7 +9,7 @@ import { useNavigate } from 'react-router-dom'
 import { usePageMeta } from '@/shared/hooks/usePageMeta'
 import { useAuthSession } from '@/shared/hooks/useAuthSession'
 import CreateListModal from '@/features/lists/CreateListModal'
-import { ActionButton } from '@/shared/components/ActionButton'
+import { ActionButton, ChipButton } from '@/shared/components/ActionButton'
 import MoodPill from '@/shared/components/MoodPill'
 import './lists.css'
 import { ListsDataProvider, useListsData } from './useListsData'
@@ -306,11 +306,7 @@ function FeaturedOpen() {
             <span>{featured.films.length} film{featured.films.length === 1 ? '' : 's'} · {user.name} · updated {featured.updated}</span>
           </div>
           <div style={{ marginTop: 20, display: 'flex', gap: 8 }}>
-            <button
-              type="button"
-              onClick={() => navigate(`/lists/${featured.id}`)}
-              style={{ padding: '10px 16px', borderRadius: 6, background: HP_GRAD, border: 'none', color: '#fff', fontFamily: 'Outfit', fontSize: 11, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', cursor: 'pointer' }}
-            >Open shelf →</button>
+            <ChipButton onClick={() => navigate(`/lists/${featured.id}`)}>Open shelf →</ChipButton>
           </div>
         </div>
         <div style={{ borderTop: `1px solid ${HP.border}` }}>

--- a/src/features/lists/PersonalList.jsx
+++ b/src/features/lists/PersonalList.jsx
@@ -21,6 +21,7 @@ import { useAuthSession } from '@/shared/hooks/useAuthSession'
 import { MOVIE_ENGINE_COLS } from '@/shared/services/movieFields'
 import { computeUserProfile, rankSlotCandidates } from '@/shared/services/recommendations'
 import { applyAllExclusions, applyExclusionsNoLanguage } from '@/shared/services/exclusions'
+import { ChipButton } from '@/shared/components/ActionButton'
 import './lists.css'
 
 // Mirrors the home-card recency floor — pre-1990 stays hidden unless the
@@ -507,13 +508,9 @@ function NotFound({ onBack }) {
       <div style={{ textAlign: 'center', maxWidth: 520 }}>
         <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.28em', textTransform: 'uppercase', color: HP.purple, marginBottom: 18 }}>For you · 404</div>
         <h1 style={{ fontFamily: 'Outfit', fontSize: 40, fontWeight: 500, color: HP.text, margin: '0 0 18px 0', letterSpacing: '-0.025em' }}>This list isn&rsquo;t available.</h1>
-        <button
-          type="button"
-          onClick={onBack}
-          style={{ padding: '10px 18px', borderRadius: 6, background: HP_GRAD, border: 'none', color: '#fff', fontFamily: 'Outfit', fontSize: 11, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', cursor: 'pointer' }}
-        >
+        <ChipButton onClick={onBack}>
           Back to lists →
-        </button>
+        </ChipButton>
       </div>
     </div>
   )

--- a/src/shared/components/ActionButton.jsx
+++ b/src/shared/components/ActionButton.jsx
@@ -38,6 +38,32 @@ export function ActionButton({ className = '', style, children, ...props }) {
   )
 }
 
+/**
+ * Canonical gradient micro-CTA chip — the small uppercase "Open shelf →" /
+ * "Back to shelves →" pill used across the lists surfaces. Gradient, Outfit 11,
+ * radius-6, uppercase with wide tracking. The compact sibling of <ActionButton>
+ * (full-size primary) — same brand DNA, chip scale.
+ *
+ * @param {object} props  Standard <button> props; `style` merges over the look.
+ */
+export function ChipButton({ className = '', style, children, ...props }) {
+  return (
+    <button
+      type="button"
+      className={`${BASE} rounded-md ${className}`.trim()}
+      style={{
+        background: HP_GRAD, border: 'none', color: '#fff',
+        fontFamily: 'Outfit', fontSize: 11, fontWeight: 600, letterSpacing: '0.06em',
+        textTransform: 'uppercase', padding: '10px 18px', cursor: 'pointer',
+        ...style,
+      }}
+      {...props}
+    >
+      {children}
+    </button>
+  )
+}
+
 export function SecondaryActionButton({
   active,
   loading = false,


### PR DESCRIPTION
## What
The small gradient uppercase micro-CTA ("Open shelf →" / "Back to shelves →") was hand-rolled **five times** across the lists surfaces — identical but for a 10-16 vs 10-18 padding drift. Added a canonical `ChipButton` to the action-button family (gradient, Outfit 11, radius-6, uppercase, 0.06em tracking) and routed the **four standalone** ones through it:

- Lists masthead — "Open shelf →"
- CuratedList 404 — "Back to shelves →"
- ListDetail 404 — "Back to shelves →"
- PersonalList 404 — "Back to lists →"

They adopt the canonical 10-18 padding (two were 10-16).

The list-detail **owner-action row** (copy / edit / reorder / delete) mixes gradient, outline, and *stateful* chips in one cluster — left intact for a dedicated follow-up so a row isn't half-migrated (it'll want a ChipButton secondary + stateful capability).

## Verify
- lint clean · test 417 ✓ · build ✓
- Authed: "OPEN SHELF →" on `/lists` and "BACK TO SHELVES →" on a curated 404 render pixel-identically (gradient, uppercase, radius-6).

Gated surfaces — not in the `/` + `/about` visual set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)