### PR TITLE
refactor(ui): Eyebrow tone/weight shorthand + roll out to people (Axis 2 batch 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -462,6 +462,7 @@ and motion language.
 - `<Input>` / `<Textarea>` / `<Select>` — pure styling primitives (no built-in label).
 - `<Checkbox id checked onChange label />` — toggle switch.
 - `<EmptyState icon title description action />` — canonical empty state.
+- `<Eyebrow tone="section|meta" rule? color? size? spacing? />` — the canonical uppercase kicker / eyebrow (`rule` adds the 22px brand rule). Use it instead of hand-rolling `textTransform:'uppercase'` labels.
 - `<SectionHeader title subtitle? seeAllTo? eyebrow? />` — carousel row header (matches the section header pattern above).
 - `<Tooltip label>{children}</Tooltip>` — hover/focus tooltip primitive.
 - `<BrandSplash label? error? />` — full-screen brand splash (200ms delayed visibility; errors immediate).

--- a/src/features/people/People.jsx
+++ b/src/features/people/People.jsx
@@ -9,6 +9,7 @@ import { useNavigate } from 'react-router-dom'
 import { supabase } from '@/shared/lib/supabase/client'
 import { useAuthSession } from '@/shared/hooks/useAuthSession'
 import { usePageMeta } from '@/shared/hooks/usePageMeta'
+import Eyebrow from '@/shared/ui/Eyebrow'
 import { HP, HP_GRAD } from './data'
 import { PeopleDataProvider, usePeopleData } from './usePeopleData'
 import './people.css'
@@ -84,9 +85,9 @@ function Masthead({ onSearch, query, setQuery }) {
       <div style={{ position: 'absolute', inset: 0, pointerEvents: 'none', background: 'radial-gradient(ellipse 50% 30% at 10% 0%, rgba(236,72,153,0.10), transparent 60%)' }} />
       <div style={{ position: 'relative' }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 14, marginBottom: 22, flexWrap: 'wrap' }}>
-          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.32em', textTransform: 'uppercase', color: HP.purple }}>People</div>
+          <Eyebrow spacing="0.32em" size={10}>People</Eyebrow>
           <div style={{ height: 1, width: 38, background: HP.purple, opacity: 0.5 }} />
-          <div style={{ fontSize: 10, fontWeight: 500, letterSpacing: '0.18em', textTransform: 'uppercase', color: HP.textMuted, fontFamily: 'Outfit' }}>{user.following} following · {user.followers} followers</div>
+          <Eyebrow tone="meta" weight={500} size={10}>{user.following} following · {user.followers} followers</Eyebrow>
         </div>
         <h1 className="ff-people-hero" style={{ fontFamily: 'Outfit', fontSize: 88, lineHeight: 0.92, fontWeight: 300, letterSpacing: '-0.05em', color: HP.text, margin: 0, textWrap: 'balance' }}>
           Your <em style={{ fontStyle: 'italic', fontWeight: 400, color: HP.textSoft }}>taste twins.</em>
@@ -168,9 +169,7 @@ function TwinsRail() {
     <section className="ff-people-section ff-people-twins" style={{ padding: '24px 88px 56px' }}>
       <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', marginBottom: 24, gap: 16, flexWrap: 'wrap' }}>
         <div>
-          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.28em', textTransform: 'uppercase', color: HP.purple, marginBottom: 12, display: 'inline-flex', alignItems: 'center', gap: 10 }}>
-            <span style={{ height: 1, width: 22, background: HP.purple, opacity: 0.6 }} />{twins.length === 0 && popular.length > 0 ? 'Popular on FeelFlick' : 'Strongest matches'}
-          </div>
+          <Eyebrow rule size={10} style={{ marginBottom: 12 }}>{twins.length === 0 && popular.length > 0 ? 'Popular on FeelFlick' : 'Strongest matches'}</Eyebrow>
           <h2 className="ff-people-h2" style={{ fontFamily: 'Outfit', fontSize: 36, lineHeight: 1, fontWeight: 500, letterSpacing: '-0.03em', color: HP.text, margin: 0 }}>
             {twins.length === 0 && popular.length > 0
               ? <>Start with the <em style={{ fontStyle: 'italic', fontWeight: 400, color: HP.textSoft }}>most-watched.</em></>
@@ -271,9 +270,7 @@ function Rising() {
     <section className="ff-people-section ff-people-rising" style={{ padding: '48px 88px', borderTop: `1px solid ${HP.border}`, background: 'rgba(255,255,255,0.012)' }}>
       <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', marginBottom: 24, flexWrap: 'wrap', gap: 16 }}>
         <div>
-          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.28em', textTransform: 'uppercase', color: HP.purple, marginBottom: 12, display: 'inline-flex', alignItems: 'center', gap: 10 }}>
-            <span style={{ height: 1, width: 22, background: HP.purple, opacity: 0.6 }} />On the rise
-          </div>
+          <Eyebrow rule size={10} style={{ marginBottom: 12 }}>On the rise</Eyebrow>
           <h2 className="ff-people-h2-sm" style={{ fontFamily: 'Outfit', fontSize: 30, lineHeight: 1, fontWeight: 500, letterSpacing: '-0.03em', color: HP.text, margin: 0 }}>Building taste in <em style={{ fontStyle: 'italic', fontWeight: 400, color: HP.textSoft }}>your direction.</em></h2>
         </div>
       </div>
@@ -315,9 +312,7 @@ function Activity() {
   return (
     <section className="ff-people-section ff-people-activity" style={{ padding: '56px 88px', borderTop: `1px solid ${HP.border}` }}>
       <div style={{ marginBottom: 24 }}>
-        <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.28em', textTransform: 'uppercase', color: HP.purple, marginBottom: 12, display: 'inline-flex', alignItems: 'center', gap: 10 }}>
-          <span style={{ height: 1, width: 22, background: HP.purple, opacity: 0.6 }} />Activity
-        </div>
+        <Eyebrow rule size={10} style={{ marginBottom: 12 }}>Activity</Eyebrow>
         <h2 className="ff-people-h2" style={{ fontFamily: 'Outfit', fontSize: 36, lineHeight: 1, fontWeight: 500, letterSpacing: '-0.03em', color: HP.text, margin: 0 }}>{heading}</h2>
         {followingIds.size === 0 && (
           <p style={{ marginTop: 10, fontSize: 12, color: HP.textMuted, fontFamily: 'Outfit, Inter, sans-serif', fontStyle: 'italic' }}>
@@ -359,7 +354,7 @@ function CrewOverlap() {
     <section className="ff-people-section ff-people-crew" style={{ padding: '56px 88px', borderTop: `1px solid ${HP.border}`, background: 'rgba(255,255,255,0.012)' }}>
       <div className="ff-people-crew-grid" style={{ display: 'grid', gridTemplateColumns: '1fr 1.6fr', gap: 64, alignItems: 'flex-start' }}>
         <div>
-          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.28em', textTransform: 'uppercase', color: HP.purple, marginBottom: 12 }}>Shared lineage</div>
+          <Eyebrow size={10} style={{ marginBottom: 12 }}>Shared lineage</Eyebrow>
           <h2 className="ff-people-h2" style={{ fontFamily: 'Outfit', fontSize: 32, lineHeight: 1.05, fontWeight: 500, letterSpacing: '-0.03em', color: HP.text, margin: 0 }}>Directors your <em style={{ fontStyle: 'italic', fontWeight: 400, color: HP.textSoft }}>circle loves.</em></h2>
           <p style={{ marginTop: 14, fontSize: 13, color: HP.textMuted, fontFamily: 'Outfit, Inter, sans-serif', lineHeight: 1.55, maxWidth: 320 }}>{sub}</p>
         </div>
@@ -384,7 +379,7 @@ function Suggested() {
   return (
     <section className="ff-people-section ff-people-suggested" style={{ padding: '56px 88px', borderTop: `1px solid ${HP.border}` }}>
       <div style={{ marginBottom: 24 }}>
-        <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.28em', textTransform: 'uppercase', color: HP.purple, marginBottom: 12 }}>Suggested</div>
+        <Eyebrow size={10} style={{ marginBottom: 12 }}>Suggested</Eyebrow>
         <h2 className="ff-people-h2-sm" style={{ fontFamily: 'Outfit', fontSize: 30, lineHeight: 1, fontWeight: 500, letterSpacing: '-0.03em', color: HP.text, margin: 0 }}>People you <em style={{ fontStyle: 'italic', fontWeight: 400, color: HP.textSoft }}>might know.</em></h2>
       </div>
       <div className="ff-people-grid-3" style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 16 }}>
@@ -420,7 +415,7 @@ function SearchResults({ results, loading, onClear }) {
     <section className="ff-people-section ff-people-search-results" style={{ padding: '24px 88px 56px' }}>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 24 }}>
         <div>
-          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.28em', textTransform: 'uppercase', color: HP.purple, marginBottom: 12 }}>Search results</div>
+          <Eyebrow size={10} style={{ marginBottom: 12 }}>Search results</Eyebrow>
           <h2 className="ff-people-h2-sm" style={{ fontFamily: 'Outfit', fontSize: 30, lineHeight: 1, fontWeight: 500, letterSpacing: '-0.03em', color: HP.text, margin: 0 }}>{results.length} match{results.length === 1 ? '' : 'es'}</h2>
         </div>
         <button type="button" onClick={onClear} style={{ ...RESET_BTN, fontSize: 11, color: HP.textMuted, fontFamily: 'Outfit', letterSpacing: '0.08em', textTransform: 'uppercase' }}>Clear ×</button>

--- a/src/features/preferences/Preferences.jsx
+++ b/src/features/preferences/Preferences.jsx
@@ -214,11 +214,11 @@ function GenresPrefs() {
       <H kicker="Genres" title="What you live in." sub="Drawn-to genres get prioritized; avoided genres are excluded as hard rules." />
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 48 }}>
         <div>
-          <Eyebrow color={HP.textMuted} spacing="0.18em" size={10} style={{ marginBottom: 14 }}>Drawn to</Eyebrow>
+          <Eyebrow tone="meta" size={10} style={{ marginBottom: 14 }}>Drawn to</Eyebrow>
           <ChipPicker items={drawnItems} hex={HP.purple} onRemove={removeDrawnGenre} onAdd={addDrawnGenre} options={allOptions} addLabel="+ Genre" />
         </div>
         <div>
-          <Eyebrow color={HP.textMuted} spacing="0.18em" size={10} style={{ marginBottom: 14 }}>Avoid (hard rule)</Eyebrow>
+          <Eyebrow tone="meta" size={10} style={{ marginBottom: 14 }}>Avoid (hard rule)</Eyebrow>
           <ChipPicker items={avoidItems} hex={HP.red} onRemove={removeAvoidGenre} onAdd={addAvoidGenre} options={allOptions} addLabel="+ Genre" />
         </div>
       </div>
@@ -233,7 +233,7 @@ function DirectorPrefs() {
       <H kicker="Directors" title="Voices you trust." sub="Trusted directors boost match scores; muted directors get filtered out entirely." />
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 48 }}>
         <div>
-          <Eyebrow color={HP.textMuted} spacing="0.18em" size={10} style={{ marginBottom: 14 }}>Trusted</Eyebrow>
+          <Eyebrow tone="meta" size={10} style={{ marginBottom: 14 }}>Trusted</Eyebrow>
           <FreeTextChips
             items={draft.trustedDirectors}
             hex={HP.green}
@@ -244,7 +244,7 @@ function DirectorPrefs() {
           />
         </div>
         <div>
-          <Eyebrow color={HP.textMuted} spacing="0.18em" size={10} style={{ marginBottom: 14 }}>Muted</Eyebrow>
+          <Eyebrow tone="meta" size={10} style={{ marginBottom: 14 }}>Muted</Eyebrow>
           <FreeTextChips
             items={draft.mutedDirectors}
             hex={HP.red}
@@ -278,7 +278,7 @@ function Runtime() {
           </div>
         </div>
         <div>
-          <Eyebrow color={HP.textMuted} spacing="0.18em" size={10} style={{ marginBottom: 14 }}>Runtime band</Eyebrow>
+          <Eyebrow tone="meta" size={10} style={{ marginBottom: 14 }}>Runtime band</Eyebrow>
           <div style={{ fontFamily: 'Outfit, Inter, sans-serif', fontSize: 13, color: HP.textSoft, fontStyle: 'italic', lineHeight: 1.65 }}>
             Films shorter than <span style={{ color: HP.text, fontWeight: 600 }}>{draft.runtimeFloor} min</span> or longer than <span style={{ color: HP.text, fontWeight: 600 }}>{draft.runtimeCap} min</span> still appear in your briefings &mdash; they just rank lower.<br />
             Films inside the band get a quiet boost so you actually press play.
@@ -402,18 +402,18 @@ function Display() {
       <H kicker="Display" title="How films arrive." sub="Doesn't change what we pick &mdash; just how each film shows up when you open it." />
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 48 }}>
         <div>
-          <Eyebrow color={HP.textMuted} spacing="0.18em" size={10} style={{ marginBottom: 6 }}>Subtitles</Eyebrow>
+          <Eyebrow tone="meta" size={10} style={{ marginBottom: 6 }}>Subtitles</Eyebrow>
           <div style={{ fontSize: 12, color: HP.textFaint, fontFamily: 'Outfit, Inter, sans-serif', fontStyle: 'italic', marginBottom: 14 }}>How you feel about reading them.</div>
           <Segmented value={draft.subtitles} onChange={setSubtitles} options={catalogs.SUBTITLE_MODES} />
         </div>
         <div>
-          <Eyebrow color={HP.textMuted} spacing="0.18em" size={10} style={{ marginBottom: 6 }}>Spoiler tier</Eyebrow>
+          <Eyebrow tone="meta" size={10} style={{ marginBottom: 6 }}>Spoiler tier</Eyebrow>
           <div style={{ fontSize: 12, color: HP.textFaint, fontFamily: 'Outfit, Inter, sans-serif', fontStyle: 'italic', marginBottom: 14 }}>How much synopsis we show by default.</div>
           <Segmented value={draft.spoilerTier} onChange={setSpoilerTier} options={catalogs.SPOILER_TIERS} />
         </div>
       </div>
       <div style={{ marginTop: 36 }}>
-        <Eyebrow color={HP.textMuted} spacing="0.18em" size={10} style={{ marginBottom: 6 }}>Languages you watch</Eyebrow>
+        <Eyebrow tone="meta" size={10} style={{ marginBottom: 6 }}>Languages you watch</Eyebrow>
         <div style={{ fontSize: 12, color: HP.textFaint, fontFamily: 'Outfit, Inter, sans-serif', fontStyle: 'italic', marginBottom: 14 }}>Films in these languages get a quiet boost.</div>
         <ChipPicker items={languageItems} hex={HP.purple} onRemove={removeLanguage} onAdd={addLanguage} options={languageOptions} addLabel="+ Language" />
       </div>

--- a/src/shared/ui/Eyebrow.jsx
+++ b/src/shared/ui/Eyebrow.jsx
@@ -7,34 +7,48 @@ import { HP } from '@/shared/lib/tokens'
  * hand-rolled ~210× inline across every surface (plus the landing's `.ff-eyebrow`),
  * including the 22px brand-rule "section kicker" that 9 surfaces each re-implemented.
  *
- * Codifies CLAUDE.md's documented Kicker pattern: Outfit 700, ~11px, 0.28em tracking,
- * uppercase, with an optional leading 22px rule.
+ * Codifies CLAUDE.md's documented Kicker pattern: Outfit 700, ~11px, uppercase,
+ * with an optional leading 22px rule.
+ *
+ * `tone` encodes the two roles (so call-sites read by intent, not raw values):
+ *   • 'section' (default) — the purple section kicker, 0.28em tracking.
+ *   • 'meta'              — a quiet muted field / meta label, tighter 0.18em.
+ * `color` / `spacing` still override the tone for edge cases (e.g. the 0.32em
+ * masthead kicker, or a textFaint label).
  *
  * @param {object}  props
  * @param {React.ReactNode} props.children  The label text.
- * @param {string}  [props.color=HP.purple]  Accent — purple for section kickers,
- *   a muted token (HP.textMuted / HP.textFaint) for quiet meta labels.
- * @param {boolean} [props.rule=false]       Prepend the 22px accent rule (kicker form).
- * @param {number}  [props.size=11]          Font size in px (10–11 in practice).
- * @param {string}  [props.spacing='0.28em'] Letter-spacing — 0.28–0.32em for section
- *   kickers, the tighter 0.18em for quiet field / meta labels.
+ * @param {'section'|'meta'} [props.tone='section']
+ * @param {string}  [props.color]           Accent override (defaults from `tone`).
+ * @param {boolean} [props.rule=false]      Prepend the 22px accent rule (kicker form).
+ * @param {number}  [props.size=11]         Font size in px (10–11 in practice).
+ * @param {string}  [props.spacing]         Letter-spacing override (defaults from `tone`).
+ * @param {number}  [props.weight=700]      Font weight (500 for soft masthead sublabels).
  * @param {string}  [props.className]
- * @param {object}  [props.style]            Merged onto the root (margins / positioning).
+ * @param {object}  [props.style]           Merged onto the root (margins / positioning).
  * @returns {JSX.Element}
  */
-export default function Eyebrow({ children, color = HP.purple, rule = false, size = 11, spacing = '0.28em', className = '', style, ...props }) {
+const TONES = {
+  section: { color: HP.purple, spacing: '0.28em' },
+  meta: { color: HP.textMuted, spacing: '0.18em' },
+}
+
+export default function Eyebrow({ children, tone = 'section', color, rule = false, size = 11, spacing, weight = 700, className = '', style, ...props }) {
+  const t = TONES[tone] || TONES.section
+  const accent = color ?? t.color
+  const ls = spacing ?? t.spacing
   return (
     <div
       className={className}
       style={{
         display: 'inline-flex', alignItems: 'center', gap: 10,
-        fontFamily: 'Outfit', fontSize: size, fontWeight: 700,
-        letterSpacing: spacing, textTransform: 'uppercase', color,
+        fontFamily: 'Outfit', fontSize: size, fontWeight: weight,
+        letterSpacing: ls, textTransform: 'uppercase', color: accent,
         ...style,
       }}
       {...props}
     >
-      {rule && <span style={{ height: 1, width: 22, background: color, opacity: 0.6, flex: 'none' }} />}
+      {rule && <span style={{ height: 1, width: 22, background: accent, opacity: 0.6, flex: 'none' }} />}
       {children}
     </div>
   )


### PR DESCRIPTION
## Axis 2 — Eyebrow rollout, batch 1
Follow-up to #164. Polishes the `Eyebrow` API and continues adopting it surface by surface.

### API
- **`tone="section|meta"`** — bundles the role's color + tracking (purple/0.28em section kicker vs muted/0.18em meta label), so call-sites read by *intent* not raw values.
- **`weight`** — added for the soft 500-weight masthead sublabels. `color`/`spacing`/`size` still override for edge cases (the 0.32em masthead, etc.).

### Adopted
- **preferences** field labels → `tone="meta"` (simpler).
- **people** — all 8 inline eyebrows migrated (masthead kicker + meta sublabel, 3 ruled section kickers, 3 plain kickers).
- **CLAUDE.md** — `<Eyebrow>` added to the shared-UI primitives list.

### Verify
- lint clean · test 417 ✓ · build ✓
- Authed `/people`: "PEOPLE" masthead + rule + "0 FOLLOWING · 0 FOLLOWERS" sublabel, and the "POPULAR ON FEELFLICK" ruled kicker — pixel-identical (preserve-the-look).

Gated surfaces — no visual-baseline impact. Remaining gated surfaces (home/movie/lists/profile/account/browse/history/watchlist/discover) follow in subsequent batches; landing/about get a deliberate regen at the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)