### PR TITLE
Polish onboarding mood and genre steps

### DIFF
--- a/src/features/onboarding/__tests__/MoodStep.test.jsx
+++ b/src/features/onboarding/__tests__/MoodStep.test.jsx
@@ -1,0 +1,76 @@
+// src/features/onboarding/__tests__/MoodStep.test.jsx
+// F2.9 — MoodStep selection behavior: up-to-MAX_MOODS, calm max feedback, and
+// the settle (no-checkbox) selected state. Real component, stateful harness.
+
+import { describe, it, expect, vi, beforeAll } from 'vitest'
+import { useState } from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+// framer-motion's useReducedMotion reads window.matchMedia (jsdom lacks it).
+beforeAll(() => {
+  if (!window.matchMedia) {
+    window.matchMedia = vi.fn().mockImplementation(query => ({
+      matches: false, media: query, onchange: null,
+      addEventListener: vi.fn(), removeEventListener: vi.fn(),
+      addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(),
+    }))
+  }
+})
+
+import MoodStep from '../steps/MoodStep'
+import { MOODS, MAX_MOODS } from '../data'
+
+// Stateful harness so toggle()'s setMoods(prev => …) actually applies + re-renders.
+function Harness({ initial = [] }) {
+  const [moods, setMoods] = useState(initial)
+  return <MoodStep moods={moods} setMoods={setMoods} onNext={() => {}} firstName={null} />
+}
+
+const tile = (label) => screen.getByRole('button', { name: new RegExp(label, 'i') })
+const pressedCount = () =>
+  screen.getAllByRole('button').filter(b => b.getAttribute('aria-pressed') === 'true').length
+
+describe('MoodStep — selection + max feedback', () => {
+  it('allows selecting up to MAX_MOODS (3) moods', () => {
+    render(<Harness />)
+    fireEvent.click(tile(MOODS[0].label))
+    fireEvent.click(tile(MOODS[1].label))
+    fireEvent.click(tile(MOODS[2].label))
+    expect(pressedCount()).toBe(MAX_MOODS)
+  })
+
+  it('does NOT add a 4th mood once 3 are selected', () => {
+    render(<Harness initial={[MOODS[0].key, MOODS[1].key, MOODS[2].key]} />)
+    expect(pressedCount()).toBe(3)
+    fireEvent.click(tile(MOODS[3].label)) // attempt a 4th
+    expect(pressedCount()).toBe(3)
+    expect(tile(MOODS[3].label)).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('shows calm max feedback (footer status + sr-only live region) at the cap', () => {
+    render(<Harness initial={[MOODS[0].key, MOODS[1].key, MOODS[2].key]} />)
+    expect(screen.getByText(/that's your max$/i)).toBeInTheDocument()  // footer status
+    expect(screen.getByText(/maximum of 3/i)).toBeInTheDocument()      // sr-only aria-live
+  })
+
+  it('dims/aria-disables unselected tiles at the cap but keeps selected tiles tappable', () => {
+    render(<Harness initial={[MOODS[0].key, MOODS[1].key, MOODS[2].key]} />)
+    expect(tile(MOODS[3].label)).toHaveAttribute('aria-disabled', 'true')  // unselected
+    expect(tile(MOODS[0].label)).not.toHaveAttribute('aria-disabled')      // selected
+    fireEvent.click(tile(MOODS[0].label)) // unselect — must still work at cap
+    expect(pressedCount()).toBe(2)
+  })
+
+  it('no longer renders a checkbox ✓ glyph on selected tiles', () => {
+    render(<Harness initial={[MOODS[0].key]} />)
+    expect(tile(MOODS[0].label)).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.queryByText('✓')).not.toBeInTheDocument()
+  })
+
+  it('does not show max feedback below the cap', () => {
+    render(<Harness initial={[MOODS[0].key, MOODS[1].key]} />)
+    expect(screen.queryByText(/your max/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/maximum of 3/i)).not.toBeInTheDocument()
+    expect(tile(MOODS[3].label)).not.toHaveAttribute('aria-disabled')
+  })
+})

--- a/src/features/onboarding/onboarding.css
+++ b/src/features/onboarding/onboarding.css
@@ -59,3 +59,15 @@
     background 1.4s cubic-bezier(0.22, 1, 0.36, 1),
     box-shadow 1.4s cubic-bezier(0.22, 1, 0.36, 1);
 }
+
+/* Mood orb "breathe" — a slow, low-amplitude scale so a SELECTED mood tile feels
+ * alive (the copy promises the screen responds). Calm 6s loop; MoodStep only
+ * applies the class when motion is allowed, and the global
+ * prefers-reduced-motion reset (index.css) collapses the animation regardless. */
+@keyframes ob-orb-breathe {
+  0%, 100% { transform: scale(1); }
+  50%      { transform: scale(1.08); }
+}
+.onboarding .ob-orb-breathe {
+  animation: ob-orb-breathe 6s ease-in-out infinite;
+}

--- a/src/features/onboarding/steps/GenresStep.jsx
+++ b/src/features/onboarding/steps/GenresStep.jsx
@@ -1,5 +1,6 @@
 // src/features/onboarding/steps/GenresStep.jsx
-// Restyled genre picker — gradient outline tiles.
+// Genre picker — territories of taste. Lifted tile surfaces (not a tag cloud)
+// with a settled selected state.
 
 import { motion, useReducedMotion } from 'framer-motion'
 
@@ -23,15 +24,15 @@ function GenreTile({ genre, isSelected, onClick }) {
       type="button"
       onClick={onClick}
       variants={reduced ? undefined : tileVariants}
-      whileTap={{ scale: 0.96 }}
+      whileTap={reduced ? undefined : { scale: 0.96 }}
       aria-pressed={isSelected}
-      className={`text-left rounded-2xl px-4 py-3.5 border transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black ${
+      className={`text-left rounded-2xl px-4 py-3.5 min-h-[44px] border transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black ${
         isSelected
-          ? 'bg-linear-to-br from-purple-500/18 to-pink-500/12 border-purple-400/50 shadow-[0_4px_16px_rgba(168,85,247,0.16)]'
-          : 'bg-white/3 border-white/8 hover:bg-white/6 hover:border-white/16'
+          ? 'bg-linear-to-br from-purple-500/18 to-pink-500/12 border-purple-400/55 shadow-[0_4px_16px_rgba(168,85,247,0.16),inset_0_0_0_1px_rgba(168,85,247,0.35)]'
+          : 'bg-white/[0.05] border-white/10 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] hover:bg-white/[0.08] hover:border-white/20'
       }`}
     >
-      <div className="ob-display text-[15px] font-bold text-white mb-0.5">{genre.name}</div>
+      <div className="ob-display text-[15px] font-medium text-white mb-0.5">{genre.name}</div>
     </motion.button>
   )
 }
@@ -80,6 +81,8 @@ export default function GenresStep({ selectedGenres, toggleGenre, onBack, onNext
           variants={reduced ? undefined : containerVariants}
           initial={reduced ? false : 'hidden'}
           animate="visible"
+          role="group"
+          aria-label="Genres"
         >
           {GENRES.map(g => (
             <GenreTile

--- a/src/features/onboarding/steps/MoodStep.jsx
+++ b/src/features/onboarding/steps/MoodStep.jsx
@@ -1,7 +1,9 @@
 // src/features/onboarding/steps/MoodStep.jsx
-// NEW step 1 (mood baseline). Tile picker, 2-3 selections, with a pulsing orb in each tile.
+// Step 1 (mood baseline). Tile picker, up to MAX_MOODS selections. A selected
+// tile "settles" into the atmosphere (accent ring + glow + lift, no checkbox),
+// and its mood orb breathes slowly when motion is allowed.
 
-import { motion } from 'framer-motion'
+import { motion, useReducedMotion } from 'framer-motion'
 
 import { MOODS, MIN_MOODS, MAX_MOODS } from '../data'
 import StepShell from '../components/StepShell'
@@ -9,8 +11,10 @@ import StepHeader from '../components/StepHeader'
 import StepFooter from '../components/StepFooter'
 
 export default function MoodStep({ moods, setMoods, onNext, firstName }) {
+  const reduced = useReducedMotion()
   const count = moods.length
   const canContinue = count >= MIN_MOODS
+  const maxReached = count >= MAX_MOODS
 
   function toggle(key) {
     setMoods(prev => {
@@ -44,6 +48,8 @@ export default function MoodStep({ moods, setMoods, onNext, firstName }) {
               ? `Pick at least ${MIN_MOODS} mood${MIN_MOODS === 1 ? '' : 's'} to continue`
               : count < MIN_MOODS
               ? `${count} selected — pick ${MIN_MOODS - count} more`
+              : maxReached
+              ? `${count} selected — that's your max`
               : `${count} selected ✓`
           }
           onContinue={onNext}
@@ -55,47 +61,47 @@ export default function MoodStep({ moods, setMoods, onNext, firstName }) {
          selected-tile glow/border to render fully — without it, the parent's
          overflow-y-auto implicitly clips the box-shadow on the top/left edges. */}
       <div className="ob-scroll flex-1 min-h-0 overflow-y-auto px-5 pb-4 sm:px-6">
-        <div className="grid grid-cols-2 lg:grid-cols-3 gap-2.5 sm:gap-3 max-w-3xl mx-auto px-1 py-2">
+        {/* Calm, screen-reader-only feedback when the selection cap is reached. */}
+        <p className="sr-only" aria-live="polite">
+          {maxReached ? `You've selected the maximum of ${MAX_MOODS} moods. Unpick one to choose a different mood.` : ''}
+        </p>
+        <div className="grid grid-cols-2 lg:grid-cols-3 gap-2.5 sm:gap-3 max-w-3xl mx-auto px-1 py-2" role="group" aria-label="Moods">
           {MOODS.map(m => {
             const on = moods.includes(m.key)
+            const dimmed = maxReached && !on
             return (
               <motion.button
                 key={m.key}
                 type="button"
                 onClick={() => toggle(m.key)}
-                whileTap={{ scale: 0.97 }}
+                whileTap={reduced ? undefined : { scale: 0.97 }}
                 aria-pressed={on}
-                className="relative text-left p-4 sm:p-5 rounded-2xl overflow-hidden cursor-pointer transition-all"
+                aria-disabled={dimmed || undefined}
+                className={`relative text-left p-4 sm:p-5 rounded-2xl overflow-hidden transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black ${dimmed ? 'cursor-not-allowed' : 'cursor-pointer'}`}
                 style={{
                   background: on ? `rgba(${m.rgb}, 0.16)` : 'rgba(255,255,255,0.03)',
-                  border: `1px solid ${on ? `rgba(${m.rgb}, 0.55)` : 'rgba(255,255,255,0.1)'}`,
+                  border: `1px solid ${on ? `rgba(${m.rgb}, 0.6)` : 'rgba(255,255,255,0.1)'}`,
                   boxShadow: on
-                    ? `0 0 16px rgba(${m.rgb}, 0.32), inset 0 0 0 1px rgba(${m.rgb}, 0.1)`
+                    ? `0 0 20px rgba(${m.rgb}, 0.30), inset 0 0 0 1px rgba(${m.rgb}, 0.45)`
                     : 'none',
                   transform: on ? 'translateY(-2px)' : 'translateY(0)',
+                  opacity: dimmed ? 0.45 : 1,
                 }}
               >
-                {/* Pulsing orb */}
+                {/* Mood orb — breathes slowly only when selected + motion is allowed
+                   (the .ob-orb-breathe animation collapses under the global
+                   prefers-reduced-motion reset; the class is also gated here). */}
                 <div
                   aria-hidden="true"
-                  className="absolute -top-5 -right-5 w-20 h-20 rounded-full"
+                  className={`absolute -top-5 -right-5 w-20 h-20 rounded-full${on && !reduced ? ' ob-orb-breathe' : ''}`}
                   style={{
                     background: `radial-gradient(circle, rgba(${m.rgb}, ${on ? 0.45 : 0.18}), transparent 70%)`,
                     filter: 'blur(12px)',
-                    transition: 'all 0.6s ease',
+                    transition: 'background 0.6s ease',
                   }}
                 />
-                <div className="relative flex items-center justify-between mb-1.5">
+                <div className="relative mb-1.5">
                   <span className="ob-display text-lg font-bold text-white">{m.label}</span>
-                  {on && (
-                    <span
-                      className="inline-flex items-center justify-center w-5 h-5 rounded-full text-black font-extrabold text-[11px]"
-                      style={{ background: `rgb(${m.rgb})` }}
-                      aria-hidden="true"
-                    >
-                      ✓
-                    </span>
-                  )}
                 </div>
                 <p className="relative text-[12.5px] text-white/60 leading-snug">{m.desc}</p>
               </motion.button>


### PR DESCRIPTION
Tightly-scoped visual + a11y polish (F2.9) of the first two onboarding step bodies — MoodStep (the mood-first front door) and GenresStep. No thresholds, data, or step order changed; the only new behavior is the calm max-selection feedback.

## MoodStep — selected state
The checkbox-like **`✓` pill is gone**. A selected tile now *settles* into the atmosphere: stronger mood border (`0.6`) + outer glow (`0.30`) + a **1px inner accent ring** (`inset 0 0 0 1px rgba(mood,0.45)`) + the existing `-2px` lift. `aria-pressed` is unchanged, and selected/unselected stay clearly distinct (color + geometry).

## MoodStep — max feedback (validation rule UNCHANGED)
`MAX_MOODS=3` still enforced in `toggle` exactly as before. When the cap is reached:
- the footer status reads **"3 selected — that's your max"** (in the calm purple state, not error styling);
- **unselected** tiles dim to `0.45` + get `aria-disabled` + `cursor-not-allowed` (the 4th-tap was a silent no-op before);
- an **`sr-only` `aria-live="polite"`** region announces *"You've selected the maximum of 3 moods. Unpick one to choose a different mood."*
- **selected** tiles stay fully tappable, so you can always unpick/swap.

## MoodStep — focus + reduced motion
- Added a `focus-visible` ring on tiles (was relying on the UA default).
- `whileTap` is now gated under `useReducedMotion`.
- The mood orb finally *breathes* — a slow **6s, scale-only** loop, applied **only when selected AND motion is allowed**, and also collapsed by the global `prefers-reduced-motion` reset (verified: no `.ob-orb-breathe` class under reduce).
- Added `role="group" aria-label="Moods"`.

## GenresStep — visual lift
- Resting tiles lifted out of placeholder/tag-cloud territory: `bg-white/[0.05]` + brighter border + a **top-light inset seam** (`inset 0 1px 0 rgba(255,255,255,0.06)`).
- Clearer **settled** selected state (added the same inner accent ring).
- Editorial label weight (`font-bold` → `font-medium`) — territories, not a survey.
- `whileTap` gated under reduced motion; **`min-h-[44px]`** touch floor; `role="group" aria-label="Genres"`.
- Genre data + `selectedGenre` IDs unchanged; **no grouping/reordering** (recommended as a later phase if desired).

## Tests
New `MoodStep.test.jsx`: allows up to 3; a 4th is rejected (`aria-pressed=false`, count stays 3); calm max feedback (footer + sr-only) appears at the cap and not below it; unselected tiles are `aria-disabled` at the cap while selected stay tappable (unpick works); no `✓` glyph on selected tiles. The existing GenresStep coverage (Continue enabled at 1 genre, tile → `toggleGenre`) still passes unchanged.

## Confirmations
- **Thresholds / genre data / `MOODS` / step order unchanged**; the only new behavior is the max-feedback message + dimming.
- **Auth / routing / Supabase writes / scoring / search logic / localStorage keys / destination route / onboarding completion timing** untouched. MoviesStep, RatingStep, CelebrationReveal, and all shared chrome were not edited.

## Validation
- `npm run lint` → clean
- `npx vitest run src/features/onboarding/__tests__/ src/shared/lib/auth/__tests__/onboardingStatus.test.js` → 56 passed (6 files)
- `npm run build` → ✓
- `npm run test` (full) → 560 passed (52 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
