### PR TITLE
Add onboarding mood signature layer

### DIFF
--- a/src/features/onboarding/Onboarding.jsx
+++ b/src/features/onboarding/Onboarding.jsx
@@ -23,7 +23,7 @@ import { completeOnboarding, markOnboardingAuthComplete } from '@/shared/service
 import { prefetchHomeData } from '@/features/home/useHomeData'
 import BrandSplash from '@/shared/ui/BrandSplash'
 
-import AmbientGlow from './components/AmbientGlow'
+import AmbientGlow, { deriveMoodSignature } from './components/AmbientGlow'
 import Progress from './components/Progress'
 import TasteStrip from './components/TasteStrip'
 import CelebrationReveal from './components/CelebrationReveal'
@@ -268,8 +268,16 @@ export default function Onboarding() {
 
   // Main layout
   return (
-    <div className="onboarding fixed inset-0 flex flex-col bg-black text-white overflow-hidden">
+    <div
+      className="onboarding fixed inset-0 flex flex-col bg-black text-white overflow-hidden"
+      style={{ '--ob-accent-rgb': deriveMoodSignature(moods) }}
+    >
       <AmbientGlow moods={moods} />
+      {/* Mood-signature atmosphere — a faint accent vignette + 1px top hairline
+         that tint the room to the user's selected mood. CSS-only (no JS motion);
+         the recolor tween collapses under the global reduced-motion reset. Mood
+         is an ambient accent only — the brand gradient stays on the foreground. */}
+      <div aria-hidden="true" className="ob-atmosphere pointer-events-none absolute inset-0" />
       {/* subtle grain */}
       <div
         aria-hidden="true"

--- a/src/features/onboarding/__tests__/OnboardingMoodSignature.test.js
+++ b/src/features/onboarding/__tests__/OnboardingMoodSignature.test.js
@@ -1,0 +1,48 @@
+// src/features/onboarding/__tests__/OnboardingMoodSignature.test.js
+// F2.8 — the wrapper mood-signature helper that drives the onboarding ambient
+// tint (CSS vars). Pure function; no rendering / no live data.
+
+import { describe, it, expect } from 'vitest'
+import { deriveMoodSignature } from '../components/AmbientGlow'
+import { MOODS } from '../data'
+
+describe('deriveMoodSignature', () => {
+  it('returns the restrained brand-purple default when no moods are selected', () => {
+    expect(deriveMoodSignature([])).toBe('168, 85, 247')
+    expect(deriveMoodSignature()).toBe('168, 85, 247')
+  })
+
+  it('returns the single mood rgb exactly (no blend)', () => {
+    const cozy = MOODS.find(m => m.key === 'cozy').rgb // '236, 72, 153'
+    expect(deriveMoodSignature(['cozy'])).toBe('236, 72, 153')
+    expect(deriveMoodSignature(['cozy'])).toBe(cozy.split(',').map(n => n.trim()).join(', '))
+  })
+
+  it('averages multiple moods deterministically and order-independently', () => {
+    // cozy 236,72,153 + wired 168,85,247 → ((236+168)/2, (72+85)/2, (153+247)/2)
+    //                                    → (202, 78.5→79, 200)
+    const a = deriveMoodSignature(['cozy', 'wired'])
+    const b = deriveMoodSignature(['wired', 'cozy'])
+    expect(a).toBe(b)              // order-independent
+    expect(a).toBe('202, 79, 200')
+  })
+
+  it('averages three moods deterministically', () => {
+    // cozy 236,72,153 + wired 168,85,247 + tense 129,140,248
+    // → ((236+168+129)/3, (72+85+140)/3, (153+247+248)/3) → (177.67→178, 99, 216)
+    expect(deriveMoodSignature(['cozy', 'wired', 'tense'])).toBe('178, 99, 216')
+  })
+
+  it('ignores unknown mood keys, falling back to the default when none are valid', () => {
+    expect(deriveMoodSignature(['bogus'])).toBe('168, 85, 247')
+    // a valid + invalid key resolves to just the valid mood
+    expect(deriveMoodSignature(['cozy', 'bogus'])).toBe('236, 72, 153')
+  })
+
+  it('always returns a well-formed "r, g, b" triplet', () => {
+    for (const m of MOODS) {
+      expect(deriveMoodSignature([m.key])).toMatch(/^\d{1,3}, \d{1,3}, \d{1,3}$/)
+    }
+    expect(deriveMoodSignature(MOODS.map(m => m.key))).toMatch(/^\d{1,3}, \d{1,3}, \d{1,3}$/)
+  })
+})

--- a/src/features/onboarding/components/AmbientGlow.jsx
+++ b/src/features/onboarding/components/AmbientGlow.jsx
@@ -13,6 +13,30 @@ function rgbForKey(key) {
   return MOODS.find(m => m.key === key)?.rgb ?? DEFAULT_PRIMARY
 }
 
+/**
+ * Derive a single ambient mood SIGNATURE ("r, g, b") from the selected mood keys,
+ * for the onboarding wrapper's atmospheric tinting (CSS vars). This is distinct
+ * from the dual-radial glow this component renders (left untouched so the shared
+ * AmbientGlow — also used by CelebrationReveal — is byte-identical).
+ *
+ * Rules: 0 moods → restrained brand purple; 1 → that mood's existing rgb; ≥2 →
+ * a deterministic, order-independent component-wise average. Mood keys, labels,
+ * and meaning are not changed; only existing rgb data is read.
+ *
+ * @param {string[]} moods — onboarding mood keys
+ * @returns {string}        — "r, g, b" for use in rgba()
+ */
+export function deriveMoodSignature(moods = []) {
+  const rgbs = (moods || [])
+    .map(key => MOODS.find(m => m.key === key)?.rgb)
+    .filter(Boolean)
+    .map(s => s.split(',').map(n => Number(n.trim())))
+  if (rgbs.length === 0) return DEFAULT_PRIMARY
+  if (rgbs.length === 1) return rgbs[0].join(', ')
+  const avg = [0, 1, 2].map(i => Math.round(rgbs.reduce((sum, c) => sum + c[i], 0) / rgbs.length))
+  return avg.join(', ')
+}
+
 export default function AmbientGlow({ moods = [] }) {
   const { primary, secondary } = useMemo(() => {
     if (moods.length === 0) return { primary: DEFAULT_PRIMARY, secondary: DEFAULT_SECONDARY }

--- a/src/features/onboarding/onboarding.css
+++ b/src/features/onboarding/onboarding.css
@@ -40,3 +40,22 @@
   scrollbar-width: thin;
   scrollbar-color: rgba(168,85,247,0.25) transparent;
 }
+
+/* Mood-signature atmosphere. --ob-accent-rgb (a single deterministic mood
+ * signature, brand-purple fallback) is set on the .onboarding root in
+ * Onboarding.jsx; the soft/border tints derive from it. Used ONLY for ambient
+ * tinting (faint edge vignette + a 1px top hairline) — never foreground chrome,
+ * CTAs, or headlines. The recolor tween collapses under the global
+ * prefers-reduced-motion reset (index.css), so no JS motion is needed. */
+.onboarding {
+  --ob-accent-soft: rgba(var(--ob-accent-rgb, 168, 85, 247), 0.10);
+  --ob-accent-border: rgba(var(--ob-accent-rgb, 168, 85, 247), 0.22);
+}
+
+.onboarding .ob-atmosphere {
+  background: radial-gradient(ellipse 130% 115% at 50% 50%, transparent 60%, var(--ob-accent-soft) 100%);
+  box-shadow: inset 0 1px 0 var(--ob-accent-border);
+  transition:
+    background 1.4s cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 1.4s cubic-bezier(0.22, 1, 0.36, 1);
+}


### PR DESCRIPTION
Tightly-scoped visual/emotional continuity pass (F2.8) — the onboarding **wrapper** now subtly tints to the user's selected mood ("the room responds to me"), the F2.5 Mood-Reactive layer on top of the Premium Cinematic base. Mood is an **ambient accent only**; the brand stays dark-cinematic + purple/pink gradient on the foreground.

## How the mood signature is derived
New exported helper `deriveMoodSignature(moods)` in `AmbientGlow.jsx` returns one deterministic `"r, g, b"` string:
- **0 moods** → restrained brand purple `168, 85, 247`.
- **1 mood** → that mood's existing `rgb` from `MOODS`, exactly.
- **≥2 moods** → an **order-independent** component-wise average (e.g. cozy + wired → `202, 79, 200`).

It only *reads* existing `MOODS` rgb data — no mood keys/labels/meaning changed (so `data.js` was untouched). Unit-tested for default / single / multi-deterministic / order-independence / unknown-key fallback / well-formed output.

## Wrapper / AmbientGlow styling changes
- **`Onboarding.jsx`**: sets `--ob-accent-rgb` on the `.onboarding` root from the signature, and adds a CSS-only `.ob-atmosphere` layer (a faint accent **edge vignette** + a **1px top hairline**) behind the content.
- **`onboarding.css`**: derives `--ob-accent-soft` (`0.10` alpha) and `--ob-accent-border` (`0.22` alpha) from `--ob-accent-rgb` (brand-purple fallback); `.ob-atmosphere` uses them with a `1.4s` recolor tween.
- **`AmbientGlow.jsx`**: the **component render is byte-identical** (verified by diff — only the helper was added). This is deliberate: `CelebrationReveal` renders `<AmbientGlow>`, and it's a forbidden file, so keeping the component unchanged leaves the celebration backdrop exactly as-is. The new wrapper signature drives the *additional* atmosphere layer.

## Reduced motion
All reactivity is CSS `background`/`box-shadow` transitions — **no JS animation**. The global `@media (prefers-reduced-motion: reduce)` reset (`index.css:106`) already collapses `transition-duration` to `~0`, so under reduce the tint applies instantly (static). Nothing new to gate.

## Confirmations
- **Mood colors remain ambient accents only** — used solely for the vignette + hairline at low alpha (`0.10`/`0.22`), behind `aria-hidden` + `pointer-events-none` layers; never a page theme.
- **CTAs / headlines / brand gradient not recolored** — the brand purple→pink gradient stays on the wordmark, progress fill, primary CTA, and the (already restrained) headline accents.
- **No text-contrast impact** — the atmosphere sits behind the `z-10` content; text colors are unchanged. No functional state depends on the mood color.
- **Step bodies / logic untouched**; **auth / routing / Supabase writes / scoring / search logic / localStorage keys / destination route / onboarding completion timing / CelebrationReveal timing** all unchanged.

## Validation
- `npm run lint` → clean
- `npx vitest run src/features/onboarding/__tests__/ src/shared/lib/auth/__tests__/onboardingStatus.test.js` → 50 passed (5 files)
- `npm run build` → ✓
- `npm run test` (full) → 554 passed (51 files)
- Render check (throwaway): `--ob-accent-rgb` serializes correctly for no/one/multiple moods; atmosphere layer renders `aria-hidden` + `pointer-events-none`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
