### PR TITLE
feat(ui): canonical Eyebrow primitive + adopt across preferences (Axis 2)

### DIFF
--- a/src/features/preferences/Preferences.jsx
+++ b/src/features/preferences/Preferences.jsx
@@ -7,6 +7,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { usePageMeta } from '@/shared/hooks/usePageMeta'
 import { ActionButton, SecondaryActionButton } from '@/shared/components/ActionButton'
+import Eyebrow from '@/shared/ui/Eyebrow'
 import { PreferencesDataProvider, usePreferencesData, genreLabelOf } from './usePreferencesData'
 import './preferences.css'
 
@@ -18,9 +19,7 @@ const RESET_BTN = { background: 'none', border: 'none', padding: 0, margin: 0, f
 function H({ kicker, title, sub }) {
   return (
     <header style={{ marginBottom: 24 }}>
-      <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.28em', textTransform: 'uppercase', color: HP.purple, marginBottom: 12, display: 'inline-flex', alignItems: 'center', gap: 10 }}>
-        <span style={{ height: 1, width: 22, background: HP.purple, opacity: 0.6 }} />{kicker}
-      </div>
+      <Eyebrow rule size={10} style={{ marginBottom: 12 }}>{kicker}</Eyebrow>
       <h2 style={{ fontFamily: 'Outfit', fontSize: 36, lineHeight: 1, fontWeight: 500, letterSpacing: '-0.03em', color: HP.text, margin: 0, textWrap: 'balance' }}>{title}</h2>
       {sub && <p style={{ marginTop: 12, fontSize: 14, color: HP.textMuted, fontFamily: 'Outfit, Inter, sans-serif', lineHeight: 1.6, maxWidth: 560, textWrap: 'pretty' }}>{sub}</p>}
     </header>
@@ -35,7 +34,7 @@ function Masthead() {
       <div style={{ position: 'absolute', inset: 0, pointerEvents: 'none', background: 'radial-gradient(ellipse 50% 30% at 10% 0%, rgba(167,139,250,0.12), transparent 60%)' }} />
       <div style={{ position: 'relative' }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 14, marginBottom: 22 }}>
-          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.32em', textTransform: 'uppercase', color: HP.purple }}>Preferences</div>
+          <Eyebrow size={10} spacing="0.32em">Preferences</Eyebrow>
           <div style={{ height: 1, width: 38, background: HP.purple, opacity: 0.5 }} />
           <div style={{ fontSize: 10, fontWeight: 500, letterSpacing: '0.18em', textTransform: 'uppercase', color: HP.textMuted, fontFamily: 'Outfit' }}>Tune the engine · DNA recomputes nightly</div>
         </div>
@@ -215,11 +214,11 @@ function GenresPrefs() {
       <H kicker="Genres" title="What you live in." sub="Drawn-to genres get prioritized; avoided genres are excluded as hard rules." />
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 48 }}>
         <div>
-          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', color: HP.textMuted, fontFamily: 'Outfit', marginBottom: 14 }}>Drawn to</div>
+          <Eyebrow color={HP.textMuted} spacing="0.18em" size={10} style={{ marginBottom: 14 }}>Drawn to</Eyebrow>
           <ChipPicker items={drawnItems} hex={HP.purple} onRemove={removeDrawnGenre} onAdd={addDrawnGenre} options={allOptions} addLabel="+ Genre" />
         </div>
         <div>
-          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', color: HP.textMuted, fontFamily: 'Outfit', marginBottom: 14 }}>Avoid (hard rule)</div>
+          <Eyebrow color={HP.textMuted} spacing="0.18em" size={10} style={{ marginBottom: 14 }}>Avoid (hard rule)</Eyebrow>
           <ChipPicker items={avoidItems} hex={HP.red} onRemove={removeAvoidGenre} onAdd={addAvoidGenre} options={allOptions} addLabel="+ Genre" />
         </div>
       </div>
@@ -234,7 +233,7 @@ function DirectorPrefs() {
       <H kicker="Directors" title="Voices you trust." sub="Trusted directors boost match scores; muted directors get filtered out entirely." />
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 48 }}>
         <div>
-          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', color: HP.textMuted, fontFamily: 'Outfit', marginBottom: 14 }}>Trusted</div>
+          <Eyebrow color={HP.textMuted} spacing="0.18em" size={10} style={{ marginBottom: 14 }}>Trusted</Eyebrow>
           <FreeTextChips
             items={draft.trustedDirectors}
             hex={HP.green}
@@ -245,7 +244,7 @@ function DirectorPrefs() {
           />
         </div>
         <div>
-          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', color: HP.textMuted, fontFamily: 'Outfit', marginBottom: 14 }}>Muted</div>
+          <Eyebrow color={HP.textMuted} spacing="0.18em" size={10} style={{ marginBottom: 14 }}>Muted</Eyebrow>
           <FreeTextChips
             items={draft.mutedDirectors}
             hex={HP.red}
@@ -279,7 +278,7 @@ function Runtime() {
           </div>
         </div>
         <div>
-          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', color: HP.textMuted, fontFamily: 'Outfit', marginBottom: 14 }}>Runtime band</div>
+          <Eyebrow color={HP.textMuted} spacing="0.18em" size={10} style={{ marginBottom: 14 }}>Runtime band</Eyebrow>
           <div style={{ fontFamily: 'Outfit, Inter, sans-serif', fontSize: 13, color: HP.textSoft, fontStyle: 'italic', lineHeight: 1.65 }}>
             Films shorter than <span style={{ color: HP.text, fontWeight: 600 }}>{draft.runtimeFloor} min</span> or longer than <span style={{ color: HP.text, fontWeight: 600 }}>{draft.runtimeCap} min</span> still appear in your briefings &mdash; they just rank lower.<br />
             Films inside the band get a quiet boost so you actually press play.
@@ -331,9 +330,7 @@ function Subscriptions() {
   return (
     <section style={{ padding: '56px 88px', borderTop: `1px solid ${HP.border}`, background: 'rgba(255,255,255,0.012)' }}>
       <header style={{ marginBottom: 24 }}>
-        <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.28em', textTransform: 'uppercase', color: HP.purple, marginBottom: 12, display: 'inline-flex', alignItems: 'center', gap: 10 }}>
-          <span style={{ height: 1, width: 22, background: HP.purple, opacity: 0.6 }} />Subscriptions
-        </div>
+        <Eyebrow rule size={10} style={{ marginBottom: 12 }}>Subscriptions</Eyebrow>
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 14, flexWrap: 'wrap' }}>
           <h2 style={{ fontFamily: 'Outfit', fontSize: 36, lineHeight: 1, fontWeight: 500, letterSpacing: '-0.03em', color: HP.text, margin: 0 }}>What you have access to.</h2>
           <span style={{ padding: '4px 10px', borderRadius: 999, border: `1px solid ${HP.borderStrong}`, background: 'rgba(255,255,255,0.04)', fontFamily: 'Outfit', fontSize: 10, fontWeight: 600, letterSpacing: '0.18em', textTransform: 'uppercase', color: HP.textMuted }}>Coming soon</span>
@@ -405,18 +402,18 @@ function Display() {
       <H kicker="Display" title="How films arrive." sub="Doesn't change what we pick &mdash; just how each film shows up when you open it." />
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 48 }}>
         <div>
-          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', color: HP.textMuted, fontFamily: 'Outfit', marginBottom: 6 }}>Subtitles</div>
+          <Eyebrow color={HP.textMuted} spacing="0.18em" size={10} style={{ marginBottom: 6 }}>Subtitles</Eyebrow>
           <div style={{ fontSize: 12, color: HP.textFaint, fontFamily: 'Outfit, Inter, sans-serif', fontStyle: 'italic', marginBottom: 14 }}>How you feel about reading them.</div>
           <Segmented value={draft.subtitles} onChange={setSubtitles} options={catalogs.SUBTITLE_MODES} />
         </div>
         <div>
-          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', color: HP.textMuted, fontFamily: 'Outfit', marginBottom: 6 }}>Spoiler tier</div>
+          <Eyebrow color={HP.textMuted} spacing="0.18em" size={10} style={{ marginBottom: 6 }}>Spoiler tier</Eyebrow>
           <div style={{ fontSize: 12, color: HP.textFaint, fontFamily: 'Outfit, Inter, sans-serif', fontStyle: 'italic', marginBottom: 14 }}>How much synopsis we show by default.</div>
           <Segmented value={draft.spoilerTier} onChange={setSpoilerTier} options={catalogs.SPOILER_TIERS} />
         </div>
       </div>
       <div style={{ marginTop: 36 }}>
-        <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', color: HP.textMuted, fontFamily: 'Outfit', marginBottom: 6 }}>Languages you watch</div>
+        <Eyebrow color={HP.textMuted} spacing="0.18em" size={10} style={{ marginBottom: 6 }}>Languages you watch</Eyebrow>
         <div style={{ fontSize: 12, color: HP.textFaint, fontFamily: 'Outfit, Inter, sans-serif', fontStyle: 'italic', marginBottom: 14 }}>Films in these languages get a quiet boost.</div>
         <ChipPicker items={languageItems} hex={HP.purple} onRemove={removeLanguage} onAdd={addLanguage} options={languageOptions} addLabel="+ Language" />
       </div>
@@ -451,7 +448,7 @@ function PreviewPanel() {
     <section style={{ padding: '56px 88px 88px', borderTop: `1px solid ${HP.border}`, background: 'rgba(167,139,250,0.04)' }}>
       <div style={{ display: 'grid', gridTemplateColumns: '1fr auto', gap: 48, alignItems: 'center' }}>
         <div>
-          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.28em', textTransform: 'uppercase', color: HP.purple, marginBottom: 12 }}>Effect on your engine</div>
+          <Eyebrow size={10} style={{ marginBottom: 12 }}>Effect on your engine</Eyebrow>
           <h2 style={{ fontFamily: 'Outfit', fontSize: 36, lineHeight: 1.05, fontWeight: 500, letterSpacing: '-0.03em', color: HP.text, margin: 0, textWrap: 'balance' }}>
             {justSaved
               ? <>Saved. <em style={{ fontStyle: 'italic', fontWeight: 400, color: HP.textSoft }}>Next briefing will retune.</em></>

--- a/src/shared/ui/Eyebrow.jsx
+++ b/src/shared/ui/Eyebrow.jsx
@@ -1,0 +1,41 @@
+// src/shared/ui/Eyebrow.jsx
+import { HP } from '@/shared/lib/tokens'
+
+/**
+ * Canonical eyebrow / kicker — the small uppercase, wide-tracked label that sits
+ * above a section header or tags a meta line. ONE source of truth for what was
+ * hand-rolled ~210× inline across every surface (plus the landing's `.ff-eyebrow`),
+ * including the 22px brand-rule "section kicker" that 9 surfaces each re-implemented.
+ *
+ * Codifies CLAUDE.md's documented Kicker pattern: Outfit 700, ~11px, 0.28em tracking,
+ * uppercase, with an optional leading 22px rule.
+ *
+ * @param {object}  props
+ * @param {React.ReactNode} props.children  The label text.
+ * @param {string}  [props.color=HP.purple]  Accent — purple for section kickers,
+ *   a muted token (HP.textMuted / HP.textFaint) for quiet meta labels.
+ * @param {boolean} [props.rule=false]       Prepend the 22px accent rule (kicker form).
+ * @param {number}  [props.size=11]          Font size in px (10–11 in practice).
+ * @param {string}  [props.spacing='0.28em'] Letter-spacing — 0.28–0.32em for section
+ *   kickers, the tighter 0.18em for quiet field / meta labels.
+ * @param {string}  [props.className]
+ * @param {object}  [props.style]            Merged onto the root (margins / positioning).
+ * @returns {JSX.Element}
+ */
+export default function Eyebrow({ children, color = HP.purple, rule = false, size = 11, spacing = '0.28em', className = '', style, ...props }) {
+  return (
+    <div
+      className={className}
+      style={{
+        display: 'inline-flex', alignItems: 'center', gap: 10,
+        fontFamily: 'Outfit', fontSize: size, fontWeight: 700,
+        letterSpacing: spacing, textTransform: 'uppercase', color,
+        ...style,
+      }}
+      {...props}
+    >
+      {rule && <span style={{ height: 1, width: 22, background: color, opacity: 0.6, flex: 'none' }} />}
+      {children}
+    </div>
+  )
+}


### PR DESCRIPTION
## Axis 2 — extract the reusable atoms (what's inside → outside)

The reusable UI atoms are trapped as **inline copies inside every surface**, so consistency has to be hand-maintained. Axis 2 pulls them into `shared/` one family at a time. **Atom 1: the eyebrow / kicker** — the biggest offender:

- ~**210 inline** copies across all 12 surfaces + the landing's `.ff-eyebrow`
- the 22px-rule **section kicker** re-implemented in **9 surfaces**

### New primitive — `shared/ui/Eyebrow.jsx`
```jsx
<Eyebrow color rule size spacing>LABEL</Eyebrow>
```
Outfit 700 uppercase; `rule` prepends the 22px brand rule; `color`/`size`/`spacing` capture the legit variants (purple section kicker vs muted 0.18em field label). Codifies CLAUDE.md's documented Kicker pattern.

### Adopted across `preferences` (proof surface)
12 inline eyebrows now flow through `<Eyebrow>`: the shared `<H>` section kicker, the 2nd ruled kicker, the masthead kicker, and 8 muted field labels.

### Extraction philosophy
Each call **preserves its exact look via props** — pure relocation, **no pixel change**. Verified authed: masthead/section kickers (with the 22px rule) and field labels render identically. *Normalising* every eyebrow to one canonical size/tracking becomes a one-place change later, once all surfaces are on the component.

## Verify
- lint clean · test 417 ✓ · build ✓
- Authed `/preferences`: "PREFERENCES" masthead, "MOOD WEIGHTS"/"DIRECTORS" ruled kickers, "DRAWN TO"/"AVOID" field labels — all pixel-identical.

Gated surface — no visual-baseline impact. Next: roll `<Eyebrow>` out to the remaining gated surfaces, then landing/about (deliberate regen), then atoms 2–4 (Tag, Card, Button-font).

🤖 Generated with [Claude Code](https://claude.com/claude-code)