### PR TITLE
Harden onboarding movies search states

### DIFF
--- a/src/features/onboarding/__tests__/MoviesHooks.test.js
+++ b/src/features/onboarding/__tests__/MoviesHooks.test.js
@@ -1,0 +1,86 @@
+// src/features/onboarding/__tests__/MoviesHooks.test.js
+// F2.13 — the new error/retry state in the MoviesStep hooks (logic-level), with
+// the underlying fetchers mocked. No engine/query/ranking change is exercised.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+
+vi.mock('../suggestionPool', () => ({ fetchSuggestionPool: vi.fn() }))
+vi.mock('@/shared/api/tmdb', () => ({ searchMovies: vi.fn() }))
+
+import { fetchSuggestionPool } from '../suggestionPool'
+import { searchMovies } from '@/shared/api/tmdb'
+import { useSuggestionPool } from '../hooks/useSuggestionPool'
+import { useMovieSearch } from '../hooks/useMovieSearch'
+
+describe('useSuggestionPool — error + retry (mount-once preserved)', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('flips poolError when the fetch rejects, non-throwing', async () => {
+    fetchSuggestionPool.mockRejectedValueOnce(new Error('boom'))
+    const { result } = renderHook(() => useSuggestionPool([28], ['cozy']))
+    await waitFor(() => expect(result.current.poolError).toBe(true))
+    expect(result.current.poolLoading).toBe(false)
+    expect(result.current.pool).toEqual([])
+  })
+
+  it('resolves with the pool and no error on success', async () => {
+    fetchSuggestionPool.mockResolvedValueOnce([{ id: 1 }])
+    const { result } = renderHook(() => useSuggestionPool([28], ['cozy']))
+    await waitFor(() => expect(result.current.poolLoading).toBe(false))
+    expect(result.current.poolError).toBe(false)
+    expect(result.current.pool).toEqual([{ id: 1 }])
+  })
+
+  it('retry re-fetches the SAME mount-captured picks and clears the error', async () => {
+    fetchSuggestionPool.mockRejectedValueOnce(new Error('boom'))
+    const { result } = renderHook(() => useSuggestionPool([28], ['cozy']))
+    await waitFor(() => expect(result.current.poolError).toBe(true))
+
+    fetchSuggestionPool.mockResolvedValueOnce([{ id: 7 }])
+    act(() => { result.current.retry() })
+    await waitFor(() => expect(result.current.poolError).toBe(false))
+    expect(result.current.pool).toEqual([{ id: 7 }])
+    expect(fetchSuggestionPool).toHaveBeenLastCalledWith([28], ['cozy'])
+  })
+
+  it('fetches once on mount and does NOT re-fetch when args change', async () => {
+    fetchSuggestionPool.mockResolvedValue([])
+    const { rerender } = renderHook(({ g, m }) => useSuggestionPool(g, m), {
+      initialProps: { g: [28], m: ['cozy'] },
+    })
+    await waitFor(() => expect(fetchSuggestionPool).toHaveBeenCalledTimes(1))
+    rerender({ g: [35], m: ['wired'] })
+    expect(fetchSuggestionPool).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useMovieSearch — search error (debounce/ranking untouched)', () => {
+  beforeEach(() => { vi.clearAllMocks(); vi.useFakeTimers() })
+  afterEach(() => vi.useRealTimers())
+
+  it('flips searchError when the search rejects (not a benign empty)', async () => {
+    searchMovies.mockRejectedValueOnce(new Error('tmdb down'))
+    const { result } = renderHook(() => useMovieSearch())
+    act(() => { result.current.setQuery('inception') })
+    await act(async () => { await vi.advanceTimersByTimeAsync(350) })
+    expect(result.current.searchError).toBe(true)
+    expect(result.current.results).toEqual([])
+  })
+
+  it('clears searchError at the start of the next search and can recover', async () => {
+    searchMovies
+      .mockRejectedValueOnce(new Error('down'))
+      .mockResolvedValueOnce({ results: [{ id: 1, poster_path: '/a.jpg', popularity: 5 }] })
+    const { result } = renderHook(() => useMovieSearch())
+    act(() => { result.current.setQuery('a') })
+    await act(async () => { await vi.advanceTimersByTimeAsync(350) })
+    expect(result.current.searchError).toBe(true)
+
+    act(() => { result.current.setQuery('ab') }) // new search start clears the error
+    expect(result.current.searchError).toBe(false)
+    await act(async () => { await vi.advanceTimersByTimeAsync(350) })
+    expect(result.current.searchError).toBe(false)
+    expect(result.current.results.length).toBe(1)
+  })
+})

--- a/src/features/onboarding/__tests__/MoviesStepStates.test.jsx
+++ b/src/features/onboarding/__tests__/MoviesStepStates.test.jsx
@@ -1,0 +1,138 @@
+// src/features/onboarding/__tests__/MoviesStepStates.test.jsx
+// F2.13 — MoviesStep rendered states (pool error/empty/loading, search input
+// label, gated autofocus) + the leaf SearchDropdown / CardSkeletonRow a11y.
+// The hooks are mocked so each state is controlled directly.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+
+vi.mock('@/shared/api/tmdb', () => ({ tmdbImg: p => `x${p}`, searchMovies: vi.fn() }))
+vi.mock('../hooks/useSuggestionPool', () => ({ useSuggestionPool: vi.fn() }))
+vi.mock('../hooks/useMovieSearch', () => ({ useMovieSearch: vi.fn() }))
+
+import { useSuggestionPool } from '../hooks/useSuggestionPool'
+import { useMovieSearch } from '../hooks/useMovieSearch'
+import MoviesStep from '../steps/MoviesStep'
+import SearchDropdown from '../steps/movies/SearchDropdown'
+import CardSkeletonRow from '../steps/movies/CardSkeletonRow'
+
+const poolState = (over = {}) => ({ pool: [], poolLoading: false, poolError: false, retry: vi.fn(), ...over })
+const searchState = (over = {}) => ({
+  query: '', setQuery: vi.fn(), results: [], searching: false, showDropdown: false,
+  setShowDropdown: vi.fn(), clearSearch: vi.fn(), searchError: false, retrySearch: vi.fn(), ...over,
+})
+const props = (over = {}) => ({
+  selectedGenreIds: [], moods: [], favoriteMovies: [], addMovie: vi.fn(), removeMovie: vi.fn(),
+  isMovieSelected: () => false, onBack: vi.fn(), onFinish: vi.fn(), loading: false, error: '', ...over,
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // default: coarse pointer (no autofocus) for everything except the explicit fine test
+  window.matchMedia = vi.fn().mockImplementation(q => ({
+    matches: false, media: q, onchange: null,
+    addEventListener: vi.fn(), removeEventListener: vi.fn(),
+    addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(),
+  }))
+  useSuggestionPool.mockReturnValue(poolState())
+  useMovieSearch.mockReturnValue(searchState())
+})
+
+describe('MoviesStep — pool states', () => {
+  it('shows a role=alert pool-error card + retry button (before the empty state)', () => {
+    const retry = vi.fn()
+    useSuggestionPool.mockReturnValue(poolState({ poolError: true, retry }))
+    render(<MoviesStep {...props()} />)
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /retry loading suggestions/i }))
+    expect(retry).toHaveBeenCalled()
+    expect(screen.queryByText(/all suggestions added/i)).not.toBeInTheDocument()
+  })
+
+  it('shows "All suggestions added" only on a TRUE empty (no error, not loading)', () => {
+    useSuggestionPool.mockReturnValue(poolState({ pool: [], poolLoading: false, poolError: false }))
+    render(<MoviesStep {...props()} />)
+    expect(screen.getByText(/all suggestions added/i)).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('shows the loading skeleton (role=status, aria-busy) while the pool loads', () => {
+    useSuggestionPool.mockReturnValue(poolState({ poolLoading: true }))
+    render(<MoviesStep {...props()} />)
+    expect(screen.getByRole('status')).toHaveAttribute('aria-busy', 'true')
+  })
+})
+
+describe('MoviesStep — search input + autofocus', () => {
+  it('gives the search input an accessible name', () => {
+    render(<MoviesStep {...props()} />)
+    expect(screen.getByRole('textbox', { name: /search for a film to add/i })).toBeInTheDocument()
+  })
+
+  it('does NOT autofocus the input under a coarse pointer', () => {
+    vi.useFakeTimers()
+    try {
+      render(<MoviesStep {...props()} />)
+      act(() => { vi.advanceTimersByTime(300) })
+      expect(screen.getByRole('textbox', { name: /search for a film to add/i })).not.toHaveFocus()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('DOES autofocus the input under a fine pointer', () => {
+    vi.useFakeTimers()
+    try {
+      window.matchMedia = vi.fn().mockImplementation(q => ({
+        matches: q.includes('fine'), media: q, onchange: null,
+        addEventListener: vi.fn(), removeEventListener: vi.fn(),
+        addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(),
+      }))
+      render(<MoviesStep {...props()} />)
+      act(() => { vi.advanceTimersByTime(150) })
+      expect(screen.getByRole('textbox', { name: /search for a film to add/i })).toHaveFocus()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('SearchDropdown — error / status / selected states', () => {
+  const film = (id, title) => ({ id, title, poster_path: `/${id}.jpg`, release_date: '2010-01-01', popularity: 5 })
+
+  it('renders a role=alert retry row on searchError, never "No results"', () => {
+    const onRetry = vi.fn()
+    render(<SearchDropdown searching={false} results={[]} isMovieSelected={() => false} onSelect={vi.fn()} searchError={true} onRetry={onRetry} />)
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.queryByText(/no results/i)).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /retry search/i }))
+    expect(onRetry).toHaveBeenCalled()
+  })
+
+  it('announces the searching state (role=status, aria-live)', () => {
+    render(<SearchDropdown searching={true} results={[]} isMovieSelected={() => false} onSelect={vi.fn()} searchError={false} />)
+    const el = screen.getByText('Searching…')
+    expect(el).toHaveAttribute('role', 'status')
+    expect(el).toHaveAttribute('aria-live', 'polite')
+  })
+
+  it('announces a TRUE no-results (role=status), not an alert', () => {
+    render(<SearchDropdown searching={false} results={[]} isMovieSelected={() => false} onSelect={vi.fn()} searchError={false} />)
+    const el = screen.getByText(/no results — try a different title/i)
+    expect(el).toHaveAttribute('role', 'status')
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('marks an already-selected result with sr-only text', () => {
+    render(<SearchDropdown searching={false} results={[film(1, 'Inception')]} isMovieSelected={() => true} onSelect={vi.fn()} searchError={false} />)
+    expect(screen.getByText('(already in your picks)')).toBeInTheDocument()
+  })
+})
+
+describe('CardSkeletonRow — a11y', () => {
+  it('exposes role=status + aria-busy + an sr-only label', () => {
+    render(<CardSkeletonRow />)
+    expect(screen.getByRole('status')).toHaveAttribute('aria-busy', 'true')
+    expect(screen.getByText('Loading suggestions')).toBeInTheDocument()
+  })
+})

--- a/src/features/onboarding/hooks/useMovieSearch.js
+++ b/src/features/onboarding/hooks/useMovieSearch.js
@@ -4,14 +4,16 @@ import { searchMovies } from '@/shared/api/tmdb'
 /**
  * Debounced TMDB live-search controller for the onboarding film picker.
  *
- * Behavior preserved verbatim from MoviesStep (F2.3): 300ms debounce, popularity
- * sort, poster filter, top-8 slice, and the clear/close transitions. (The audit's
- * Escape / outside-click / listbox a11y improvements are deliberately NOT added
- * in this structure pass.)
+ * Behavior preserved verbatim: 300ms debounce, popularity sort, poster filter,
+ * top-8 slice, and the clear/close transitions. A search failure now flips
+ * `searchError` (cleared at each new search start) so the dropdown can show a
+ * real error instead of masquerading as "No results"; `retrySearch` re-runs the
+ * SAME query through the SAME debounced path (no query/ranking change).
  *
  * @returns {{
  *   query: string, setQuery: function, results: object[], searching: boolean,
  *   showDropdown: boolean, setShowDropdown: function, clearSearch: function,
+ *   searchError: boolean, retrySearch: function,
  * }}
  */
 export function useMovieSearch() {
@@ -19,11 +21,14 @@ export function useMovieSearch() {
   const [results, setResults] = useState([])
   const [searching, setSearching] = useState(false)
   const [showDropdown, setShowDropdown] = useState(false)
+  const [searchError, setSearchError] = useState(false)
+  const [retryTick, setRetryTick] = useState(0)
   const searchTimeoutRef = useRef(null)
 
   // Live search with debounce
   useEffect(() => {
     clearTimeout(searchTimeoutRef.current)
+    setSearchError(false)
     if (!query.trim()) {
       setResults([])
       setSearching(false)
@@ -43,12 +48,13 @@ export function useMovieSearch() {
         )
       } catch {
         setResults([])
+        setSearchError(true)
       } finally {
         setSearching(false)
       }
     }, 300)
     return () => clearTimeout(searchTimeoutRef.current)
-  }, [query])
+  }, [query, retryTick])
 
   // Reset query + close the dropdown (used by the clear button and after a pick).
   const clearSearch = () => {
@@ -56,5 +62,8 @@ export function useMovieSearch() {
     setShowDropdown(false)
   }
 
-  return { query, setQuery, results, searching, showDropdown, setShowDropdown, clearSearch }
+  // Re-run the same query through the same debounced path.
+  const retrySearch = () => setRetryTick(t => t + 1)
+
+  return { query, setQuery, results, searching, showDropdown, setShowDropdown, clearSearch, searchError, retrySearch }
 }

--- a/src/features/onboarding/hooks/useSuggestionPool.js
+++ b/src/features/onboarding/hooks/useSuggestionPool.js
@@ -1,30 +1,39 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { fetchSuggestionPool } from '../suggestionPool'
 
 /**
  * Build & hold the onboarding Step-3 suggestion pool.
  *
- * MOUNT-ONCE by design: the original MoviesStep fetched the pool once on mount
- * with an intentionally empty dependency array, capturing the genres/moods from
- * the first render so the suggestion row doesn't re-shuffle under the user mid-
- * selection. This hook preserves that exactly — including the swallowed-error /
- * no-retry loading behavior. (The audit flagged the swallowed pool error as a
- * future UX issue; it is deliberately NOT addressed in this structure pass.)
+ * MOUNT-ONCE by design: the pool is fetched once on mount, capturing the
+ * genres/moods from the first render so the suggestion row doesn't re-shuffle
+ * under the user mid-selection. `retry` re-runs the SAME fetch with those same
+ * mount-captured picks (no re-shuffle, no query change). The fetch stays
+ * non-throwing; a failure now also flips `poolError` so MoviesStep can surface a
+ * real error + retry instead of a benign "All suggestions added" empty state.
  *
  * @param {number[]} selectedGenreIds — TMDB genre IDs from Step 2
  * @param {string[]} moods            — onboarding mood keys from Step 1
- * @returns {{ pool: object[], poolLoading: boolean }}
+ * @returns {{ pool: object[], poolLoading: boolean, poolError: boolean, retry: function }}
  */
 export function useSuggestionPool(selectedGenreIds, moods) {
   const [pool, setPool] = useState([])
   const [poolLoading, setPoolLoading] = useState(true)
+  const [poolError, setPoolError] = useState(false)
+  // Capture the mount-time picks so retry re-fetches the identical set.
+  const argsRef = useRef({ selectedGenreIds, moods })
+
+  const load = useCallback(() => {
+    setPoolLoading(true)
+    setPoolError(false)
+    const { selectedGenreIds: genreIds, moods: moodKeys } = argsRef.current
+    fetchSuggestionPool(genreIds, moodKeys)
+      .then(films => { setPool(films); setPoolLoading(false) })
+      .catch(() => { setPoolLoading(false); setPoolError(true) })
+  }, [])
 
   useEffect(() => {
-    setPoolLoading(true)
-    fetchSuggestionPool(selectedGenreIds, moods)
-      .then(films => { setPool(films); setPoolLoading(false) })
-      .catch(() => setPoolLoading(false))
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps -- mount-once: capture initial picks, don't re-fetch
+    load()
+  }, [load]) // load is stable (useCallback []) → mount-once preserved
 
-  return { pool, poolLoading }
+  return { pool, poolLoading, poolError, retry: load }
 }

--- a/src/features/onboarding/steps/MoviesStep.jsx
+++ b/src/features/onboarding/steps/MoviesStep.jsx
@@ -48,10 +48,13 @@ export default function MoviesStep({
   error,
 }) {
   const searchInputRef = useRef(null)
-  const { pool, poolLoading } = useSuggestionPool(selectedGenreIds, moods)
-  const { query, setQuery, results, searching, showDropdown, setShowDropdown, clearSearch } = useMovieSearch()
+  const { pool, poolLoading, poolError, retry } = useSuggestionPool(selectedGenreIds, moods)
+  const { query, setQuery, results, searching, showDropdown, setShowDropdown, clearSearch, searchError, retrySearch } = useMovieSearch()
 
+  // Desktop convenience only — gate the autofocus behind a fine pointer so a
+  // mobile soft keyboard doesn't pop over the curation on step entry.
   useEffect(() => {
+    if (!window.matchMedia?.('(pointer: fine)')?.matches) return
     const timer = setTimeout(() => searchInputRef.current?.focus(), 100)
     return () => clearTimeout(timer)
   }, [])
@@ -111,6 +114,7 @@ export default function MoviesStep({
             onChange={e => setQuery(e.target.value)}
             onFocus={() => { if (query.trim()) setShowDropdown(true) }}
             placeholder="Search any film…"
+            aria-label="Search for a film to add"
             className="w-full pl-10 pr-9 py-2.5 rounded-xl bg-white/[0.07] border border-white/10 text-sm text-white placeholder-white/30 focus:outline-none focus:ring-1 focus:ring-purple-400/50 focus:border-purple-400/30 transition-all"
           />
           {query && (
@@ -132,6 +136,8 @@ export default function MoviesStep({
             results={results}
             isMovieSelected={isMovieSelected}
             onSelect={handleSelectFromSearch}
+            searchError={searchError}
+            onRetry={retrySearch}
           />
         )}
       </div>
@@ -151,6 +157,18 @@ export default function MoviesStep({
           </p>
           {poolLoading ? (
             <CardSkeletonRow />
+          ) : poolError ? (
+            <div role="alert" className="flex items-center justify-between gap-3 p-3 rounded-xl bg-red-500/10 border border-red-500/20 text-red-300 text-sm">
+              <span>Couldn&apos;t load your suggestions.</span>
+              <button
+                type="button"
+                onClick={retry}
+                aria-label="Retry loading suggestions"
+                className="shrink-0 rounded-lg px-3 py-1.5 text-xs font-medium bg-white/10 hover:bg-white/15 text-white transition-colors"
+              >
+                Retry
+              </button>
+            </div>
           ) : suggestions.length === 0 ? (
             <p className="text-sm text-white/30 py-2">
               All suggestions added — search for more above

--- a/src/features/onboarding/steps/movies/CardSkeletonRow.jsx
+++ b/src/features/onboarding/steps/movies/CardSkeletonRow.jsx
@@ -1,14 +1,17 @@
 // Loading placeholder for the Suggestions row — staggered animate-pulse cards.
+// Announced to assistive tech (role=status + aria-busy + sr-only label); the
+// decorative boxes are aria-hidden and reduced-motion-safe.
 export default function CardSkeletonRow() {
   return (
-    <div className="flex gap-3 sm:gap-4 overflow-x-hidden">
+    <div className="flex gap-3 sm:gap-4 overflow-x-hidden" role="status" aria-busy="true">
+      <span className="sr-only">Loading suggestions</span>
       {Array.from({ length: 5 }).map((_, i) => (
-        <div key={i} className="shrink-0 w-28 sm:w-32 md:w-36 flex flex-col gap-1.5">
+        <div key={i} className="shrink-0 w-28 sm:w-32 md:w-36 flex flex-col gap-1.5" aria-hidden="true">
           <div
-            className="aspect-2/3 rounded-lg bg-white/4 animate-pulse"
+            className="aspect-2/3 rounded-lg bg-white/4 animate-pulse motion-reduce:animate-none"
             style={{ animationDelay: `${i * 60}ms` }}
           />
-          <div className="h-2.5 w-3/4 bg-white/4 rounded animate-pulse" />
+          <div className="h-2.5 w-3/4 bg-white/4 rounded animate-pulse motion-reduce:animate-none" />
         </div>
       ))}
     </div>

--- a/src/features/onboarding/steps/movies/MovieCard.jsx
+++ b/src/features/onboarding/steps/movies/MovieCard.jsx
@@ -24,7 +24,7 @@ export default function MovieCard({ movie, isSelected, onClick }) {
         {!loaded && <div className="absolute inset-0 animate-pulse bg-white/4" />}
         <img
           src={tmdbImg(movie.poster_path, 'w342')}
-          alt={movie.title}
+          alt=""
           loading="lazy"
           className={`w-full h-full object-cover transition-all duration-300 ${
             loaded ? 'opacity-100' : 'opacity-0'

--- a/src/features/onboarding/steps/movies/SearchDropdown.jsx
+++ b/src/features/onboarding/steps/movies/SearchDropdown.jsx
@@ -3,15 +3,31 @@ import { Check } from 'lucide-react'
 import { tmdbImg } from '@/shared/api/tmdb'
 
 // Live-search results dropdown. Rendered by MoviesStep inside `{showDropdown && …}`,
-// so it assumes it is mounted only when open. Markup moved verbatim from MoviesStep
-// (F2.3) — no Escape / outside-click / listbox semantics added in this pass.
-export default function SearchDropdown({ searching, results, isMovieSelected, onSelect }) {
+// so it assumes it is mounted only when open. A search FAILURE shows a distinct
+// role="alert" retry row (never the benign "No results"); the searching / true
+// no-results states are announced via role="status". (Full combobox/listbox
+// keyboard semantics are a later pass.)
+export default function SearchDropdown({ searching, results, isMovieSelected, onSelect, searchError, onRetry }) {
   return (
     <div className="absolute left-5 right-5 sm:left-6 sm:right-6 top-full mt-1 z-50 bg-black/95 border border-white/10 rounded-xl overflow-hidden shadow-2xl backdrop-blur-xl">
-      {searching ? (
-        <p className="px-4 py-3 text-sm text-white/40">Searching…</p>
+      {searchError ? (
+        <div role="alert" className="flex items-center justify-between gap-3 px-4 py-3 text-sm text-red-300">
+          <span>Couldn&apos;t reach search.</span>
+          {onRetry && (
+            <button
+              type="button"
+              onClick={onRetry}
+              aria-label="Retry search"
+              className="shrink-0 rounded-lg px-3 py-1 text-xs font-medium bg-white/10 hover:bg-white/15 text-white transition-colors"
+            >
+              Retry
+            </button>
+          )}
+        </div>
+      ) : searching ? (
+        <p role="status" aria-live="polite" className="px-4 py-3 text-sm text-white/40">Searching…</p>
       ) : results.length === 0 ? (
-        <p className="px-4 py-3 text-sm text-white/30">No results — try a different title</p>
+        <p role="status" aria-live="polite" className="px-4 py-3 text-sm text-white/30">No results — try a different title</p>
       ) : (
         <div className="max-h-60 overflow-y-auto divide-y divide-white/5">
           {results.map(m => {
@@ -34,7 +50,10 @@ export default function SearchDropdown({ searching, results, isMovieSelected, on
                   {yr && <p className="text-xs text-white/40">{yr}</p>}
                 </div>
                 {selected && (
-                  <Check className="shrink-0 h-4 w-4 text-purple-400" />
+                  <>
+                    <Check className="shrink-0 h-4 w-4 text-purple-400" aria-hidden="true" />
+                    <span className="sr-only">(already in your picks)</span>
+                  </>
                 )}
               </button>
             )


### PR DESCRIPTION
Foundation pass (F2.13) before the larger MoviesStep grid redesign — hardens the cold-start step's **error, loading, a11y, and mobile-entry** behavior. **The shelf layout is deliberately not redesigned** (the grid/"Your anchors" work is a later phase).

## Pool error + retry
`useSuggestionPool` now exposes **`poolError` + `retry`**. A failed fetch flips `poolError` (still non-throwing); `retry` re-runs the **same** fetch with the **mount-captured** genres/moods (mount-once + no re-shuffle preserved). In MoviesStep, a swallowed pool failure **no longer masquerades as *"All suggestions added"*** — it renders a distinct `role="alert"` card + a **"Retry loading suggestions"** button **before** the empty state; *"All suggestions added"* now shows only when `!loading && !poolError && empty`.

## Search error
`useMovieSearch` now exposes **`searchError` + `retrySearch`** (re-runs the same query through the **same** debounced path). `SearchDropdown` shows a distinct `role="alert"` *"Couldn't reach search — retry"* row on a failure (**never** the benign *"No results"*); *"No results — try a different title"* is kept strictly for true empties.

## Accessibility
- Search input gains an accessible name: `aria-label="Search for a film to add"` (placeholder unchanged).
- Dropdown `Searching…` / true no-results are `role="status"` `aria-live="polite"`; the search-error row is `role="alert"`.
- Already-selected search results gain an sr-only **"(already in your picks)"** (was icon-only).
- `CardSkeletonRow`: `role="status"` + `aria-busy="true"` + sr-only **"Loading suggestions"**; decorative boxes `aria-hidden`; pulses gated with `motion-reduce:animate-none`.
- `MovieCard` poster `alt=""` (the title is visible and the button is labeled — kills the SR double-read). Card `aria-pressed`/`aria-label` unchanged.

## Mobile autofocus
The delayed search-input focus is gated behind `window.matchMedia('(pointer: fine)').matches` — **desktop autofocus is unchanged**; a coarse-pointer/mobile entry no longer pops the soft keyboard over the curation.

## Tests
- **`MoviesHooks.test.js`**: `useSuggestionPool` poolError/retry + mount-once-doesn't-refetch; `useMovieSearch` searchError set on reject + cleared on the next search (debounce/ranking untouched).
- **`MoviesStepStates.test.jsx`**: pool-error card + retry, true-empty vs failed-empty, skeleton `role=status`/`aria-busy`, search input accessible name, **gated autofocus** (coarse = no focus / fine = focus), and `SearchDropdown` error/`role=status`/sr-only states.
- Existing MoviesStep `MIN_MOVIES=5` gate tests (Continue disabled <5 / enabled at 5 / `onFinish` / search-clear) and the `suggestionPool` tests are **untouched and green**.

## Confirmations
- **Layout was not redesigned** — the two horizontal shelves remain (verified: `snap-x snap-mandatory` still present).
- **Scoring / Supabase filters / TMDB search ranking** unchanged — the 300ms debounce, popularity sort, poster filter, and top-8 slice are byte-identical; `suggestionPool.js` untouched.
- **Auth / routing / Supabase writes / localStorage / onboarding completion** untouched; `MIN_MOVIES=5`, the frozen footer status strings, and the Continue label are unchanged. `Onboarding.jsx` and the shared chrome were not touched.

## Validation
- `npm run lint` → clean
- `npx vitest run src/features/onboarding/__tests__/ src/shared/lib/auth/__tests__/onboardingStatus.test.js` → 75 passed (8 files)
- `npm run build` → ✓
- `npm run test` (full) → 579 passed (54 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
