### PR TITLE
refactor(ui): roll Eyebrow out to home (Axis 2 batch 2)

### DIFF
--- a/src/features/home/sections-bottom.jsx
+++ b/src/features/home/sections-bottom.jsx
@@ -3,6 +3,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Check, ChevronRight } from 'lucide-react'
+import Eyebrow from '@/shared/ui/Eyebrow'
 import { HP, HP_GRAD } from './data'
 import { SmartImg } from './atoms'
 import { useHomeData } from './useHomeData'
@@ -13,9 +14,7 @@ import { logSurfaceImpressions } from '@/shared/services/recommendations'
 
 const Heading = ({ kicker, title, sub }) => (
   <header style={{ marginBottom: 36 }}>
-    <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.24em', textTransform: 'uppercase', color: HP.purple, marginBottom: 14, display: 'inline-flex', alignItems: 'center', gap: 10 }}>
-      <span style={{ height: 1, width: 22, background: HP.purple, opacity: 0.6 }} />{kicker}
-    </div>
+    <Eyebrow rule size={10} spacing="0.24em" style={{ marginBottom: 14 }}>{kicker}</Eyebrow>
     <h2 style={{ fontFamily: 'Outfit, Inter, sans-serif', fontSize: 'clamp(28px, 4.5vw, 44px)', lineHeight: 1.0, fontWeight: 500, letterSpacing: '-0.035em', color: HP.text, margin: 0, textWrap: 'balance' }}>{title}</h2>
     {sub && <p style={{ marginTop: 14, fontSize: 14, color: HP.textMuted, maxWidth: 540, fontFamily: 'Outfit, Inter, sans-serif', textWrap: 'pretty' }}>{sub}</p>}
   </header>
@@ -447,9 +446,7 @@ export function CuratedLists({ onOpenList }) {
         className="mb-9 flex flex-col gap-3 sm:mb-10 lg:mb-12 lg:flex-row lg:items-end lg:justify-between lg:gap-8"
       >
         <div>
-          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.24em', textTransform: 'uppercase', color: HP.purple, marginBottom: 14, display: 'inline-flex', alignItems: 'center', gap: 10 }}>
-            <span style={{ height: 1, width: 22, background: HP.purple, opacity: 0.6 }} />{isCurated ? 'Lists' : 'For you'}
-          </div>
+          <Eyebrow rule size={10} spacing="0.24em" style={{ marginBottom: 14 }}>{isCurated ? 'Lists' : 'For you'}</Eyebrow>
           <h2 style={{ fontFamily: 'Outfit, Inter, sans-serif', fontSize: 'clamp(28px, 4.5vw, 44px)', lineHeight: 1.0, fontWeight: 500, letterSpacing: '-0.035em', color: HP.text, margin: 0, textWrap: 'balance' }}>
             {isCurated ? 'Curated edits.' : 'Lists, hand-cut for you.'}
           </h2>

--- a/src/features/home/sections-top.jsx
+++ b/src/features/home/sections-top.jsx
@@ -9,6 +9,7 @@ import { ActionButton, SecondaryActionButton } from '@/shared/components/ActionB
 import { useUserMovieStatus } from '@/shared/hooks/useUserMovieStatus'
 import { getMovieWatchProviders } from '@/shared/api/tmdb'
 import { logSurfaceImpressions } from '@/shared/services/recommendations'
+import Eyebrow from '@/shared/ui/Eyebrow'
 import { HP, HP_GRAD, MOOD_META } from './data'
 import { SmartImg } from './atoms'
 import { useHomeData } from './useHomeData'
@@ -41,7 +42,7 @@ export function MoodReactor({ currentMood, setMood, onReshuffle }) {
       <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:gap-5">
         <div className="flex flex-none items-baseline gap-2.5">
           <span aria-hidden style={{ height: 1, width: 18, background: HP.purple, opacity: 0.6, alignSelf: 'center' }} />
-          <span style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.28em', textTransform: 'uppercase', color: HP.textMuted, fontFamily: 'Outfit', whiteSpace: 'nowrap' }}>Tonight I feel</span>
+          <Eyebrow color={HP.textMuted} size={10} style={{ whiteSpace: 'nowrap' }}>Tonight I feel</Eyebrow>
         </div>
         <div
           ref={pillsRef}
@@ -246,10 +247,7 @@ function BriefingSlide({ film, idx, matchPct, user, onWatch, onSkip, onMarkedWat
         {/* Slot label kicker — bigger on desktop where it's the marquee header.
             self-center on mobile so it centers like the title/meta/synopsis
             below it; self-start on desktop matches the left-aligned column. */}
-        <div className="self-center lg:self-start" style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.28em', textTransform: 'uppercase', color: HP.purple, marginBottom: 12, display: 'inline-flex', alignItems: 'center', gap: 10 }}>
-          <span aria-hidden style={{ height: 1, width: 22, background: HP.purple, opacity: 0.6 }} />
-          {slotLabel}
-        </div>
+        <Eyebrow rule className="self-center lg:self-start" style={{ marginBottom: 12 }}>{slotLabel}</Eyebrow>
         {/* Title — matches the /movie/:id hero typography: Outfit 600 with a
             tight negative letter-spacing and lineHeight 0.94. Sized down
             from 92px to fit this two-column row, then scaled responsively

--- a/src/shared/ui/Eyebrow.jsx
+++ b/src/shared/ui/Eyebrow.jsx
@@ -48,7 +48,7 @@ export default function Eyebrow({ children, tone = 'section', color, rule = fals
       }}
       {...props}
     >
-      {rule && <span style={{ height: 1, width: 22, background: accent, opacity: 0.6, flex: 'none' }} />}
+      {rule && <span aria-hidden style={{ height: 1, width: 22, background: accent, opacity: 0.6, flex: 'none' }} />}
       {children}
     </div>
   )


### PR DESCRIPTION
## Axis 2 — Eyebrow rollout, batch 2 (home)
Continues #164/#165. home's section kickers now flow through `<Eyebrow>`:
- **sections-top** — the Briefing slot kicker ("TONIGHT'S PICK") + the "Tonight I feel" mood-input label.
- **sections-bottom** — the shared `Heading` helper kicker (used by every section) + the Lists/For-you kicker.

Preserve-the-look (size/spacing/color via props), **pixel-identical** authed.

Also adds `aria-hidden` to the canonical rule span (decorative) — pure a11y, no visual change, applies to every `<Eyebrow rule>`.

Left for a later pass (not the kicker atom): home's metadata strips, badge labels, %-labels, and the already-encapsulated `DNAKicker` (18px-rule variant).

## Verify
- lint clean · test 417 ✓ · build ✓
- Authed `/home`: "TONIGHT'S PICK" slot kicker (rule + purple) and "TONIGHT I FEEL" render identical.

Gated surface — no visual-baseline impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)