### PR TITLE
refactor(ui): roll Eyebrow out to history + watchlist (Axis 2 batch 3)

### DIFF
--- a/src/features/history/History.jsx
+++ b/src/features/history/History.jsx
@@ -7,6 +7,7 @@ import { useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { usePageMeta } from '@/shared/hooks/usePageMeta'
 import MoodPill from '@/shared/components/MoodPill'
+import Eyebrow from '@/shared/ui/Eyebrow'
 import { HP, HP_GRAD } from './data'
 import { HistoryDataProvider, useHistoryData } from './useHistoryData'
 import './history.css'
@@ -23,11 +24,11 @@ function Masthead() {
   return (
     <section className="ff-hist-section ff-hist-section--masthead" style={{ padding:'40px 88px 12px' }}>
       <div style={{ display:'flex', alignItems:'center', gap:14, flexWrap:'wrap' }}>
-        <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.32em', textTransform:'uppercase', color:HP.purple }}>Diary</div>
+        <Eyebrow spacing="0.32em" size={10}>Diary</Eyebrow>
         <div style={{ height:1, width:38, background:HP.purple, opacity:0.5 }} />
-        <div style={{ fontSize:10, fontWeight:500, letterSpacing:'0.18em', textTransform:'uppercase', color:HP.textMuted, fontFamily:'Outfit' }}>
+        <Eyebrow tone="meta" weight={500} size={10}>
           {stats.totalLogged} film{stats.totalLogged === 1 ? '' : 's'} · {stats.totalHours} hours · {stats.streakDays}-day streak
-        </div>
+        </Eyebrow>
       </div>
     </section>
   );
@@ -46,7 +47,7 @@ function PulseStrip() {
       <div className="ff-hist-pulse-grid" style={{ display:'grid', gridTemplateColumns:'repeat(4,1fr)', gap:20 }}>
         {items.map(s => (
           <div key={s.label} style={{ padding:'20px 22px', borderRadius:6, background:'rgba(255,255,255,0.025)', border:`1px solid ${HP.border}` }}>
-            <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.18em', textTransform:'uppercase', color:HP.textMuted, fontFamily:'Outfit', marginBottom:8 }}>{s.label}</div>
+            <Eyebrow tone="meta" size={10} style={{ marginBottom:8 }}>{s.label}</Eyebrow>
             <div style={{ fontFamily:'Outfit', fontSize:44, fontWeight:200, color:HP.text, letterSpacing:'-0.045em', lineHeight:1 }}>{s.value}</div>
             <div style={{ marginTop:6, fontSize:11, color:HP.textSoft, fontFamily:'Outfit', fontStyle:'italic' }}>{s.hint}</div>
           </div>
@@ -240,7 +241,7 @@ function EmptyState() {
   const navigate = useNavigate();
   return (
     <section className="ff-hist-section" style={{ padding:'72px 88px 96px', textAlign:'center', borderTop:`1px solid ${HP.border}` }}>
-      <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color:HP.purple, marginBottom:18 }}>The diary is blank</div>
+      <Eyebrow size={10} style={{ marginBottom:18 }}>The diary is blank</Eyebrow>
       <h2 style={{ fontFamily:'Outfit', fontSize:36, lineHeight:1, fontWeight:500, letterSpacing:'-0.03em', color:HP.text, margin:'0 0 14px 0' }}>Mark something watched.</h2>
       <p style={{ margin:'0 auto 28px', maxWidth:480, fontSize:14, color:HP.textMuted, fontFamily:'Outfit, Inter, sans-serif', lineHeight:1.6 }}>
         Hit Mark Watched on any film detail page and it lands here, grouped by month with your rating and a note line.
@@ -271,7 +272,7 @@ function PageError({ error }) {
   return (
     <div style={{ minHeight:'60vh', display:'flex', alignItems:'center', justifyContent:'center', padding:24 }}>
       <div style={{ textAlign:'center', maxWidth:520 }}>
-        <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color: HP.purple, marginBottom:18 }}>Diary · error</div>
+        <Eyebrow size={10} style={{ marginBottom:18 }}>Diary · error</Eyebrow>
         <h1 style={{ fontFamily:'Outfit, Inter, sans-serif', fontSize:36, fontWeight:500, color:HP.text, margin:'0 0 18px 0', letterSpacing:'-0.025em' }}>Couldn&rsquo;t load your diary.</h1>
         <p style={{ margin:0, color:'rgba(250,250,250,0.6)', fontSize:14, lineHeight:1.6 }}>{error}</p>
       </div>

--- a/src/features/watchlist/Watchlist.jsx
+++ b/src/features/watchlist/Watchlist.jsx
@@ -9,6 +9,7 @@ import { useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { usePageMeta } from '@/shared/hooks/usePageMeta'
 import MoodPill from '@/shared/components/MoodPill'
+import Eyebrow from '@/shared/ui/Eyebrow'
 import { HP, HP_GRAD } from './data'
 import { WatchlistDataProvider, useWatchlistData } from './useWatchlistData'
 import './watchlist.css'
@@ -27,11 +28,11 @@ function Masthead() {
       <div style={{ position:'absolute', inset:0, pointerEvents:'none', background:'radial-gradient(ellipse 60% 35% at 10% 0%, rgba(167,139,250,0.14), transparent 60%)' }} />
       <div style={{ position:'relative' }}>
         <div style={{ display:'flex', alignItems:'center', gap:14, marginBottom:24, flexWrap:'wrap' }}>
-          <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.32em', textTransform:'uppercase', color:HP.purple }}>Watchlist</div>
+          <Eyebrow spacing="0.32em" size={10}>Watchlist</Eyebrow>
           <div style={{ height:1, width:38, background:HP.purple, opacity:0.5 }} />
-          <div style={{ fontSize:10, fontWeight:500, letterSpacing:'0.18em', textTransform:'uppercase', color:HP.textMuted, fontFamily:'Outfit' }}>
+          <Eyebrow tone="meta" weight={500} size={10}>
             {stats.watchlistTotal} film{stats.watchlistTotal === 1 ? '' : 's'} saved
-          </div>
+          </Eyebrow>
         </div>
         <h1 className="ff-wl-hero" style={{ fontFamily:'Outfit', fontSize:88, lineHeight:0.92, fontWeight:300, letterSpacing:'-0.05em', color:HP.text, margin:0, textWrap:'balance' }}>
           The <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>queue.</em>
@@ -64,7 +65,7 @@ function PulseStrip() {
           <div key={s.label} style={{ padding:'20px 22px', borderRadius:6, background:'rgba(255,255,255,0.025)', border:`1px solid ${HP.border}`, display:'grid', gridTemplateColumns:'auto 1fr', gap:18, alignItems:'center' }}>
             <span style={{ fontFamily:'Outfit', fontSize:44, fontWeight:200, color:s.hex, letterSpacing:'-0.045em', lineHeight:1 }}>{s.value}</span>
             <div>
-              <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.18em', textTransform:'uppercase', color:HP.textMuted, fontFamily:'Outfit' }}>{s.label}</div>
+              <Eyebrow tone="meta" size={10}>{s.label}</Eyebrow>
               <div style={{ marginTop:4, fontSize:12, color:HP.textSoft, fontFamily:'Outfit', fontStyle:'italic' }}>{s.hint}</div>
             </div>
           </div>
@@ -160,9 +161,7 @@ function TonightTier({ picks }) {
   return (
     <section className="ff-wl-section ff-wl-tonight" style={{ padding:'8px 88px 48px' }}>
       <div style={{ marginBottom:24, display:'flex', alignItems:'baseline', gap:14, flexWrap:'wrap' }}>
-        <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color:HP.purple, display:'inline-flex', alignItems:'center', gap:10 }}>
-          <span style={{ height:1, width:22, background:HP.purple, opacity:0.6 }} />{kicker}
-        </div>
+        <Eyebrow rule size={10}>{kicker}</Eyebrow>
         <span style={{ fontSize:12, color:HP.textMuted, fontFamily:'Outfit', fontStyle:'italic' }}>{sub}</span>
       </div>
       <div className="ff-wl-tonight-grid" style={{ display:'grid', gridTemplateColumns:`repeat(${Math.min(picks.length, 3)},1fr)`, gap:24 }}>
@@ -231,9 +230,7 @@ function Grid({ items }) {
   if (items.length === 0) return <EmptyState />;
   return (
     <section className="ff-wl-section ff-wl-grid-section" style={{ padding:'0 88px 56px' }}>
-      <div style={{ marginBottom:20, fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color:HP.purple, display:'inline-flex', alignItems:'center', gap:10 }}>
-        <span style={{ height:1, width:22, background:HP.purple, opacity:0.6 }} />The full queue
-      </div>
+      <Eyebrow rule size={10} style={{ marginBottom:20 }}>The full queue</Eyebrow>
       <div className="ff-wl-grid" style={{ display:'grid', gridTemplateColumns:'repeat(5,1fr)', gap:22 }}>
         {items.map(f => (
           <button
@@ -269,9 +266,7 @@ function List({ items }) {
   if (items.length === 0) return <EmptyState />;
   return (
     <section className="ff-wl-section ff-wl-list-section" style={{ padding:'0 88px 56px' }}>
-      <div style={{ marginBottom:20, fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color:HP.purple, display:'inline-flex', alignItems:'center', gap:10 }}>
-        <span style={{ height:1, width:22, background:HP.purple, opacity:0.6 }} />The full queue
-      </div>
+      <Eyebrow rule size={10} style={{ marginBottom:20 }}>The full queue</Eyebrow>
       <div style={{ borderTop:`1px solid ${HP.border}` }}>
         {items.map(f => (
           <div key={f.id} className="ff-wl-list-row" style={{ display:'grid', gridTemplateColumns:'48px 1fr auto auto auto auto', gap:24, alignItems:'center', padding:'18px 0', borderBottom:`1px solid ${HP.border}` }}>
@@ -328,7 +323,7 @@ function EmptyState() {
   const navigate = useNavigate();
   return (
     <section className="ff-wl-section" style={{ padding:'72px 88px 96px', textAlign:'center' }}>
-      <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color:HP.purple, marginBottom:18 }}>The queue is empty</div>
+      <Eyebrow size={10} style={{ marginBottom:18 }}>The queue is empty</Eyebrow>
       <h2 style={{ fontFamily:'Outfit', fontSize:36, lineHeight:1, fontWeight:500, letterSpacing:'-0.03em', color:HP.text, margin:'0 0 14px 0' }}>Save a film to start.</h2>
       <p style={{ margin:'0 auto 28px', maxWidth:480, fontSize:14, color:HP.textMuted, fontFamily:'Outfit, Inter, sans-serif', lineHeight:1.6 }}>
         Tap Save on any film detail page and it lands here, re-sorted by mood + match every evening.
@@ -363,7 +358,7 @@ function CleanupNudge({ count, onReview }) {
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={HP.amber} strokeWidth="2" strokeLinecap="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>
         </div>
         <div>
-          <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.22em', textTransform:'uppercase', color:HP.amber, marginBottom:6 }}>Queue hygiene</div>
+          <Eyebrow color={HP.amber} spacing="0.22em" size={10} style={{ marginBottom:6 }}>Queue hygiene</Eyebrow>
           <div style={{ fontFamily:'Outfit', fontSize:22, fontWeight:500, color:HP.text, letterSpacing:'-0.02em' }}>{count} film{count === 1 ? '' : 's'} {count === 1 ? 'has' : 'have'} been waiting over 60 days.</div>
           <div style={{ marginTop:6, fontSize:13, color:HP.textMuted, fontFamily:'Outfit, Inter, sans-serif', fontStyle:'italic' }}>Be honest. Cut what you won&rsquo;t watch &mdash; it sharpens tomorrow&rsquo;s picks.</div>
         </div>
@@ -450,7 +445,7 @@ function PageError({ error }) {
   return (
     <div style={{ minHeight:'60vh', display:'flex', alignItems:'center', justifyContent:'center', padding:24 }}>
       <div style={{ textAlign:'center', maxWidth:520 }}>
-        <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color: HP.purple, marginBottom:18 }}>Queue · error</div>
+        <Eyebrow size={10} style={{ marginBottom:18 }}>Queue · error</Eyebrow>
         <h1 style={{ fontFamily:'Outfit, Inter, sans-serif', fontSize:36, fontWeight:500, color:HP.text, margin:'0 0 18px 0', letterSpacing:'-0.025em' }}>Couldn&rsquo;t load your queue.</h1>
         <p style={{ margin:0, color:'rgba(250,250,250,0.6)', fontSize:14, lineHeight:1.6 }}>{error}</p>
       </div>


### PR DESCRIPTION
## Axis 2 — Eyebrow rollout, batch 3 (history + watchlist)
The diary + queue surfaces' eyebrows now flow through `<Eyebrow>` (preserve-the-look):
- **history** (5): masthead "Diary" kicker + meta sublabel, the stat-card field labels, empty + error kickers.
- **watchlist** (9): masthead kicker + meta sublabel, filter field label, "Tonight" ruled kicker, both "The full queue" ruled kickers, empty + error kickers, amber "Queue hygiene" kicker.

Left inline (not the kicker atom): card-overlay badges (● Tonight / Stale / numbered mood labels).

## Verify
- lint clean · test 417 ✓ · build ✓
- Authed `/history` masthead pixel-identical ("DIARY" + rule + "38 FILMS · 88 HOURS · 0-DAY STREAK" + the stat field labels). Watchlist shares the same masthead/kicker patterns (equivalence + `<Eyebrow>` count check: 9 expected/9 found).

Gated surfaces — no visual-baseline impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)