### PR TITLE
Revoice RatingStep as editorial verdicts

### DIFF
--- a/src/features/onboarding/__tests__/OnboardingSteps.test.jsx
+++ b/src/features/onboarding/__tests__/OnboardingSteps.test.jsx
@@ -196,11 +196,12 @@ describe('RatingStep — real sentiment buttons (auto-finishes; no confirm butto
     ...over,
   })
 
-  it('renders the three sentiment buttons (Meh / Liked / Loved) as the rating affordance', () => {
+  it('renders the three verdict buttons (Okay / Liked / Loved) as the rating affordance', () => {
     render(<RatingStep {...props()} />)
     expect(screen.getByRole('button', { name: 'Loved' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Liked' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Meh' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Okay' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Meh' })).not.toBeInTheDocument()
   })
 
   it('does NOT render a "See my recommendations" confirm button (the step auto-finishes)', () => {

--- a/src/features/onboarding/__tests__/RatingStepA11y.test.jsx
+++ b/src/features/onboarding/__tests__/RatingStepA11y.test.jsx
@@ -37,10 +37,10 @@ const live = (container) => container.querySelector('[aria-live="polite"]')
 beforeEach(() => setMatchMedia(false))
 
 describe('RatingStep — frozen affordance (unchanged in F2.17)', () => {
-  it('keeps the Meh/Liked/Loved buttons and onRate(film, key) mapping', () => {
+  it('keeps the Okay/Liked/Loved buttons and onRate(film, key) mapping', () => {
     const onRate = vi.fn()
     render(<RatingStep {...props({ onRate })} />)
-    expect(screen.getByRole('button', { name: 'Meh' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Okay' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Liked' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Loved' })).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Loved' }))
@@ -76,7 +76,7 @@ describe('RatingStep — live announcements + error semantics', () => {
   it('announces the next film after Skip, without calling onRate', () => {
     const onRate = vi.fn()
     const { container } = render(<RatingStep {...props({ onRate })} />)
-    fireEvent.click(screen.getByRole('button', { name: /skip this one/i }))
+    fireEvent.click(screen.getByRole('button', { name: /skip for now/i }))
     expect(live(container)).toHaveTextContent('Now rating Beta — 2 to go')
     expect(onRate).not.toHaveBeenCalled()
   })
@@ -121,7 +121,7 @@ describe('RatingStep — keyboard parity (scoped to the rating stage)', () => {
     const onRate = vi.fn()
     render(<RatingStep {...props({ onRate })} />)
     fireEvent.keyDown(screen.getByRole('button', { name: 'Loved' }), { key: 'ArrowRight' })
-    fireEvent.keyDown(screen.getByRole('button', { name: /skip this one/i }), { key: 'ArrowLeft' })
+    fireEvent.keyDown(screen.getByRole('button', { name: /skip for now/i }), { key: 'ArrowLeft' })
     expect(onRate).not.toHaveBeenCalled()
   })
 })
@@ -157,7 +157,7 @@ describe('RatingStep — guard, auto-finish, focus, reduced motion', () => {
   it('gives the sentiment buttons and Skip a focus-visible affordance', () => {
     render(<RatingStep {...props()} />)
     expect(screen.getByRole('button', { name: 'Loved' }).className).toMatch(/focus-visible:ring-2/)
-    expect(screen.getByRole('button', { name: /skip this one/i }).className).toMatch(/focus-visible:ring-2/)
+    expect(screen.getByRole('button', { name: /skip for now/i }).className).toMatch(/focus-visible:ring-2/)
   })
 
   it('makes the rating stage keyboard-focusable with a descriptive label', () => {

--- a/src/features/onboarding/__tests__/RatingStepVerdict.test.jsx
+++ b/src/features/onboarding/__tests__/RatingStepVerdict.test.jsx
@@ -1,0 +1,103 @@
+// src/features/onboarding/__tests__/RatingStepVerdict.test.jsx
+// F2.18 — editorial verdict revoice: word-led Okay/Liked/Loved controls, visible
+// label == accessible name, no dating-app symbols/stamps/next-card peek, and
+// tap-primary copy. The frozen keys/mappings/guards/timers are exercised here +
+// in OnboardingSteps + RatingStepA11y; nothing about them changes.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+vi.mock('@/shared/api/tmdb', () => ({ tmdbImg: (p) => `https://img/${p}` }))
+
+import RatingStep from '../steps/RatingStep'
+
+const film = (id, title) => ({ id, title, poster_path: `/${id}.jpg`, release_date: '2014-01-01' })
+const props = (over = {}) => ({
+  favoriteMovies: [film(1, 'Alpha'), film(2, 'Beta'), film(3, 'Gamma')],
+  ratings: {}, onRate: vi.fn(), onBack: vi.fn(), onFinish: vi.fn(), error: '', ...over,
+})
+
+beforeEach(() => {
+  window.matchMedia = vi.fn().mockImplementation((q) => ({
+    matches: false, media: q, onchange: null,
+    addEventListener: vi.fn(), removeEventListener: vi.fn(),
+    addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(),
+  }))
+})
+
+describe('RatingStep — editorial verdict controls', () => {
+  it('names the three controls Okay / Liked / Loved (never Meh)', () => {
+    render(<RatingStep {...props()} />)
+    expect(screen.getByRole('button', { name: 'Okay' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Liked' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Loved' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Meh' })).not.toBeInTheDocument()
+  })
+
+  it('matches each visible label to its accessible name (WCAG 2.5.3)', () => {
+    render(<RatingStep {...props()} />)
+    for (const label of ['Okay', 'Liked', 'Loved']) {
+      const btn = screen.getByRole('button', { name: label })
+      expect(btn).toHaveTextContent(label)
+      expect(btn).toHaveAttribute('aria-label', label)
+    }
+  })
+
+  it('renders no ✕ / ✓ / ♥ verdict symbols', () => {
+    const { container } = render(<RatingStep {...props()} />)
+    expect(container.textContent).not.toMatch(/[✕✓♥]/)
+  })
+
+  it('maps Okay→okay, Liked→liked, Loved→loved on click (frozen keys)', () => {
+    for (const [label, key] of [['Okay', 'okay'], ['Liked', 'liked'], ['Loved', 'loved']]) {
+      const onRate = vi.fn()
+      const { unmount } = render(<RatingStep {...props({ onRate })} />)
+      fireEvent.click(screen.getByRole('button', { name: label }))
+      expect(onRate).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }), key)
+      unmount()
+    }
+  })
+
+  it('keeps aria-pressed reflecting the committed verdict', () => {
+    render(<RatingStep {...props({ ratings: { 1: 9 } })} />) // 9 = SENTIMENT_RATINGS.loved
+    expect(screen.getByRole('button', { name: 'Loved' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'Okay' })).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('gives every verdict control a ≥44px target + focus-visible ring', () => {
+    render(<RatingStep {...props()} />)
+    for (const label of ['Okay', 'Liked', 'Loved']) {
+      const cls = screen.getByRole('button', { name: label }).getAttribute('class')
+      expect(cls).toMatch(/min-h-\[48px\]/)
+      expect(cls).toMatch(/focus-visible:ring-2/)
+    }
+  })
+})
+
+describe('RatingStep — dating-app idiom removed', () => {
+  it('renders only the current poster — no next-card peek', () => {
+    const { container } = render(<RatingStep {...props()} />)
+    expect(container.querySelectorAll('img')).toHaveLength(1)
+  })
+
+  it('renders no directional stamp (no font-extrabold overlay, "Loved" not duplicated)', () => {
+    const { container } = render(<RatingStep {...props()} />)
+    expect(container.querySelector('.font-extrabold')).toBeNull()
+    expect(screen.getAllByText('Loved')).toHaveLength(1)
+  })
+
+  it('leads with tap-primary guidance, not swipe-first / punitive language', () => {
+    render(<RatingStep {...props()} />)
+    expect(screen.getByText(/choose your verdict below\. swipe is optional\./i)).toBeInTheDocument()
+    expect(screen.queryByText(/swipe right to love/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/left to pass/i)).not.toBeInTheDocument()
+  })
+
+  it('treats Skip as a quiet tertiary "Skip for now" with no arrow', () => {
+    render(<RatingStep {...props()} />)
+    const skip = screen.getByRole('button', { name: /skip for now/i })
+    expect(skip).toHaveTextContent('Skip for now')
+    expect(skip.textContent).not.toMatch(/→/)
+    expect(skip.getAttribute('class')).toMatch(/min-h-\[44px\]/)
+  })
+})

--- a/src/features/onboarding/steps/RatingStep.jsx
+++ b/src/features/onboarding/steps/RatingStep.jsx
@@ -1,7 +1,7 @@
 // src/features/onboarding/steps/RatingStep.jsx
-// Tinder-style swipeable card: drag right = Loved, left = Meh, up = Liked.
-// Buttons remain as accessible fallback. Counter syncs immediately on commit;
-// the next card peeks behind the current one for stack depth.
+// Step 4 — the verdict. A calm single-poster card with editorial verdict controls
+// (Okay / Liked / Loved) as the primary, tap-first interaction; swipe is a quiet
+// optional shortcut (right→Loved, up→Liked, left→Okay). Counter syncs on commit.
 
 import { useEffect, useMemo, useRef, useState } from 'react'
 import {
@@ -17,12 +17,13 @@ import { ChevronLeft, Sparkles } from 'lucide-react'
 import { tmdbImg } from '@/shared/api/tmdb'
 import { SENTIMENT_RATINGS } from '@/features/onboarding/data'
 
-// Order matches the prototype: Meh → Liked → Loved (left to right, ramping up).
-// Keys must match SENTIMENT_RATINGS in the legacy module.
+// Ascending editorial verdicts — Okay → Liked → Loved (left to right). Keys must
+// match SENTIMENT_RATINGS; `rgb` drives each tier's tint/border/elevation, with
+// Loved as the gentle brand apex.
 const SENTIMENTS = [
-  { key: 'okay',  label: 'Meh',   symbol: '✕', tint: '120, 120, 130' },
-  { key: 'liked', label: 'Liked', symbol: '✓', tint: '168, 85, 247' },
-  { key: 'loved', label: 'Loved', symbol: '♥', tint: '236, 72, 153' },
+  { key: 'okay',  label: 'Okay',  rgb: '150, 150, 162' },
+  { key: 'liked', label: 'Liked', rgb: '168, 85, 247' },
+  { key: 'loved', label: 'Loved', rgb: '236, 72, 153' },
 ]
 
 const ratingToSentiment = (rating) => {
@@ -142,7 +143,7 @@ export default function RatingStep({ favoriteMovies, ratings, onRate, onBack, on
         {liveMessage}
       </div>
       <span id="rating-kbd-help" className="sr-only">
-        Use the verdict buttons below, or press Left for Meh, Up for Liked, and Right for Loved.
+        Use the verdict buttons below, or press Left for Okay, Up for Liked, and Right for Loved.
       </span>
       <div className="flex-none px-5 pb-3 pt-5 sm:px-6 sm:pb-4 sm:pt-6">
         <button
@@ -180,8 +181,8 @@ export default function RatingStep({ favoriteMovies, ratings, onRate, onBack, on
           {allRated
             ? 'That’s all of them. Building your first picks…'
             : reduced
-              ? "Tap one. We'll move on automatically."
-              : 'Swipe right to love, left to pass, up to like. Or tap.'}
+              ? "Choose one. We'll move on automatically."
+              : 'Choose your verdict below. Swipe is optional.'}
         </p>
       </div>
 
@@ -200,24 +201,6 @@ export default function RatingStep({ favoriteMovies, ratings, onRate, onBack, on
             {...stageProps}
             className="relative h-full max-h-full aspect-2/3 rounded-2xl focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
           >
-            {/* Background card peek — next film sits behind the current one
-               for stack depth (Tinder convention). Static / non-interactive.
-               Skipped when on the last card or when all rated. */}
-            {!allRated && films[idx + 1] && (
-              <div
-                key={`bg-${films[idx + 1].id}`}
-                aria-hidden="true"
-                className="pointer-events-none absolute inset-0"
-                style={{
-                  transform: 'translateY(10px) scale(0.94)',
-                  opacity: 0.45,
-                  transformOrigin: 'center top',
-                }}
-              >
-                <FilmCard movie={films[idx + 1]} />
-              </div>
-            )}
-
             <AnimatePresence mode="wait" initial={false}>
               {allRated ? (
                 // Brief placeholder while the Onboarding container's full
@@ -263,9 +246,9 @@ export default function RatingStep({ favoriteMovies, ratings, onRate, onBack, on
             <button
               type="button"
               onClick={handleSkip}
-              className="rounded-full px-5 py-2 text-sm font-medium text-white/55 transition-colors hover:text-white/85 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+              className="inline-flex min-h-[44px] items-center justify-center rounded-full px-4 text-sm font-medium text-white/50 transition-colors hover:text-white/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
             >
-              Skip this one →
+              Skip for now
             </button>
           </div>
         </div>
@@ -275,29 +258,22 @@ export default function RatingStep({ favoriteMovies, ratings, onRate, onBack, on
 }
 
 // === Swipeable film card ==================================================
-// Wraps FilmCard in a draggable motion.div. Tracks x/y motion values to
-// animate rotation, fade in directional "stamps" (MEH/LIKED/LOVED), and
-// commit a rating when the drag passes SWIPE_THRESHOLD in any direction.
+// Wraps FilmCard in a draggable motion.div — the optional swipe shortcut behind
+// the editorial verdict controls. Tracks x/y motion values for a restrained
+// cinematic tilt and commits a rating when the drag passes SWIPE_THRESHOLD.
 //
-// Mapping (Step 3 already framed these films as "loved"):
+// Mapping (Step 3 framed these films as loved anchors):
 //   swipe right → 'loved'
 //   swipe up    → 'liked'
 //   swipe left  → 'okay'
 //
-// Calls `onDragHintChange` whenever the drag direction crosses a threshold
-// (in/out of right / left / up zones) so the parent can highlight the
-// matching sentiment button.
+// Calls `onDragHintChange` whenever the drag direction crosses a threshold so
+// the parent can highlight the matching verdict control.
 function SwipeableFilmCard({ movie, reduced, exitDirection, onSwipe, onDragHintChange }) {
   const x = useMotionValue(0)
   const y = useMotionValue(0)
-  // Mild rotation in the swipe direction — Tinder signature feel.
-  const rotate = useTransform(x, [-260, 260], [-14, 14])
-
-  // Directional stamp opacities — fade in as the drag passes ~40px in that
-  // direction, fully visible by SWIPE_THRESHOLD-ish.
-  const mehOpacity = useTransform(x, [-130, -40], [1, 0])
-  const lovedOpacity = useTransform(x, [40, 130], [0, 1])  // right
-  const likedOpacity = useTransform(y, [-130, -40], [1, 0]) // up
+  // Restrained cinematic tilt in the drag direction (subtle, not a card-fling).
+  const rotate = useTransform(x, [-260, 260], [-6, 6])
 
   const exitVariant =
     exitDirection === 'right' ? { x: 600, opacity: 0, rotate: 24 } :
@@ -355,27 +331,6 @@ function SwipeableFilmCard({ movie, reduced, exitDirection, onSwipe, onDragHintC
       className="relative h-full w-full touch-none select-none"
     >
       <FilmCard movie={movie} />
-
-      {/* Directional stamps — appear over the poster as the user drags. */}
-      <Stamp opacity={mehOpacity}   position="top-left"      rotate="-rotate-12" borderClass="border-white/60"    textClass="text-white/85"    label="Meh" />
-      <Stamp opacity={lovedOpacity} position="top-right"     rotate="rotate-12"  borderClass="border-pink-400"    textClass="text-pink-300"    label="Loved" />
-      <Stamp opacity={likedOpacity} position="bottom-center" rotate=""           borderClass="border-purple-400"  textClass="text-purple-300"  label="Liked" />
-    </motion.div>
-  )
-}
-
-function Stamp({ opacity, position, rotate, borderClass, textClass, label }) {
-  const positionClass =
-    position === 'top-left' ? 'top-5 left-5' :
-    position === 'top-right' ? 'top-5 right-5' :
-    'bottom-5 left-1/2 -translate-x-1/2'
-  return (
-    <motion.div
-      style={{ opacity }}
-      aria-hidden="true"
-      className={`pointer-events-none absolute ${positionClass} px-3 py-1.5 rounded-md border-[3px] ${borderClass} ${textClass} font-extrabold text-sm uppercase tracking-[0.18em] ${rotate} bg-black/40 backdrop-blur-sm`}
-    >
-      {label}
     </motion.div>
   )
 }
@@ -404,7 +359,7 @@ function FilmCard({ movie }) {
       />
       <div className="pointer-events-none absolute inset-x-0 bottom-0 h-32 bg-linear-to-t from-black/90 via-black/50 to-transparent" />
       <div className="pointer-events-none absolute inset-x-5 bottom-4">
-        <div className="ob-display text-xl font-semibold tracking-tight text-white drop-shadow-[0_2px_8px_rgba(0,0,0,0.6)] sm:text-2xl">
+        <div className="ob-display text-xl font-medium tracking-tight text-white drop-shadow-[0_2px_8px_rgba(0,0,0,0.6)] sm:text-2xl">
           {movie.title}
         </div>
         {year && <div className="text-xs text-white/75 drop-shadow-[0_1px_4px_rgba(0,0,0,0.6)]">{year}</div>}
@@ -413,52 +368,43 @@ function FilmCard({ movie }) {
   )
 }
 
-// === Sentiment buttons ====================================================
-// Buttons mirror the swipe gestures and stay accessible as a tap fallback.
-// `dragHint` lets the matching button glow while the user is mid-drag so the
-// visual response is unified across both input modes.
+// === Verdict controls =====================================================
+// Three word-led editorial controls (Okay / Liked / Loved) — the primary,
+// tap-first interaction. Equal footprint for mobile stability; Loved is the
+// gentle apex via tone / weight / elevation, not size. `dragHint` highlights the
+// matching control while the optional swipe is mid-gesture; aria-pressed marks
+// the committed verdict.
 function SentimentRow({ active, dragHint, onRate, reduced }) {
   return (
-    <div className="flex flex-col items-center">
-      <div className="flex items-center justify-center gap-4">
-        {SENTIMENTS.map((s) => {
-          const on = active === s.key || dragHint === s.key
-          return (
-            <motion.button
-              key={s.key}
-              type="button"
-              onClick={() => onRate(s.key)}
-              aria-pressed={active === s.key}
-              aria-label={s.label}
-              whileTap={reduced ? undefined : { scale: 0.92 }}
-              animate={dragHint === s.key ? { scale: 1.08 } : { scale: 1 }}
-              transition={{ duration: 0.15, ease: [0.22, 1, 0.36, 1] }}
-              className="grid h-16 w-16 place-items-center rounded-full text-2xl text-white transition-shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
-              style={{
-                background: on ? `rgba(${s.tint}, 0.32)` : `rgba(${s.tint}, 0.12)`,
-                border: `1.5px solid rgba(${s.tint}, ${on ? 0.85 : 0.5})`,
-                boxShadow: on
-                  ? `0 12px 28px rgba(${s.tint}, 0.35)`
-                  : `0 8px 20px rgba(${s.tint}, 0.18)`,
-              }}
-            >
-              <span aria-hidden="true">{s.symbol}</span>
-            </motion.button>
-          )
-        })}
-      </div>
-      <div className="mt-2 flex items-center justify-center gap-4">
-        {SENTIMENTS.map((s) => (
-          <span
+    <div className="grid w-full grid-cols-3 gap-2 sm:gap-3">
+      {SENTIMENTS.map((s) => {
+        const on = active === s.key || dragHint === s.key
+        const apex = s.key === 'loved'
+        return (
+          <motion.button
             key={s.key}
-            className={`w-16 text-center text-[11px] font-semibold transition-colors ${
-              dragHint === s.key ? 'text-white' : 'text-white/55'
+            type="button"
+            onClick={() => onRate(s.key)}
+            aria-pressed={active === s.key}
+            aria-label={s.label}
+            whileTap={reduced ? undefined : { scale: 0.97 }}
+            animate={dragHint === s.key ? { scale: 1.03 } : { scale: 1 }}
+            transition={{ duration: 0.15, ease: [0.22, 1, 0.36, 1] }}
+            className={`min-h-[48px] rounded-xl px-2 text-center text-sm tracking-tight transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black ${
+              apex ? 'font-semibold text-white' : `font-medium ${on ? 'text-white' : 'text-white/75'}`
             }`}
+            style={{
+              background: on ? `rgba(${s.rgb}, ${apex ? 0.22 : 0.16})` : `rgba(${s.rgb}, ${apex ? 0.1 : 0.05})`,
+              border: `1px solid rgba(${s.rgb}, ${on ? (apex ? 0.75 : 0.55) : (apex ? 0.4 : 0.2)})`,
+              boxShadow: apex
+                ? (on ? `0 10px 26px rgba(${s.rgb}, 0.3)` : `0 6px 16px rgba(${s.rgb}, 0.18)`)
+                : 'none',
+            }}
           >
             {s.label}
-          </span>
-        ))}
-      </div>
+          </motion.button>
+        )
+      })}
     </div>
   )
 }


### PR DESCRIPTION
Visual follow-up to the merged F2.17 a11y foundation (F2.18). The Step-4 verdict previously self-identified as **"Tinder-style"** — card-flick + flying ✕/✓/♥ stamps + a peek-stack — the exact dating-app / gamified idiom the doctrine rejects. This revoices it into calm, **tap-first editorial verdict controls**, preserving every frozen contract byte-for-byte.

## Why the dating-app language was removed
Mood-first, taste-deep, patient and cinematic — *not* a swipe game. The user is giving a considered verdict on films they chose as loved anchors, so "Meh"/✕/"pass" framing was both off-brand and punitive.

## New labels — `Okay / Liked / Loved`
Meh → **Okay** (Liked/Loved unchanged). **Visible label == accessible name** (no `aria-label="Meh"` behind a visible "Okay") — WCAG 2.5.3. Internal keys + numeric mappings are unchanged.

## Verdict-control hierarchy
The three equal 64px icon circles become a word-led `grid-cols-3` row of rounded editorial controls (min-h 48px, fit cleanly at 360px). Ascending emphasis via **tone / weight / elevation**, same footprint:
- **Okay** — quiet neutral surface, restrained border, medium weight.
- **Liked** — subtle purple tint/border.
- **Loved** — gentle pink apex: strongest border + a modest glow + semibold (no oversized heart, badge, bounce, or celebration).

`aria-pressed`, click handlers, F2.17 focus-visible rings, `dragHint` highlight, and reduced-motion gating are all preserved.

## Symbols, stamps, and next-card peek removed
Dropped ✕/✓/♥ (+ the now-unused `symbol` field; `tint`→`rgb`); deleted the `Stamp` component, its three instances, and the meh/liked/loved opacity transforms (drag feedback now comes from the existing `dragHint` → the control's highlighted state); removed the decorative `films[idx+1]` peek so only the current poster renders.

## Retained optional swipe + softened rotation
Drag, `SWIPE_THRESHOLD=110`, the right→loved/up→liked/left→okay mappings (+ up-priority), exit directions, and the commit point are **unchanged**. Only the visible tilt is softened (±14° → **±6°**). Swipe is now a quiet optional shortcut.

## Tap-primary copy + tertiary Skip
"Choose your verdict below. Swipe is optional." (reduced: "Choose one. We'll move on automatically."); the sr-only keyboard help now reads "Left for Okay, Up for Liked, Right for Loved." Skip → **"Skip for now"** (no arrow), quiet text button, ≥44px, focus ring; behavior unchanged. Film-card title softened `font-semibold` → `font-medium`.

## Tests
Existing label/Skip assertions updated (Meh→Okay; "Skip this one"→"Skip for now") and kept green in OnboardingSteps + RatingStepA11y. New **`RatingStepVerdict.test.jsx`**: labels==accessible names, no ✕/✓/♥, Okay→okay / Liked→liked / Loved→loved, `aria-pressed`, ≥44px + focus-ring, single poster (no peek), no stamp (no `font-extrabold`, "Loved" not duplicated), tap-primary copy, Skip label. The F2.17 a11y/keyboard/live-region/auto-finish/guard coverage is untouched.

## Confirmations
- **Numeric ratings, sentiment keys, swipe mappings, thresholds, timers, live-region behavior, auth/routing/Supabase/localStorage/completion unchanged** — verified: `SENTIMENT_RATINGS {loved:9,liked:7,okay:5}` (`data.js` untouched), keys `okay`/`liked`/`loved`, the swipe map + up-priority, `SWIPE_THRESHOLD=110`, `ADVANCE_DELAY_MS=280`, the 700ms auto-finish, the `isAdvancingRef` guard, Skip-without-rating, Back, the prop contract, `onRate(movie,key)`, index progression, reduced-motion drag-disable, the F2.17 Arrow mappings + error role, no terminal confirm CTA.
- `Onboarding.jsx`, `CelebrationReveal.jsx`, `DnaRail.jsx`, MoviesStep/MoodStep/GenresStep, services, and celebration timing were not touched.

## Validation
- `npm run lint` → clean
- `npx vitest run src/features/onboarding/__tests__/ src/shared/lib/auth/__tests__/onboardingStatus.test.js` → 120 passed (10 files)
- `npm run build` → ✓
- `npm run test` (full) → 624 passed (56 files)
- Playwright 360/390/430/768/1280 + reduced-motion: no overflow, 3 controls @48px in viewport, single poster, no symbols, Loved apex elevation, "Skip for now", pulse suppressed under reduce, 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
