### PR TITLE
Reskin onboarding chrome and progress a11y

### DIFF
--- a/src/features/onboarding/Onboarding.jsx
+++ b/src/features/onboarding/Onboarding.jsx
@@ -13,7 +13,7 @@
 
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { motion, AnimatePresence } from 'framer-motion'
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion'
 
 import { supabase } from '@/shared/lib/supabase/client'
 import { useAuthSession } from '@/shared/hooks/useAuthSession'
@@ -53,6 +53,7 @@ function loadDraft() {
 export default function Onboarding() {
   const navigate = useNavigate()
   const { ready, session } = useAuthSession()
+  const reduced = useReducedMotion()
 
   usePageMeta({ title: 'Taste profile · FeelFlick' })
 
@@ -292,10 +293,10 @@ export default function Onboarding() {
           <AnimatePresence mode="wait" initial={false}>
             <motion.div
               key={step}
-              initial={{ opacity: 0, y: 14 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -14 }}
-              transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+              initial={reduced ? false : { opacity: 0, y: 14 }}
+              animate={reduced ? { opacity: 1 } : { opacity: 1, y: 0 }}
+              exit={reduced ? { opacity: 0 } : { opacity: 0, y: -14 }}
+              transition={reduced ? { duration: 0 } : { duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
               className="h-full"
             >
               {step === 0 && (

--- a/src/features/onboarding/__tests__/OnboardingChrome.test.jsx
+++ b/src/features/onboarding/__tests__/OnboardingChrome.test.jsx
@@ -1,0 +1,79 @@
+// src/features/onboarding/__tests__/OnboardingChrome.test.jsx
+// F2.6 — persistent onboarding chrome: Progress progressbar semantics +
+// reduced-motion resilience, and TasteStrip's non-color category labels +
+// hide-when-empty behavior.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+// framer-motion's useReducedMotion (Progress) reads window.matchMedia, which
+// jsdom doesn't provide. Default to "no preference"; one test flips it.
+beforeEach(() => {
+  window.matchMedia = vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+})
+
+import Progress from '../components/Progress'
+import TasteStrip from '../components/TasteStrip'
+
+describe('Progress — progressbar semantics', () => {
+  it('exposes role=progressbar with min/max and aria-valuenow = step + 1', () => {
+    render(<Progress step={0} />)
+    const bar = screen.getByRole('progressbar', { name: /onboarding progress/i })
+    expect(bar).toHaveAttribute('aria-valuemin', '1')
+    expect(bar).toHaveAttribute('aria-valuemax', '4')
+    expect(bar).toHaveAttribute('aria-valuenow', '1')
+  })
+
+  it('aria-valuenow tracks the current step (step 3 → 4 of 4)', () => {
+    render(<Progress step={3} />)
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '4')
+  })
+
+  it('renders the FEELFLICK wordmark without font-black / font-extrabold', () => {
+    render(<Progress step={1} />)
+    const mark = screen.getByText('FEELFLICK')
+    expect(mark.className).not.toMatch(/font-(black|extrabold)/)
+  })
+
+  it('still renders the progressbar under prefers-reduced-motion', () => {
+    window.matchMedia = vi.fn().mockImplementation(query => ({
+      matches: true, media: query, onchange: null,
+      addEventListener: vi.fn(), removeEventListener: vi.fn(),
+      addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(),
+    }))
+    render(<Progress step={2} />)
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '3')
+  })
+})
+
+describe('TasteStrip — non-color labels + hide-when-empty', () => {
+  it('returns null when all counts are zero', () => {
+    const { container } = render(<TasteStrip moods={[]} genres={[]} films={[]} ratings={{}} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders explicit category labels (not color-only) when counts exist', () => {
+    render(<TasteStrip moods={['cozy']} genres={[18, 28]} films={[{ id: 1 }]} ratings={{ 1: 9 }} />)
+    expect(screen.getByText('Mood')).toBeInTheDocument()
+    expect(screen.getByText('Genre')).toBeInTheDocument()
+    expect(screen.getByText('Film')).toBeInTheDocument()
+    expect(screen.getByText('Rated')).toBeInTheDocument()
+  })
+
+  it('omits a category whose count is zero', () => {
+    render(<TasteStrip moods={['cozy']} genres={[]} films={[]} ratings={{}} />)
+    expect(screen.getByText('Mood')).toBeInTheDocument()
+    expect(screen.queryByText('Genre')).not.toBeInTheDocument()
+    expect(screen.queryByText('Film')).not.toBeInTheDocument()
+    expect(screen.queryByText('Rated')).not.toBeInTheDocument()
+  })
+})

--- a/src/features/onboarding/components/Progress.jsx
+++ b/src/features/onboarding/components/Progress.jsx
@@ -1,30 +1,47 @@
 // src/features/onboarding/components/Progress.jsx
-// 4-segment progress bar with FEELFLICK wordmark + step counter.
+// Persistent onboarding identity + progress lockup: the FEELFLICK wordmark
+// (matching the canonical landing Wordmark spec — Outfit 600, +0.04em tracking,
+// brand gradient) + one continuous editorial progress rail + a step counter.
 
-import { motion } from 'framer-motion'
+import { motion, useReducedMotion } from 'framer-motion'
 
 const TOTAL = 4
 
 export default function Progress({ step }) {
+  const reduced = useReducedMotion()
+  const current = step + 1            // 1..TOTAL
+  const fraction = current / TOTAL    // 0.25..1 — honestly represents 4 steps
+
   return (
     <div className="flex-none px-5 pt-4 pb-1 sm:px-6 sm:pt-6 flex items-center gap-3 sm:gap-4">
-      <span className="ob-display text-[13px] sm:text-[15px] font-extrabold tracking-[0.02em] bg-linear-to-r from-purple-500 to-pink-500 bg-clip-text text-transparent">
+      {/* Wordmark — canonical landing spec (no font-extrabold / font-black).
+          Inline letterSpacing overrides .ob-display's -0.02em. */}
+      <span
+        className="ob-display text-[13px] sm:text-[15px] font-semibold bg-linear-to-r from-purple-600 to-pink-500 bg-clip-text text-transparent"
+        style={{ letterSpacing: '0.04em' }}
+      >
         FEELFLICK
       </span>
-      <div className="flex-1 flex items-center gap-1.5">
-        {Array.from({ length: TOTAL }).map((_, i) => (
-          <div key={i} className="h-[3px] flex-1 rounded-full bg-white/8 overflow-hidden">
-            <motion.div
-              className="h-full bg-linear-to-r from-purple-500 to-pink-500 rounded-full"
-              initial={{ scaleX: 0, originX: 0 }}
-              animate={{ scaleX: i <= step ? 1 : 0 }}
-              transition={{ type: 'spring', stiffness: 100, damping: 20 }}
-            />
-          </div>
-        ))}
+
+      {/* One continuous editorial hairline rail with a single brand-gradient fill. */}
+      <div
+        className="flex-1 h-[3px] rounded-full bg-white/8 overflow-hidden"
+        role="progressbar"
+        aria-valuemin={1}
+        aria-valuemax={TOTAL}
+        aria-valuenow={current}
+        aria-label="Onboarding progress"
+      >
+        <motion.div
+          className="h-full rounded-full bg-linear-to-r from-purple-600 to-pink-500"
+          initial={false}
+          animate={{ width: `${fraction * 100}%` }}
+          transition={reduced ? { duration: 0 } : { type: 'spring', stiffness: 100, damping: 20 }}
+        />
       </div>
-      <span className="text-[10px] sm:text-[11px] uppercase tracking-[0.18em] text-white/40">
-        {String(step + 1).padStart(2, '0')} / 0{TOTAL}
+
+      <span className="text-[10px] sm:text-[11px] uppercase tracking-[0.18em] text-white/55">
+        {String(current).padStart(2, '0')} / 0{TOTAL}
       </span>
     </div>
   )

--- a/src/features/onboarding/components/TasteStrip.jsx
+++ b/src/features/onboarding/components/TasteStrip.jsx
@@ -1,22 +1,31 @@
 // src/features/onboarding/components/TasteStrip.jsx
-// Tiny "profile building" line that grows with each step's signal.
+// Tiny "profile building" line that grows with each step's signal. Each tally
+// carries an explicit category LABEL (Mood / Genre / Film / Rated) so the
+// distinction is not conveyed by purple/pink color alone — a non-color
+// affordance. (The fuller DNA-strip fusion is a later phase; this stays compact.)
 
 export default function TasteStrip({ moods, genres, films, ratings }) {
-  const m = moods.length
-  const g = genres.length
-  const f = films.length
-  const r = Object.keys(ratings || {}).length
+  const counts = [
+    { label: 'Mood',  n: moods.length },
+    { label: 'Genre', n: genres.length },
+    { label: 'Film',  n: films.length },
+    { label: 'Rated', n: Object.keys(ratings || {}).length },
+  ].filter(c => c.n > 0)
 
-  if (m + g + f + r === 0) return null
+  if (counts.length === 0) return null
 
   return (
     <div className="flex-none px-5 pt-2 sm:px-6 flex items-center gap-2 text-[10px] uppercase tracking-[0.08em] text-white/40">
       <span>Profile building</span>
       <span className="flex-1 h-px bg-linear-to-r from-purple-500/30 to-transparent" />
-      {m > 0 && <span className="text-purple-300/85">{m} mood{m === 1 ? '' : 's'}</span>}
-      {g > 0 && <span className="text-purple-300/85">· {g} genre{g === 1 ? '' : 's'}</span>}
-      {f > 0 && <span className="text-pink-300/85">· {f} film{f === 1 ? '' : 's'}</span>}
-      {r > 0 && <span className="text-pink-300/85">· {r} rated</span>}
+      <span className="flex items-center gap-2.5">
+        {counts.map(c => (
+          <span key={c.label} className="flex items-center gap-1">
+            <span className="text-white/45">{c.label}</span>
+            <span className="text-white/75 tabular-nums">{c.n}</span>
+          </span>
+        ))}
+      </span>
     </div>
   )
 }


### PR DESCRIPTION
First visual implementation phase for `/onboarding` (F2.6), tightly scoped to the **frame/chrome only** — no step bodies touched. Foundation wave of the F2.5 "Premium Cinematic Tuning" direction.

## Progress
- **Identity:** the FEELFLICK wordmark now matches the **canonical landing `Wordmark` spec** — Outfit, `font-weight 600`, `+0.04em` tracking, brand purple→pink gradient. No `font-extrabold`, no `font-black`. Implemented locally (no cross-import from the landing feature folder); inline `letterSpacing` overrides `.ob-display`'s `-0.02em`.
- **Rail:** the four chunky spring-animated segments become **one continuous editorial hairline track** (`bg-white/8`) with a single brand-gradient fill at `width = (step+1)/4`. Still honestly represents four steps; the `step` prop contract is unchanged.
- **A11y:** the rail gains `role="progressbar"` + `aria-valuemin={1}` / `aria-valuemax={4}` / `aria-valuenow={step+1}` + `aria-label="Onboarding progress"`; the visible counter contrast is lifted `text-white/40 → text-white/55` (passes AA on the dark base).

## Reduced motion
- `Progress.jsx` and `Onboarding.jsx` now read `useReducedMotion`.
- **Progress fill:** instant (`duration: 0`) under reduce; spring otherwise.
- **Step transition** (`Onboarding.jsx`): under reduce it's instant and **opacity-only / no y-transform** (`initial={false}`, `animate={{opacity:1}}`, `exit={{opacity:0}}`, `duration:0`); non-reduced users keep the same 0.4s `y:14` slide.
- `CelebrationReveal` reduced-motion behavior is untouched.

## TasteStrip
- Each tally now carries an explicit category **label** — `Mood / Genre / Film / Rated` — in neutral white, so the distinction is no longer conveyed by purple/pink **color alone** (non-color affordance). Counts use `tabular-nums`.
- Behavior preserved: returns `null` when all counts are zero; still hidden on Step 4 by the unchanged parent logic; same inputs. **Not** fused into a DNA strip (that's a later phase).

## Tests
- New `OnboardingChrome.test.jsx`: Progress exposes `role="progressbar"` with correct `aria-valuenow` (step 0 → 1, step 3 → 4) and min/max, wordmark has no `font-black/extrabold`, and the progressbar still renders under `prefers-reduced-motion`; TasteStrip returns null when empty, renders the `Mood/Genre/Film/Rated` labels when counts exist, and omits zero-count categories.

## Confirmations
- **Step bodies untouched** — `git status` shows only `Progress.jsx`, `TasteStrip.jsx`, `Onboarding.jsx`, and the new test; no `steps/` file changed.
- **Auth / routing / Supabase writes / scoring / search / localStorage keys / validation thresholds / destination route / completion timing** all unchanged — the only `Onboarding.jsx` edits are the `useReducedMotion` import/hook and the step-transition gating.

## Validation
- `npm run lint` → clean
- `npx vitest run src/features/onboarding/__tests__/ src/shared/lib/auth/__tests__/onboardingStatus.test.js` → 44 passed (4 files)
- `npm run build` → ✓
- `npm run test` (full) → 548 passed (50 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
