### PR TITLE
Improve onboarding movie search combobox

### DIFF
--- a/src/features/onboarding/__tests__/MoviesHooks.test.js
+++ b/src/features/onboarding/__tests__/MoviesHooks.test.js
@@ -85,4 +85,16 @@ describe('useMovieSearch — search error (debounce/ranking untouched)', () => {
     expect(result.current.searchError).toBe(false)
     expect(result.current.results.length).toBe(1)
   })
+
+  it('resets activeIndex on a new search and on clear', () => {
+    searchMovies.mockResolvedValue({ results: [] })
+    const { result } = renderHook(() => useMovieSearch())
+    act(() => { result.current.setActiveIndex(2) })
+    expect(result.current.activeIndex).toBe(2)
+    act(() => { result.current.setQuery('inception') }) // new search → reset
+    expect(result.current.activeIndex).toBe(-1)
+    act(() => { result.current.setActiveIndex(1) })
+    act(() => { result.current.clearSearch() })          // clear → reset
+    expect(result.current.activeIndex).toBe(-1)
+  })
 })

--- a/src/features/onboarding/__tests__/MoviesStepStates.test.jsx
+++ b/src/features/onboarding/__tests__/MoviesStepStates.test.jsx
@@ -19,7 +19,8 @@ import CardSkeletonRow from '../steps/movies/CardSkeletonRow'
 const poolState = (over = {}) => ({ pool: [], poolLoading: false, poolError: false, retry: vi.fn(), ...over })
 const searchState = (over = {}) => ({
   query: '', setQuery: vi.fn(), results: [], searching: false, showDropdown: false,
-  setShowDropdown: vi.fn(), clearSearch: vi.fn(), searchError: false, retrySearch: vi.fn(), ...over,
+  setShowDropdown: vi.fn(), clearSearch: vi.fn(), searchError: false, retrySearch: vi.fn(),
+  activeIndex: -1, setActiveIndex: vi.fn(), ...over,
 })
 const props = (over = {}) => ({
   selectedGenreIds: [], moods: [], favoriteMovies: [], addMovie: vi.fn(), removeMovie: vi.fn(),
@@ -115,7 +116,7 @@ describe('MoviesStep — editorial grid layout', () => {
 describe('MoviesStep — search input + autofocus', () => {
   it('gives the search input an accessible name', () => {
     render(<MoviesStep {...props()} />)
-    expect(screen.getByRole('textbox', { name: /search for a film to add/i })).toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: /search for a film to add/i })).toBeInTheDocument()
   })
 
   it('does NOT autofocus the input under a coarse pointer', () => {
@@ -123,7 +124,7 @@ describe('MoviesStep — search input + autofocus', () => {
     try {
       render(<MoviesStep {...props()} />)
       act(() => { vi.advanceTimersByTime(300) })
-      expect(screen.getByRole('textbox', { name: /search for a film to add/i })).not.toHaveFocus()
+      expect(screen.getByRole('combobox', { name: /search for a film to add/i })).not.toHaveFocus()
     } finally {
       vi.useRealTimers()
     }
@@ -139,10 +140,104 @@ describe('MoviesStep — search input + autofocus', () => {
       }))
       render(<MoviesStep {...props()} />)
       act(() => { vi.advanceTimersByTime(150) })
-      expect(screen.getByRole('textbox', { name: /search for a film to add/i })).toHaveFocus()
+      expect(screen.getByRole('combobox', { name: /search for a film to add/i })).toHaveFocus()
     } finally {
       vi.useRealTimers()
     }
+  })
+})
+
+describe('MoviesStep — combobox semantics + keyboard', () => {
+  const film = (id, title) => ({ id, title, poster_path: `/${id}.jpg`, release_date: '2010-01-01', popularity: id })
+  const open = (over = {}) =>
+    searchState({ query: 'inc', results: [film(11, 'A'), film(12, 'B'), film(13, 'C')], showDropdown: true, ...over })
+
+  it('marks the input as a combobox controlling the listbox', () => {
+    useMovieSearch.mockReturnValue(open({ activeIndex: -1 }))
+    render(<MoviesStep {...props()} />)
+    const input = screen.getByRole('combobox', { name: /search for a film to add/i })
+    expect(input).toHaveAttribute('aria-autocomplete', 'list')
+    expect(input).toHaveAttribute('aria-expanded', 'true')
+    expect(input).toHaveAttribute('aria-controls', 'ob-search-listbox')
+  })
+
+  it('reflects the active option via aria-activedescendant', () => {
+    useMovieSearch.mockReturnValue(open({ activeIndex: 1 }))
+    render(<MoviesStep {...props()} />)
+    expect(screen.getByRole('combobox')).toHaveAttribute('aria-activedescendant', 'ob-search-listbox-opt-12')
+  })
+
+  it('renders the results as a listbox of options with the active one selected', () => {
+    useMovieSearch.mockReturnValue(open({ activeIndex: 0 }))
+    render(<MoviesStep {...props()} />)
+    const listbox = screen.getByRole('listbox', { name: /search results/i })
+    const options = within(listbox).getAllByRole('option')
+    expect(options).toHaveLength(3)
+    expect(options[0]).toHaveAttribute('aria-selected', 'true')
+    expect(options[1]).toHaveAttribute('aria-selected', 'false')
+    expect(options[0].id).toBe('ob-search-listbox-opt-11')
+  })
+
+  it('ArrowDown / ArrowUp move the active option (wrapping)', () => {
+    const setActiveIndex = vi.fn()
+    useMovieSearch.mockReturnValue(open({ activeIndex: -1, setActiveIndex }))
+    render(<MoviesStep {...props()} />)
+    const input = screen.getByRole('combobox')
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    let updater = setActiveIndex.mock.calls.at(-1)[0]
+    expect(updater(-1)).toBe(0) // none → first
+    expect(updater(2)).toBe(0)  // last → wraps to first (n=3)
+    fireEvent.keyDown(input, { key: 'ArrowUp' })
+    updater = setActiveIndex.mock.calls.at(-1)[0]
+    expect(updater(-1)).toBe(2) // none → last
+    expect(updater(0)).toBe(2)  // first → wraps to last
+  })
+
+  it('Home / End jump to first / last option', () => {
+    const setActiveIndex = vi.fn()
+    useMovieSearch.mockReturnValue(open({ activeIndex: 1, setActiveIndex }))
+    render(<MoviesStep {...props()} />)
+    const input = screen.getByRole('combobox')
+    fireEvent.keyDown(input, { key: 'Home' })
+    expect(setActiveIndex).toHaveBeenLastCalledWith(0)
+    fireEvent.keyDown(input, { key: 'End' })
+    expect(setActiveIndex).toHaveBeenLastCalledWith(2)
+  })
+
+  it('Enter selects the active option', () => {
+    const addMovie = vi.fn()
+    useMovieSearch.mockReturnValue(open({ activeIndex: 1 }))
+    render(<MoviesStep {...props({ addMovie })} />)
+    fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Enter' })
+    expect(addMovie).toHaveBeenCalledWith(expect.objectContaining({ id: 12 }))
+  })
+
+  it('Escape closes the dropdown', () => {
+    const setShowDropdown = vi.fn()
+    useMovieSearch.mockReturnValue(open({ activeIndex: 0, setShowDropdown }))
+    render(<MoviesStep {...props()} />)
+    fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Escape' })
+    expect(setShowDropdown).toHaveBeenCalledWith(false)
+  })
+
+  it('arrow / enter with no options neither selects nor throws', () => {
+    const addMovie = vi.fn()
+    useMovieSearch.mockReturnValue(searchState({ query: 'zzz', results: [], showDropdown: true }))
+    render(<MoviesStep {...props({ addMovie })} />)
+    const input = screen.getByRole('combobox')
+    expect(() => {
+      fireEvent.keyDown(input, { key: 'ArrowDown' })
+      fireEvent.keyDown(input, { key: 'Enter' })
+    }).not.toThrow()
+    expect(addMovie).not.toHaveBeenCalled()
+  })
+
+  it('an outside pointerdown closes the dropdown', () => {
+    const setShowDropdown = vi.fn()
+    useMovieSearch.mockReturnValue(open({ activeIndex: 0, setShowDropdown }))
+    render(<MoviesStep {...props()} />)
+    fireEvent.pointerDown(document.body)
+    expect(setShowDropdown).toHaveBeenCalledWith(false)
   })
 })
 
@@ -173,8 +268,25 @@ describe('SearchDropdown — error / status / selected states', () => {
   })
 
   it('marks an already-selected result with sr-only text', () => {
-    render(<SearchDropdown searching={false} results={[film(1, 'Inception')]} isMovieSelected={() => true} onSelect={vi.fn()} searchError={false} />)
+    render(<SearchDropdown searching={false} results={[film(1, 'Inception')]} isMovieSelected={() => true} onSelect={vi.fn()} searchError={false} activeIndex={-1} listboxId="ob-search-listbox" />)
     expect(screen.getByText('(already in your picks)')).toBeInTheDocument()
+  })
+
+  it('selecting a result by mouse click still calls onSelect', () => {
+    const onSelect = vi.fn()
+    render(<SearchDropdown searching={false} results={[film(1, 'A')]} isMovieSelected={() => false} onSelect={onSelect} searchError={false} activeIndex={-1} listboxId="ob-search-listbox" />)
+    fireEvent.click(within(screen.getByRole('listbox')).getByRole('option'))
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }))
+  })
+
+  it('renders results as a listbox of options with stable ids + the active one selected', () => {
+    render(<SearchDropdown searching={false} results={[film(1, 'A'), film(2, 'B')]} isMovieSelected={() => false} onSelect={vi.fn()} searchError={false} activeIndex={1} listboxId="ob-search-listbox" />)
+    const listbox = screen.getByRole('listbox', { name: /search results/i })
+    const options = within(listbox).getAllByRole('option')
+    expect(options).toHaveLength(2)
+    expect(options[0].id).toBe('ob-search-listbox-opt-1')
+    expect(options[0]).toHaveAttribute('aria-selected', 'false')
+    expect(options[1]).toHaveAttribute('aria-selected', 'true')
   })
 })
 

--- a/src/features/onboarding/hooks/useMovieSearch.js
+++ b/src/features/onboarding/hooks/useMovieSearch.js
@@ -10,10 +10,15 @@ import { searchMovies } from '@/shared/api/tmdb'
  * real error instead of masquerading as "No results"; `retrySearch` re-runs the
  * SAME query through the SAME debounced path (no query/ranking change).
  *
+ * `activeIndex` is the combobox active-option index (-1 = none); it resets on
+ * each new search and on clear. The search EXECUTION (debounce/sort/filter/slice
+ * + error handling) is unchanged — only open/active-option state is added here.
+ *
  * @returns {{
  *   query: string, setQuery: function, results: object[], searching: boolean,
  *   showDropdown: boolean, setShowDropdown: function, clearSearch: function,
  *   searchError: boolean, retrySearch: function,
+ *   activeIndex: number, setActiveIndex: function,
  * }}
  */
 export function useMovieSearch() {
@@ -22,6 +27,7 @@ export function useMovieSearch() {
   const [searching, setSearching] = useState(false)
   const [showDropdown, setShowDropdown] = useState(false)
   const [searchError, setSearchError] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(-1)
   const [retryTick, setRetryTick] = useState(0)
   const searchTimeoutRef = useRef(null)
 
@@ -29,6 +35,7 @@ export function useMovieSearch() {
   useEffect(() => {
     clearTimeout(searchTimeoutRef.current)
     setSearchError(false)
+    setActiveIndex(-1) // new search → no active option
     if (!query.trim()) {
       setResults([])
       setSearching(false)
@@ -60,10 +67,11 @@ export function useMovieSearch() {
   const clearSearch = () => {
     setQuery('')
     setShowDropdown(false)
+    setActiveIndex(-1)
   }
 
   // Re-run the same query through the same debounced path.
   const retrySearch = () => setRetryTick(t => t + 1)
 
-  return { query, setQuery, results, searching, showDropdown, setShowDropdown, clearSearch, searchError, retrySearch }
+  return { query, setQuery, results, searching, showDropdown, setShowDropdown, clearSearch, searchError, retrySearch, activeIndex, setActiveIndex }
 }

--- a/src/features/onboarding/steps/MoviesStep.jsx
+++ b/src/features/onboarding/steps/MoviesStep.jsx
@@ -18,6 +18,8 @@ import MovieCard from './movies/MovieCard'
 import CardSkeletonRow from './movies/CardSkeletonRow'
 import SearchDropdown from './movies/SearchDropdown'
 
+const SEARCH_LISTBOX_ID = 'ob-search-listbox'
+
 /**
  * Onboarding step 3: movie selection.
  * Layout: search bar with dropdown → Suggestions row → Your picks row.
@@ -48,8 +50,12 @@ export default function MoviesStep({
   error,
 }) {
   const searchInputRef = useRef(null)
+  const searchAreaRef = useRef(null)
   const { pool, poolLoading, poolError, retry } = useSuggestionPool(selectedGenreIds, moods)
-  const { query, setQuery, results, searching, showDropdown, setShowDropdown, clearSearch, searchError, retrySearch } = useMovieSearch()
+  const {
+    query, setQuery, results, searching, showDropdown, setShowDropdown,
+    clearSearch, searchError, retrySearch, activeIndex, setActiveIndex,
+  } = useMovieSearch()
 
   // Desktop convenience only — gate the autofocus behind a fine pointer so a
   // mobile soft keyboard doesn't pop over the curation on step entry.
@@ -59,10 +65,73 @@ export default function MoviesStep({
     return () => clearTimeout(timer)
   }, [])
 
+  // Close the dropdown on an outside pointerdown. Clicks on the input/options are
+  // inside searchAreaRef, so selecting an option still works (pointerdown there
+  // doesn't close before the option's click fires).
+  useEffect(() => {
+    if (!showDropdown) return
+    function handlePointerDown(e) {
+      if (searchAreaRef.current && !searchAreaRef.current.contains(e.target)) {
+        setShowDropdown(false)
+        setActiveIndex(-1)
+      }
+    }
+    document.addEventListener('pointerdown', handlePointerDown)
+    return () => document.removeEventListener('pointerdown', handlePointerDown)
+  }, [showDropdown, setShowDropdown, setActiveIndex])
+
   function handleSelectFromSearch(movie) {
     addMovie(movie)
     clearSearch()
+    // Keep focus in the search field so the user can keep adding anchors.
+    searchInputRef.current?.focus()
   }
+
+  // Combobox keyboard model — focus stays on the input; aria-activedescendant
+  // points at the active option. Search execution (debounce/sort/filter/slice)
+  // is untouched; this only moves the active option + selects/closes.
+  function handleSearchKeyDown(e) {
+    if (!showDropdown) return
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      setShowDropdown(false)
+      setActiveIndex(-1)
+      return
+    }
+    const n = results.length
+    if (n === 0) return
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault()
+        setActiveIndex(i => (i + 1) % n)
+        break
+      case 'ArrowUp':
+        e.preventDefault()
+        setActiveIndex(i => (i <= 0 ? n - 1 : i - 1))
+        break
+      case 'Home':
+        e.preventDefault()
+        setActiveIndex(0)
+        break
+      case 'End':
+        e.preventDefault()
+        setActiveIndex(n - 1)
+        break
+      case 'Enter':
+        if (activeIndex >= 0 && activeIndex < n) {
+          e.preventDefault()
+          handleSelectFromSearch(results[activeIndex])
+        }
+        break
+      default:
+        break
+    }
+  }
+
+  const activeDescId =
+    showDropdown && activeIndex >= 0 && results[activeIndex]
+      ? `${SEARCH_LISTBOX_ID}-opt-${results[activeIndex].id}`
+      : undefined
 
   const count = favoriteMovies.length
   const canFinish = count >= MIN_MOVIES
@@ -104,15 +173,21 @@ export default function MoviesStep({
       }
     >
       {/* Search bar + dropdown */}
-      <div className="flex-none px-5 pb-4 sm:px-6 sm:pb-5 relative">
+      <div ref={searchAreaRef} className="flex-none px-5 pb-4 sm:px-6 sm:pb-5 relative">
         <div className="relative">
           <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4 text-white/30 pointer-events-none" />
           <input
             ref={searchInputRef}
             type="text"
+            role="combobox"
+            aria-expanded={Boolean(showDropdown && results.length > 0)}
+            aria-controls={showDropdown && results.length > 0 ? SEARCH_LISTBOX_ID : undefined}
+            aria-autocomplete="list"
+            aria-activedescendant={activeDescId}
             value={query}
             onChange={e => setQuery(e.target.value)}
             onFocus={() => { if (query.trim()) setShowDropdown(true) }}
+            onKeyDown={handleSearchKeyDown}
             placeholder="Search any film…"
             aria-label="Search for a film to add"
             className="w-full pl-10 pr-9 py-2.5 rounded-xl bg-white/[0.07] border border-white/10 text-sm text-white placeholder-white/30 focus:outline-none focus:ring-1 focus:ring-purple-400/50 focus:border-purple-400/30 transition-all"
@@ -138,6 +213,8 @@ export default function MoviesStep({
             onSelect={handleSelectFromSearch}
             searchError={searchError}
             onRetry={retrySearch}
+            activeIndex={activeIndex}
+            listboxId={SEARCH_LISTBOX_ID}
           />
         )}
       </div>

--- a/src/features/onboarding/steps/movies/SearchDropdown.jsx
+++ b/src/features/onboarding/steps/movies/SearchDropdown.jsx
@@ -1,13 +1,22 @@
+import { useEffect, useRef } from 'react'
 import { Check } from 'lucide-react'
 
 import { tmdbImg } from '@/shared/api/tmdb'
 
-// Live-search results dropdown. Rendered by MoviesStep inside `{showDropdown && …}`,
-// so it assumes it is mounted only when open. A search FAILURE shows a distinct
-// role="alert" retry row (never the benign "No results"); the searching / true
-// no-results states are announced via role="status". (Full combobox/listbox
-// keyboard semantics are a later pass.)
-export default function SearchDropdown({ searching, results, isMovieSelected, onSelect, searchError, onRetry }) {
+// Live-search results dropdown (the combobox popup). When results exist it is a
+// role="listbox" of role="option" buttons; the active option (driven by the
+// input's keyboard handler via `activeIndex`) is highlighted + announced through
+// aria-activedescendant on the input. A search FAILURE shows a role="alert" retry
+// row (never the benign "No results"); searching / true no-results are role="status".
+export default function SearchDropdown({
+  searching, results, isMovieSelected, onSelect, searchError, onRetry, activeIndex, listboxId,
+}) {
+  const activeRef = useRef(null)
+  // Keep the keyboard-active option scrolled into view.
+  useEffect(() => {
+    activeRef.current?.scrollIntoView?.({ block: 'nearest' })
+  }, [activeIndex])
+
   return (
     <div className="absolute left-5 right-5 sm:left-6 sm:right-6 top-full mt-1 z-50 bg-black/95 border border-white/10 rounded-xl overflow-hidden shadow-2xl backdrop-blur-xl">
       {searchError ? (
@@ -29,16 +38,22 @@ export default function SearchDropdown({ searching, results, isMovieSelected, on
       ) : results.length === 0 ? (
         <p role="status" aria-live="polite" className="px-4 py-3 text-sm text-white/30">No results — try a different title</p>
       ) : (
-        <div className="max-h-60 overflow-y-auto divide-y divide-white/5">
-          {results.map(m => {
+        <div role="listbox" id={listboxId} aria-label="Search results" className="max-h-60 overflow-y-auto divide-y divide-white/5">
+          {results.map((m, i) => {
             const yr = m.release_date ? new Date(m.release_date).getFullYear() : null
             const selected = isMovieSelected(m.id)
+            const active = i === activeIndex
             return (
               <button
                 key={m.id}
+                id={`${listboxId}-opt-${m.id}`}
+                role="option"
+                aria-selected={active}
+                ref={active ? activeRef : null}
                 type="button"
+                tabIndex={-1}
                 onClick={() => onSelect(m)}
-                className="w-full flex items-center gap-3 px-4 py-2.5 hover:bg-white/6 text-left transition-colors"
+                className={`w-full flex items-center gap-3 px-4 py-2.5 text-left transition-colors ${active ? 'bg-white/10' : 'hover:bg-white/6'}`}
               >
                 <img
                   src={tmdbImg(m.poster_path, 'w92')}


### PR DESCRIPTION
Implements the F2.12-deferred **APG combobox/listbox** interaction model for the MoviesStep search — keyboard- and screen-reader-friendly, with **search behavior unchanged**.

## Combobox / listbox semantics
- **Input:** `role="combobox"` + `aria-expanded` (true when the listbox is shown) + `aria-controls` (the listbox id, only when present) + `aria-autocomplete="list"` + `aria-activedescendant` (the active option's id when one is active). Keeps the F2.13 accessible name + placeholder.
- **SearchDropdown:** results render as a `role="listbox"` (`aria-label="Search results"`) of `role="option"` buttons with **stable ids** (`${listboxId}-opt-${m.id}`), `aria-selected` on the active option, a visual active highlight, and scroll-into-view. Options are `tabIndex=-1` (the combobox keeps focus on the input). The already-added `sr-only` "(already in your picks)", the loading/no-results `role="status"`, and the search-error `role="alert"` are all preserved.

## Keyboard
On the input: **ArrowDown/ArrowUp** move the active option (wrapping), **Home/End** jump to first/last, **Enter** selects the active option, **Escape** closes the dropdown. With no options, arrows/Enter are **no-ops** (never throw). Normal typing is unaffected (the handler only acts while the dropdown is open).

## Outside-click / Escape / focus
A document `pointerdown` listener (gated to the search-area ref) closes the dropdown on an outside click — clicks on the input/options are *inside*, so option selection still works (no aggressive blur). Escape closes; selecting/clearing closes as before. After selecting, **focus returns to the input** so the user can keep adding anchors.

## Hook
`useMovieSearch` gains `activeIndex` / `setActiveIndex` (reset on each new search and on clear). The **300ms debounce, popularity sort, poster filter, top-8 slice, and F2.13 error handling are byte-identical** (verified).

## Tests
Combobox attrs; listbox/options + ids + `aria-selected`; Arrow/Home/End/Enter/Escape; no-options no-op; outside-click close; **mouse-click select still works**; `activeIndex` reset (hook). Existing `textbox`→`combobox` role queries updated; the `MIN_MOVIES=5` gate + F2.13 error/a11y tests are untouched. Render check (Playwright 360/390/430/1280): combobox + listbox + active option render correctly, no overflow, **0 console errors**.

## Confirmations
- **Search ranking / query behavior unchanged** — debounce/sort/filter/top-8 + the F2.13 error states are preserved; `suggestionPool.js` untouched.
- **Layout / grid / "Your anchors" panel untouched** — `MovieCard`, `CardSkeletonRow`, `useSuggestionPool`, and the grid are unchanged.
- **Auth / routing / Supabase writes / localStorage / onboarding completion** untouched; `MIN_MOVIES=5`, footer status strings, and the Continue label are unchanged. `Onboarding.jsx` and the shared chrome were not touched.

## Validation
- `npm run lint` → clean
- `npx vitest run src/features/onboarding/__tests__/ src/shared/lib/auth/__tests__/onboardingStatus.test.js` → 93 passed (8 files)
- `npm run build` → ✓
- `npm run test` (full) → 596 passed (54 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
