### PR TITLE
refactor(ui): roll Eyebrow out to account (Axis 2 batch 4)

### DIFF
--- a/src/features/account/Account.jsx
+++ b/src/features/account/Account.jsx
@@ -8,6 +8,7 @@
 // the prototype's internal nav has been dropped.
 
 import { usePageMeta } from '@/shared/hooks/usePageMeta'
+import Eyebrow from '@/shared/ui/Eyebrow'
 import { HP } from './data'
 import {
   Masthead, IdentityCard, Notifications,
@@ -73,7 +74,7 @@ function SignedOut() {
   return (
     <div className="ff-account-v2" style={{ minHeight:'100vh', background:HP.bgDeep, color:HP.text, display:'flex', alignItems:'center', justifyContent:'center', padding:24, fontFamily:'Inter, sans-serif' }}>
       <div style={{ textAlign:'center', maxWidth:480 }}>
-        <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color: HP.purple, marginBottom:18 }}>Account</div>
+        <Eyebrow size={10} style={{ marginBottom:18 }}>Account</Eyebrow>
         <h1 style={{ fontFamily:'Outfit, Inter, sans-serif', fontSize:42, fontWeight:500, color: HP.text, margin:'0 0 18px 0', letterSpacing:'-0.025em' }}>Sign in to manage your settings.</h1>
         <p style={{ margin:0, color:'rgba(250,250,250,0.6)', fontSize:14, lineHeight:1.6 }}>The settings drawer needs an account to attach to.</p>
       </div>
@@ -85,7 +86,7 @@ function PageError({ error }) {
   return (
     <div className="ff-account-v2" style={{ minHeight:'100vh', background:HP.bgDeep, color:HP.text, display:'flex', alignItems:'center', justifyContent:'center', padding:24, fontFamily:'Inter, sans-serif' }}>
       <div style={{ textAlign:'center', maxWidth:520 }}>
-        <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color: HP.purple, marginBottom:18 }}>Account · error</div>
+        <Eyebrow size={10} style={{ marginBottom:18 }}>Account · error</Eyebrow>
         <h1 style={{ fontFamily:'Outfit, Inter, sans-serif', fontSize:36, fontWeight:500, color:HP.text, margin:'0 0 18px 0', letterSpacing:'-0.025em' }}>Couldn&rsquo;t load your settings.</h1>
         <p style={{ margin:0, color:'rgba(250,250,250,0.6)', fontSize:14, lineHeight:1.6 }}>{error}</p>
       </div>

--- a/src/features/account/sections-bottom.jsx
+++ b/src/features/account/sections-bottom.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { supabase } from '@/shared/lib/supabase/client'
 import { formatMonthYear } from '@/shared/lib/format/date'
 import { setAnalyticsOptOut } from '@/shared/services/analytics'
+import Eyebrow from '@/shared/ui/Eyebrow'
 import { HP, HP_GRAD, CONNECTIONS, FOUNDING_CUTOFF } from './data'
 import { SectionHead, Toggle } from './sections-top'
 import { useAccountData } from './useAccountData'
@@ -117,7 +118,7 @@ function PlanCard() {
       <div className="ff-acct-plan-card" style={{ padding:'32px 36px', borderRadius:8, background:`linear-gradient(135deg, ${HP.purple}11, ${HP.pink}08)`, border:`1px solid ${HP.purple}33`, position:'relative', overflow:'hidden' }}>
         <div style={{ position:'absolute', top:'-30%', right:'-10%', width:'40%', aspectRatio:1, borderRadius:999, background:`radial-gradient(circle, ${HP.purple}33, transparent 70%)`, filter:'blur(40px)' }} />
         <div style={{ position:'relative' }}>
-          <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.22em', textTransform:'uppercase', color:HP.purple, marginBottom:10 }}>Current plan</div>
+          <Eyebrow spacing="0.22em" size={10} style={{ marginBottom:10 }}>Current plan</Eyebrow>
           <div className="ff-acct-plan-headline" style={{ fontFamily:'Outfit', fontSize:32, fontWeight:300, color:HP.text, letterSpacing:'-0.03em', marginBottom:14 }}>
             {tier}
             {isFounding && (

--- a/src/features/account/sections-top.jsx
+++ b/src/features/account/sections-top.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { supabase } from '@/shared/lib/supabase/client'
 import { formatMonthYear } from '@/shared/lib/format/date'
+import Eyebrow from '@/shared/ui/Eyebrow'
 import { HP, HP_GRAD } from './data'
 import { useAccountData } from './useAccountData'
 
@@ -14,9 +15,9 @@ function Masthead() {
   return (
     <section className="ff-acct-section ff-acct-section--masthead" style={{ padding:'40px 88px 12px' }}>
       <div style={{ display:'flex', alignItems:'center', gap:14, flexWrap:'wrap' }}>
-        <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.32em', textTransform:'uppercase', color:HP.purple }}>Account</div>
+        <Eyebrow spacing="0.32em" size={10}>Account</Eyebrow>
         <div style={{ height:1, width:38, background:HP.purple, opacity:0.5 }} />
-        <div style={{ fontSize:10, fontWeight:500, letterSpacing:'0.18em', textTransform:'uppercase', color:HP.textMuted, fontFamily:'Outfit' }}>Identity, privacy, plan</div>
+        <Eyebrow tone="meta" weight={500} size={10}>Identity, privacy, plan</Eyebrow>
       </div>
     </section>
   );
@@ -172,7 +173,7 @@ function Stat({ n, label }) {
   return (
     <div>
       <div style={{ fontFamily:'Outfit', fontSize:28, fontWeight:200, color:HP.text, letterSpacing:'-0.035em', lineHeight:1 }}>{n}</div>
-      <div style={{ marginTop:4, fontSize:9, fontWeight:700, letterSpacing:'0.18em', textTransform:'uppercase', color:HP.textMuted, fontFamily:'Outfit' }}>{label}</div>
+      <Eyebrow tone="meta" size={9} style={{ marginTop:4 }}>{label}</Eyebrow>
     </div>
   );
 }
@@ -181,9 +182,7 @@ function Stat({ n, label }) {
 function SectionHead({ kicker, title, sub }) {
   return (
     <div style={{ marginBottom:24 }}>
-      <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color:HP.purple, marginBottom:12, display:'inline-flex', alignItems:'center', gap:10 }}>
-        <span style={{ height:1, width:22, background:HP.purple, opacity:0.6 }} />{kicker}
-      </div>
+      <Eyebrow rule size={10} style={{ marginBottom:12 }}>{kicker}</Eyebrow>
       <h2 style={{ fontFamily:'Outfit', fontSize:36, lineHeight:1, fontWeight:500, letterSpacing:'-0.03em', color:HP.text, margin:0, textWrap:'balance' }}>{title}</h2>
       {sub && <p style={{ marginTop:12, fontSize:13.5, color:HP.textMuted, fontFamily:'Outfit, Inter, sans-serif', lineHeight:1.55, maxWidth:540 }}>{sub}</p>}
     </div>


### PR DESCRIPTION
## Axis 2 — Eyebrow rollout, batch 4 (account)
account's eyebrows now flow through `<Eyebrow>` (preserve-the-look), 7 across 3 files:
- **sections-top** — masthead "Account" kicker + meta sublabel, the stat field label (size 9), the shared `H`-helper ruled section kicker.
- **sections-bottom** — the "Current plan" kicker.
- **Account.jsx** — the loading + error-state kickers.

Left inline (not the kicker atom): the "View my profile →" link, the nav badge pill, and the delete-confirm form `<label>`s.

## Verify
- lint clean · test 417 ✓ · build ✓
- `<Eyebrow>` counts match (2 + 4 + 1 = 7); no section kickers left inline.
- **By equivalence:** every pattern used here (masthead kicker + meta sublabel, ruled H-kicker, meta field label) was already confirmed pixel-identical on the 5 prior surfaces (#164–167). (The image reader hit a cumulative limit this session, so this batch leans on structural + equivalence verification rather than a fresh screenshot.)

Gated surface — no visual-baseline impact (the linux Visual Regression gate still runs on `/` + `/about` and will confirm nothing leaked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)