### PR TITLE
Refactor onboarding step chrome

### DIFF
--- a/src/features/onboarding/components/BackButton.jsx
+++ b/src/features/onboarding/components/BackButton.jsx
@@ -1,0 +1,17 @@
+import { ChevronLeft } from 'lucide-react'
+
+// Onboarding step "Back" affordance. Markup is identical across GenresStep,
+// MoviesStep, and RatingStep; this is the single source. Step 1 (MoodStep) has
+// no back button, so it simply doesn't render one.
+export default function BackButton({ onClick }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex items-center gap-1.5 text-sm text-white/40 hover:text-white/70 transition-colors mb-3 sm:mb-4"
+    >
+      <ChevronLeft className="h-4 w-4" />
+      Back
+    </button>
+  )
+}

--- a/src/features/onboarding/components/StepFooter.jsx
+++ b/src/features/onboarding/components/StepFooter.jsx
@@ -1,0 +1,35 @@
+import { ChevronRight } from 'lucide-react'
+
+import Button from '@/shared/ui/Button'
+
+/**
+ * Shared onboarding step footer: a status/help line above a primary action.
+ * The wrapper + inner column + Button usage are identical across the adopting
+ * steps (MoodStep / GenresStep / MoviesStep); the gate value, copy, label,
+ * disabled expression, and the trailing chevron vary per step and are props.
+ *
+ * RatingStep does NOT use this — its footer is a SentimentRow + Skip with
+ * auto-finish (no primary Continue button), so it stays custom (see F2.4 notes).
+ *
+ * @param {object}   props
+ * @param {string}   props.statusClassName    — full class for the status <p> (keeps the
+ *                                               per-step color logic + Movies' duration-200)
+ * @param {React.ReactNode} props.status       — status/help text
+ * @param {function} props.onContinue          — primary action handler
+ * @param {boolean}  props.disabled            — disabled expression (each step's exact gate)
+ * @param {React.ReactNode} [props.label='Continue'] — button label (Movies passes 'Saving…'/'Continue')
+ * @param {boolean}  [props.showChevron=true]  — trailing ChevronRight (Movies omits it)
+ */
+export default function StepFooter({ statusClassName, status, onContinue, disabled, label = 'Continue', showChevron = true }) {
+  return (
+    <div className="flex-none px-5 pb-6 pt-3 sm:px-6 sm:pb-8 sm:pt-4 border-t border-white/6">
+      <div className="max-w-sm mx-auto flex flex-col items-center gap-3">
+        <p className={statusClassName}>{status}</p>
+        <Button variant="primary" size="lg" onClick={onContinue} disabled={disabled} fullWidth>
+          {label}
+          {showChevron && <ChevronRight className="h-4 w-4" />}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/features/onboarding/components/StepHeader.jsx
+++ b/src/features/onboarding/components/StepHeader.jsx
@@ -1,0 +1,33 @@
+import BackButton from './BackButton'
+
+/**
+ * Shared onboarding step header: optional back button → kicker → display
+ * headline → subcopy. The kicker + headline typography is identical across the
+ * adopting steps (MoodStep / GenresStep / MoviesStep) and is baked here; the
+ * bits that legitimately vary per step are props, so adoption is render-faithful:
+ *
+ * @param {object}   props
+ * @param {string}   props.className         — header wrapper class (each step's exact padding)
+ * @param {function} [props.onBack]          — when present, renders <BackButton>; omit for Step 1
+ * @param {React.ReactNode} props.kicker      — kicker text (e.g. "Genres · 2 of 4")
+ * @param {React.ReactNode} props.children    — headline content (keeps each step's exact <em> accent)
+ * @param {React.ReactNode} [props.subcopy]   — description paragraph content
+ * @param {string}   [props.subcopyClassName] — subcopy <p> class (varies: text-white/55+max-w-xl vs /60)
+ */
+export default function StepHeader({ className, onBack, kicker, children, subcopy, subcopyClassName }) {
+  return (
+    <div className={className}>
+      {onBack && <BackButton onClick={onBack} />}
+      <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-purple-400/85 mb-2.5 sm:mb-3">
+        {kicker}
+      </p>
+      <h2
+        className="ob-display text-[32px] sm:text-4xl md:text-5xl font-normal text-white leading-[1.05]"
+        style={{ textWrap: 'balance' }}
+      >
+        {children}
+      </h2>
+      {subcopy != null && <p className={subcopyClassName}>{subcopy}</p>}
+    </div>
+  )
+}

--- a/src/features/onboarding/components/StepShell.jsx
+++ b/src/features/onboarding/components/StepShell.jsx
@@ -1,0 +1,23 @@
+/**
+ * Shared onboarding step scaffold: the full-height flex column every step uses,
+ * with header / body / footer slots. The body (`children`) varies per step
+ * (tile grid, search + carousels, etc.) and is rendered as direct flex children
+ * so each step keeps its own layout.
+ *
+ * Intentionally does NOT include Progress or TasteStrip — those are parent-level
+ * siblings rendered by Onboarding.jsx outside the step.
+ *
+ * @param {object} props
+ * @param {React.ReactNode} props.header   — the <StepHeader> (or equivalent)
+ * @param {React.ReactNode} props.footer   — the <StepFooter> (or equivalent)
+ * @param {React.ReactNode} props.children — the step body
+ */
+export default function StepShell({ header, footer, children }) {
+  return (
+    <div className="h-full flex flex-col">
+      {header}
+      {children}
+      {footer}
+    </div>
+  )
+}

--- a/src/features/onboarding/steps/GenresStep.jsx
+++ b/src/features/onboarding/steps/GenresStep.jsx
@@ -2,10 +2,11 @@
 // Restyled genre picker — gradient outline tiles.
 
 import { motion, useReducedMotion } from 'framer-motion'
-import { ChevronRight, ChevronLeft } from 'lucide-react'
 
-import Button from '@/shared/ui/Button'
 import { GENRES } from '@/features/onboarding/data'
+import StepShell from '../components/StepShell'
+import StepHeader from '../components/StepHeader'
+import StepFooter from '../components/StepFooter'
 
 const MIN_GENRES = 1
 
@@ -41,35 +42,38 @@ export default function GenresStep({ selectedGenres, toggleGenre, onBack, onNext
   const canContinue = count >= MIN_GENRES
 
   return (
-    <div className="h-full flex flex-col">
-      <div className="flex-none px-5 pt-5 pb-4 sm:px-6 sm:pt-6 sm:pb-5">
-        <button
-          type="button"
-          onClick={onBack}
-          className="flex items-center gap-1.5 text-sm text-white/40 hover:text-white/70 transition-colors mb-3 sm:mb-4"
-        >
-          <ChevronLeft className="h-4 w-4" />
-          Back
-        </button>
-        <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-purple-400/85 mb-2.5 sm:mb-3">
-          Genres · 2 of 4
-        </p>
-        <h2
-          className="ob-display text-[32px] sm:text-4xl md:text-5xl font-normal text-white leading-[1.05]"
-          style={{ textWrap: 'balance' }}
+    <StepShell
+      header={
+        <StepHeader
+          className="flex-none px-5 pt-5 pb-4 sm:px-6 sm:pt-6 sm:pb-5"
+          onBack={onBack}
+          kicker="Genres · 2 of 4"
+          subcopy={<>Pick at least {MIN_GENRES} — this steers what we reach for first. Nothing&apos;s
+          locked in; you can always add more later.</>}
+          subcopyClassName="text-[13px] sm:text-sm md:text-[15px] text-white/55 mt-2 sm:mt-3 leading-relaxed max-w-xl"
         >
           Which{' '}
           <em className="bg-linear-to-r from-purple-500 to-pink-500 bg-clip-text text-transparent italic">
             territories
           </em>
           {' '}do you live in?
-        </h2>
-        <p className="text-[13px] sm:text-sm md:text-[15px] text-white/55 mt-2 sm:mt-3 leading-relaxed max-w-xl">
-          Pick at least {MIN_GENRES} — this steers what we reach for first. Nothing&apos;s
-          locked in; you can always add more later.
-        </p>
-      </div>
-
+        </StepHeader>
+      }
+      footer={
+        <StepFooter
+          statusClassName={`text-xs font-medium transition-colors ${canContinue ? 'text-purple-400' : 'text-white/30'}`}
+          status={
+            count === 0
+              ? `Select at least ${MIN_GENRES} to continue`
+              : count < MIN_GENRES
+              ? `${count} selected — pick ${MIN_GENRES - count} more`
+              : `${count} selected ✓`
+          }
+          onContinue={onNext}
+          disabled={!canContinue}
+        />
+      }
+    >
       <div className="ob-scroll flex-1 min-h-0 overflow-y-auto px-5 pb-4 sm:px-6">
         <motion.div
           className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2.5 sm:gap-3 max-w-3xl mx-auto px-1 py-2"
@@ -87,22 +91,6 @@ export default function GenresStep({ selectedGenres, toggleGenre, onBack, onNext
           ))}
         </motion.div>
       </div>
-
-      <div className="flex-none px-5 pb-6 pt-3 sm:px-6 sm:pb-8 sm:pt-4 border-t border-white/6">
-        <div className="max-w-sm mx-auto flex flex-col items-center gap-3">
-          <p className={`text-xs font-medium transition-colors ${canContinue ? 'text-purple-400' : 'text-white/30'}`}>
-            {count === 0
-              ? `Select at least ${MIN_GENRES} to continue`
-              : count < MIN_GENRES
-              ? `${count} selected — pick ${MIN_GENRES - count} more`
-              : `${count} selected ✓`}
-          </p>
-          <Button variant="primary" size="lg" onClick={onNext} disabled={!canContinue} fullWidth>
-            Continue
-            <ChevronRight className="h-4 w-4" />
-          </Button>
-        </div>
-      </div>
-    </div>
+    </StepShell>
   )
 }

--- a/src/features/onboarding/steps/MoodStep.jsx
+++ b/src/features/onboarding/steps/MoodStep.jsx
@@ -2,10 +2,11 @@
 // NEW step 1 (mood baseline). Tile picker, 2-3 selections, with a pulsing orb in each tile.
 
 import { motion } from 'framer-motion'
-import { ChevronRight } from 'lucide-react'
 
-import Button from '@/shared/ui/Button'
 import { MOODS, MIN_MOODS, MAX_MOODS } from '../data'
+import StepShell from '../components/StepShell'
+import StepHeader from '../components/StepHeader'
+import StepFooter from '../components/StepFooter'
 
 export default function MoodStep({ moods, setMoods, onNext, firstName }) {
   const count = moods.length
@@ -20,27 +21,36 @@ export default function MoodStep({ moods, setMoods, onNext, firstName }) {
   }
 
   return (
-    <div className="h-full flex flex-col">
-      {/* Header */}
-      <div className="flex-none px-5 pt-5 pb-4 sm:px-6 sm:pt-8 sm:pb-5">
-        <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-purple-400/85 mb-2.5 sm:mb-3">
-          {firstName ? `Hey ${firstName} —` : 'Mood baseline · 1 of 4'}
-        </p>
-        <h2
-          className="ob-display text-[32px] sm:text-4xl md:text-5xl font-normal text-white leading-[1.05]"
-          style={{ textWrap: 'balance' }}
+    <StepShell
+      header={
+        <StepHeader
+          className="flex-none px-5 pt-5 pb-4 sm:px-6 sm:pt-8 sm:pb-5"
+          kicker={firstName ? `Hey ${firstName} —` : 'Mood baseline · 1 of 4'}
+          subcopy={<>Pick {MIN_MOODS}–{MAX_MOODS} moods you actually find yourself in. We&apos;ll calibrate from
+          here — and the screen will respond as you choose.</>}
+          subcopyClassName="text-[13px] sm:text-sm md:text-[15px] text-white/55 mt-2 sm:mt-3 leading-relaxed max-w-xl"
         >
           The vibe you{' '}
           <em className="bg-linear-to-r from-purple-500 to-pink-500 bg-clip-text text-transparent italic">
             live in.
           </em>
-        </h2>
-        <p className="text-[13px] sm:text-sm md:text-[15px] text-white/55 mt-2 sm:mt-3 leading-relaxed max-w-xl">
-          Pick {MIN_MOODS}–{MAX_MOODS} moods you actually find yourself in. We&apos;ll calibrate from
-          here — and the screen will respond as you choose.
-        </p>
-      </div>
-
+        </StepHeader>
+      }
+      footer={
+        <StepFooter
+          statusClassName={`text-xs font-medium transition-colors ${canContinue ? 'text-purple-400' : 'text-white/30'}`}
+          status={
+            count === 0
+              ? `Pick at least ${MIN_MOODS} mood${MIN_MOODS === 1 ? '' : 's'} to continue`
+              : count < MIN_MOODS
+              ? `${count} selected — pick ${MIN_MOODS - count} more`
+              : `${count} selected ✓`
+          }
+          onContinue={onNext}
+          disabled={!canContinue}
+        />
+      }
+    >
       {/* Mood tiles. WHY: inner py-2 + px-1 creates the buffer needed for the
          selected-tile glow/border to render fully — without it, the parent's
          overflow-y-auto implicitly clips the box-shadow on the top/left edges. */}
@@ -93,27 +103,6 @@ export default function MoodStep({ moods, setMoods, onNext, firstName }) {
           })}
         </div>
       </div>
-
-      {/* Footer */}
-      <div className="flex-none px-5 pb-6 pt-3 sm:px-6 sm:pb-8 sm:pt-4 border-t border-white/6">
-        <div className="max-w-sm mx-auto flex flex-col items-center gap-3">
-          <p
-            className={`text-xs font-medium transition-colors ${
-              canContinue ? 'text-purple-400' : 'text-white/30'
-            }`}
-          >
-            {count === 0
-              ? `Pick at least ${MIN_MOODS} mood${MIN_MOODS === 1 ? '' : 's'} to continue`
-              : count < MIN_MOODS
-              ? `${count} selected — pick ${MIN_MOODS - count} more`
-              : `${count} selected ✓`}
-          </p>
-          <Button variant="primary" size="lg" onClick={onNext} disabled={!canContinue} fullWidth>
-            Continue
-            <ChevronRight className="h-4 w-4" />
-          </Button>
-        </div>
-      </div>
-    </div>
+    </StepShell>
   )
 }

--- a/src/features/onboarding/steps/MoviesStep.jsx
+++ b/src/features/onboarding/steps/MoviesStep.jsx
@@ -1,17 +1,19 @@
 // src/features/onboarding/steps/MoviesStep.jsx
 // Step 3 — Films picker. COMPOSITION LAYER: the suggestion-pool engine lives in
 // suggestionPool.js, the pool fetch + live TMDB search in the useSuggestionPool /
-// useMovieSearch hooks, and the card / skeleton / dropdown in ./movies/*. This
-// file just wires them into the header / search / suggestions / picks / footer
-// layout. Logic extracted in F2.3 — UI, copy, layout, styling, and behavior are
-// unchanged.
+// useMovieSearch hooks, the card / skeleton / dropdown in ./movies/*, and the
+// shared step chrome in ../components/{StepShell,StepHeader,StepFooter}. This file
+// just wires the search + suggestions + picks body between the header and footer.
+// UI, copy, layout, styling, and behavior are unchanged.
 import { useEffect, useRef } from 'react'
-import { Search, X, ChevronLeft } from 'lucide-react'
+import { Search, X } from 'lucide-react'
 
-import Button from '@/shared/ui/Button'
 import { MIN_MOVIES } from '../suggestionPool'
 import { useSuggestionPool } from '../hooks/useSuggestionPool'
 import { useMovieSearch } from '../hooks/useMovieSearch'
+import StepShell from '../components/StepShell'
+import StepHeader from '../components/StepHeader'
+import StepFooter from '../components/StepFooter'
 import MovieCard from './movies/MovieCard'
 import CardSkeletonRow from './movies/CardSkeletonRow'
 import SearchDropdown from './movies/SearchDropdown'
@@ -65,35 +67,39 @@ export default function MoviesStep({
   const suggestions = pool.filter(m => !isMovieSelected(m.id))
 
   return (
-    <div className="h-full flex flex-col">
-      {/* Header */}
-      <div className="flex-none px-5 pt-5 pb-4 sm:px-6 sm:pt-6">
-        <button
-          type="button"
-          onClick={onBack}
-          className="flex items-center gap-1.5 text-sm text-white/40 hover:text-white/70 transition-colors mb-3 sm:mb-4"
-        >
-          <ChevronLeft className="h-4 w-4" />
-          Back
-        </button>
-        <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-purple-400/85 mb-2.5 sm:mb-3">
-          Films · 3 of 4
-        </p>
-        <h2
-          className="ob-display text-[32px] sm:text-4xl md:text-5xl font-normal leading-[1.05] text-white"
-          style={{ textWrap: 'balance' }}
+    <StepShell
+      header={
+        <StepHeader
+          className="flex-none px-5 pt-5 pb-4 sm:px-6 sm:pt-6"
+          onBack={onBack}
+          kicker="Films · 3 of 4"
+          subcopy={<>Pick 5 films that shaped your taste. These anchor your first picks — so go
+          honest, not impressive.</>}
+          subcopyClassName="text-[13px] sm:text-sm md:text-[15px] text-white/60 mt-2 leading-relaxed"
         >
           What have you{' '}
           <em className="bg-linear-to-r from-purple-500 to-pink-500 bg-clip-text italic text-transparent">
             loved?
           </em>
-        </h2>
-        <p className="text-[13px] sm:text-sm md:text-[15px] text-white/60 mt-2 leading-relaxed">
-          Pick 5 films that shaped your taste. These anchor your first picks — so go
-          honest, not impressive.
-        </p>
-      </div>
-
+        </StepHeader>
+      }
+      footer={
+        <StepFooter
+          statusClassName={`text-xs font-medium transition-colors duration-200 ${canFinish ? 'text-purple-400' : 'text-white/30'}`}
+          status={
+            count === 0
+              ? `Select at least ${MIN_MOVIES} films to continue`
+              : count < MIN_MOVIES
+              ? `${count} selected — pick ${MIN_MOVIES - count} more`
+              : `${count} selected ✓`
+          }
+          onContinue={onFinish}
+          disabled={!canFinish || loading}
+          label={loading ? 'Saving…' : 'Continue'}
+          showChevron={false}
+        />
+      }
+    >
       {/* Search bar + dropdown */}
       <div className="flex-none px-5 pb-4 sm:px-6 sm:pb-5 relative">
         <div className="relative">
@@ -182,24 +188,6 @@ export default function MoviesStep({
           </div>
         )}
       </div>
-
-      {/* Footer */}
-      <div className="flex-none px-5 pb-6 pt-3 sm:px-6 sm:pb-8 sm:pt-4 border-t border-white/6">
-        <div className="max-w-sm mx-auto flex flex-col items-center gap-3">
-          <p className={`text-xs font-medium transition-colors duration-200 ${
-            canFinish ? 'text-purple-400' : 'text-white/30'
-          }`}>
-            {count === 0
-              ? `Select at least ${MIN_MOVIES} films to continue`
-              : count < MIN_MOVIES
-              ? `${count} selected — pick ${MIN_MOVIES - count} more`
-              : `${count} selected ✓`}
-          </p>
-          <Button variant="primary" size="lg" onClick={onFinish} disabled={!canFinish || loading} fullWidth>
-            {loading ? 'Saving…' : 'Continue'}
-          </Button>
-        </div>
-      </div>
-    </div>
+    </StepShell>
   )
 }


### PR DESCRIPTION
Behavior-preserving decomposition (F2.4): extracts the duplicated onboarding step chrome into shared components so the steps are safer to restyle later. **No intentional UI / copy / layout / behavior change** — proven render-faithful below.

## Shared components added
- **`StepShell`** — the full-height `h-full flex flex-col` column with header / body / footer slots. Intentionally does **not** pull in `Progress` or `TasteStrip` (those stay parent-level siblings in `Onboarding.jsx`).
- **`StepHeader`** — optional `BackButton` → kicker → display headline (keeps each step's exact `<em>` accent as children) → subcopy. The repeated kicker + headline typography is baked; the bits that legitimately vary per step (header padding `className`, `subcopyClassName`, presence of back) are props.
- **`StepFooter`** — the status/help line + primary Continue `Button`. Per-step variation (gate `disabled`, status copy + class, button `label`, trailing chevron) via props.
- **`BackButton`** — the identical step back affordance.

## Steps that adopted them
- **MoodStep** (no back button — Step 1), **GenresStep**, **MoviesStep**.

## Left custom (intentionally)
- **RatingStep** — too unique to fold in safely: it uses a different utility-class **ordering** convention throughout, a **`text-[30px]`** headline (others are `text-[32px]`), conditional `allRated` header content, unique header padding, and a **SentimentRow + Skip + auto-finish** footer (no primary Continue button) that does not fit `StepFooter`. Deferred to a later pass.

## Render-faithfulness (verified)
- Rendered each adopted step against its pre-F2.4 (git HEAD) original and diffed the HTML:
  - **GenresStep** → **byte-identical** HTML.
  - **MoodStep** (with and without `firstName`) → **byte-identical** HTML.
  - **MoviesStep** → header **identical** (modulo a harmless baked-`<h2>` Tailwind class *reorder* — order-independent), footer **byte-identical** (default + `loading` "Saving…" states); the search/suggestions body is the verbatim F2.3 markup.

## Confirmations
- **UI / copy / layout / behavior** not intentionally changed (the only delta is the `<h2>` class-token order on MoviesStep, which renders identically).
- **Auth / routing / Supabase writes / scoring / localStorage** untouched — only the four step files' chrome + the new components changed; `Onboarding.jsx`, services, gates, router, `suggestionPool.js`, and the hooks are unchanged. `MIN_GENRES=1` / `MIN_MOVIES=5` / `MIN_MOODS` gating and Continue handlers are identical.

## Validation
- `npm run lint` → clean
- `npx vitest run src/features/onboarding/__tests__/ src/shared/lib/auth/__tests__/onboardingStatus.test.js` → 37 passed (3 files)
- `npm run build` → ✓
- `npm run test` (full) → 541 passed (49 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
