### PR TITLE
Refactor onboarding movies step logic

### DIFF
--- a/src/features/onboarding/__tests__/suggestionPool.test.js
+++ b/src/features/onboarding/__tests__/suggestionPool.test.js
@@ -1,0 +1,97 @@
+// src/features/onboarding/__tests__/suggestionPool.test.js
+// Focused tests for the extracted suggestion-pool PURE functions (no live
+// Supabase / TMDB). Pins the scoring + collection-dedup + merge + shape
+// contracts so a future MoviesStep redesign cannot silently drift the engine.
+import { describe, it, expect } from 'vitest'
+import {
+  mergeUnique,
+  shapeFilm,
+  scoreCandidates,
+  dedupByCollection,
+} from '../suggestionPool'
+
+describe('suggestionPool.shapeFilm', () => {
+  it('maps a DB row to the picker shape (tmdb_id→id, id→internalId)', () => {
+    const row = {
+      id: 'uuid-1',
+      tmdb_id: 603,
+      title: 'The Matrix',
+      poster_path: '/m.jpg',
+      release_date: '1999-03-31',
+      primary_genre: 'Science Fiction',
+      extra: 'ignored',
+    }
+    expect(shapeFilm(row)).toEqual({
+      id: 603,
+      internalId: 'uuid-1',
+      title: 'The Matrix',
+      poster_path: '/m.jpg',
+      release_date: '1999-03-31',
+    })
+  })
+})
+
+describe('suggestionPool.mergeUnique', () => {
+  it('dedupes by tmdb_id, preserving the first occurrence and order', () => {
+    const a = [{ tmdb_id: 1, title: 'A1' }, { tmdb_id: 2, title: 'A2' }]
+    const b = [{ tmdb_id: 2, title: 'B2-dupe' }, { tmdb_id: 3, title: 'B3' }]
+    const out = mergeUnique([a, b])
+    expect(out.map(m => m.tmdb_id)).toEqual([1, 2, 3])
+    expect(out.find(m => m.tmdb_id === 2).title).toBe('A2') // first occurrence wins
+  })
+
+  it('skips rows without a tmdb_id', () => {
+    const out = mergeUnique([[{ title: 'no-id' }, { tmdb_id: 5 }]])
+    expect(out.map(m => m.tmdb_id)).toEqual([5])
+  })
+})
+
+describe('suggestionPool.scoreCandidates', () => {
+  // Use the current year so the recency ramp contributes 0 — keeps the
+  // arithmetic assertions deterministic regardless of when the suite runs.
+  const year = new Date().getFullYear()
+
+  it('sorts descending by score; quality (ff_audience_rating) drives the base', () => {
+    const films = [
+      { tmdb_id: 1, ff_audience_rating: 70, release_year: year },
+      { tmdb_id: 2, ff_audience_rating: 90, release_year: year },
+    ]
+    const out = scoreCandidates(films, { dbNames: [], tagSet: [] })
+    expect(out.map(m => m.tmdb_id)).toEqual([2, 1])
+    expect(out.find(m => m.tmdb_id === 2)._score).toBe(90)
+  })
+
+  it('adds +4 per overlapping mood tag and +6 for a primary-genre match', () => {
+    const out = scoreCandidates(
+      [{ tmdb_id: 1, ff_audience_rating: 50, release_year: year, mood_tags: ['cozy', 'tender'], primary_genre: 'Drama' }],
+      { dbNames: ['Drama'], tagSet: ['cozy', 'tender'] },
+    )
+    // base 50 + 2 overlaps × 4 (8) + genre 6 = 64
+    expect(out[0]._score).toBe(64)
+  })
+
+  it('defaults a missing rating to base 50', () => {
+    const out = scoreCandidates([{ tmdb_id: 1, release_year: year }], { dbNames: [], tagSet: [] })
+    expect(out[0]._score).toBe(50)
+  })
+})
+
+describe('suggestionPool.dedupByCollection', () => {
+  it('penalizes the 2nd+ film from the same collection by 20 and re-sorts', () => {
+    const scored = [
+      { tmdb_id: 1, collection_id: 'godfather', _score: 100 },
+      { tmdb_id: 2, collection_id: 'godfather', _score: 98 },
+      { tmdb_id: 3, collection_id: null, _score: 85 },
+    ]
+    const out = dedupByCollection(scored)
+    // film 2 drops 98 → 78, sinking below film 3 (85)
+    expect(out.map(m => m.tmdb_id)).toEqual([1, 3, 2])
+    expect(out.find(m => m.tmdb_id === 2)._score).toBe(78)
+  })
+
+  it('leaves films without a collection untouched', () => {
+    const scored = [{ tmdb_id: 1, _score: 50 }, { tmdb_id: 2, _score: 40 }]
+    const out = dedupByCollection(scored)
+    expect(out.map(m => m._score)).toEqual([50, 40])
+  })
+})

--- a/src/features/onboarding/hooks/useMovieSearch.js
+++ b/src/features/onboarding/hooks/useMovieSearch.js
@@ -1,0 +1,60 @@
+import { useEffect, useRef, useState } from 'react'
+import { searchMovies } from '@/shared/api/tmdb'
+
+/**
+ * Debounced TMDB live-search controller for the onboarding film picker.
+ *
+ * Behavior preserved verbatim from MoviesStep (F2.3): 300ms debounce, popularity
+ * sort, poster filter, top-8 slice, and the clear/close transitions. (The audit's
+ * Escape / outside-click / listbox a11y improvements are deliberately NOT added
+ * in this structure pass.)
+ *
+ * @returns {{
+ *   query: string, setQuery: function, results: object[], searching: boolean,
+ *   showDropdown: boolean, setShowDropdown: function, clearSearch: function,
+ * }}
+ */
+export function useMovieSearch() {
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState([])
+  const [searching, setSearching] = useState(false)
+  const [showDropdown, setShowDropdown] = useState(false)
+  const searchTimeoutRef = useRef(null)
+
+  // Live search with debounce
+  useEffect(() => {
+    clearTimeout(searchTimeoutRef.current)
+    if (!query.trim()) {
+      setResults([])
+      setSearching(false)
+      setShowDropdown(false)
+      return
+    }
+    setSearching(true)
+    setShowDropdown(true)
+    searchTimeoutRef.current = setTimeout(async () => {
+      try {
+        const data = await searchMovies(query)
+        setResults(
+          (data?.results || [])
+            .filter(m => m.poster_path)
+            .sort((a, b) => (b.popularity || 0) - (a.popularity || 0))
+            .slice(0, 8)
+        )
+      } catch {
+        setResults([])
+      } finally {
+        setSearching(false)
+      }
+    }, 300)
+    return () => clearTimeout(searchTimeoutRef.current)
+  }, [query])
+
+  // Reset query + close the dropdown (used by the clear button and after a pick).
+  const clearSearch = () => {
+    setQuery('')
+    setShowDropdown(false)
+  }
+
+  return { query, setQuery, results, searching, showDropdown, setShowDropdown, clearSearch }
+}

--- a/src/features/onboarding/hooks/useSuggestionPool.js
+++ b/src/features/onboarding/hooks/useSuggestionPool.js
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react'
+import { fetchSuggestionPool } from '../suggestionPool'
+
+/**
+ * Build & hold the onboarding Step-3 suggestion pool.
+ *
+ * MOUNT-ONCE by design: the original MoviesStep fetched the pool once on mount
+ * with an intentionally empty dependency array, capturing the genres/moods from
+ * the first render so the suggestion row doesn't re-shuffle under the user mid-
+ * selection. This hook preserves that exactly — including the swallowed-error /
+ * no-retry loading behavior. (The audit flagged the swallowed pool error as a
+ * future UX issue; it is deliberately NOT addressed in this structure pass.)
+ *
+ * @param {number[]} selectedGenreIds — TMDB genre IDs from Step 2
+ * @param {string[]} moods            — onboarding mood keys from Step 1
+ * @returns {{ pool: object[], poolLoading: boolean }}
+ */
+export function useSuggestionPool(selectedGenreIds, moods) {
+  const [pool, setPool] = useState([])
+  const [poolLoading, setPoolLoading] = useState(true)
+
+  useEffect(() => {
+    setPoolLoading(true)
+    fetchSuggestionPool(selectedGenreIds, moods)
+      .then(films => { setPool(films); setPoolLoading(false) })
+      .catch(() => setPoolLoading(false))
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps -- mount-once: capture initial picks, don't re-fetch
+
+  return { pool, poolLoading }
+}

--- a/src/features/onboarding/steps/MoviesStep.jsx
+++ b/src/features/onboarding/steps/MoviesStep.jsx
@@ -1,312 +1,20 @@
 // src/features/onboarding/steps/MoviesStep.jsx
-// Step 3 — Films picker. Live TMDB search + Supabase suggestion pool filtered
-// by the user's selected genres. Visual chrome stays consistent with v2 (purple/
-// pink palette, Outfit display font via .ob-display).
-import { useEffect, useRef, useState } from 'react'
-import { Search, X, ChevronLeft, Check } from 'lucide-react'
+// Step 3 — Films picker. COMPOSITION LAYER: the suggestion-pool engine lives in
+// suggestionPool.js, the pool fetch + live TMDB search in the useSuggestionPool /
+// useMovieSearch hooks, and the card / skeleton / dropdown in ./movies/*. This
+// file just wires them into the header / search / suggestions / picks / footer
+// layout. Logic extracted in F2.3 — UI, copy, layout, styling, and behavior are
+// unchanged.
+import { useEffect, useRef } from 'react'
+import { Search, X, ChevronLeft } from 'lucide-react'
 
-import { supabase } from '@/shared/lib/supabase/client'
-import { tmdbImg, searchMovies } from '@/shared/api/tmdb'
 import Button from '@/shared/ui/Button'
-import { GENRES } from '@/features/onboarding/data'
-
-const MIN_MOVIES = 5
-const POOL_SIZE = 30
-// How many candidates to pull per query branch (genre + mood). Higher = more
-// variety in the final scored pool. ~80 per branch lands in ~150 distinct
-// candidates after dedup, then we score and trim to POOL_SIZE.
-const CANDIDATE_LIMIT = 80
-
-const GENRE_DB_NAME = Object.fromEntries(GENRES.map(g => [g.id, g.dbName]))
-
-// Bridge from onboarding's 6-key mood vocabulary (cozy/wired/tender/fun/tense/
-// mythic — see [data.js](../data.js)) to the `mood_tags` strings the catalog
-// actually uses. Derived from observed tag frequencies in the live DB.
-// Distinct from useHomeData's ONBOARDING_MOOD_TO_BRIEFING → MOOD_BRIDGE chain
-// (which targets 6-key Briefing display categories); here we map directly to
-// the catalog vocabulary because we're scoring films, not picking display rows.
-// Bridge expansion (2026-05-21 audit): folded in unmapped high-frequency
-// catalog tags so onboarding moods cover ~5,000 more films without changing
-// the 6-mood UI:
-//   tender ← melancholic, somber, devastating  ("sad in a good way" register)
-//   tense  ← gritty                            (harsh realism)
-//   fun    ← empowering                        (uplift through triumph)
-//   wired  ← dreamy                            (mind-altering atmosphere)
-const ONBOARDING_MOOD_TO_TAGS = {
-  cozy:   ['cozy', 'heartwarming', 'lighthearted', 'whimsical'],
-  wired:  ['mind-bending', 'contemplative', 'provocative', 'mysterious', 'dreamy'],
-  tender: ['tender', 'romantic', 'bittersweet', 'melancholic', 'somber', 'devastating'],
-  fun:    ['playful', 'lighthearted', 'whimsical', 'uplifting', 'exhilarating', 'empowering'],
-  tense:  ['tense', 'suspenseful', 'intense', 'thrilling', 'unsettling', 'dark', 'gritty'],
-  mythic: ['exhilarating', 'haunting', 'inspiring', 'nostalgic'],
-}
-
-// Columns pulled from the `movies` table. Includes scoring inputs (mood_tags,
-// discovery_potential, collection_id, popularity) on top of the display fields.
-const POOL_SELECT = 'id, tmdb_id, title, poster_path, release_date, release_year, primary_genre, mood_tags, ff_audience_rating, discovery_potential, collection_id, popularity'
-
-// Recency: audience is millennial + Gen Z. Films before RECENCY_FLOOR_YEAR are
-// hard-filtered from the candidate queries (they're cultural artifacts the
-// audience is unlikely to have seen, and surfacing them as "what have you
-// loved?" choices misleads the engine). Films from RECENCY_FLOOR_YEAR onward
-// get a linear penalty that decays from RECENCY_MAX_PENALTY at the floor year
-// down to 0 at the current year — so a 1990 film sits well below a 2024 film
-// of equivalent rating, but quality still ultimately decides.
-const RECENCY_FLOOR_YEAR = 1990
-const RECENCY_MAX_PENALTY = 20
-
-// Niche genres that require explicit user selection before surfacing. Mirrors
-// recommendations.js GATED_GENRES (recommendations.js:1416). A film whose
-// primary_genre falls in this set is excluded from the suggestion pool unless
-// the user explicitly picked that genre in Step 2 — otherwise the pool would
-// surface animation/documentaries to users who didn't signal interest, biasing
-// their cold-start profile.
-const GATED_PRIMARY_GENRES = new Set(['Animation', 'Family', 'Documentary', 'Horror'])
-
-// Popularity boost — log-scale, capped. TMDB popularity is right-tailed
-// (p50≈2, p99≈32, max≈690 in our catalog) so a raw multiplier would let
-// spikes dominate. Log-scale gives a bounded, smooth lift that nudges
-// recognisable films up without drowning out the audience-rating signal.
-// pop=10 → +5.2, pop=100 → +10.0, pop=500+ → capped at 12.
-const POPULARITY_MAX_BOOST = 12
-const POPULARITY_COEFFICIENT = 5
-
-// === DATA FETCHING ===
-
-/**
- * Build the suggestion pool from the user's onboarding picks.
- *
- * Two parallel candidate fetches (by genre + by mood overlap), merged client-
- * side, then scored on quality + mood overlap + primary-genre match + a small
- * discovery lift, with a collection-dedup penalty so The Godfather Pt I and
- * Pt II don't sit back-to-back.
- *
- * @param {number[]} genreIds  — TMDB genre IDs selected in Step 2
- * @param {string[]} moods     — onboarding mood keys selected in Step 1
- * @returns {Promise<object[]>}  — POOL_SIZE shaped film objects
- */
-async function fetchSuggestionPool(genreIds, moods) {
-  const dbNames = (genreIds || []).map(id => GENRE_DB_NAME[id]).filter(Boolean)
-  const tagSet = (moods || []).flatMap(k => ONBOARDING_MOOD_TO_TAGS[k] || [])
-
-  // Defensive fallbacks — Step 1 enforces ≥1 mood and Step 2 enforces ≥1
-  // genre, but if either array is empty we still want a sane pool.
-  if (!dbNames.length && !tagSet.length) return fetchGlobalPool()
-
-  const queries = []
-  if (dbNames.length > 0) {
-    queries.push(
-      supabase
-        .from('movies')
-        .select(POOL_SELECT)
-        .in('primary_genre', dbNames)
-        .gte('release_year', RECENCY_FLOOR_YEAR)
-        .not('poster_path', 'is', null)
-        .eq('is_valid', true)
-        .gte('ff_audience_confidence', 50)
-        .order('ff_audience_rating', { ascending: false, nullsFirst: false })
-        .limit(CANDIDATE_LIMIT),
-    )
-  }
-  if (tagSet.length > 0) {
-    queries.push(
-      supabase
-        .from('movies')
-        .select(POOL_SELECT)
-        .overlaps('mood_tags', tagSet)
-        .gte('release_year', RECENCY_FLOOR_YEAR)
-        .not('poster_path', 'is', null)
-        .eq('is_valid', true)
-        .gte('ff_audience_confidence', 50)
-        .order('ff_audience_rating', { ascending: false, nullsFirst: false })
-        .limit(CANDIDATE_LIMIT),
-    )
-  }
-
-  const results = await Promise.all(queries)
-  const merged = mergeUnique(results.map(r => r.data || []))
-
-  // Apply gated-genre filter: drop films whose primary_genre is in the
-  // niche-genre set unless the user explicitly picked that genre. This is
-  // applied client-side because the by-genre branch is already naturally
-  // gated (`.in('primary_genre', dbNames)`), and we only need to scrub the
-  // by-mood branch's leaks here.
-  const userDbNameSet = new Set(dbNames)
-  const blockedGenres = new Set(
-    [...GATED_PRIMARY_GENRES].filter(g => !userDbNameSet.has(g))
-  )
-  const candidates = blockedGenres.size > 0
-    ? merged.filter(m => !m.primary_genre || !blockedGenres.has(m.primary_genre))
-    : merged
-
-  const scored = scoreCandidates(candidates, { dbNames, tagSet })
-  return dedupByCollection(scored).slice(0, POOL_SIZE).map(shapeFilm)
-}
-
-/**
- * Fallback when neither moods nor genres are present (shouldn't happen via
- * the UI, defensive).
- */
-async function fetchGlobalPool() {
-  const { data } = await supabase
-    .from('movies')
-    .select(POOL_SELECT)
-    .gte('release_year', RECENCY_FLOOR_YEAR)
-    .not('ff_audience_rating', 'is', null)
-    .not('poster_path', 'is', null)
-    .eq('is_valid', true)
-    .order('ff_audience_rating', { ascending: false })
-    .limit(POOL_SIZE)
-
-  return (data || []).map(shapeFilm)
-}
-
-/** Shape a DB row into the {id, internalId, ...} format the picker UI expects. */
-function shapeFilm(m) {
-  return {
-    id: m.tmdb_id,
-    internalId: m.id,
-    title: m.title,
-    poster_path: m.poster_path,
-    release_date: m.release_date,
-  }
-}
-
-/** Merge multiple candidate arrays, deduping by tmdb_id, preserving first occurrence. */
-function mergeUnique(arrays) {
-  const seen = new Set()
-  const out = []
-  for (const arr of arrays) {
-    for (const m of arr) {
-      if (!m?.tmdb_id || seen.has(m.tmdb_id)) continue
-      seen.add(m.tmdb_id)
-      out.push(m)
-    }
-  }
-  return out
-}
-
-/**
- * Score each candidate film. Higher is better. See the suggestion-engine plan
- * for the formula rationale.
- */
-function scoreCandidates(candidates, { dbNames, tagSet }) {
-  const dbNameSet = new Set(dbNames)
-  const tagSetLower = new Set(tagSet)
-  // Linear recency ramp: max penalty at RECENCY_FLOOR_YEAR, decays to 0 by the
-  // current year. Films older than the floor are already hard-filtered out of
-  // the candidate queries; this only differentiates 1990s/2000s/2010s/2020s
-  // films within the surviving pool.
-  const currentYear = new Date().getFullYear()
-  const yearSpan = Math.max(1, currentYear - RECENCY_FLOOR_YEAR)
-  return candidates
-    .map(m => {
-      const base = m.ff_audience_rating ?? 50
-      const moodOverlap = Array.isArray(m.mood_tags)
-        ? m.mood_tags.reduce((n, t) => n + (tagSetLower.has(t) ? 1 : 0), 0)
-        : 0
-      const genreBonus = dbNameSet.has(m.primary_genre) ? 6 : 0
-      const discoveryBonus = (m.discovery_potential || 0) * 0.05
-      const recencyPenalty = m.release_year
-        ? -RECENCY_MAX_PENALTY * Math.max(0, Math.min(1, (currentYear - m.release_year) / yearSpan))
-        : 0
-      // Popularity boost — log-scale, capped. Surfaces recognisable films so
-      // users can decide early without scanning unfamiliar titles.
-      const popularityBoost = m.popularity
-        ? Math.min(POPULARITY_MAX_BOOST, Math.log10(m.popularity + 1) * POPULARITY_COEFFICIENT)
-        : 0
-      return {
-        ...m,
-        _score: base + moodOverlap * 4 + genreBonus + discoveryBonus + recencyPenalty + popularityBoost,
-      }
-    })
-    .sort((a, b) => b._score - a._score)
-}
-
-/**
- * Apply a -20 score penalty to the second+ film from the same collection
- * (e.g. The Godfather franchise) so they don't sit back-to-back. We just
- * re-sort once after the penalty; films with no collection are unaffected.
- */
-function dedupByCollection(scored) {
-  const seenCollection = new Set()
-  const adjusted = scored.map(m => {
-    if (!m.collection_id) return m
-    if (seenCollection.has(m.collection_id)) return { ...m, _score: m._score - 20 }
-    seenCollection.add(m.collection_id)
-    return m
-  })
-  return adjusted.sort((a, b) => b._score - a._score)
-}
-
-// === MOVIE CARD ===
-// Fixed-width card: poster + title + year below (not overlaid).
-
-function MovieCard({ movie, isSelected, onClick }) {
-  const [loaded, setLoaded] = useState(false)
-  const year = movie.release_date ? new Date(movie.release_date).getFullYear() : null
-
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-pressed={isSelected}
-      aria-label={`${isSelected ? 'Remove' : 'Select'} ${movie.title}`}
-      className="shrink-0 w-28 sm:w-32 md:w-36 flex flex-col gap-1.5 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black rounded-lg group"
-    >
-      <div className={`relative aspect-2/3 w-full rounded-lg overflow-hidden transition-shadow duration-200 ${
-        isSelected
-          ? 'ring-2 ring-purple-400 shadow-[0_0_16px_rgba(168,85,247,0.4)]'
-          : 'ring-1 ring-white/6 group-hover:ring-white/20'
-      }`}>
-        {!loaded && <div className="absolute inset-0 animate-pulse bg-white/4" />}
-        <img
-          src={tmdbImg(movie.poster_path, 'w342')}
-          alt={movie.title}
-          loading="lazy"
-          className={`w-full h-full object-cover transition-all duration-300 ${
-            loaded ? 'opacity-100' : 'opacity-0'
-          } ${isSelected ? 'brightness-75' : 'group-hover:brightness-110'}`}
-          onLoad={() => setLoaded(true)}
-        />
-        {isSelected && <div className="absolute inset-0 bg-purple-600/15" />}
-        {isSelected && (
-          <div className="absolute top-1.5 right-1.5 h-5 w-5 rounded-full bg-purple-500 flex items-center justify-center shadow">
-            <Check className="h-3 w-3 text-white stroke-3" />
-          </div>
-        )}
-      </div>
-      <div className="px-0.5">
-        <p className={`text-[11px] font-medium leading-tight line-clamp-2 transition-colors ${
-          isSelected ? 'text-purple-300' : 'text-white/80'
-        }`}>
-          {movie.title}
-        </p>
-        {year && <p className="text-[10px] text-white/35 mt-0.5">{year}</p>}
-      </div>
-    </button>
-  )
-}
-
-// === CARD SKELETON ROW ===
-
-function CardSkeletonRow() {
-  return (
-    <div className="flex gap-3 sm:gap-4 overflow-x-hidden">
-      {Array.from({ length: 5 }).map((_, i) => (
-        <div key={i} className="shrink-0 w-28 sm:w-32 md:w-36 flex flex-col gap-1.5">
-          <div
-            className="aspect-2/3 rounded-lg bg-white/4 animate-pulse"
-            style={{ animationDelay: `${i * 60}ms` }}
-          />
-          <div className="h-2.5 w-3/4 bg-white/4 rounded animate-pulse" />
-        </div>
-      ))}
-    </div>
-  )
-}
-
-// === MAIN COMPONENT ===
+import { MIN_MOVIES } from '../suggestionPool'
+import { useSuggestionPool } from '../hooks/useSuggestionPool'
+import { useMovieSearch } from '../hooks/useMovieSearch'
+import MovieCard from './movies/MovieCard'
+import CardSkeletonRow from './movies/CardSkeletonRow'
+import SearchDropdown from './movies/SearchDropdown'
 
 /**
  * Onboarding step 3: movie selection.
@@ -337,60 +45,18 @@ export default function MoviesStep({
   loading,
   error,
 }) {
-  const [pool, setPool] = useState([])
-  const [poolLoading, setPoolLoading] = useState(true)
-  const [query, setQuery] = useState('')
-  const [results, setResults] = useState([])
-  const [searching, setSearching] = useState(false)
-  const [showDropdown, setShowDropdown] = useState(false)
   const searchInputRef = useRef(null)
-  const searchTimeoutRef = useRef(null)
-
-  useEffect(() => {
-    setPoolLoading(true)
-    fetchSuggestionPool(selectedGenreIds, moods)
-      .then(films => { setPool(films); setPoolLoading(false) })
-      .catch(() => setPoolLoading(false))
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+  const { pool, poolLoading } = useSuggestionPool(selectedGenreIds, moods)
+  const { query, setQuery, results, searching, showDropdown, setShowDropdown, clearSearch } = useMovieSearch()
 
   useEffect(() => {
     const timer = setTimeout(() => searchInputRef.current?.focus(), 100)
     return () => clearTimeout(timer)
   }, [])
 
-  // Live search with debounce
-  useEffect(() => {
-    clearTimeout(searchTimeoutRef.current)
-    if (!query.trim()) {
-      setResults([])
-      setSearching(false)
-      setShowDropdown(false)
-      return
-    }
-    setSearching(true)
-    setShowDropdown(true)
-    searchTimeoutRef.current = setTimeout(async () => {
-      try {
-        const data = await searchMovies(query)
-        setResults(
-          (data?.results || [])
-            .filter(m => m.poster_path)
-            .sort((a, b) => (b.popularity || 0) - (a.popularity || 0))
-            .slice(0, 8)
-        )
-      } catch {
-        setResults([])
-      } finally {
-        setSearching(false)
-      }
-    }, 300)
-    return () => clearTimeout(searchTimeoutRef.current)
-  }, [query])
-
   function handleSelectFromSearch(movie) {
     addMovie(movie)
-    setQuery('')
-    setShowDropdown(false)
+    clearSearch()
   }
 
   const count = favoriteMovies.length
@@ -444,7 +110,7 @@ export default function MoviesStep({
           {query && (
             <button
               type="button"
-              onClick={() => { setQuery(''); setShowDropdown(false) }}
+              onClick={clearSearch}
               aria-label="Clear search"
               className="absolute right-3 top-1/2 -translate-y-1/2 text-white/30 hover:text-white/60"
             >
@@ -455,41 +121,12 @@ export default function MoviesStep({
 
         {/* Search dropdown */}
         {showDropdown && (
-          <div className="absolute left-5 right-5 sm:left-6 sm:right-6 top-full mt-1 z-50 bg-black/95 border border-white/10 rounded-xl overflow-hidden shadow-2xl backdrop-blur-xl">
-            {searching ? (
-              <p className="px-4 py-3 text-sm text-white/40">Searching…</p>
-            ) : results.length === 0 ? (
-              <p className="px-4 py-3 text-sm text-white/30">No results — try a different title</p>
-            ) : (
-              <div className="max-h-60 overflow-y-auto divide-y divide-white/5">
-                {results.map(m => {
-                  const yr = m.release_date ? new Date(m.release_date).getFullYear() : null
-                  const selected = isMovieSelected(m.id)
-                  return (
-                    <button
-                      key={m.id}
-                      type="button"
-                      onClick={() => handleSelectFromSearch(m)}
-                      className="w-full flex items-center gap-3 px-4 py-2.5 hover:bg-white/6 text-left transition-colors"
-                    >
-                      <img
-                        src={tmdbImg(m.poster_path, 'w92')}
-                        alt=""
-                        className="w-8 h-12 rounded object-cover shrink-0 bg-white/4"
-                      />
-                      <div className="flex-1 min-w-0">
-                        <p className="text-sm font-medium text-white truncate">{m.title}</p>
-                        {yr && <p className="text-xs text-white/40">{yr}</p>}
-                      </div>
-                      {selected && (
-                        <Check className="shrink-0 h-4 w-4 text-purple-400" />
-                      )}
-                    </button>
-                  )
-                })}
-              </div>
-            )}
-          </div>
+          <SearchDropdown
+            searching={searching}
+            results={results}
+            isMovieSelected={isMovieSelected}
+            onSelect={handleSelectFromSearch}
+          />
         )}
       </div>
 

--- a/src/features/onboarding/steps/movies/CardSkeletonRow.jsx
+++ b/src/features/onboarding/steps/movies/CardSkeletonRow.jsx
@@ -1,0 +1,16 @@
+// Loading placeholder for the Suggestions row — staggered animate-pulse cards.
+export default function CardSkeletonRow() {
+  return (
+    <div className="flex gap-3 sm:gap-4 overflow-x-hidden">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div key={i} className="shrink-0 w-28 sm:w-32 md:w-36 flex flex-col gap-1.5">
+          <div
+            className="aspect-2/3 rounded-lg bg-white/4 animate-pulse"
+            style={{ animationDelay: `${i * 60}ms` }}
+          />
+          <div className="h-2.5 w-3/4 bg-white/4 rounded animate-pulse" />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/features/onboarding/steps/movies/MovieCard.jsx
+++ b/src/features/onboarding/steps/movies/MovieCard.jsx
@@ -1,0 +1,51 @@
+import { useState } from 'react'
+import { Check } from 'lucide-react'
+
+import { tmdbImg } from '@/shared/api/tmdb'
+
+// Fixed-width card: poster + title + year below (not overlaid).
+export default function MovieCard({ movie, isSelected, onClick }) {
+  const [loaded, setLoaded] = useState(false)
+  const year = movie.release_date ? new Date(movie.release_date).getFullYear() : null
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={isSelected}
+      aria-label={`${isSelected ? 'Remove' : 'Select'} ${movie.title}`}
+      className="shrink-0 w-28 sm:w-32 md:w-36 flex flex-col gap-1.5 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black rounded-lg group"
+    >
+      <div className={`relative aspect-2/3 w-full rounded-lg overflow-hidden transition-shadow duration-200 ${
+        isSelected
+          ? 'ring-2 ring-purple-400 shadow-[0_0_16px_rgba(168,85,247,0.4)]'
+          : 'ring-1 ring-white/6 group-hover:ring-white/20'
+      }`}>
+        {!loaded && <div className="absolute inset-0 animate-pulse bg-white/4" />}
+        <img
+          src={tmdbImg(movie.poster_path, 'w342')}
+          alt={movie.title}
+          loading="lazy"
+          className={`w-full h-full object-cover transition-all duration-300 ${
+            loaded ? 'opacity-100' : 'opacity-0'
+          } ${isSelected ? 'brightness-75' : 'group-hover:brightness-110'}`}
+          onLoad={() => setLoaded(true)}
+        />
+        {isSelected && <div className="absolute inset-0 bg-purple-600/15" />}
+        {isSelected && (
+          <div className="absolute top-1.5 right-1.5 h-5 w-5 rounded-full bg-purple-500 flex items-center justify-center shadow">
+            <Check className="h-3 w-3 text-white stroke-3" />
+          </div>
+        )}
+      </div>
+      <div className="px-0.5">
+        <p className={`text-[11px] font-medium leading-tight line-clamp-2 transition-colors ${
+          isSelected ? 'text-purple-300' : 'text-white/80'
+        }`}>
+          {movie.title}
+        </p>
+        {year && <p className="text-[10px] text-white/35 mt-0.5">{year}</p>}
+      </div>
+    </button>
+  )
+}

--- a/src/features/onboarding/steps/movies/SearchDropdown.jsx
+++ b/src/features/onboarding/steps/movies/SearchDropdown.jsx
@@ -1,0 +1,46 @@
+import { Check } from 'lucide-react'
+
+import { tmdbImg } from '@/shared/api/tmdb'
+
+// Live-search results dropdown. Rendered by MoviesStep inside `{showDropdown && …}`,
+// so it assumes it is mounted only when open. Markup moved verbatim from MoviesStep
+// (F2.3) — no Escape / outside-click / listbox semantics added in this pass.
+export default function SearchDropdown({ searching, results, isMovieSelected, onSelect }) {
+  return (
+    <div className="absolute left-5 right-5 sm:left-6 sm:right-6 top-full mt-1 z-50 bg-black/95 border border-white/10 rounded-xl overflow-hidden shadow-2xl backdrop-blur-xl">
+      {searching ? (
+        <p className="px-4 py-3 text-sm text-white/40">Searching…</p>
+      ) : results.length === 0 ? (
+        <p className="px-4 py-3 text-sm text-white/30">No results — try a different title</p>
+      ) : (
+        <div className="max-h-60 overflow-y-auto divide-y divide-white/5">
+          {results.map(m => {
+            const yr = m.release_date ? new Date(m.release_date).getFullYear() : null
+            const selected = isMovieSelected(m.id)
+            return (
+              <button
+                key={m.id}
+                type="button"
+                onClick={() => onSelect(m)}
+                className="w-full flex items-center gap-3 px-4 py-2.5 hover:bg-white/6 text-left transition-colors"
+              >
+                <img
+                  src={tmdbImg(m.poster_path, 'w92')}
+                  alt=""
+                  className="w-8 h-12 rounded object-cover shrink-0 bg-white/4"
+                />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-white truncate">{m.title}</p>
+                  {yr && <p className="text-xs text-white/40">{yr}</p>}
+                </div>
+                {selected && (
+                  <Check className="shrink-0 h-4 w-4 text-purple-400" />
+                )}
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/features/onboarding/suggestionPool.js
+++ b/src/features/onboarding/suggestionPool.js
@@ -1,0 +1,241 @@
+// src/features/onboarding/suggestionPool.js
+// Onboarding Step 3 suggestion-pool ENGINE — the Supabase candidate fetch +
+// quality/mood/genre/discovery/recency/popularity scoring that seeds a new
+// user's Cinematic DNA. Extracted verbatim from MoviesStep.jsx (F2.3) so the
+// recommendation-adjacent logic lives apart from the step's presentation.
+//
+// OFF-LIMITS to retune in a UI pass: the scoring values, query filters, and the
+// ONBOARDING_MOOD_TO_TAGS bridge here are byte-identical to the originals and are
+// recommendation-engine territory (gated by the recommendation-engine skill +
+// DB-first analysis). This is a behavior-preserving move only.
+import { supabase } from '@/shared/lib/supabase/client'
+import { GENRES } from './data'
+
+export const MIN_MOVIES = 5
+const POOL_SIZE = 30
+// How many candidates to pull per query branch (genre + mood). Higher = more
+// variety in the final scored pool. ~80 per branch lands in ~150 distinct
+// candidates after dedup, then we score and trim to POOL_SIZE.
+const CANDIDATE_LIMIT = 80
+
+const GENRE_DB_NAME = Object.fromEntries(GENRES.map(g => [g.id, g.dbName]))
+
+// Bridge from onboarding's 6-key mood vocabulary (cozy/wired/tender/fun/tense/
+// mythic — see [data.js](../data.js)) to the `mood_tags` strings the catalog
+// actually uses. Derived from observed tag frequencies in the live DB.
+// Distinct from useHomeData's ONBOARDING_MOOD_TO_BRIEFING → MOOD_BRIDGE chain
+// (which targets 6-key Briefing display categories); here we map directly to
+// the catalog vocabulary because we're scoring films, not picking display rows.
+// Bridge expansion (2026-05-21 audit): folded in unmapped high-frequency
+// catalog tags so onboarding moods cover ~5,000 more films without changing
+// the 6-mood UI:
+//   tender ← melancholic, somber, devastating  ("sad in a good way" register)
+//   tense  ← gritty                            (harsh realism)
+//   fun    ← empowering                        (uplift through triumph)
+//   wired  ← dreamy                            (mind-altering atmosphere)
+const ONBOARDING_MOOD_TO_TAGS = {
+  cozy:   ['cozy', 'heartwarming', 'lighthearted', 'whimsical'],
+  wired:  ['mind-bending', 'contemplative', 'provocative', 'mysterious', 'dreamy'],
+  tender: ['tender', 'romantic', 'bittersweet', 'melancholic', 'somber', 'devastating'],
+  fun:    ['playful', 'lighthearted', 'whimsical', 'uplifting', 'exhilarating', 'empowering'],
+  tense:  ['tense', 'suspenseful', 'intense', 'thrilling', 'unsettling', 'dark', 'gritty'],
+  mythic: ['exhilarating', 'haunting', 'inspiring', 'nostalgic'],
+}
+
+// Columns pulled from the `movies` table. Includes scoring inputs (mood_tags,
+// discovery_potential, collection_id, popularity) on top of the display fields.
+const POOL_SELECT = 'id, tmdb_id, title, poster_path, release_date, release_year, primary_genre, mood_tags, ff_audience_rating, discovery_potential, collection_id, popularity'
+
+// Recency: audience is millennial + Gen Z. Films before RECENCY_FLOOR_YEAR are
+// hard-filtered from the candidate queries (they're cultural artifacts the
+// audience is unlikely to have seen, and surfacing them as "what have you
+// loved?" choices misleads the engine). Films from RECENCY_FLOOR_YEAR onward
+// get a linear penalty that decays from RECENCY_MAX_PENALTY at the floor year
+// down to 0 at the current year — so a 1990 film sits well below a 2024 film
+// of equivalent rating, but quality still ultimately decides.
+const RECENCY_FLOOR_YEAR = 1990
+const RECENCY_MAX_PENALTY = 20
+
+// Niche genres that require explicit user selection before surfacing. Mirrors
+// recommendations.js GATED_GENRES (recommendations.js:1416). A film whose
+// primary_genre falls in this set is excluded from the suggestion pool unless
+// the user explicitly picked that genre in Step 2 — otherwise the pool would
+// surface animation/documentaries to users who didn't signal interest, biasing
+// their cold-start profile.
+const GATED_PRIMARY_GENRES = new Set(['Animation', 'Family', 'Documentary', 'Horror'])
+
+// Popularity boost — log-scale, capped. TMDB popularity is right-tailed
+// (p50≈2, p99≈32, max≈690 in our catalog) so a raw multiplier would let
+// spikes dominate. Log-scale gives a bounded, smooth lift that nudges
+// recognisable films up without drowning out the audience-rating signal.
+// pop=10 → +5.2, pop=100 → +10.0, pop=500+ → capped at 12.
+const POPULARITY_MAX_BOOST = 12
+const POPULARITY_COEFFICIENT = 5
+
+// === DATA FETCHING ===
+
+/**
+ * Build the suggestion pool from the user's onboarding picks.
+ *
+ * Two parallel candidate fetches (by genre + by mood overlap), merged client-
+ * side, then scored on quality + mood overlap + primary-genre match + a small
+ * discovery lift, with a collection-dedup penalty so The Godfather Pt I and
+ * Pt II don't sit back-to-back.
+ *
+ * @param {number[]} genreIds  — TMDB genre IDs selected in Step 2
+ * @param {string[]} moods     — onboarding mood keys selected in Step 1
+ * @returns {Promise<object[]>}  — POOL_SIZE shaped film objects
+ */
+export async function fetchSuggestionPool(genreIds, moods) {
+  const dbNames = (genreIds || []).map(id => GENRE_DB_NAME[id]).filter(Boolean)
+  const tagSet = (moods || []).flatMap(k => ONBOARDING_MOOD_TO_TAGS[k] || [])
+
+  // Defensive fallbacks — Step 1 enforces ≥1 mood and Step 2 enforces ≥1
+  // genre, but if either array is empty we still want a sane pool.
+  if (!dbNames.length && !tagSet.length) return fetchGlobalPool()
+
+  const queries = []
+  if (dbNames.length > 0) {
+    queries.push(
+      supabase
+        .from('movies')
+        .select(POOL_SELECT)
+        .in('primary_genre', dbNames)
+        .gte('release_year', RECENCY_FLOOR_YEAR)
+        .not('poster_path', 'is', null)
+        .eq('is_valid', true)
+        .gte('ff_audience_confidence', 50)
+        .order('ff_audience_rating', { ascending: false, nullsFirst: false })
+        .limit(CANDIDATE_LIMIT),
+    )
+  }
+  if (tagSet.length > 0) {
+    queries.push(
+      supabase
+        .from('movies')
+        .select(POOL_SELECT)
+        .overlaps('mood_tags', tagSet)
+        .gte('release_year', RECENCY_FLOOR_YEAR)
+        .not('poster_path', 'is', null)
+        .eq('is_valid', true)
+        .gte('ff_audience_confidence', 50)
+        .order('ff_audience_rating', { ascending: false, nullsFirst: false })
+        .limit(CANDIDATE_LIMIT),
+    )
+  }
+
+  const results = await Promise.all(queries)
+  const merged = mergeUnique(results.map(r => r.data || []))
+
+  // Apply gated-genre filter: drop films whose primary_genre is in the
+  // niche-genre set unless the user explicitly picked that genre. This is
+  // applied client-side because the by-genre branch is already naturally
+  // gated (`.in('primary_genre', dbNames)`), and we only need to scrub the
+  // by-mood branch's leaks here.
+  const userDbNameSet = new Set(dbNames)
+  const blockedGenres = new Set(
+    [...GATED_PRIMARY_GENRES].filter(g => !userDbNameSet.has(g))
+  )
+  const candidates = blockedGenres.size > 0
+    ? merged.filter(m => !m.primary_genre || !blockedGenres.has(m.primary_genre))
+    : merged
+
+  const scored = scoreCandidates(candidates, { dbNames, tagSet })
+  return dedupByCollection(scored).slice(0, POOL_SIZE).map(shapeFilm)
+}
+
+/**
+ * Fallback when neither moods nor genres are present (shouldn't happen via
+ * the UI, defensive).
+ */
+async function fetchGlobalPool() {
+  const { data } = await supabase
+    .from('movies')
+    .select(POOL_SELECT)
+    .gte('release_year', RECENCY_FLOOR_YEAR)
+    .not('ff_audience_rating', 'is', null)
+    .not('poster_path', 'is', null)
+    .eq('is_valid', true)
+    .order('ff_audience_rating', { ascending: false })
+    .limit(POOL_SIZE)
+
+  return (data || []).map(shapeFilm)
+}
+
+/** Shape a DB row into the {id, internalId, ...} format the picker UI expects. */
+export function shapeFilm(m) {
+  return {
+    id: m.tmdb_id,
+    internalId: m.id,
+    title: m.title,
+    poster_path: m.poster_path,
+    release_date: m.release_date,
+  }
+}
+
+/** Merge multiple candidate arrays, deduping by tmdb_id, preserving first occurrence. */
+export function mergeUnique(arrays) {
+  const seen = new Set()
+  const out = []
+  for (const arr of arrays) {
+    for (const m of arr) {
+      if (!m?.tmdb_id || seen.has(m.tmdb_id)) continue
+      seen.add(m.tmdb_id)
+      out.push(m)
+    }
+  }
+  return out
+}
+
+/**
+ * Score each candidate film. Higher is better. See the suggestion-engine plan
+ * for the formula rationale.
+ */
+export function scoreCandidates(candidates, { dbNames, tagSet }) {
+  const dbNameSet = new Set(dbNames)
+  const tagSetLower = new Set(tagSet)
+  // Linear recency ramp: max penalty at RECENCY_FLOOR_YEAR, decays to 0 by the
+  // current year. Films older than the floor are already hard-filtered out of
+  // the candidate queries; this only differentiates 1990s/2000s/2010s/2020s
+  // films within the surviving pool.
+  const currentYear = new Date().getFullYear()
+  const yearSpan = Math.max(1, currentYear - RECENCY_FLOOR_YEAR)
+  return candidates
+    .map(m => {
+      const base = m.ff_audience_rating ?? 50
+      const moodOverlap = Array.isArray(m.mood_tags)
+        ? m.mood_tags.reduce((n, t) => n + (tagSetLower.has(t) ? 1 : 0), 0)
+        : 0
+      const genreBonus = dbNameSet.has(m.primary_genre) ? 6 : 0
+      const discoveryBonus = (m.discovery_potential || 0) * 0.05
+      const recencyPenalty = m.release_year
+        ? -RECENCY_MAX_PENALTY * Math.max(0, Math.min(1, (currentYear - m.release_year) / yearSpan))
+        : 0
+      // Popularity boost — log-scale, capped. Surfaces recognisable films so
+      // users can decide early without scanning unfamiliar titles.
+      const popularityBoost = m.popularity
+        ? Math.min(POPULARITY_MAX_BOOST, Math.log10(m.popularity + 1) * POPULARITY_COEFFICIENT)
+        : 0
+      return {
+        ...m,
+        _score: base + moodOverlap * 4 + genreBonus + discoveryBonus + recencyPenalty + popularityBoost,
+      }
+    })
+    .sort((a, b) => b._score - a._score)
+}
+
+/**
+ * Apply a -20 score penalty to the second+ film from the same collection
+ * (e.g. The Godfather franchise) so they don't sit back-to-back. We just
+ * re-sort once after the penalty; films with no collection are unaffected.
+ */
+export function dedupByCollection(scored) {
+  const seenCollection = new Set()
+  const adjusted = scored.map(m => {
+    if (!m.collection_id) return m
+    if (seenCollection.has(m.collection_id)) return { ...m, _score: m._score - 20 }
+    seenCollection.add(m.collection_id)
+    return m
+  })
+  return adjusted.sort((a, b) => b._score - a._score)
+}


### PR DESCRIPTION
Behavior-preserving decomposition (F2.3) of the 568-LOC `MoviesStep.jsx` so it's safer to redesign later. Separates the recommendation-adjacent **engine**, the **search/pool hooks**, and the **presentation** from the step's composition. **No UI, copy, layout, styling, validation, scoring, query-filter, auth, routing, Supabase-write, or localStorage change.**

## What logic was extracted
- **`suggestionPool.js`** — the engine: `MIN_MOVIES`, `POOL_SIZE`, `CANDIDATE_LIMIT`, `GENRE_DB_NAME`, `ONBOARDING_MOOD_TO_TAGS`, `POOL_SELECT`, `RECENCY_FLOOR_YEAR`, `RECENCY_MAX_PENALTY`, `GATED_PRIMARY_GENRES`, `POPULARITY_MAX_BOOST`, `POPULARITY_COEFFICIENT`, and `fetchSuggestionPool` / `fetchGlobalPool` / `shapeFilm` / `mergeUnique` / `scoreCandidates` / `dedupByCollection`. Moved **verbatim** (a `diff` confirmed the constants + scoring + query filters are byte-for-byte identical). Exports only what `MoviesStep` and the tests need.
- **`hooks/useSuggestionPool.js`** — the mount-once pool fetch, preserved exactly (empty-deps capture of the initial picks; swallowed-error / no-retry loading kept — the audit's retry-UX fix is deliberately **not** done here).
- **`hooks/useMovieSearch.js`** — the debounced TMDB live search moved verbatim: query/results/searching/showDropdown state, 300ms debounce, popularity sort, poster filter, top-8 slice, clear/close transitions. (No Escape/outside-click/listbox semantics added — future a11y work.)
- **`steps/movies/MovieCard.jsx`, `CardSkeletonRow.jsx`, `SearchDropdown.jsx`** — presentational pieces moved verbatim (`SearchDropdown`'s JSX diffed byte-identical to the original inline dropdown; only `handleSelectFromSearch`→`onSelect`, the same function).

## Files created / changed
- **Changed:** `src/features/onboarding/steps/MoviesStep.jsx` (now a thin composition layer)
- **New:** `suggestionPool.js`, `hooks/useSuggestionPool.js`, `hooks/useMovieSearch.js`, `steps/movies/{MovieCard,CardSkeletonRow,SearchDropdown}.jsx`, `__tests__/suggestionPool.test.js`

## Confirmations
- **Scoring values + query filters unchanged** — `diff` shows the engine constants and `fetchSuggestionPool`/`fetchGlobalPool`/`scoreCandidates`/`dedupByCollection`/`mergeUnique`/`shapeFilm` are byte-identical to the originals.
- **UI / copy / layout / styling unchanged** — the `MoviesStep` main render diffed byte-identical to the original except the clear-button handler (`clearSearch`, same effect) and the dropdown (`<SearchDropdown>`, same DOM).
- **Auth / routing / Supabase writes / localStorage untouched** — only `MoviesStep` + the new modules were touched; `Onboarding.jsx`, services, gates, router, and `data.js` are unchanged. `MIN_MOVIES=5` gating, Continue→`onFinish`, and the suggestion behavior are identical.

## Validation
- `npm run lint` → clean
- `npx vitest run src/features/onboarding/__tests__/ src/shared/lib/auth/__tests__/onboardingStatus.test.js` → 37 passed (3 files) — real `MoviesStep` render still enforces `MIN_MOVIES=5`; +8 new engine tests
- `npm run build` → ✓
- `npm run test` (full) → 541 passed (49 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
