### PR TITLE
Polish onboarding step typography

### DIFF
--- a/src/features/onboarding/components/BackButton.jsx
+++ b/src/features/onboarding/components/BackButton.jsx
@@ -8,7 +8,7 @@ export default function BackButton({ onClick }) {
     <button
       type="button"
       onClick={onClick}
-      className="flex items-center gap-1.5 text-sm text-white/40 hover:text-white/70 transition-colors mb-3 sm:mb-4"
+      className="flex items-center gap-1.5 text-sm text-white/40 hover:text-white/70 transition-colors mb-3 sm:mb-4 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
     >
       <ChevronLeft className="h-4 w-4" />
       Back

--- a/src/features/onboarding/components/StepHeader.jsx
+++ b/src/features/onboarding/components/StepHeader.jsx
@@ -18,11 +18,11 @@ export default function StepHeader({ className, onBack, kicker, children, subcop
   return (
     <div className={className}>
       {onBack && <BackButton onClick={onBack} />}
-      <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-purple-400/85 mb-2.5 sm:mb-3">
+      <p className="ob-eyebrow text-white/55 mb-2.5 sm:mb-3">
         {kicker}
       </p>
       <h2
-        className="ob-display text-[32px] sm:text-4xl md:text-5xl font-normal text-white leading-[1.05]"
+        className="ob-headline text-white"
         style={{ textWrap: 'balance' }}
       >
         {children}

--- a/src/features/onboarding/onboarding.css
+++ b/src/features/onboarding/onboarding.css
@@ -10,6 +10,26 @@
   letter-spacing: -0.02em;
 }
 
+/* Editorial step typography — onboarding-local, echoing the landing's
+ * .ff-eyebrow / .ff-d2 register without importing landing files. The display
+ * weight is kept at 300 (not the landing hero's 200) so headlines stay legible
+ * at onboarding sizes on the dark base. */
+.onboarding .ob-eyebrow {
+  font-family: 'Outfit', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+}
+
+.onboarding .ob-headline {
+  font-family: 'Outfit', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  font-weight: 300;
+  font-size: clamp(30px, 4.8vw, 48px);
+  letter-spacing: -0.035em;
+  line-height: 1.04;
+}
+
 .onboarding .ob-scroll::-webkit-scrollbar { width: 6px; }
 .onboarding .ob-scroll::-webkit-scrollbar-thumb {
   background: rgba(168, 85, 247, 0.25);

--- a/src/features/onboarding/steps/GenresStep.jsx
+++ b/src/features/onboarding/steps/GenresStep.jsx
@@ -47,13 +47,13 @@ export default function GenresStep({ selectedGenres, toggleGenre, onBack, onNext
         <StepHeader
           className="flex-none px-5 pt-5 pb-4 sm:px-6 sm:pt-6 sm:pb-5"
           onBack={onBack}
-          kicker="Genres · 2 of 4"
+          kicker="The territories · 2 of 4"
           subcopy={<>Pick at least {MIN_GENRES} — this steers what we reach for first. Nothing&apos;s
           locked in; you can always add more later.</>}
           subcopyClassName="text-[13px] sm:text-sm md:text-[15px] text-white/55 mt-2 sm:mt-3 leading-relaxed max-w-xl"
         >
           Which{' '}
-          <em className="bg-linear-to-r from-purple-500 to-pink-500 bg-clip-text text-transparent italic">
+          <em className="italic font-light text-purple-300">
             territories
           </em>
           {' '}do you live in?

--- a/src/features/onboarding/steps/MoodStep.jsx
+++ b/src/features/onboarding/steps/MoodStep.jsx
@@ -25,13 +25,13 @@ export default function MoodStep({ moods, setMoods, onNext, firstName }) {
       header={
         <StepHeader
           className="flex-none px-5 pt-5 pb-4 sm:px-6 sm:pt-8 sm:pb-5"
-          kicker={firstName ? `Hey ${firstName} —` : 'Mood baseline · 1 of 4'}
+          kicker={firstName ? `Hey ${firstName} —` : 'The vibe · 1 of 4'}
           subcopy={<>Pick {MIN_MOODS}–{MAX_MOODS} moods you actually find yourself in. We&apos;ll calibrate from
           here — and the screen will respond as you choose.</>}
           subcopyClassName="text-[13px] sm:text-sm md:text-[15px] text-white/55 mt-2 sm:mt-3 leading-relaxed max-w-xl"
         >
           The vibe you{' '}
-          <em className="bg-linear-to-r from-purple-500 to-pink-500 bg-clip-text text-transparent italic">
+          <em className="italic font-light text-purple-300">
             live in.
           </em>
         </StepHeader>

--- a/src/features/onboarding/steps/MoviesStep.jsx
+++ b/src/features/onboarding/steps/MoviesStep.jsx
@@ -72,13 +72,13 @@ export default function MoviesStep({
         <StepHeader
           className="flex-none px-5 pt-5 pb-4 sm:px-6 sm:pt-6"
           onBack={onBack}
-          kicker="Films · 3 of 4"
+          kicker="The anchors · 3 of 4"
           subcopy={<>Pick 5 films that shaped your taste. These anchor your first picks — so go
           honest, not impressive.</>}
           subcopyClassName="text-[13px] sm:text-sm md:text-[15px] text-white/60 mt-2 leading-relaxed"
         >
           What have you{' '}
-          <em className="bg-linear-to-r from-purple-500 to-pink-500 bg-clip-text italic text-transparent">
+          <em className="italic font-light text-purple-300">
             loved?
           </em>
         </StepHeader>

--- a/src/features/onboarding/steps/RatingStep.jsx
+++ b/src/features/onboarding/steps/RatingStep.jsx
@@ -103,29 +103,29 @@ export default function RatingStep({ favoriteMovies, ratings, onRate, onBack, on
         <button
           type="button"
           onClick={onBack}
-          className="mb-3 flex items-center gap-1.5 text-sm text-white/40 transition-colors hover:text-white/70 sm:mb-4"
+          className="mb-3 flex items-center gap-1.5 text-sm text-white/40 transition-colors hover:text-white/70 sm:mb-4 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
         >
           <ChevronLeft className="h-4 w-4" />
           Back
         </button>
-        <p className="mb-2.5 text-[11px] font-bold uppercase tracking-[0.22em] text-purple-400/85 sm:mb-3">
-          Rate · 4 of 4 · {allRated ? 'all done' : `${remaining} to go`}
+        <p className="ob-eyebrow text-white/55 mb-2.5 sm:mb-3">
+          The verdict · 4 of 4 · {allRated ? 'all done' : `${remaining} to go`}
         </p>
         <h2
-          className="ob-display text-[30px] font-normal leading-[1.05] text-white sm:text-4xl md:text-5xl"
+          className="ob-headline text-white"
           style={{ textWrap: 'balance' }}
         >
           {allRated ? (
             <>
               Nice — all{' '}
-              <em className="bg-linear-to-r from-purple-500 to-pink-500 bg-clip-text italic text-transparent">
+              <em className="italic font-light text-purple-300">
                 rated.
               </em>
             </>
           ) : (
             <>
               How did this one{' '}
-              <em className="bg-linear-to-r from-purple-500 to-pink-500 bg-clip-text italic text-transparent">
+              <em className="italic font-light text-purple-300">
                 land?
               </em>
             </>


### PR DESCRIPTION
Tightly-scoped visual/brand-language pass (F2.7) on the shared step **chrome** — aligns onboarding step headers with the polished landing/editorial dialect ("Premium Cinematic Tuning"). No step bodies redesigned, no behavior changed.

## StepHeader
- New onboarding-local type classes in `onboarding.css` — `.ob-eyebrow` and `.ob-headline` — echoing the landing's `.ff-eyebrow` / `.ff-d2` register **without importing landing files**.
  - **Headline:** Outfit display, weight **300** (kept legible at onboarding sizes — deliberately *not* the landing hero's 200, which the F2.5 audit flagged as thin on dark), tighter `-0.035em` tracking, and a **fluid `clamp(30px, 4.8vw, 48px)`** scale replacing the stepped `text-[32px]/4xl/5xl`. `textWrap: 'balance'` preserved.
  - **Kicker:** `.ob-eyebrow` (Outfit 600, `0.26em`, uppercase) in a **restrained faint-white** (`text-white/55`) — replacing the loud `font-bold` `tracking-[0.22em]` `text-purple-400/85`.

## Kicker / beat labels
Replaced the survey-like wizard labels with cinematic **beat names**, preserving the numeric progress meaning:
- Mood — `The vibe · 1 of 4` *(fallback; the `Hey {firstName} —` greeting is kept for named users)*
- Genres — `The territories · 2 of 4`
- Movies — `The anchors · 3 of 4`
- Rating — `The verdict · 4 of 4 · {N to go}`

Only kicker copy changed — headlines, subcopy, button labels, validation status copy, and completion copy are all untouched.

## Accent treatment
The three shared-header steps' headline `<em>` move from the saturated **gradient-clip** (`bg-linear-to-r … bg-clip-text text-transparent`) to a **restrained `italic font-light text-purple-300`** — the landing's italic-accent approach. Purple retained; no neon/gradient. The headline words are unchanged.

## RatingStep alignment
RatingStep stays custom (not folded into `StepHeader`), but its header now speaks the shared language: `.ob-eyebrow` kicker + `.ob-headline` (which also fixes its `text-[30px]` drift vs the others' 32px) + the restrained accent + the matching `The verdict` beat name. **Swipe mechanics, sentiment buttons, auto-finish, skip, rating state machine, and completion behavior are untouched.**

## StepFooter & BackButton
- **StepFooter:** left untouched — the status messages + per-step gate colors are passed in as props (and are test-pinned), and the footer is a structural wrapper, so there was nothing to safely align there without risking gate messaging.
- **BackButton** (and RatingStep's inline back): added a premium `focus-visible` ring (`focus-visible:ring-2 ring-purple-400/60` + offset). No display/width/padding/click change → no layout shift.

## Confirmations
- **Step bodies / logic not redesigned** — only headers, the eyebrow/headline type, the accent class, and the back-button focus ring changed; tiles, grids, search, swipe deck, and gates are as-is.
- **Auth / routing / Supabase writes / scoring / search logic / localStorage keys / validation thresholds / destination route / completion timing / CelebrationReveal** all unchanged.

## Validation
- `npm run lint` → clean
- `npx vitest run src/features/onboarding/__tests__/ src/shared/lib/auth/__tests__/onboardingStatus.test.js` → 44 passed (4 files) — Genres minimum, Movies `MIN_MOVIES=5`, Rating sentiment, and Progress/TasteStrip chrome coverage all intact
- `npm run build` → ✓
- `npm run test` (full) → 548 passed (50 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
