### PR TITLE
docs: add synthetic persona usability lab (F10C)

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ and ending green on `lint → test → build`. See the roadmap in the
 - **F9H.1 — Enable real CI gates** ✅ done (uploaded the 5 repo secrets from approved local sources — no values exposed — + restricted the Lighthouse collect to `index.html`; **E2E + Lighthouse now run for real** — `docs/ci-real-gates-verification-f9h1.md`)
 - **F10A — Private preview + outcome baseline** ✅ done (preview plan + decision criteria, tester guide, launch runbook, feedback template, outcome-baseline collection plan; pre-preview dev baseline; engine frozen — `docs/private-preview-*-f10a.md`, `docs/outcome-baseline-collection-f10a.md`)
 - **F10B — Run private preview, Wave 1** 🟡 in progress (prepared the Wave-1 operating sheet + tester invite copy + a PII-free tracker template; ran + recorded the pre-invite readiness gate — prod/headers/CSP/Sentry/CI/Cloudflare/Supabase all healthy; **invites not yet sent** — `docs/private-preview-wave-1-f10b.md`)
+- **F10C — Synthetic persona usability lab** ✅ done (a parallel UX-inspection track while awaiting real testers: persona schema + 16 archetypes + task script + rubric + Claude prompt pack + tooling proposal + a 2-persona pilot — **synthetic ≠ real-user validation; does not unblock F8C** — `docs/personas/`)
 - **F8C — Gated engine tuning** ⏭️ next — **still blocked** until the **F10B private preview** (Wave 1 → 2) collects a non-trivial, stable real-user outcome baseline (capture mechanism is proven; real-user volume is not there yet)
 
 ---

--- a/docs/PLANNING.md
+++ b/docs/PLANNING.md
@@ -20,6 +20,13 @@
       **Invites NOT yet sent (your action).** Next: send the 2–3 Wave-1 invites, run the
       per-tester onboarding smoke, monitor daily, collect the first windowed real-user
       capture. **F8C still BLOCKED.**
+- [ ] **F10C — Synthetic Persona Usability Lab** (parallel UX track while we wait for real
+      testers): built a reusable persona lab under `docs/personas/` (schema, 16 personas,
+      task script, rubric, Claude prompt pack, tooling proposal) + ran a 2-persona pilot.
+      **Synthetic ≠ real users — does NOT unblock F8C.** Top pilot signal: cold-start
+      re-seeding is the shared pinch point (no diary/Trakt import; "three questions" thin for
+      cinephiles, value gated for scrollers); the honesty layer (no fabricated why/reviews/score)
+      is a real strength. All findings are hypotheses to validate in Wave 1.
 
 ## Up Next (prioritized)
 - [x] ~~Apply the Sentry Allowed-Domains dashboard fix~~ — ✅ done (user) + **verified
@@ -60,6 +67,16 @@
       outcome-capture baseline (`docs/sql/recommendation-evaluation-queries.sql` §7).
 
 ## Done This Week
+- [x] **F10C — Synthetic Persona Usability Lab** (docs/UX-inspection only; engine frozen `2.17`):
+      created `docs/personas/` — `persona-schema-f10c.md`, `synthetic-personas-f10c.md` (10 platform
+      archetypes + 6 FeelFlick targets, all clearly labeled synthetic/no-proprietary-data),
+      `persona-usability-tasks-f10c.md` (10 core tasks + persona probes), `persona-usability-rubric-f10c.md`
+      (13 evidence-required dims), `claude-persona-test-prompts-f10c.md` (reusable run prompts +
+      guardrails), `persona-testing-tooling-proposal-f10c.md` (docs-only `/persona-test` + subagent +
+      Playwright proposal — nothing installed), and `persona-pilot-findings-f10c.md` (2-persona pilot:
+      P3 Netflix scroller + P1 Letterboxd power user, live-landing + code-grounded). **Does NOT unblock
+      F8C** (synthetic). Pilot Insights: cold-start re-seeding gap; cold Briefing shows no "why" (honest);
+      honesty layer is a strength; `/home` tail anti-drift watch. No app/engine change.
 - [x] **F10B — Run Private Preview, Wave 1 (prep)** (operations/docs only; engine frozen `2.17`):
       created the Wave-1 operating sheet (`private-preview-wave-1-f10b.md`) — cohort (2–3),
       invite sequence, tester invite copy (DM/email/reminder/feedback), daily monitoring

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,7 @@ guardrails, workflows), the source of truth is **`CLAUDE.md`** at the root, plus
 - [`runbooks/`](runbooks/) — operational runbooks (dev setup, debugging).
 - [`sql/`](sql/) — **read-only** analysis query templates (e.g. `recommendation-evaluation-queries.sql`).
 - [`eval/`](eval/) — generated evaluation baselines (fixture-based; regenerate via `scripts/eval/`).
+- [`personas/`](personas/) — **F10C Synthetic Persona Usability Lab** (UX inspection, **synthetic ≠ real users**, does **not** unblock F8C): `persona-schema-f10c.md`, `synthetic-personas-f10c.md` (16 archetypes), `persona-usability-tasks-f10c.md`, `persona-usability-rubric-f10c.md`, `claude-persona-test-prompts-f10c.md`, `persona-testing-tooling-proposal-f10c.md` (docs-only), and `persona-pilot-findings-f10c.md` (2-persona pilot). Start with the schema; run via the prompt pack.
 
 ## archive/
 Historical / superseded docs — see [`archive/README.md`](archive/README.md). Not current.

--- a/docs/personas/claude-persona-test-prompts-f10c.md
+++ b/docs/personas/claude-persona-test-prompts-f10c.md
@@ -1,0 +1,126 @@
+# F10C — Claude Persona-Testing Prompt Pack
+
+> **Phase F10C. Reusable prompts for running a synthetic persona walkthrough with Claude
+> Code.** Copy-paste these to drive a structured run. **Guardrails are part of every prompt:**
+> describe only observed behavior, separate persona-reaction from product-recommendation, and
+> never claim synthetic feedback is real-user validation. These runs **do not** change the app
+> and **do not** unblock F8C.
+
+**Status:** ✅ prompt pack ready. **Date:** 2026-06-04. Pairs with
+[personas](synthetic-personas-f10c.md) · [tasks](persona-usability-tasks-f10c.md) ·
+[rubric](persona-usability-rubric-f10c.md).
+
+---
+
+## Global guardrails (prepend to any run)
+
+```
+You are running a SYNTHETIC persona usability test of FeelFlick. Hard rules:
+1. Synthetic personas are archetypes, NOT real users. Never describe their reactions as
+   real-user validation, evidence, or proof. Always label findings "synthetic — to be
+   validated with real users."
+2. Describe ONLY what is actually on screen or in the code. Do NOT invent product behavior,
+   copy, screens, or data that you did not observe. If you can't reach a surface, mark the
+   task NOT OBSERVED and say why.
+3. Keep two voices separate every step:
+   - PERSONA REACTION: "as {persona}, I see X, I expect Y, I feel Z, I do W."
+   - PRODUCT NOTE: "as a tester, the issue is …" (severity P0/P1/P2/Insight).
+4. A bad recommendation is a rec-quality / Insight signal for F8C — note it, do NOT propose
+   scoring/ranking/threshold/engine changes. F8C is blocked.
+5. Change no app code. This is read-only UX inspection.
+6. No fabricated social proof, counts, or claims — and flag any you see in the product.
+```
+
+## 1. Run as a specific persona
+
+```
+Adopt persona {P# — name} from docs/personas/synthetic-personas-f10c.md. Internalize all
+their schema fields (decision style, tolerances, frustration, trust requirements, success
+criteria, likely objections, feedback style). Stay in character for the whole run, but keep
+the PRODUCT NOTE voice available. Confirm the persona in one sentence before starting.
+```
+
+## 2. Think aloud while using FeelFlick
+
+```
+Walk through FeelFlick as {persona}, thinking aloud at each step: what you SEE → what you
+EXPECT → what you FEEL → what you DO next. Narrate honestly in character (including boredom,
+distrust, delight). Quote the actual on-screen copy you react to. Where you only inspected
+the code (not a live screen), say so explicitly.
+```
+
+## 3. Complete the task script
+
+```
+Run the core task script T1–T10 from docs/personas/persona-usability-tasks-f10c.md, plus the
+persona-specific probe(s) for {persona}. For each task record: what you did · friction ·
+trust break · confusing copy · what worked · NOT OBSERVED (if unreachable). Don't skip the
+abandon-reason task (T10).
+```
+
+## 4. Record friction
+
+```
+For every point of friction, capture: WHERE (route/surface), the exact COPY or affordance,
+WHAT the persona expected, WHAT happened, and the FEELING (confused / distrustful / bored /
+delighted). Friction with a quote beats friction described abstractly.
+```
+
+## 5. Separate persona reaction from product recommendation
+
+```
+For each finding, output two labeled lines:
+  PERSONA REACTION: (in character, subjective)
+  PRODUCT NOTE: (as a tester — the underlying UX/copy/trust issue, with severity)
+Never merge them. A persona disliking a good film ≠ a product defect; a persona confused by
+unclear copy IS a product defect.
+```
+
+## 6. Classify issues (P0/P1/P2/Insight)
+
+```
+Tag every PRODUCT NOTE:
+  P0  — blocking / breaks trust hard / fabricated content / can't complete core path
+  P1  — significant friction or confusion most of this persona type would hit
+  P2  — polish / minor copy / single-edge
+  Insight — product/strategy/rec-quality signal (incl. "the pick itself was off") — log, don't act
+Group by surface. Note when ≥3 personas hit the same issue (a pattern outranks any one score).
+```
+
+## 7. Score the rubric (evidence-required)
+
+```
+Fill the docs/personas/persona-usability-rubric-f10c.md scorecard for {persona}: D1–D13, each
+1–5 WITH a one-line evidence quote/observation. A score without evidence is invalid — drop it.
+State the methodology (live-browser public / code-grounded authenticated / mixed) at the top.
+```
+
+## 8. Anti-fabrication check (run before finalizing)
+
+```
+Before writing findings, audit your own output:
+- Did I describe any screen/copy/behavior I did NOT actually observe? Remove or mark NOT OBSERVED.
+- Did I imply any reaction is real-user evidence? Re-label as synthetic/hypothesis.
+- Did I propose any engine/scoring change? Remove — F8C is blocked; recategorize as Insight.
+- Did I invent counts, quotes, or social proof? Remove.
+Then write the findings.
+```
+
+## 9. Findings write-up
+
+```
+Summarize the run into the docs/personas/persona-pilot-findings-f10c.md format: persona ·
+methodology · tasks completed/NOT OBSERVED · observed friction · trust breaks · confusing copy ·
+what worked · rubric scorecard (with evidence) · issue backlog (P0/P1/P2/Insight) · "to validate
+with real users." End with the one-line reminder that this is synthetic and does not unblock F8C.
+```
+
+## Reusable one-liner (kick off a full run)
+
+```
+Run a synthetic persona usability test of FeelFlick as {P# — name}: adopt the persona, think
+aloud through task script T1–T10 + the persona probes, keep PERSONA REACTION vs PRODUCT NOTE
+separate, describe only observed behavior, score the rubric with evidence, classify issues
+P0/P1/P2/Insight, propose NO engine changes, and label everything synthetic /
+to-be-validated-with-real-users. Write it up in the pilot-findings format.
+```

--- a/docs/personas/persona-pilot-findings-f10c.md
+++ b/docs/personas/persona-pilot-findings-f10c.md
@@ -1,0 +1,126 @@
+# F10C — Persona Pilot Findings
+
+> **SYNTHETIC PERSONA PILOT — NOT real-user validation.** Two archetype walkthroughs
+> (P3 Netflix casual scroller, P1 Letterboxd power user) run against the live landing +
+> the actual authenticated-surface code. Every finding is a **hypothesis to validate with
+> real testers** (Wave 1+). **No app code changed. F8C stays blocked** — rec-quality
+> observations are logged as Insight, never acted on as tuning.
+
+**Status:** ✅ 2-persona pilot complete. **Date:** 2026-06-04. **Engine:** frozen `2.17`.
+
+## Methodology (honest about what was observed)
+
+| Surface | How observed |
+|---|---|
+| `/` landing (T1, T2) | **LIVE BROWSER** (localhost dev build = main code) — copy quoted is real, captured from the DOM |
+| Onboarding, Briefing/WhyThisPick, Film File/PrimaryCaseCard/ViewerNotes, Profile/DnaConfidence (T3–T8) | **CODE-GROUNDED** — reactions cite the *actual component copy* read from source (`src/features/...`). The authenticated UI was **not** live-walked under a real session in this pilot (real testers use Google OAuth — the live authenticated walk is deferred to Wave 1's per-tester smoke). |
+| T9–T10 | persona judgment over the above |
+
+> Tasks relying on a *real recommendation for a real account* (does the actual pick fit?) are
+> marked **NOT OBSERVED** — they need a live session + real history, i.e. real testers.
+
+---
+
+## Pilot A — P3 "Scroller" (Netflix casual scroller)
+
+*Success criteria: opened FeelFlick, got a pick, watched it — no scrolling. Tolerances: foreign/subtitles/slow ★. Patience: low.*
+
+| Task | Persona reaction (in character) | Product note |
+|---|---|---|
+| **T1 clarity** | "Landing says **'Films that know you.'** then **'You spent 23 minutes picking. You watched thirty.'** — ok, that's literally me. **'Not three options. One pick…'** — yes, I want that." | ✅ Strong wedge read; the anti-scroll hook is this persona's exact pain. |
+| **T2 sign-in** | "It wants me to **'Start free →'** with Google before I see a pick. Pricing says **'$0 · One price. No tiers.'** Fine, free + Google is one tap — but I'm mildly annoyed I can't see *a* pick first." | ⚠️ Value-gated behind sign-in+onboarding. Low-friction (Google, $0) but a real drop-off risk for impatient users — **validate the funnel**. |
+| **T3 onboarding** | "**'Three short questions. One film.'** — ok, short, I can do three." *(code-grounded: onboarding seeds a few loved films.)* | ✅ The "three questions" promise fits low patience. (Live flow NOT live-walked.) |
+| **T4 pick fit** | "I want the pick to feel right immediately and **not** be some subtitled art film." | **NOT OBSERVED** — needs a real session/history. Insight: this persona's ★ foreign/slow tolerance means the quality-gated engine could surface something too niche for night 1. |
+| **T5 why → decide** | "On a brand-new account the pick shows its slot + synopsis but **no 'Why this pick'** line." *(WhyThisPick is null-safe — renders nothing when there's no grounded reason.)* | ⚠️ **Insight:** honest-by-design, but a cold scroller gets a pick with no visible justification on night 1 — less persuasive exactly when trust is lowest. |
+| **T6 Film File** | "If I bother opening it, the match shows **'NN% · match · how it fits your taste so far'** — that hedge is reassuring, not hypey." | ✅ Honest match gloss lands well even for a casual user. (Low patience may mean they never open it.) |
+| **T7 DNA** | "Profile says **'Still learning'** and **'taste evidence… not a score of you.'** I don't really care about DNA, but it's not lying to me." | ✅ Honest; not a draw for this persona but not a turn-off. |
+| **T8 anti-scroll** | "After the pick, is there a wall of rows tempting me back into scrolling?" | ⚠️ **Insight/anti-drift watch:** the `/home` supporting tail (carousels) must stay visibly secondary to the Briefing or it re-creates the Netflix grid for this exact persona. Verify live. |
+| **T9 return** | "If tonight's one pick is good and I skip the 23-minute scroll, yeah I'd come back." | ✅ Return hinges on pick quality (real-user dependent). |
+| **T10 abandon** | "If the pick is a slow foreign film I've never heard of, or setup takes too long, I'm out." | Insight (F8C-relevant) + the sign-in/onboarding funnel. |
+
+**P3 scorecard** *(methodology: live landing + code-grounded auth)*
+
+```
+D1  First-10s clarity        5/5  "You spent 23 minutes picking. You watched thirty." = exact pain
+D2  Onboarding friction      3/5  "Three short questions" good; but value gated behind sign-in (not live-walked)
+D3  Trust in Tonight pick    NOT OBSERVED (needs real session)
+D4  "Why this pick" quality  2/5  cold-start shows NO why (null-safe) — unjustified pick when trust lowest
+D5  Film File case-making    4/5  honest match gloss "how it fits your taste so far"; may not be opened
+D6  DNA honesty              4/5  "taste evidence… not a score of you" — honest, low interest for this persona
+D7  Anti-scroll strength     3/5  single-pick framing strong; supporting-tail carousels are a re-scroll risk (verify)
+D8  Perceived personalization NOT OBSERVED (needs real pick)
+D9  Emotional resonance      4/5  the "23 minutes" line creates real recognition/relief
+D10 Task completion          3/5  core path plausible; gated on onboarding completing (not live-walked)
+D11 Confusion points         4/5  copy is clear; only the no-why cold pick is a soft confusion
+D12 Switching likelihood     3/5  "I'd try it instead of scrolling — if the first pick lands"
+D13 Return likelihood        3/5  conditional on real pick quality
+```
+
+---
+
+## Pilot B — P1 "Diarist" (Letterboxd power user)
+
+*Success criteria: a pick that earns "huh, good call" + a deep cut he hasn't seen. Tolerances: all ★★★★★. Distrusts popularity-driven recs; respects honesty.*
+
+| Task | Persona reaction (in character) | Product note |
+|---|---|---|
+| **T1 clarity** | "**'Films that know you'** — bold claim, I'm skeptical. But **'Not three options. One pick, with the article that makes its case'** — *that* I respect. And **'The engine has a voice. M. reads your taste…'** is a nice touch." | ✅ The case-making framing speaks directly to a cinephile; the "knows you" claim invites scrutiny (good — he'll test it). |
+| **T2 sign-in** | "Sign in with Google, fine. But **can I bring my Letterboxd history?** I have thousands of logged films — I don't want to rebuild my taste from three questions." | ⚠️ **Insight (cross-persona):** no diary/Trakt/Letterboxd import → a deep cinephile starts *cold*, which underrepresents him. The wedge's "taste-deep" promise is hardest to feel for imported-taste users on night 1. |
+| **T3 onboarding** | "**'Three short questions. One film.'** — three questions cannot represent my taste. I'll do it, but my night-1 DNA will be a caricature." | ⚠️ Insight: cold-start seeding is thin for power users (mirror image of P3's "three is fine"). |
+| **T4 pick fit** | "Show me a pick that names a *real* seed I love and isn't just Letterboxd-popular." | **NOT OBSERVED** — needs his real history. This is the make-or-break for P1/P14. |
+| **T5 why → decide** | "The 'why' format is **'Because you loved {X}'** — if {X} is genuinely one of mine, I'm sold; if it's generic **'Picked for you'**, I bounce. Good that it shows **nothing** rather than faking a reason." | ✅ The null-safe WhyThisPick (no fabricated reason) earns cinephile trust — *honesty over persuasion* is the right call for this persona. |
+| **T6 Film File** | "**'FeelFlick's read'** as an editorial hook, and Viewer notes say **'Illustrative impressions FeelFlick generated… not real reviews or quotes from real critics.'** — I *respect* that they don't fake critic quotes. That's rare." | ✅ **Standout win.** The honest reframe directly disarms the anti-slop distrust; no fabricated authority. |
+| **T7 DNA** | "**'taste evidence… not a score of you, and not a measure of accuracy'** — correct framing. But on a fresh account it says **'Still learning'**, which, again, underrates me because it has no import." | ✅ Honest framing respected; ⚠️ undercut by the cold-start import gap. |
+| **T8 anti-scroll / diary** | "Where's my **diary / lists**? I live in Letterboxd's log." *(Lists exist but as editorial seasoning, not a logging home base — by doctrine.)* | ✅ **Working as intended** (not-a-Letterboxd-clone). Insight: set expectations in copy so power users aren't confused that logging is substrate, not the front door. |
+| **T9 return** | "If it surfaces deep cuts that fit my taste and never repeats, I'd keep a nightly habit alongside Letterboxd." | ✅ Return hinges on specificity + non-repetition (real-user dependent; P16 territory). |
+| **T10 abandon** | "One mainstream/popularity-driven pick, one fabricated claim, or making me rebuild my whole taste here — and I'm gone." | Insight (F8C honesty/quality) + the import gap. |
+
+**P1 scorecard** *(methodology: live landing + code-grounded auth)*
+
+```
+D1  First-10s clarity        4/5  "the article that makes its case" resonates; "knows you" invites (healthy) skepticism
+D2  Onboarding friction      2/5  no Letterboxd/Trakt import → deep taste starts cold; "three questions" underrepresents
+D3  Trust in Tonight pick    NOT OBSERVED (needs his real history)
+D4  "Why this pick" quality  4/5  "Because you loved {seed}" is the right shape; null-safe (no fake why) earns trust
+D5  Film File case-making    5/5  "FeelFlick's read" + "…not real reviews or quotes from real critics" = honest, rare, respected
+D6  DNA honesty              5/5  "taste evidence… not a score of you, and not a measure of accuracy" — exactly right
+D7  Anti-scroll strength     4/5  single justified pick is the anti-grid he wants; diary-as-substrate may confuse at first
+D8  Perceived personalization NOT OBSERVED (needs real seeds)
+D9  Emotional resonance      3/5  intrigued + skeptical; resonance depends on the first real pick
+D10 Task completion          3/5  completes, but starts cold without import
+D11 Confusion points         4/5  main confusion: "where's my diary/lists" (expectation, not a bug)
+D12 Switching likelihood     3/5  "alongside Letterboxd, not instead — until it proves taste"
+D13 Return likelihood        4/5  high IF picks are specific + non-repeating + honest
+```
+
+---
+
+## Cross-persona patterns (the signal)
+
+1. **🔶 Cold-start re-seeding is the shared pinch point — from both ends.** The scroller has *low patience* for onboarding; the cinephile finds *three questions too thin* and wants to import an existing diary. Both start cold, and the "taste-deep" promise is weakest on night 1. **Highest-value Insight** (also hits P5 Trakt, P14 anti-slop, P15 cold-start). → a real-user question: how much taste can we earn *fast* (or import) before the first pick?
+2. **🔶 Cold-start Briefing shows no "why" (by honest design).** WhyThisPick is null-safe — correct for honesty, but a brand-new user's first pick can look unjustified exactly when trust is lowest. Worth a *future* copy decision (an honest "still learning your taste — here's a starting pick" line vs. nothing) — **not** an engine change.
+3. **✅ The honesty layer is a genuine, differentiating strength.** WhyThisPick never fabricates; ViewerNotes says "not real reviews"; DnaConfidence says "not a score of you." This directly disarms the distrust of the most skeptical archetypes (P1, P10, P14). Protect it.
+4. **🔶 Anti-drift watch: the `/home` supporting tail.** For the scroller, carousels below the Briefing risk re-creating the grid. Verify the Briefing stays visibly primary in a live session.
+5. **🔶 Scope-honesty gaps** (no where-to-watch P4, no library P8, no diary-import P1) are *by doctrine* — the question is whether the app says "not yet" gracefully in copy. Verify.
+
+## Issue backlog (synthetic — validate with real users; none are F8C tuning)
+
+| ID | Severity | Issue | Personas | Note |
+|---|---|---|---|---|
+| F10C-1 | **Insight (high)** | Cold-start re-seeding underrepresents users with deep external taste; no import path → warm users start cold | P1, P5, P14, P15 | Product/strategy, not engine. Validate the night-1 value gap with real testers. |
+| F10C-2 | **Insight / P2** | Cold-start Briefing renders no "Why this pick" (null-safe) → first pick can feel unjustified | P3, P15 | Honest by design; consider an honest cold-state line (future UI phase, not F10C). |
+| F10C-3 | **P2** | Value (the pick) is gated behind Google sign-in + onboarding; impatient archetypes may drop | P3, P7, P9 | Mitigated by $0 + "three questions"; measure real funnel drop-off. |
+| F10C-4 | **Insight (anti-drift)** | `/home` supporting-tail carousels risk re-introducing scroll | P3, P7 | Verify Briefing-primacy live; keep tail subordinate (doctrine). |
+| F10C-5 | **Insight** | Scope gaps (where-to-watch, library, diary import) need graceful "not yet" copy | P4, P8, P1 | By doctrine out-of-scope; it's a copy/expectation issue. |
+| — | **Win** | Honesty layer (no fabricated why/reviews/score) is a real trust differentiator | P1, P10, P14 | Protect in all future changes. |
+
+## What should be validated with real users (Wave 1+)
+
+- Does a **real** night-1 pick (real history) actually fit — for both a casual and a cinephile? (D3/D8 — NOT OBSERVED here.)
+- The **sign-in → onboarding → first-pick funnel** drop-off for impatient users (F10C-3).
+- Whether the **cold-start no-why** pick reads as honest or as unjustified to a real new user (F10C-2).
+- Whether the **`/home` tail** keeps the Briefing primary in real use, or invites scrolling (F10C-4).
+- Whether power users feel the **import gap** as a deal-breaker (F10C-1).
+
+> Reminder: these are **synthetic-persona hypotheses**, not validation. They prioritize what to
+> watch for when real testers arrive — and they do **not** unblock F8C.

--- a/docs/personas/persona-schema-f10c.md
+++ b/docs/personas/persona-schema-f10c.md
@@ -1,0 +1,68 @@
+# F10C — Persona Schema
+
+> **Phase F10C. Synthetic Persona Usability Lab — UX inspection only.** This is the
+> field definition every persona in [synthetic-personas-f10c.md](synthetic-personas-f10c.md)
+> must fill. **Synthetic personas are archetypes, not real users.** They do **not**
+> unblock F8C and their reactions are **not** real-user validation — they are a
+> structured lens for finding copy/trust/friction problems *before* real testers arrive.
+
+**Status:** ✅ schema defined. **Date:** 2026-06-04. **Engine:** untouched / frozen `2.17`.
+
+---
+
+## Why a schema
+
+A shared schema makes personas (a) comparable across the same task script and rubric,
+(b) honest (every field is a plausible *behavior or motivation*, never a claim about a
+real person or proprietary platform data), and (c) reusable as Claude-driven test
+subjects. Each persona reads against the [wedge](../product-doctrine.md): does FeelFlick's
+single justified nightly pick land for *this* archetype, or does it get judged as a
+worse version of the platform they already use?
+
+## Required fields
+
+Every persona document must include **all** of the following:
+
+| # | Field | What it captures |
+|---|---|---|
+| 1 | **Persona name** | A short memorable handle (archetype label, not a real name) |
+| 2 | **Platform archetype** | The product behavior they model (e.g. "Letterboxd power user") |
+| 3 | **Age range / life context** | Plausible band + situation (student, parent, commuter…) — context, not a real identity |
+| 4 | **Movie-watching frequency** | How often they watch (nightly / few-a-week / weekend / sporadic) |
+| 5 | **Primary platform used** | Where they mostly decide/watch today |
+| 6 | **Secondary platforms used** | Other tools in their stack |
+| 7 | **Watch-decision style** | How they choose (browse-til-tired, list-driven, mood-led, social-led, availability-led…) |
+| 8 | **Favorite genres / avoided genres** | Taste shape (to test fit + DNA honesty) |
+| 9 | **Tolerance** for old films / foreign films / subtitles / slow cinema | Low / medium / high per axis (tests anti-bubble + quality framing) |
+| 10 | **Social vs solo watching** | Mostly alone, with a partner, group |
+| 11 | **Mood-dependence** | How much their pick depends on tonight's mood (low→high) — the front door |
+| 12 | **Patience level** | Tolerance for friction / onboarding / a "slow" answer |
+| 13 | **Current frustration** | The unmet pain in their status quo |
+| 14 | **Switching trigger** | What would make them try/adopt something new |
+| 15 | **Trust requirements** | What a recommendation must show before they believe it |
+| 16 | **What would make FeelFlick valuable** | The win condition for this archetype |
+| 17 | **What would make them abandon FeelFlick** | The deal-breaker(s) |
+| 18 | **First-session success criteria** | What "this was worth it" looks like on night 1 |
+| 19 | **Likely tasks** | Which task-script items they'll care about most |
+| 20 | **Likely objections** | The pushback they'll voice |
+| 21 | **Feedback style** | How they express reactions (blunt, effusive, analytical, terse, comparative…) |
+
+## Authoring rules
+
+- **Archetype, not identity.** Fields describe *plausible behavior and motivation* based on
+  observable product patterns — never a real person, and never a claim of access to any
+  platform's private/proprietary user data.
+- **Behavior-grounded.** Anchor each field in something observable (how the platform works,
+  what that workflow optimizes for), not invented demographics-as-destiny.
+- **Wedge-relevant.** Every persona must let us test at least one wedge clause (mood-first,
+  taste-deep, single justified pick, anti-scroll) and at least one [do-not-become](../product-doctrine.md#do-not-become-list) risk.
+- **No real-user claim.** A persona's reaction is a *hypothesis to validate with real
+  testers*, never evidence on its own.
+
+## How a persona is used
+
+1. Instantiated as a Claude test subject via the [prompt pack](claude-persona-test-prompts-f10c.md).
+2. Runs the shared [task script](persona-usability-tasks-f10c.md) (+ its persona-specific tasks).
+3. Scored on the [rubric](persona-usability-rubric-f10c.md) — **scores require written evidence**.
+4. Findings + issues roll up into [persona-pilot-findings-f10c.md](persona-pilot-findings-f10c.md)
+   and the issue backlog, always labeled **synthetic / to-be-validated-with-real-users**.

--- a/docs/personas/persona-testing-tooling-proposal-f10c.md
+++ b/docs/personas/persona-testing-tooling-proposal-f10c.md
@@ -1,0 +1,91 @@
+# F10C — Persona-Testing Tooling Proposal (docs only)
+
+> **Phase F10C. A *proposal* for repeatable persona-testing tooling — NOT shipped.** No
+> executable command, skill, hook, or workflow is added in this phase. This documents three
+> options for a later, explicitly-approved phase to implement. The repo convention is
+> `.claude/skills/<name>/SKILL.md` (there is **no** `.claude/commands/` dir today), plus a
+> `PostToolUse` lint hook in `.claude/settings.json`. **Nothing here executes** until approved.
+
+**Status:** ✅ proposal only — no files created in `.claude/`. **Date:** 2026-06-04.
+
+---
+
+## Why propose, not build
+
+The persona lab is fully usable **today** via the [prompt pack](claude-persona-test-prompts-f10c.md)
+(copy-paste). Tooling would make runs repeatable, but adding an auto-triggering skill or a hook
+is a behavior change that needs its own approved phase (per CLAUDE.md Hard Stops + the
+project-guardrail-skills convention). So F10C ships the *design*, not the wiring.
+
+---
+
+## Option A — `/persona-test` slash command (proposed)
+
+A user-invocable command that runs the standard walkthrough for a chosen persona.
+
+- **Where it would live:** `.claude/commands/persona-test.md` *(this dir does not exist yet;
+  creating it introduces a new convention — defer to approval).*
+- **Invocation:** `/persona-test P3` or `/persona-test "Netflix casual scroller"`.
+- **Behavior (proposed):** load the persona + global guardrails + task script + rubric, run a
+  live or code-grounded walkthrough, emit a findings block in the pilot-findings format.
+- **Proposed template (NOT installed):**
+
+```markdown
+---
+description: Run a synthetic persona usability walkthrough of FeelFlick (UX inspection only)
+argument-hint: <persona id or name, e.g. P3 or "Letterboxd power user">
+---
+Run a SYNTHETIC persona usability test of FeelFlick as persona: $ARGUMENTS.
+Read docs/personas/{synthetic-personas,persona-usability-tasks,persona-usability-rubric,
+claude-persona-test-prompts}-f10c.md. Apply the global guardrails (synthetic ≠ real users;
+describe only observed behavior; PERSONA REACTION vs PRODUCT NOTE; propose NO engine changes —
+F8C is blocked). Run task script T1–T10 + the persona probes, score the rubric WITH evidence,
+classify issues P0/P1/P2/Insight, and write up in the pilot-findings format. Change no app code.
+```
+
+> **Guardrail:** even if added, this is a *user-invocable* command — never auto-triggering. It
+> must not edit app code, tune the engine, or claim real-user validity.
+
+## Option B — Persona QA subagent (proposed)
+
+A dedicated subagent (`Agent` tool / `subagent_type`) for isolated persona runs.
+
+- **Design:** read-only tools only (Read, Grep, Glob, chrome-devtools **read-only** verbs:
+  navigate, snapshot, list_console_messages, evaluate_script for inspection). **No** Edit/Write
+  to `src/`, **no** Supabase write tools, **no** engine files.
+- **Charter:** "Adopt one persona, run the task script against the live app / code, produce
+  evidence-backed rubric scores + an issue backlog. Never modify the app. Never claim real-user
+  validation. Route rec-quality observations to Insight (F8C stays blocked)."
+- **Why a subagent:** isolates each persona's context (no cross-contamination between runs) and
+  lets several personas run in parallel for a cohort sweep, each returning just its findings.
+- **Status:** design only — not registered as an agent in this phase.
+
+## Option C — Playwright walkthrough integration (proposed)
+
+Semi-automated, deterministic surface coverage to *support* (not replace) the persona reasoning.
+
+- **Idea:** a `e2e/persona/*.persona.js` set (named so Vitest skips them, like the existing
+  `*.e2e.js`) that drives the standard route path (`/` → auth → `/onboarding` → `/home` →
+  `/movie/:id` → `/profile` → Discover) and **captures artifacts** — screenshots + the visible
+  copy/a11y snapshot per surface — which the persona/runner then *reacts to*.
+- **Auth:** reuse the existing E2E client-side sign-in against the dev test user
+  (`E2E_TEST_EMAIL`/`PASSWORD`), same as `e2e/app/*` — no new auth path, no secrets in the repo.
+- **Boundary:** Playwright provides **deterministic observation** (what's actually rendered);
+  the **judgment stays with the persona** (Claude). Playwright never asserts UX quality — it only
+  gathers ground truth so findings can't drift into invented behavior.
+- **Out of scope here:** writing the specs. This phase only proposes the shape; a later approved
+  phase would add them under `e2e/persona/` with their own gitignored artifact dir.
+
+## What F10C actually ships
+
+- The persona docs + prompt pack (usable now, no tooling required).
+- This proposal. **No `.claude/commands/`, no new skill, no hook, no `e2e/persona/` specs, no
+  `package.json`/workflow change.** Each option above is a separate, approval-gated follow-up.
+
+## Recommendation
+
+Start with the **prompt pack (already shipped)** for the next few runs; if persona testing
+becomes routine, implement **Option A (`/persona-test`)** first (lowest blast radius, user-
+invoked), then **Option C (Playwright artifacts)** to harden observation, and **Option B
+(subagent)** only if parallel cohort sweeps are needed. All three remain **read-only, non-engine,
+synthetic-labeled**.

--- a/docs/personas/persona-usability-rubric-f10c.md
+++ b/docs/personas/persona-usability-rubric-f10c.md
@@ -1,0 +1,77 @@
+# F10C — Persona Usability Rubric
+
+> **Phase F10C. Scoring rubric for synthetic persona runs.** Each dimension scores **1–5**,
+> but **a score is invalid without written evidence** (a quote, an observed step, a specific
+> copy string, a screenshot ref). **Scores alone are banned.** These are synthetic-run
+> signals for prioritizing UX work — **not real-user validation**, and they **do not unblock F8C.**
+
+**Status:** ✅ rubric defined. **Date:** 2026-06-04. Use with the
+[task script](persona-usability-tasks-f10c.md) + [personas](synthetic-personas-f10c.md).
+
+---
+
+## Scoring rules
+
+- **1–5 per dimension**, where **1 = broken/blocking**, **3 = works but flawed**, **5 = magical/trustworthy**.
+- **Evidence required.** Every score carries ≥1 line of *what was observed* (quote the copy,
+  name the step, cite the surface). No evidence → the score is discarded.
+- **Score the experience, not the engine.** A bad *pick* is a rec-quality signal for F8C, **not**
+  a low usability score — note it separately. The rubric measures whether the *product makes its
+  case clearly and honestly*, which is UX, not tuning.
+- **Persona-relative.** A 5 for the Netflix scroller (low-effort, safe) differs from a 5 for the
+  anti-slop cinephile (honest, non-mediocre). Score against *that persona's* success criteria.
+- **NOT OBSERVED ≠ 0.** If a surface wasn't reached, mark the dimension NOT OBSERVED, don't guess.
+
+## Dimensions
+
+| # | Dimension | The question | 1 (broken) | 5 (magical/trustworthy) |
+|---|---|---|---|---|
+| **D1** | **First-10-second clarity** | In 10s on the landing, does the persona get what FeelFlick is? | "no idea what this does" | "one film for tonight, with a reason — got it instantly" |
+| **D2** | **Onboarding friction** | How costly is the path to first value? | abandons; too long/unclear | quick, "why we ask" is clear, value felt fast |
+| **D3** | **Trust in the Tonight pick** | Does the pick feel right for *this* persona's mood + taste? | random/popular/off | "this gets me" |
+| **D4** | **Quality of "Why this pick"** | Is the reason specific, true, useful — not generic? | "Picked for you" / empty | "Because you loved X" — specific + believable |
+| **D5** | **Film File case-making** | Does the PrimaryCaseCard build trust in the pick? | thin / no case | a sharp, honest, tiered case that earns the watch |
+| **D6** | **Cinematic DNA honesty** | Does the DNA feel *true*, including honest about thin data? | fake/flattering/over-confident | accurate; honestly "still learning" when cold |
+| **D7** | **Anti-scroll strength** | Does it reduce deciding, not add a grid to evaluate? | becomes a feed/carousel wall | one decision, made; scrolling reduced |
+| **D8** | **Perceived personalization** | Does it feel made for *me*, not a generic popular set? | "this is just popular stuff" | "this is *my* taste" |
+| **D9** | **Emotional resonance** | Does the session land emotionally (relief, delight, being understood)? | indifferent/annoyed | "it understood how I felt" |
+| **D10** | **Task completion** | Did the persona complete the core path (arrive→mood→pick→decide)? | blocked | smooth end-to-end |
+| **D11** | **Confusion points** | How free of confusing copy/affordances was it? (5 = none) | repeatedly lost | nothing confusing |
+| **D12** | **Switching likelihood** | Would this persona *switch from their status quo*? | "no, my app is fine" | "I'd use this instead tonight" |
+| **D13** | **Return likelihood** | Would they come back tomorrow? | "one-and-done" | "this could be a nightly ritual" |
+
+## Per-run scorecard template
+
+```
+Persona: P# — {name}
+Run date: {date} · Methodology: {live-browser public / code-grounded authenticated / mixed}
+
+D1  First-10s clarity      [_/5]  evidence: "…"
+D2  Onboarding friction    [_/5]  evidence: "…"
+D3  Trust in Tonight pick   [_/5]  evidence: "…"
+D4  "Why this pick" quality [_/5]  evidence: "…"
+D5  Film File case-making   [_/5]  evidence: "…"
+D6  DNA honesty             [_/5]  evidence: "…"
+D7  Anti-scroll strength    [_/5]  evidence: "…"
+D8  Perceived personalization[_/5] evidence: "…"
+D9  Emotional resonance     [_/5]  evidence: "…"
+D10 Task completion         [_/5]  evidence: "…"
+D11 Confusion points        [_/5]  evidence: "…"
+D12 Switching likelihood    [_/5]  evidence: "…"
+D13 Return likelihood       [_/5]  evidence: "…"
+
+Top friction:  …
+Top trust break: …
+What worked:   …
+Issues raised: [P0/P1/P2/Insight] …
+To validate with real users: …
+```
+
+## Reading the scores (honestly)
+
+- **A dimension ≤2 with evidence = a real UX problem** → issue backlog (P0/P1/P2).
+- **A low D3/D4 that's about the *pick itself* (not the framing)** = a **rec-quality / Insight**
+  signal for F8C — record it, **do not** act on it as tuning (F8C stays blocked).
+- **Aggregate scores are directional only.** With synthetic personas, the *evidence and issues*
+  matter; the numbers are a sorting aid, never a verdict and never "validated."
+- **Cross-persona patterns** (the same confusion across ≥3 personas) outrank any single score.

--- a/docs/personas/persona-usability-tasks-f10c.md
+++ b/docs/personas/persona-usability-tasks-f10c.md
@@ -1,0 +1,67 @@
+# F10C — Persona Usability Task Script
+
+> **Phase F10C. The shared walkthrough every persona runs.** Same 10 core tasks for all,
+> plus persona-specific probes. Tasks are **observational** — the persona *uses* the live
+> app and thinks aloud; **nothing in the app changes.** Synthetic runs are UX inspection,
+> **not real-user validation**, and do **not** unblock F8C.
+
+**Status:** ✅ task script defined. **Date:** 2026-06-04. Routes per the
+[surface hierarchy](../product-doctrine.md#surface-hierarchy). Score with the
+[rubric](persona-usability-rubric-f10c.md); record evidence, not just scores.
+
+---
+
+## How to run
+
+- The runner adopts the persona ([prompt pack](claude-persona-test-prompts-f10c.md)), then
+  performs each task **in character**, **thinking aloud** (what they see → expect → feel → do).
+- **Separate two voices** every task: the **persona reaction** ("as this user, I feel…") vs.
+  the **product note** ("as a tester, the issue is…"). Never blur them.
+- **Only describe what's actually on screen / in the code** — no invented behavior. If a
+  surface can't be reached in the run, mark the task **NOT OBSERVED** (don't fabricate it).
+- Capture per task: what they did · friction · trust break · confusing copy · what worked ·
+  rubric evidence · any P0/P1/P2/Insight issue.
+
+## Core tasks (all personas, in order)
+
+| # | Task | Surface | What it probes |
+|---|---|---|---|
+| **T1** | **Land on the homepage and explain what FeelFlick is** (10s, then 60s) | `/` (logged-out landing) | first-10-second clarity; does the wedge read? |
+| **T2** | **Decide whether to sign in — and articulate *why* sign-in is needed** | landing → auth CTA | value-before-commitment; is the ask justified? |
+| **T3** | **Complete onboarding** (seed a few loved films) | `/onboarding` | onboarding friction; "why we ask" clarity |
+| **T4** | **Evaluate tonight's pick** — does it fit my mood + taste? | `/home` Briefing | mood-first + taste-deep fit; perceived personalization |
+| **T5** | **Read "Why this pick" and decide: open / save / skip** | `/home` Briefing + WhyThisPick | quality of the case; decision confidence |
+| **T6** | **Open the Film File — does the PrimaryCaseCard build trust?** | `/movie/:id` | case-making layer (the moat); honesty |
+| **T7** | **Check Cinematic DNA — does it feel honest, or generic/flattering?** | `/profile` | DNA honesty; trust |
+| **T8** | **Try to find *another* film without falling into endless browsing** | Discover / Browse / back to Briefing | anti-scroll strength; does a second recommender compete? |
+| **T9** | **Give one reason you'd return tomorrow** | whole session | return likelihood; ritual potential |
+| **T10** | **Give one reason you'd abandon the app** | whole session | the deal-breaker; switching likelihood |
+
+> A run is "complete" when T1–T10 are attempted and each is either evidenced or marked
+> NOT OBSERVED with the reason.
+
+## Persona-specific probes (add to the core run)
+
+| Persona | Extra task | What it tests |
+|---|---|---|
+| **P1 Letterboxd** | Look for **diary / lists / logging** — compare to your Letterboxd expectations. Does FeelFlick try to replace it, or stay complementary? | not-a-Letterboxd-clone boundary; substrate-not-front-door |
+| **P4 JustWatch** | Ask **"where can I watch this?"** on the pick / Film File. Is the answer present, honest, or absent? | where-to-watch as convenience vs. missing-and-frustrating |
+| **P5 Trakt** | Look for **history / completion tracking**; check whether a watched film is ever re-recommended. | history use; repeated-pick guard |
+| **P3 Netflix** | After the pick, judge: **did this reduce my scrolling vs. Netflix**, honestly? | anti-scroll, head-to-head with the grid |
+| **P8 Plex** | Ask whether **personal-library support** matters to you, and how gracefully the app handles "not supported yet." | scope-honesty; control |
+| **P13 Couple** | Judge whether the single pick **helps a *shared* decision** (two people), and where it falls short. | single-pick as tiebreaker; multi-user gap |
+| **P2 TMDB** | Scrutinize the **match % / numbers** — do they read as honest evidence or an arbitrary grade? | numbers-mean-what-they-say |
+| **P6 Apple TV** | Judge the **craft + editorial voice** of the Film File writing specifically. | craft benchmark |
+| **P10 Reddit** | Hunt for **fake social proof / fabricated hype** anywhere; flag any claim that "people like you…" without basis. | no-fake-social-proof |
+| **P14 Anti-slop** | Pressure-test: is the pick **mediocre/popular**? Is any reason **fabricated**? Is it **recency-biased**? | the full honesty + quality gate |
+| **P15 Cold-start** | On thin data, does the app **honestly signal it's still learning** rather than fake confidence? | cold-state honesty (F7) |
+| **P16 Warmed-up** | Does the pick **visibly use your depth**, is the DNA **accurate**, and is tonight ≠ yesterday? | compounding + repeated-pick fatigue |
+| **P9 YouTube** | Is there a **trailer / instant visual hook**, and is the pick appealing within seconds? | visual-first appeal |
+| **P7 Prime** | Is the whole path **low-effort enough** to feel "safe and easy"? | convenience threshold |
+
+## Output of a run
+
+Each run produces a row/section in [persona-pilot-findings-f10c.md](persona-pilot-findings-f10c.md)
+(for piloted personas) or a future findings doc: tasks completed/NOT OBSERVED, friction, trust
+breaks, confusing copy, what worked, rubric scores **with evidence**, and an issue list tagged
+**P0 / P1 / P2 / Insight** — every item labeled **synthetic, to-be-validated-with-real-users**.

--- a/docs/personas/synthetic-personas-f10c.md
+++ b/docs/personas/synthetic-personas-f10c.md
@@ -1,0 +1,169 @@
+# F10C — Synthetic Persona Set
+
+> **Phase F10C. Synthetic personas for usability inspection — NOT real users.** These are
+> **archetypes** built from *observable product behavior and plausible motivation*. They do
+> **not** represent real users of any platform, and imply **no access to any platform's
+> proprietary data**. A persona's reaction is a **hypothesis to validate with real testers**
+> (Wave 1+), never evidence on its own, and they **do not unblock F8C**.
+
+**Status:** ✅ 16 personas (10 platform archetypes + 6 FeelFlick targets). **Date:** 2026-06-04.
+Fields per [persona-schema-f10c.md](persona-schema-f10c.md). Read against the [wedge](../product-doctrine.md).
+
+---
+
+## A. Platform-archetype personas (the competitive mindset they bring)
+
+### P1 — "Diarist" · Letterboxd power user
+- **Age/context:** 24–34, urban, deeply online cinephile. **Frequency:** 4–6 films/wk. **Primary:** Letterboxd (+ a streaming app to actually watch). **Secondary:** Mubi, physical media, Twitter/Letterboxd lists.
+- **Decision style:** list-driven + identity-driven (logs everything; watchlist is curated). **Genres:** arthouse, world cinema, auteur retrospectives; **avoids:** formula blockbusters. **Tolerance:** old ★★★★★ / foreign ★★★★★ / subtitles ★★★★★ / slow ★★★★★.
+- **Social/solo:** mostly solo, social *about* films. **Mood-dependence:** medium (often project/season-driven). **Patience:** high for depth, low for being condescended to.
+- **Frustration:** algorithms don't know *taste*, just popularity; no tool *picks* tonight from his own canon. **Switching trigger:** a rec engine that demonstrably reads his actual taste. **Trust requirements:** specific, grounded reasons + no fake authority; respect for deep cuts.
+- **Valuable when:** the pick names a real seed he loves and surfaces something he hasn't seen but should. **Abandons if:** picks feel mainstream/popularity-driven, reasons are generic, or it feels like a worse Letterboxd. **First-session success:** one pick that earns a "huh, good call."
+- **Likely tasks:** Tonight-pick judgment, Film File depth, DNA honesty, diary/list expectations. **Objections:** "this is just popular stuff," "where's my diary/lists." **Feedback style:** analytical, comparative, blunt.
+
+### P2 — "Spec-checker" · TMDB metadata browser
+- **Age/context:** 20–40, data-minded hobbyist/dev. **Frequency:** few/wk. **Primary:** TMDB/IMDb to look things up. **Secondary:** whatever streams it.
+- **Decision style:** fact-first (cast, crew, runtime, ratings) then decide. **Genres:** broad; rating/vote-count sensitive. **Tolerance:** old ★★★★ / foreign ★★★ / subtitles ★★★ / slow ★★★.
+- **Social/solo:** solo. **Mood-dependence:** low–medium. **Patience:** medium; wants the data to back a claim.
+- **Frustration:** has the *data* but no engine that turns it into a *decision for me*. **Switching trigger:** transparent, evidence-backed picks. **Trust requirements:** the "why" must cite something checkable (a seed, a real signal), and numbers must mean what they say.
+- **Valuable when:** the match % / "why" reads as honest evidence, not a grade. **Abandons if:** numbers feel arbitrary/inflated or the reason is hand-wavy. **First-session success:** a pick whose reasoning he can verify and agree with.
+- **Likely tasks:** Tonight pick + "why" scrutiny, Film File data, match %. **Objections:** "what does this score actually mean?" **Feedback style:** precise, skeptical.
+
+### P3 — "Scroller" · Netflix casual scroller
+- **Age/context:** 25–45, busy, tired evenings. **Frequency:** most nights (background + intentional). **Primary:** Netflix. **Secondary:** Prime, Disney+, YouTube.
+- **Decision style:** browse-til-tired; often gives up or rewatches. **Genres:** comfort comedies, thrillers, true-crime, popular dramas; **avoids:** subtitles, "homework" films. **Tolerance:** old ★★ / foreign ★ / subtitles ★ / slow ★.
+- **Social/solo:** solo or with partner. **Mood-dependence:** high (but unaware of it). **Patience:** low — wants to be watching within minutes.
+- **Frustration:** the endless grid + 20 minutes of deciding = decision fatigue. **Switching trigger:** "it just tells me what to watch and I trust it." **Trust requirements:** low overhead; the pick must feel right *fast* and not niche/pretentious.
+- **Valuable when:** one good pick removes the scroll. **Abandons if:** onboarding is long, the pick feels random/too arty, or it becomes another grid. **First-session success:** opened FeelFlick, got a pick, watched it — no scrolling.
+- **Likely tasks:** first-10-sec clarity, onboarding friction, Tonight pick, anti-scroll. **Objections:** "why do I have to sign in/onboard," "I've never heard of this film." **Feedback style:** terse, gut-reaction.
+
+### P4 — "Where-can-I-watch" · JustWatch availability-first user
+- **Age/context:** 28–45, multi-subscription household. **Frequency:** few/wk. **Primary:** JustWatch (then the service that has it). **Secondary:** all the major streamers.
+- **Decision style:** availability-first — won't watch what he can't stream tonight. **Genres:** broad mainstream. **Tolerance:** old ★★ / foreign ★★ / subtitles ★★ / slow ★★.
+- **Social/solo:** with partner/family. **Mood-dependence:** medium. **Patience:** medium; allergic to dead ends.
+- **Frustration:** great rec → can't stream it → wasted. **Switching trigger:** picks that respect where he can actually watch. **Trust requirements:** must answer "where can I watch this?"
+- **Valuable when:** the pick is watchable tonight (or clearly tells him where). **Abandons if:** recommends things he can't access and never says so. **First-session success:** a pick he can press play on within his subscriptions.
+- **Likely tasks:** Tonight pick + "where can I watch this?", Film File. **Objections:** "ok but is it on anything I have?" **Feedback style:** practical, impatient. **(Note: where-to-watch is a [do-not-become](../product-doctrine.md#do-not-become-list) convenience, not the loop — this persona stress-tests that boundary.)**
+
+### P5 — "Completionist" · Trakt tracker
+- **Age/context:** 22–38, systematic. **Frequency:** near-nightly. **Primary:** Trakt (tracking) + streamers. **Secondary:** Letterboxd, spreadsheets.
+- **Decision style:** progress/collection-driven; loves stats + history. **Genres:** broad, franchise + prestige. **Tolerance:** old ★★★ / foreign ★★★ / subtitles ★★★ / slow ★★★.
+- **Social/solo:** solo. **Mood-dependence:** low–medium. **Patience:** high for tracking, low for things that ignore his history.
+- **Frustration:** recs that don't account for what he's already watched. **Switching trigger:** an engine that *uses* his history well. **Trust requirements:** must not re-recommend watched films; must show it learns.
+- **Valuable when:** the pick clearly reflects his logged history + never repeats. **Abandons if:** it re-shows watched films or ignores history. **First-session success:** a pick that proves it read his diary.
+- **Likely tasks:** Tonight pick, history/diary, DNA, repeated-pick check. **Objections:** "I already saw this," "where's my tracking." **Feedback style:** systematic, detail-oriented.
+
+### P6 — "Curator's-eye" · Apple TV editorial-quality user
+- **Age/context:** 30–50, design-literate, pays for quality. **Frequency:** few/wk, intentional. **Primary:** Apple TV+/app. **Secondary:** Mubi, Criterion.
+- **Decision style:** quality + craft-led; trusts good editorial. **Genres:** prestige drama, elevated genre, craft-forward. **Tolerance:** old ★★★★ / foreign ★★★★ / subtitles ★★★★ / slow ★★★★.
+- **Social/solo:** solo or partner. **Mood-dependence:** medium. **Patience:** medium; intolerant of jank/ugliness.
+- **Frustration:** most apps feel cheap/cluttered; recs lack a point of view. **Switching trigger:** Apple-grade craft + a real editorial voice. **Trust requirements:** polish, restraint, a credible "why," no fake hype.
+- **Valuable when:** the Film File reads like a sharp, honest editorial case. **Abandons if:** it looks cheap, over-promises, or the case is thin. **First-session success:** "this feels considered."
+- **Likely tasks:** first-impression craft, Film File case-making, "why" quality. **Objections:** "the writing feels generic," "this looks unfinished." **Feedback style:** discerning, aesthetic.
+
+### P7 — "Just-put-something-on" · Prime Video mainstream convenience user
+- **Age/context:** 30–55, mainstream, low film-identity. **Frequency:** most nights, low-effort. **Primary:** Prime Video. **Secondary:** whatever's bundled.
+- **Decision style:** convenience + familiarity; picks known stars/franchises. **Genres:** action, rom-com, popular thrillers; **avoids:** subtitles, "difficult" films. **Tolerance:** old ★★ / foreign ★ / subtitles ★ / slow ★.
+- **Social/solo:** family/partner. **Mood-dependence:** low (consciously). **Patience:** low.
+- **Frustration:** too many options, none obviously "for tonight." **Switching trigger:** less effort, a safe pick. **Trust requirements:** familiar enough to feel safe; no pretension.
+- **Valuable when:** one safe, enjoyable pick with zero effort. **Abandons if:** picks feel niche/arty or onboarding asks too much. **First-session success:** a no-brainer pick they actually enjoy.
+- **Likely tasks:** onboarding friction, Tonight pick, anti-scroll. **Objections:** "never heard of it," "too much setup." **Feedback style:** casual, brief.
+
+### P8 — "Library-owner" · Plex collector
+- **Age/context:** 30–50, tech-savvy, owns a media library. **Frequency:** few/wk. **Primary:** Plex (own server). **Secondary:** streamers, physical media.
+- **Decision style:** collection-led; values ownership + control. **Genres:** broad + deep catalog, cult/obscure. **Tolerance:** old ★★★★ / foreign ★★★ / subtitles ★★★ / slow ★★★.
+- **Social/solo:** solo/family. **Mood-dependence:** medium. **Patience:** high for setup, expects control.
+- **Frustration:** recs ignore *his* library; cloud-only tools don't fit. **Switching trigger:** something that respects his own collection (or at least doesn't fight it). **Trust requirements:** control + transparency; no lock-in feel.
+- **Valuable when:** the pick fits his taste even if library-integration isn't there. **Abandons if:** it assumes he only streams, or feels like a walled garden. **First-session success:** a pick that fits, with controls he understands.
+- **Likely tasks:** Tonight pick, Preferences/dials, "does my own library matter?". **Objections:** "does this know my Plex?" **Feedback style:** technical, control-focused. **(Note: personal-library support is out of scope; this persona tests how gracefully FeelFlick says "not yet.")**
+
+### P9 — "Trailer-led" · YouTube/trailer casual chooser
+- **Age/context:** 18–30, short-attention, visual. **Frequency:** sporadic, impulse. **Primary:** YouTube (trailers/clips). **Secondary:** whatever's free/handy.
+- **Decision style:** trailer/vibe-led; decides in seconds. **Genres:** spectacle, comedy, horror, hype titles. **Tolerance:** old ★ / foreign ★ / subtitles ★ / slow ★.
+- **Social/solo:** friends. **Mood-dependence:** high (vibe). **Patience:** very low.
+- **Frustration:** nothing looks exciting fast enough. **Switching trigger:** instant, visual, low-commitment. **Trust requirements:** must *look* good immediately; a trailer helps.
+- **Valuable when:** a pick that looks exciting in seconds. **Abandons if:** text-heavy, slow, or "boring-looking." **First-session success:** an instant "ooh, that one."
+- **Likely tasks:** first-10-sec clarity, Tonight pick visual appeal, Film File trailer. **Objections:** "too much reading," "looks boring." **Feedback style:** impulsive, visual.
+
+### P10 — "Tell-me-what's-good" · Reddit/word-of-mouth seeker
+- **Age/context:** 22–40, trusts people over algorithms. **Frequency:** few/wk. **Primary:** Reddit/forums/friends for what to watch. **Secondary:** streamers.
+- **Decision style:** social-proof-led; "what do people I trust say is good." **Genres:** broad, hidden-gems hungry. **Tolerance:** old ★★★ / foreign ★★★ / subtitles ★★★ / slow ★★.
+- **Social/solo:** solo, socially-informed. **Mood-dependence:** medium. **Patience:** medium.
+- **Frustration:** algorithmic recs feel soulless; wants a *reason* a human would give. **Switching trigger:** recs that feel like a trusted friend's, with a real why. **Trust requirements:** an honest, human-sounding reason — and crucially **no fake social proof**.
+- **Valuable when:** the "why" feels like a smart friend's case, grounded in *his* taste. **Abandons if:** it fabricates hype/counts/"people like you," or feels generic. **First-session success:** a pick + reason he'd repeat to a friend.
+- **Likely tasks:** "why" quality + honesty, Film File case, DNA. **Objections:** "says who?", "this smells like marketing." **Feedback style:** skeptical of hype, values authenticity. **(Tests the no-fake-social-proof rule hard.)**
+
+---
+
+## B. FeelFlick target personas (who the wedge is *for*)
+
+### P11 — "Fried" · Mood-first exhausted scroller  ⭐ core target
+- **Age/context:** 28–42, full days, fried by 9pm. **Frequency:** most nights. **Primary:** Netflix/Prime. **Secondary:** YouTube.
+- **Decision style:** wants to *not* decide; mood is everything but unnamed. **Genres:** comfort + occasional reach. **Tolerance:** old ★★ / foreign ★★ / subtitles ★★ / slow ★★.
+- **Social/solo:** solo or partner. **Mood-dependence:** very high. **Patience:** low for setup, high for something that finally *gets* it.
+- **Frustration:** "I have 2 hours and I can't decide, so I scroll and give up." (The [primary user problem](../product-doctrine.md#primary-user-problem).) **Switching trigger:** one trustworthy pick that ends the scroll. **Trust requirements:** the pick must *feel* like it read her mood + the reason must ring true.
+- **Valuable when:** mood in → one pick out → watched, no scroll. **Abandons if:** it makes her work, or the pick ignores how she feels. **First-session success:** "it just knew" — watched something good with no fatigue.
+- **Likely tasks:** mood signal, Tonight pick fit, anti-scroll, return reason. **Objections:** "I don't want to fill out a survey." **Feedback style:** emotional, relief-or-frustration.
+
+### P12 — "Curious" · Taste-curious but not cinephile  ⭐ core target
+- **Age/context:** 25–40, likes good films, no film-school vocabulary. **Frequency:** few/wk. **Primary:** streamers. **Secondary:** friends' recs.
+- **Decision style:** open to being guided; wants to discover *her* taste. **Genres:** broad, growth-curious. **Tolerance:** old ★★★ / foreign ★★★ / subtitles ★★★ / slow ★★.
+- **Social/solo:** solo/partner. **Mood-dependence:** medium–high. **Patience:** medium.
+- **Frustration:** doesn't know what she'd love beyond the obvious. **Switching trigger:** a tool that reflects + expands her taste without condescension. **Trust requirements:** the DNA must feel *true* and the picks must feel personal, not generic.
+- **Valuable when:** the Cinematic DNA shows her something real about herself + the pick stretches her *just enough*. **Abandons if:** DNA feels fake/flattering or picks feel random. **First-session success:** "this gets me, and showed me something new."
+- **Likely tasks:** onboarding, Tonight pick, DNA honesty, "find another." **Objections:** "is this DNA real or just flattery?" **Feedback style:** curious, reflective.
+
+### P13 — "The Couple" · Deciding what to watch tonight  ⭐ core target
+- **Age/context:** two people, 28–45, different tastes, shared sofa. **Frequency:** most nights together. **Primary:** Netflix/Prime. **Secondary:** Disney+.
+- **Decision style:** negotiation — the nightly "what do *we* watch" standoff. **Genres:** the overlap of two sets. **Tolerance:** old ★★ / foreign ★★ / subtitles ★★ / slow ★★ (lowest-common-denominator).
+- **Social/solo:** always together. **Mood-dependence:** high (joint mood). **Patience:** very low — the negotiation is the pain.
+- **Frustration:** 30 minutes of "I don't know, what do you want." **Switching trigger:** something that breaks the standoff with one pick both accept. **Trust requirements:** one pick neither vetoes; a reason both buy.
+- **Valuable when:** it ends the negotiation fast with a pick they both accept. **Abandons if:** it only models one person, or restarts the debate. **First-session success:** "it picked, we both said yes, done."
+- **Likely tasks:** Tonight pick as a tiebreaker, shared decision-making. **Objections:** "but it doesn't know *both* of us." **Feedback style:** two voices, relief-seeking. **(Note: multi-user is out of scope today — this persona surfaces the gap + whether single-user picks still help a couple.)**
+
+### P14 — "Allergic-to-slop" · Serious film lover who hates algorithmic slop  ⭐ core target
+- **Age/context:** 30–50, real taste, burned by recommendation engines. **Frequency:** 3–5/wk. **Primary:** Mubi/Criterion/Letterboxd-informed. **Secondary:** streamers reluctantly.
+- **Decision style:** taste-led + quality-gated; deeply distrusts "the algorithm." **Genres:** auteur, world, elevated genre; **avoids:** content-farm filler. **Tolerance:** old ★★★★★ / foreign ★★★★★ / subtitles ★★★★★ / slow ★★★★★.
+- **Social/solo:** solo. **Mood-dependence:** medium. **Patience:** high for quality, zero for slop.
+- **Frustration:** algorithms push popular mediocrity + dishonest hype. **Switching trigger:** an engine with taste *and* honesty. **Trust requirements:** never mediocre, never fabricated, reasons specific + true, anti-recency respected.
+- **Valuable when:** the pick is genuinely good + the case is honest + it isn't recency/popularity-biased. **Abandons instantly if:** one fabricated claim, one mediocre popular pick, or fake social proof. **First-session success:** "it didn't insult me — that pick was real."
+- **Likely tasks:** Tonight pick quality, Film File honesty, DNA, "find another" without slop. **Objections:** "this is just the algorithm again," "prove it's not popularity." **Feedback style:** exacting, unforgiving, high-signal. **(The harshest honesty test — the trust moat lives or dies here.)**
+
+### P15 — "Cold-start" · New user with almost no logged history  ⭐ core target
+- **Age/context:** 25–45, just arrived, zero history. **Frequency:** TBD. **Primary:** whatever streamer. **Secondary:** —.
+- **Decision style:** undefined yet; first impression decides everything. **Genres:** a few seeds from onboarding. **Tolerance:** unknown.
+- **Social/solo:** solo. **Mood-dependence:** unknown. **Patience:** low — must see value before committing.
+- **Frustration:** new tools usually demand data before giving value. **Switching trigger:** value *before* commitment — a believable pick on night 1. **Trust requirements:** must be honest that it barely knows her yet (no fake confidence) while still giving a plausible pick.
+- **Valuable when:** onboarding is short and the first pick is believable despite thin data. **Abandons if:** it fakes confidence/DNA it can't have, or the cold pick is random. **First-session success:** a believable first pick + honest "I'm still learning you."
+- **Likely tasks:** onboarding, first Tonight pick, DNA cold-state honesty. **Objections:** "how can it know me already? (it shouldn't pretend to)." **Feedback style:** wary, first-impression-driven. **(Tests the cold→warm trust jump — the hardest moment, F7's honesty work.)**
+
+### P16 — "Warmed-up" · Returning user with enough history for Cinematic DNA  ⭐ core target
+- **Age/context:** 25–45, ~20–50 films logged over weeks. **Frequency:** nightly ritual forming. **Primary:** FeelFlick (aspirationally). **Secondary:** streamers to watch.
+- **Decision style:** trusts the ritual if it keeps earning it. **Genres:** a now-legible taste shape. **Tolerance:** per her real DNA.
+- **Social/solo:** solo. **Mood-dependence:** high (mood × deep taste). **Patience:** medium; expects the payoff of having "fed" it.
+- **Frustration:** would be betrayed by déjà-vu picks or a DNA that feels off. **Switching trigger:** already in — stays only if it keeps compounding. **Trust requirements:** picks must visibly use her depth; DNA must be accurate; no repeats.
+- **Valuable when:** the pick feels *made for her* + the DNA reads true + tonight ≠ yesterday. **Abandons if:** repeated picks, stale DNA, or it stops feeling personal. **First-session success:** "this is the best it's been — it knows me now."
+- **Likely tasks:** Tonight pick depth, DNA accuracy, repeated-pick fatigue, return loop. **Objections:** "I've seen this pick before," "my DNA feels stale." **Feedback style:** invested, expects compounding value. **(The payoff persona — proves the loop compounds.)**
+
+---
+
+## Coverage map (which wedge clause + do-not-become risk each stresses)
+
+| Persona | Wedge clause most tested | Do-not-become risk stressed |
+|---|---|---|
+| P1 Letterboxd | taste-deep | not-a-Letterboxd-clone |
+| P2 TMDB | makes-its-case (evidence) | not-a-TMDB-wrapper |
+| P3 Netflix | anti-scroll | not-a-Netflix-grid |
+| P4 JustWatch | single-pick (actionable) | not-a-JustWatch-replacement |
+| P5 Trakt | taste-deep (history) | not-a-generic-tracker |
+| P6 Apple TV | makes-its-case (craft) | craft benchmark (borrow) |
+| P7 Prime | anti-scroll (low effort) | not-a-grid |
+| P8 Plex | taste-deep | not-a-tracker / scope honesty |
+| P9 YouTube | mood-first (vibe) | anti-scroll (visual) |
+| P10 Reddit | makes-its-case (honesty) | no-fake-social-proof |
+| P11 Fried | mood-first + anti-scroll | the core problem |
+| P12 Curious | taste-deep (DNA) | personalization honesty |
+| P13 Couple | single-pick (tiebreak) | scope: multi-user gap |
+| P14 Anti-slop | all four (honesty) | every anti-drift tell |
+| P15 Cold-start | taste-deep (cold honesty) | no-fabrication |
+| P16 Warmed-up | taste-deep (compounding) | repeated-pick / DNA honesty |


### PR DESCRIPTION
## F10C — Synthetic Persona Usability Lab

**Docs / UX-inspection only.** Engine **frozen** at `algorithm_version 2.17`. No runtime, scoring, ranking, threshold, schema, RLS, Edge Function, OpenAI-prompt, UI, auth, or package change. **Synthetic personas are archetypes, not real users — they do NOT unblock F8C and are not real-user validation.**

### New `docs/personas/`
- **persona-schema-f10c.md** — the 21-field schema + authoring rules (archetype, not identity; no proprietary-data claims).
- **synthetic-personas-f10c.md** — **16 personas**: 10 platform archetypes (Letterboxd, TMDB, Netflix, JustWatch, Trakt, Apple TV, Prime, Plex, YouTube, Reddit) + 6 FeelFlick targets (mood-first exhausted scroller, taste-curious, couple, anti-slop cinephile, cold-start, warmed-up) + a wedge/do-not-become coverage map.
- **persona-usability-tasks-f10c.md** — 10 core tasks + persona-specific probes.
- **persona-usability-rubric-f10c.md** — 13 dimensions, 1–5, **evidence required** (scores alone banned).
- **claude-persona-test-prompts-f10c.md** — reusable run prompts + anti-fabrication / anti-overclaim guardrails.
- **persona-testing-tooling-proposal-f10c.md** — **proposal only** for `/persona-test` + persona-QA subagent + Playwright artifacts; **nothing installed in `.claude/`**.
- **persona-pilot-findings-f10c.md** — 2-persona pilot (**P3 Netflix scroller**, **P1 Letterboxd power user**): live-landing observation + code-grounded auth surfaces, evidence-backed rubric scores, issue backlog (all Insight/P2 — none are F8C tuning).

### Pilot signal
- 🔶 **Cold-start re-seeding** is the shared pinch point (no diary/Trakt import; "three questions" thin for cinephiles, value gated for scrollers).
- 🔶 Cold-start Briefing shows **no "why"** by honest design (null-safe) → first pick can feel unjustified.
- ✅ The **honesty layer** (null-safe WhyThisPick, "not real reviews" ViewerNotes, "not a score of you" DnaConfidence) is a genuine trust differentiator — protect it.
- 🔶 Anti-drift watch: keep the `/home` supporting tail subordinate to the Briefing.

### Validation
lint ✅ · **487 tests** ✅ · build ✅ · `npm audit --omit=dev --audit-level=high` ✅ 0 high/critical. Docs-only (no `src`/`.claude`/config touched). `stash@{0}` untouched. **F8C remains blocked.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)