### PR TITLE
Add RatingStep a11y and keyboard foundation

### DIFF
--- a/src/features/onboarding/__tests__/RatingStepA11y.test.jsx
+++ b/src/features/onboarding/__tests__/RatingStepA11y.test.jsx
@@ -1,0 +1,193 @@
+// src/features/onboarding/__tests__/RatingStepA11y.test.jsx
+// F2.17 — RatingStep accessibility + keyboard foundation (render-faithful).
+// Live announcements, role=alert, focus-visible affordances, arrow-key parity
+// scoped to the rating-stage, and reduced-motion completeness. The frozen
+// contracts (SENTIMENT_RATINGS, swipe map, 280ms guard, 700ms auto-finish) are
+// exercised through the existing commit path — none are changed here.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+
+vi.mock('@/shared/api/tmdb', () => ({ tmdbImg: (p) => `https://img/${p}` }))
+
+import RatingStep from '../steps/RatingStep'
+
+const film = (id, title) => ({ id, title, poster_path: `/${id}.jpg`, release_date: '2014-01-01' })
+const props = (over = {}) => ({
+  favoriteMovies: [film(1, 'Alpha'), film(2, 'Beta'), film(3, 'Gamma')],
+  ratings: {},
+  onRate: vi.fn(),
+  onBack: vi.fn(),
+  onFinish: vi.fn(),
+  error: '',
+  ...over,
+})
+
+// framer-motion's useReducedMotion reads window.matchMedia (absent in jsdom).
+function setMatchMedia(reduced = false) {
+  window.matchMedia = vi.fn().mockImplementation((q) => ({
+    matches: reduced && /reduced-motion/.test(q),
+    media: q, onchange: null,
+    addEventListener: vi.fn(), removeEventListener: vi.fn(),
+    addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(),
+  }))
+}
+const live = (container) => container.querySelector('[aria-live="polite"]')
+
+beforeEach(() => setMatchMedia(false))
+
+describe('RatingStep — frozen affordance (unchanged in F2.17)', () => {
+  it('keeps the Meh/Liked/Loved buttons and onRate(film, key) mapping', () => {
+    const onRate = vi.fn()
+    render(<RatingStep {...props({ onRate })} />)
+    expect(screen.getByRole('button', { name: 'Meh' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Liked' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Loved' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Loved' }))
+    expect(onRate).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }), 'loved')
+  })
+
+  it('renders no "See my recommendations" confirm CTA', () => {
+    render(<RatingStep {...props()} />)
+    expect(screen.queryByRole('button', { name: /see my recommendations/i })).not.toBeInTheDocument()
+  })
+})
+
+describe('RatingStep — live announcements + error semantics', () => {
+  it('surfaces the error container as role=alert', () => {
+    render(<RatingStep {...props({ error: 'Could not save your ratings.' })} />)
+    expect(screen.getByRole('alert')).toHaveTextContent('Could not save your ratings.')
+  })
+
+  it('announces the current film + remaining via a polite, atomic live region', () => {
+    const { container } = render(<RatingStep {...props()} />)
+    const region = live(container)
+    expect(region).toBeTruthy()
+    expect(region).toHaveAttribute('aria-atomic', 'true')
+    expect(region).toHaveTextContent('Now rating Alpha — 3 to go')
+  })
+
+  it('announces the next film after a rating advances', () => {
+    const { container } = render(<RatingStep {...props()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Loved' }))
+    expect(live(container)).toHaveTextContent('Now rating Beta — 2 to go')
+  })
+
+  it('announces the next film after Skip, without calling onRate', () => {
+    const onRate = vi.fn()
+    const { container } = render(<RatingStep {...props({ onRate })} />)
+    fireEvent.click(screen.getByRole('button', { name: /skip this one/i }))
+    expect(live(container)).toHaveTextContent('Now rating Beta — 2 to go')
+    expect(onRate).not.toHaveBeenCalled()
+  })
+
+  it('announces all-rated when every film is rated', () => {
+    vi.useFakeTimers()
+    try {
+      const { container } = render(<RatingStep {...props({ favoriteMovies: [film(1, 'Alpha')] })} />)
+      fireEvent.click(screen.getByRole('button', { name: 'Loved' }))
+      expect(live(container)).toHaveTextContent('All rated — building your picks')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('RatingStep — keyboard parity (scoped to the rating stage)', () => {
+  const stage = () => screen.getByRole('group', { name: /rate alpha/i })
+
+  it('ArrowRight on the stage commits loved', () => {
+    const onRate = vi.fn()
+    render(<RatingStep {...props({ onRate })} />)
+    fireEvent.keyDown(stage(), { key: 'ArrowRight' })
+    expect(onRate).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }), 'loved')
+  })
+
+  it('ArrowUp on the stage commits liked', () => {
+    const onRate = vi.fn()
+    render(<RatingStep {...props({ onRate })} />)
+    fireEvent.keyDown(stage(), { key: 'ArrowUp' })
+    expect(onRate).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }), 'liked')
+  })
+
+  it('ArrowLeft on the stage commits okay', () => {
+    const onRate = vi.fn()
+    render(<RatingStep {...props({ onRate })} />)
+    fireEvent.keyDown(stage(), { key: 'ArrowLeft' })
+    expect(onRate).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }), 'okay')
+  })
+
+  it('does NOT rate when Arrow keys are pressed on a sentiment button or Skip', () => {
+    const onRate = vi.fn()
+    render(<RatingStep {...props({ onRate })} />)
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Loved' }), { key: 'ArrowRight' })
+    fireEvent.keyDown(screen.getByRole('button', { name: /skip this one/i }), { key: 'ArrowLeft' })
+    expect(onRate).not.toHaveBeenCalled()
+  })
+})
+
+describe('RatingStep — guard, auto-finish, focus, reduced motion', () => {
+  it('commits only once on rapid double activation (double-commit guard)', () => {
+    const onRate = vi.fn()
+    render(<RatingStep {...props({ onRate })} />)
+    const loved = screen.getByRole('button', { name: 'Loved' })
+    fireEvent.click(loved)
+    fireEvent.click(loved)
+    expect(onRate).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires onFinish exactly once, 700ms after the last rating', () => {
+    vi.useFakeTimers()
+    try {
+      const onFinish = vi.fn()
+      render(<RatingStep {...props({ favoriteMovies: [film(1, 'Alpha'), film(2, 'Beta')], onFinish })} />)
+      fireEvent.click(screen.getByRole('button', { name: 'Loved' })) // rate Alpha
+      act(() => { vi.advanceTimersByTime(300) })                     // clear the 280ms guard
+      fireEvent.click(screen.getByRole('button', { name: 'Loved' })) // rate Beta → allRated
+      expect(onFinish).not.toHaveBeenCalled()
+      act(() => { vi.advanceTimersByTime(700) })
+      expect(onFinish).toHaveBeenCalledTimes(1)
+      act(() => { vi.advanceTimersByTime(2000) })
+      expect(onFinish).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('gives the sentiment buttons and Skip a focus-visible affordance', () => {
+    render(<RatingStep {...props()} />)
+    expect(screen.getByRole('button', { name: 'Loved' }).className).toMatch(/focus-visible:ring-2/)
+    expect(screen.getByRole('button', { name: /skip this one/i }).className).toMatch(/focus-visible:ring-2/)
+  })
+
+  it('makes the rating stage keyboard-focusable with a descriptive label', () => {
+    render(<RatingStep {...props()} />)
+    const region = screen.getByRole('group', { name: /rate alpha/i })
+    expect(region).toHaveAttribute('tabindex', '0')
+    expect(region).toHaveAttribute('aria-describedby', 'rating-kbd-help')
+  })
+
+  // NOTE: reduced-motion *drag-disable* is a framer-motion runtime behavior
+  // (useReducedMotion caches its media-query subscription per module, so flipping
+  // matchMedia mid-file is unreliable in jsdom) — it is verified in the Playwright
+  // emulateMedia('prefers-reduced-motion','reduce') pass. The CSS-based
+  // motion-reduce additions (the F2.17 work) are unit-tested below.
+  it('marks the loading skeleton as motion-reduce safe', () => {
+    const { container } = render(<RatingStep {...props()} />)
+    const skeleton = container.querySelector('.animate-pulse')
+    expect(skeleton).toBeTruthy()
+    expect(skeleton.getAttribute('class')).toMatch(/motion-reduce:animate-none/)
+  })
+
+  it('marks the all-rated handoff sparkle as motion-reduce safe', () => {
+    vi.useFakeTimers()
+    try {
+      const { container } = render(<RatingStep {...props({ favoriteMovies: [] })} />)
+      const pulse = container.querySelector('.animate-pulse')
+      expect(pulse).toBeTruthy()
+      expect(pulse.getAttribute('class')).toMatch(/motion-reduce:animate-none/)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/features/onboarding/steps/RatingStep.jsx
+++ b/src/features/onboarding/steps/RatingStep.jsx
@@ -97,8 +97,53 @@ export default function RatingStep({ favoriteMovies, ratings, onRate, onBack, on
     setIdx((i) => Math.min(i + 1, films.length))
   }
 
+  // Keyboard parity for the swipe directions. Fires ONLY when the rating-stage
+  // region itself owns focus (never from a button/link/interactive descendant),
+  // and routes through the SAME commitRate + guard as tap/swipe — the frozen
+  // right→loved / up→liked / left→okay mapping, no duplication.
+  const handleStageKeyDown = (e) => {
+    if (e.target !== e.currentTarget) return
+    if (allRated || !current || isAdvancingRef.current) return
+    let sentiment = null
+    let direction = null
+    if (e.key === 'ArrowRight') { sentiment = 'loved'; direction = 'right' }
+    else if (e.key === 'ArrowUp') { sentiment = 'liked'; direction = 'up' }
+    else if (e.key === 'ArrowLeft') { sentiment = 'okay'; direction = 'left' }
+    else return
+    e.preventDefault()
+    commitRate(sentiment, direction)
+  }
+
+  // The sole detailed film-progress announcement (DnaRail suppresses its tally
+  // on Step 4). Derived only from existing current/remaining/allRated — no new
+  // progression state, no second visible counter.
+  const liveMessage = allRated
+    ? 'All rated — building your picks'
+    : current
+      ? `Now rating ${current.title} — ${remaining} to go`
+      : ''
+
+  // Focus/keyboard wiring for the active card; absent once allRated so the stage
+  // stops being a tab stop during the celebration handoff.
+  const stageProps = !allRated && current
+    ? {
+        tabIndex: 0,
+        role: 'group',
+        'aria-label': `Rate ${current.title}`,
+        'aria-describedby': 'rating-kbd-help',
+        onKeyDown: handleStageKeyDown,
+      }
+    : {}
+
   return (
     <div className="flex h-full flex-col">
+      {/* Sole detailed film-progress announcement (sr-only). */}
+      <div className="sr-only" aria-live="polite" aria-atomic="true">
+        {liveMessage}
+      </div>
+      <span id="rating-kbd-help" className="sr-only">
+        Use the verdict buttons below, or press Left for Meh, Up for Liked, and Right for Loved.
+      </span>
       <div className="flex-none px-5 pb-3 pt-5 sm:px-6 sm:pb-4 sm:pt-6">
         <button
           type="button"
@@ -145,13 +190,16 @@ export default function RatingStep({ favoriteMovies, ratings, onRate, onBack, on
          the sentiment buttons on phones + tablets). */}
       <div className="min-h-0 flex-1 px-5 pb-2 sm:px-6">
         {error && (
-          <div className="mb-4 rounded-xl border border-red-500/20 bg-red-500/10 p-3 text-center text-sm text-red-300">
+          <div role="alert" className="mb-4 rounded-xl border border-red-500/20 bg-red-500/10 p-3 text-center text-sm text-red-300">
             {error}
           </div>
         )}
 
         <div className="mx-auto flex h-full w-full max-w-md items-center justify-center">
-          <div className="relative h-full max-h-full aspect-2/3">
+          <div
+            {...stageProps}
+            className="relative h-full max-h-full aspect-2/3 rounded-2xl focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+          >
             {/* Background card peek — next film sits behind the current one
                for stack depth (Tinder convention). Static / non-interactive.
                Skipped when on the last card or when all rated. */}
@@ -184,7 +232,7 @@ export default function RatingStep({ favoriteMovies, ratings, onRate, onBack, on
                   transition={{ duration: 0.3 }}
                   className="grid h-full place-items-center"
                 >
-                  <Sparkles className="h-10 w-10 text-purple-400/70 animate-pulse" aria-hidden="true" />
+                  <Sparkles className="h-10 w-10 text-purple-400/70 animate-pulse motion-reduce:animate-none" aria-hidden="true" />
                 </motion.div>
               ) : (
                 <SwipeableFilmCard
@@ -215,7 +263,7 @@ export default function RatingStep({ favoriteMovies, ratings, onRate, onBack, on
             <button
               type="button"
               onClick={handleSkip}
-              className="rounded-full px-5 py-2 text-sm font-medium text-white/55 transition-colors hover:text-white/85"
+              className="rounded-full px-5 py-2 text-sm font-medium text-white/55 transition-colors hover:text-white/85 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
             >
               Skip this one →
             </button>
@@ -343,7 +391,7 @@ function FilmCard({ movie }) {
 
   return (
     <div className="relative h-full w-full overflow-hidden rounded-2xl shadow-[0_20px_40px_rgba(0,0,0,0.5)]">
-      {!loaded && <div className="absolute inset-0 animate-pulse bg-white/4" />}
+      {!loaded && <div className="absolute inset-0 animate-pulse bg-white/4 motion-reduce:animate-none" />}
       <img
         src={tmdbImg(movie.poster_path || movie.backdrop_path, 'w780')}
         alt=""
@@ -385,7 +433,7 @@ function SentimentRow({ active, dragHint, onRate, reduced }) {
               whileTap={reduced ? undefined : { scale: 0.92 }}
               animate={dragHint === s.key ? { scale: 1.08 } : { scale: 1 }}
               transition={{ duration: 0.15, ease: [0.22, 1, 0.36, 1] }}
-              className="grid h-16 w-16 place-items-center rounded-full text-2xl text-white transition-shadow"
+              className="grid h-16 w-16 place-items-center rounded-full text-2xl text-white transition-shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
               style={{
                 background: on ? `rgba(${s.tint}, 0.32)` : `rgba(${s.tint}, 0.12)`,
                 border: `1.5px solid rgba(${s.tint}, ${on ? 0.85 : 0.5})`,


### PR DESCRIPTION
Render-faithful accessibility + keyboard foundation for the Step-4 verdict (F2.17). **No visual re-voice** — the Meh/Liked/Loved labels, ✕/✓/♥ symbols, directional stamps, next-card peek, layout, copy, and colours are all unchanged (that is F2.18). The only visible delta is keyboard focus rings.

## Live announcements
One RatingStep-owned, `sr-only` `aria-live="polite"` `aria-atomic="true"` status region, derived **only** from the existing `current`/`remaining`/`allRated` (no new progression state, no second visible counter): announces "Now rating {title} — {n} to go" on the current/next film and "All rated — building your picks" at the end. DnaRail suppresses its tally on Step 4, so this is the sole detailed film-progress announcement.

## Error semantics
The error container is now `role="alert"` (copy + styling unchanged).

## Keyboard shortcuts + focus scoping
A focusable **rating-stage region** (`tabIndex=0`, `role="group"`, `aria-label="Rate {title}"`, `aria-describedby` → sr-only instructions) maps **ArrowRight→loved / ArrowUp→liked / ArrowLeft→okay** through the **existing `commitRate`** — the frozen swipe map, no duplication. Critically scoped: shortcuts fire **only when the stage itself owns focus** (`e.target === e.currentTarget` — never from a button/Skip/interactive descendant), `preventDefault()` only for a handled Arrow, and a no-op when `allRated` / no current film / a commit is already advancing. The stage stops being a tab stop once `allRated`.

## Focus-visible improvements
The three sentiment buttons + Skip (and the new stage) gain the same focus-ring family as Back (`focus-visible:ring-2 ring-purple-400/60 ring-offset-2 ring-offset-black`). No dimensions/colors/labels/behaviour changed.

## Focus behaviour
No programmatic focus moves per rating or Skip — the live region carries the change. The final commit still hands off via the **unchanged 700ms `onFinish`**; no focus is forced onto the temporary Sparkles handoff.

## Reduced-motion completion
`motion-reduce:animate-none` added to the handoff Sparkles pulse + the FilmCard loading skeleton. Drag + `whileTap` remain `reduced`-gated (unchanged). Playwright `emulateMedia('reduce')` confirms the pulse animation collapses to `none` in a real browser.

## Tests
New `RatingStepA11y.test.jsx` (17): error `role=alert`; live region (current + next-after-rating + next-after-Skip + all-rated); Skip advances without `onRate`; ArrowRight/Up/Left → `onRate(film, 'loved'/'liked'/'okay')`; Arrow keys on a button/Skip do **not** rate; rapid double-activation commits once; final `onFinish` fires exactly once after 700ms; focus-visible affordances; stage focusable + described; motion-reduce-safe pulses. The existing RatingStep + `SENTIMENT_RATINGS` assertions are untouched. *(Reduced-motion drag-disable is a framer runtime behavior — `useReducedMotion` caches its media-query subscription per file, so it's verified in the Playwright pass, not jsdom.)*

## Confirmations
- **Swipe mappings, thresholds, timers, rating values, labels, symbols, stamps, peek, and visible copy are unchanged** — verified: `SWIPE_THRESHOLD=110`, `ADVANCE_DELAY_MS=280`, 700ms `onFinish`, `SENTIMENT_RATINGS {loved:9,liked:7,okay:5}`, the keys, the swipe map + up-priority, the `isAdvancingRef` guard, Skip-without-rating, Back, the prop contract, `onRate(movie,key)`, index progression, no terminal confirm button.
- **Auth / routing / Supabase / localStorage / completion untouched** — `Onboarding.jsx`, `CelebrationReveal.jsx`, `DnaRail.jsx`, MoviesStep, services, and celebration timing were not touched.

## Validation
- `npm run lint` → clean
- `npx vitest run src/features/onboarding/__tests__/ src/shared/lib/auth/__tests__/onboardingStatus.test.js` → 110 passed (9 files)
- `npm run build` → ✓
- `npm run test` (full) → 614 passed (55 files)
- Playwright 360/390/430/768/1280 + reduced-motion: no overflow, stage focusable, live region + focus rings present, pulse suppressed under reduce, 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
