### PR TITLE
Add CelebrationReveal a11y and finish-flow tests

### DIFF
--- a/src/features/onboarding/__tests__/CelebrationReveal.test.jsx
+++ b/src/features/onboarding/__tests__/CelebrationReveal.test.jsx
@@ -1,0 +1,129 @@
+// src/features/onboarding/__tests__/CelebrationReveal.test.jsx
+// F2.20 — CelebrationReveal a11y/semantic foundation. ONE concise sr-only
+// completion status (not a multi-stage live region), a single visible h1, no
+// focus movement, and render-safety across data variants. Reduced-motion VISUAL
+// timing (delays→0) is verified in Playwright; jsdom checks structure only.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+
+vi.mock('@/shared/api/tmdb', () => ({ tmdbImg: (p) => `https://img/${p}` }))
+
+import CelebrationReveal from '../components/CelebrationReveal'
+
+const film = (id, title, poster = `/${id}.jpg`) => ({ id, title, poster_path: poster, release_date: '2014-01-01' })
+const props = (over = {}) => ({
+  moods: ['cozy'],
+  selectedGenres: [18],
+  favoriteMovies: [film(1, 'Alpha'), film(2, 'Beta'), film(3, 'Gamma'), film(4, 'Delta'), film(5, 'Echo')],
+  ratings: { 1: 9, 2: 7 },
+  fadingOut: false,
+  ...over,
+})
+
+function setMatchMedia(reduced = false) {
+  window.matchMedia = vi.fn().mockImplementation((q) => ({
+    matches: reduced && /reduced-motion/.test(q),
+    media: q, onchange: null,
+    addEventListener: vi.fn(), removeEventListener: vi.fn(),
+    addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(),
+  }))
+}
+const status = () => document.querySelector('[role="status"]')
+beforeEach(() => setMatchMedia(false))
+
+describe('CelebrationReveal — semantics', () => {
+  it('renders exactly one visible h1 "Tonight is yours." (not aria-hidden)', () => {
+    render(<CelebrationReveal {...props()} />)
+    const h1s = screen.getAllByRole('heading', { level: 1 })
+    expect(h1s).toHaveLength(1)
+    expect(h1s[0]).toHaveTextContent(/tonight is\s*yours\./i)
+    expect(h1s[0]).not.toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('exposes exactly one polite + atomic status — not on the visible wrapper', () => {
+    const { container } = render(<CelebrationReveal {...props()} />)
+    const statuses = container.querySelectorAll('[role="status"]')
+    expect(statuses).toHaveLength(1)
+    expect(statuses[0]).toHaveAttribute('aria-live', 'polite')
+    expect(statuses[0]).toHaveAttribute('aria-atomic', 'true')
+    expect(statuses[0].className).toMatch(/sr-only/)
+    // the visible heading is NOT inside the live region
+    expect(within(statuses[0]).queryByRole('heading')).toBeNull()
+  })
+
+  it('announces one concise completion sentence after mount (no count tally / list)', () => {
+    render(<CelebrationReveal {...props()} />)
+    expect(status()).toHaveTextContent(/your taste is tuned.*opening your first picks\./i)
+    expect(status().textContent).not.toMatch(/genre|loved|liked|\d+\s*film/i)
+  })
+
+  it('does not move focus', () => {
+    render(<CelebrationReveal {...props()} />)
+    expect(document.body).toHaveFocus()
+  })
+})
+
+describe('CelebrationReveal — announcement variants', () => {
+  it('degrades to the no-title sentence when no usable titles exist', () => {
+    render(<CelebrationReveal {...props({ favoriteMovies: [{ id: 1, poster_path: '/1.jpg' }] })} />)
+    expect(status()).toHaveTextContent('Your taste is tuned. Opening your first picks.')
+    expect(status().textContent).not.toMatch(/undefined|with ,|,\s+and\b/)
+  })
+
+  it('uses one title cleanly', () => {
+    render(<CelebrationReveal {...props({ favoriteMovies: [film(1, 'Inception')] })} />)
+    expect(status()).toHaveTextContent('Your taste is tuned with Inception. Opening your first picks.')
+  })
+
+  it('joins two titles with "and"', () => {
+    render(<CelebrationReveal {...props({ favoriteMovies: [film(1, 'Alpha'), film(2, 'Beta')] })} />)
+    expect(status()).toHaveTextContent('Your taste is tuned with Alpha and Beta. Opening your first picks.')
+  })
+
+  it('keeps 3+ titles concise with "and more"', () => {
+    render(<CelebrationReveal {...props()} />)
+    expect(status()).toHaveTextContent('Your taste is tuned with Alpha, Beta, and more. Opening your first picks.')
+  })
+})
+
+describe('CelebrationReveal — content + data variants', () => {
+  it('renders the apex + coaching copy', () => {
+    render(<CelebrationReveal {...props()} />)
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/tonight is\s*yours\./i)
+    expect(screen.getByText(/see films you already know/i)).toBeInTheDocument()
+    expect(screen.getByText(/mark watched/i)).toBeInTheDocument()
+  })
+
+  it.each([
+    ['one mood', { moods: ['cozy'] }],
+    ['three moods', { moods: ['cozy', 'wired', 'mythic'] }],
+    ['five films', {}],
+    ['missing-poster fallback', { favoriteMovies: [film(1, 'NoPoster', null)] }],
+    ['no loved ratings', { ratings: { 1: 7, 2: 5 } }],
+    ['mixed liked/loved', { ratings: { 1: 9, 2: 7, 3: 5 } }],
+    ['empty optional data', { moods: [], selectedGenres: [], favoriteMovies: [], ratings: {} }],
+  ])('renders without error and one live region: %s', (_label, over) => {
+    expect(() => render(<CelebrationReveal {...props(over)} />)).not.toThrow()
+    expect(document.querySelectorAll('[role="status"]')).toHaveLength(1)
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1)
+  })
+
+  it('keeps decorative posters out of the a11y tree (alt="")', () => {
+    const { container } = render(<CelebrationReveal {...props()} />)
+    const imgs = container.querySelectorAll('img')
+    expect(imgs.length).toBe(5)
+    imgs.forEach(img => expect(img.getAttribute('alt')).toBe(''))
+  })
+})
+
+describe('CelebrationReveal — reduced motion (structure; visual timing is Playwright)', () => {
+  it('still renders one live region + the full composition under reduced motion', () => {
+    setMatchMedia(true)
+    render(<CelebrationReveal {...props()} />)
+    expect(document.querySelectorAll('[role="status"]')).toHaveLength(1)
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1)
+    expect(screen.getByText(/see films you already know/i)).toBeInTheDocument()
+    expect(document.querySelectorAll('img')).toHaveLength(5)
+  })
+})

--- a/src/features/onboarding/__tests__/OnboardingFinishFlow.test.jsx
+++ b/src/features/onboarding/__tests__/OnboardingFinishFlow.test.jsx
@@ -1,0 +1,108 @@
+// src/features/onboarding/__tests__/OnboardingFinishFlow.test.jsx
+// F2.20 — locks the FROZEN onboarding finish ordering under test WITHOUT editing
+// Onboarding.jsx. Drives the real handleFinish via the rating step's 700ms
+// auto-finish and asserts: completeOnboarding({markAuthComplete:false}) + prefetch
+// run, then after the 12s hold, navigate('/discover') fires BEFORE
+// markOnboardingAuthComplete(). Runs under reduced-motion so framer skips its
+// infinite animations during the fake-timer advance (the ordering is identical;
+// reduced-motion only skips the 900ms fade wait, which Onboarding does by design).
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+
+const h = vi.hoisted(() => {
+  const calls = []
+  return {
+    calls,
+    completeOnboarding: vi.fn((opts) => { calls.push(['completeOnboarding', opts]); return Promise.resolve() }),
+    markOnboardingAuthComplete: vi.fn(() => { calls.push(['markOnboardingAuthComplete']); return Promise.resolve() }),
+    prefetchHomeData: vi.fn(() => { calls.push(['prefetchHomeData']); return Promise.resolve() }),
+    navigate: vi.fn((to) => { calls.push(['navigate', to]) }),
+  }
+})
+
+vi.mock('@/shared/services/onboarding', () => ({
+  completeOnboarding: h.completeOnboarding,
+  markOnboardingAuthComplete: h.markOnboardingAuthComplete,
+}))
+vi.mock('@/features/home/useHomeData', () => ({ prefetchHomeData: h.prefetchHomeData }))
+vi.mock('react-router-dom', async (orig) => ({ ...(await orig()), useNavigate: () => h.navigate }))
+vi.mock('@/shared/hooks/useAuthSession', () => ({
+  useAuthSession: () => ({ ready: true, session: { user: { id: 'u1', user_metadata: {} } } }),
+}))
+vi.mock('@/shared/lib/auth/onboardingStatus', () => ({ deriveOnboardingStatus: () => ({ isComplete: false }) }))
+vi.mock('@/shared/hooks/usePageMeta', () => ({ usePageMeta: () => {} }))
+vi.mock('@/shared/lib/supabase/client', () => ({
+  supabase: { from: () => ({ select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: { onboarding_complete: false } }) }) }) }) },
+}))
+vi.mock('@/shared/api/tmdb', () => ({ tmdbImg: (p) => `https://img/${p}`, searchMovies: vi.fn().mockResolvedValue({ results: [] }) }))
+
+import Onboarding from '../Onboarding'
+
+const DRAFT_KEY = 'ff_onboarding_draft_v1'
+function seedDraft() {
+  localStorage.setItem(DRAFT_KEY, JSON.stringify({
+    step: 3, moods: ['cozy'], selectedGenres: [18],
+    favoriteMovies: [{ id: 1, title: 'Alpha', poster_path: '/a.jpg', release_date: '2014-01-01' }],
+    ratings: {},
+  }))
+}
+
+beforeEach(() => {
+  h.calls.length = 0
+  vi.clearAllMocks()
+  localStorage.clear()
+  // reduced-motion: framer skips infinite animations during the fake-timer advance.
+  window.matchMedia = vi.fn().mockImplementation((q) => ({
+    matches: /reduced-motion/.test(q), media: q, onchange: null,
+    addEventListener: vi.fn(), removeEventListener: vi.fn(),
+    addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(),
+  }))
+})
+afterEach(() => { vi.useRealTimers(); localStorage.clear() })
+
+const names = () => h.calls.map(c => c[0])
+
+// Render Onboarding pre-seeded at the rating step, flush the async auth gate,
+// then rate the one film so RatingStep reaches allRated and schedules its 700ms
+// auto-finish (= handleFinish).
+async function driveToFinish() {
+  seedDraft()
+  render(<Onboarding />)
+  await act(async () => { await vi.advanceTimersByTimeAsync(10) }) // flush auth gate → checking=false
+  fireEvent.click(screen.getByRole('button', { name: 'Loved' }))
+}
+
+describe('Onboarding finish flow — frozen ordering', () => {
+  it('completeOnboarding(markAuthComplete:false) + prefetch, then /discover BEFORE markOnboardingAuthComplete', async () => {
+    vi.useFakeTimers()
+    await driveToFinish()
+    // 700ms auto-finish → handleFinish → 12000ms hold → (fade skipped under reduced) → nav → auth
+    await act(async () => { await vi.advanceTimersByTimeAsync(13500) })
+
+    expect(h.completeOnboarding).toHaveBeenCalledTimes(1)
+    expect(h.completeOnboarding.mock.calls[0][0]).toMatchObject({ markAuthComplete: false })
+    expect(h.prefetchHomeData).toHaveBeenCalled()
+    expect(h.markOnboardingAuthComplete).toHaveBeenCalledTimes(1)
+
+    const log = names()
+    const completeIdx = log.indexOf('completeOnboarding')
+    const navIdx = h.calls.findIndex(c => c[0] === 'navigate' && c[1] === '/discover')
+    const authIdx = log.indexOf('markOnboardingAuthComplete')
+    expect(completeIdx).toBeGreaterThanOrEqual(0)
+    expect(navIdx).toBeGreaterThan(completeIdx)   // navigate only after completion resolves
+    expect(authIdx).toBeGreaterThan(navIdx)        // auth flip AFTER navigation
+    expect(h.navigate.mock.calls.every(c => c[0] === '/discover')).toBe(true) // sole destination
+  })
+
+  it('does NOT navigate or flip auth before the 12s hold elapses', async () => {
+    vi.useFakeTimers()
+    await driveToFinish()
+    await act(async () => { await vi.advanceTimersByTimeAsync(700) })  // handleFinish starts
+    await act(async () => { await vi.advanceTimersByTimeAsync(3000) }) // 3s into the 12s hold
+    expect(h.completeOnboarding).toHaveBeenCalled()           // started
+    expect(h.completeOnboarding.mock.calls[0][0]).toMatchObject({ markAuthComplete: false })
+    expect(h.navigate).not.toHaveBeenCalled()                 // not yet
+    expect(h.markOnboardingAuthComplete).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/onboarding/components/CelebrationReveal.jsx
+++ b/src/features/onboarding/components/CelebrationReveal.jsx
@@ -1,8 +1,19 @@
+import { useEffect, useState } from 'react'
 import { motion, useReducedMotion } from 'framer-motion'
 import { Sparkles } from 'lucide-react'
 import { tmdbImg } from '@/shared/api/tmdb'
 import { MOODS, GENRES, SENTIMENT_RATINGS } from '../data'
 import AmbientGlow from './AmbientGlow'
+
+// One concise completion sentence for the dedicated sr-only live region — folds
+// in an aggregate film reference when titles exist, never a long poster list or
+// a count tally. (Visible stages are NOT a live region; this is the only one.)
+function buildAnnouncement(titles) {
+  if (titles.length === 0) return 'Your taste is tuned. Opening your first picks.'
+  if (titles.length === 1) return `Your taste is tuned with ${titles[0]}. Opening your first picks.`
+  if (titles.length === 2) return `Your taste is tuned with ${titles[0]} and ${titles[1]}. Opening your first picks.`
+  return `Your taste is tuned with ${titles[0]}, ${titles[1]}, and more. Opening your first picks.`
+}
 
 // === Celebration reveal ====================================================
 // Multi-stage immersive reveal that plays after the last rating commits.
@@ -22,8 +33,9 @@ import AmbientGlow from './AmbientGlow'
 //        (Stage 5; held until fade-out at ~12s so it has reading time before
 //         /discover takes over — also smooths the transition seam.)
 //
-// `prefers-reduced-motion` users get a static-but-staggered version:
-// elements still fade in (no movement) and particles are suppressed.
+// `prefers-reduced-motion` users get the complete composition immediately: every
+// stage delay collapses to 0 (no staggered wait), movement is removed, and
+// particles are suppressed. The parent's frozen 12s hold is preserved upstream.
 const EASE = [0.16, 1, 0.3, 1]                          // quartOut — long settle, no overshoot
 const SPRING = { type: 'spring', stiffness: 70, damping: 18, mass: 0.9 }
 
@@ -49,8 +61,24 @@ export default function CelebrationReveal({ moods, selectedGenres, favoriteMovie
   // Posters from their picks (truncate to 5 even if more exist).
   const posterFilms = (favoriteMovies || []).slice(0, 5)
 
+  // Single, concise completion announcement. Empty on first render, then set
+  // ONCE after mount so assistive tech hears a real content change ("" → text)
+  // rather than reading the visible multi-stage choreography piece by piece.
+  const announcementText = buildAnnouncement(
+    posterFilms.map(f => f.title).filter(Boolean)
+  )
+  const [announcement, setAnnouncement] = useState('')
+  useEffect(() => {
+    setAnnouncement(announcementText)
+  }, [announcementText])
+
   return (
     <div className="onboarding fixed inset-0 z-9999 flex flex-col items-center justify-center bg-black overflow-hidden">
+      {/* The ONLY live region — one concise polite+atomic completion status. */}
+      <p className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+        {announcement}
+      </p>
+
       {/* Slow, deep ambient glow — mood-tinted */}
       <AmbientGlow moods={moods} />
 
@@ -86,8 +114,6 @@ export default function CelebrationReveal({ moods, selectedGenres, favoriteMovie
          reveal the page). Read together, ~2.3s of cinematic darkness. */}
       <motion.div
         className="relative z-10 flex w-full max-w-2xl flex-col items-center px-6 text-center"
-        role="status"
-        aria-live="polite"
         initial={false}
         animate={
           fadingOut
@@ -126,7 +152,7 @@ export default function CelebrationReveal({ moods, selectedGenres, favoriteMovie
           <motion.p
             initial={{ opacity: 0, y: 6 }}
             animate={{ opacity: 0.85, y: 0 }}
-            transition={{ duration: reduced ? 0.4 : 0.9, delay: 0.4, ease: EASE }}
+            transition={{ duration: reduced ? 0.4 : 0.9, delay: reduced ? 0 : 0.4, ease: EASE }}
             className="ob-display mt-6 text-[11px] font-semibold uppercase tracking-[0.32em] text-purple-200/85"
           >
             Profile tuned · Edition №001
@@ -138,7 +164,7 @@ export default function CelebrationReveal({ moods, selectedGenres, favoriteMovie
           <motion.div
             initial="hidden"
             animate="visible"
-            variants={{ visible: { transition: { delayChildren: 1.2, staggerChildren: 0.22 } } }}
+            variants={{ visible: { transition: { delayChildren: reduced ? 0 : 1.2, staggerChildren: reduced ? 0 : 0.22 } } }}
             className="mt-9 flex flex-wrap items-center justify-center gap-3"
           >
             {selectedMoods.map((m) => (
@@ -173,7 +199,7 @@ export default function CelebrationReveal({ moods, selectedGenres, favoriteMovie
         <motion.p
           initial={{ opacity: 0, y: 8 }}
           animate={{ opacity: 0.72, y: 0 }}
-          transition={{ duration: reduced ? 0.4 : 0.9, delay: 2.4, ease: EASE }}
+          transition={{ duration: reduced ? 0.4 : 0.9, delay: reduced ? 0 : 2.4, ease: EASE }}
           className="mt-6 text-[13px] tracking-[0.02em] text-white/65"
         >
           {filmCount} film{filmCount === 1 ? '' : 's'}
@@ -188,7 +214,7 @@ export default function CelebrationReveal({ moods, selectedGenres, favoriteMovie
             <motion.p
               initial={{ opacity: 0, y: 8 }}
               animate={{ opacity: 0.55, y: 0 }}
-              transition={{ duration: reduced ? 0.4 : 0.9, delay: 3.0, ease: EASE }}
+              transition={{ duration: reduced ? 0.4 : 0.9, delay: reduced ? 0 : 3.0, ease: EASE }}
               className="mb-5 text-[12px] tracking-[0.02em] text-white/55"
             >
               From the films you’ve loved
@@ -196,7 +222,7 @@ export default function CelebrationReveal({ moods, selectedGenres, favoriteMovie
             <motion.div
               initial="hidden"
               animate="visible"
-              variants={{ visible: { transition: { delayChildren: 3.4, staggerChildren: 0.18 } } }}
+              variants={{ visible: { transition: { delayChildren: reduced ? 0 : 3.4, staggerChildren: reduced ? 0 : 0.18 } } }}
               className="flex items-end justify-center gap-2.5 sm:gap-3.5"
             >
               {posterFilms.map((film, i) => {
@@ -245,7 +271,7 @@ export default function CelebrationReveal({ moods, selectedGenres, favoriteMovie
                         initial={{ opacity: 0, scale: 0.6 }}
                         animate={{ opacity: 1, scale: 1 }}
                         transition={{
-                          delay: 3.4 + i * 0.18 + 0.55,
+                          delay: reduced ? 0 : 3.4 + i * 0.18 + 0.55,
                           duration: reduced ? 0.3 : 0.6,
                           ease: EASE,
                         }}
@@ -266,7 +292,7 @@ export default function CelebrationReveal({ moods, selectedGenres, favoriteMovie
         <motion.div
           initial={{ opacity: 0, y: 16 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: reduced ? 0.5 : 1.2, delay: 5.5, ease: EASE }}
+          transition={{ duration: reduced ? 0.5 : 1.2, delay: reduced ? 0 : 5.5, ease: EASE }}
           className="mt-12"
         >
           <h1
@@ -291,7 +317,7 @@ export default function CelebrationReveal({ moods, selectedGenres, favoriteMovie
         <motion.div
           initial={{ opacity: 0, y: 14 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: reduced ? 0.5 : 1.4, delay: 7.6, ease: EASE }}
+          transition={{ duration: reduced ? 0.5 : 1.4, delay: reduced ? 0 : 7.6, ease: EASE }}
           className="mt-10 max-w-[460px]"
         >
           <p className="ob-display text-[10px] font-semibold uppercase tracking-[0.32em] text-purple-200/65">


### PR DESCRIPTION
Render-faithful accessibility/semantic foundation for the final onboarding surface (F2.20), plus the missing finish-flow test net. **No visual/content simplification** — the Sparkles icon, "Profile tuned · Edition №001", mood pills, stats line, poster mosaic, ♥ loved badges, particles, and all normal-motion choreography stay (that is F2.21). Normal-motion visible output is unchanged.

## The old broad live-region problem
The visible animated content wrapper carried `role="status"` + `aria-live="polite"` around **~7 stages that mount over ~9s** → competing, jumbled, fragmented polite announcements as each Framer stage entered, with an `<h1>` non-standardly inside a live region.

## The new single atomic completion announcement
`role="status"`/`aria-live` is **removed from the visible wrapper** (it becomes ordinary content). One dedicated **`sr-only`** node now carries `role="status"` `aria-live="polite"` **`aria-atomic="true"`**; its text is **empty on first render and set once after mount** (`useState('')` + `useEffect`) so assistive tech hears a single coherent change rather than a 9s drip:
> `Your taste is tuned[ with {t1}[ and {t2}][, {t1}, {t2}, and more]]. Opening your first picks.`

No count tally, no long poster list, no per-stage announcements; missing titles degrade cleanly (no `undefined`/blank separators).

## The visible h1 remains the only h1
`<h1>Tonight is yours.</h1>` stays the sole heading (already present in the DOM from mount), not `aria-hidden`, no second sr-only heading.

## Reduced-motion delay compression
Every staged `delay` + `delayChildren` + `staggerChildren` is now `reduced ? 0 : <existing>` (kicker, mood pills, stats, poster caption, poster mosaic, heart badges, editorial close, coaching). **Normal-motion values are byte-identical**; reduced-motion users get the complete static composition immediately. The frozen 12s hold stays owned by `Onboarding.jsx`. No focus movement; decorative Sparkles/grain/particles/♥/posters stay `aria-hidden` (posters `alt=""`).

## Finish-flow ordering tests
`OnboardingFinishFlow.test.jsx` drives the **real `handleFinish`** (via the rating step's 700ms auto-finish, `Onboarding.jsx` unedited) and asserts: `completeOnboarding` called once with `{ markAuthComplete: false }`; `prefetchHomeData` started; `navigate('/discover')` fires **before** `markOnboardingAuthComplete()`; `markOnboardingAuthComplete()` exactly once; `/discover` the sole destination; and **no** navigation/auth-flip before the 12s hold. Ordering is asserted via an explicit call log. `CelebrationReveal.test.jsx` covers one h1, one polite+atomic sr-only status off the wrapper, announcement variants, data variants (1/3 moods, 5 films, missing poster, no-loved, mixed liked/loved, empty), no focus move, decorative `alt=""`, and reduced-motion structure.

## Confirmations
- **Visible normal-motion presentation is unchanged** — only the `sr-only` status node + the reduced-motion delay guards changed; every `reduced ? 0 : X` preserves the original `X`.
- **The 12-second hold, 900ms fade, auth ordering, Supabase writes, and `/discover` destination are unchanged** — `Onboarding.jsx` is untouched (`CELEBRATION_MIN_MS=12000`, `markAuthComplete:false`, the 900ms fade, `navigate('/discover')` before `markOnboardingAuthComplete()` all intact).
- No Skip control added; no Sparkles/Edition/heart/stats/particle removal (F2.21).

## Validation
- `npm run lint` → clean
- `npx vitest run src/features/onboarding/__tests__/ src/shared/lib/auth/__tests__/onboardingStatus.test.js` → 140 passed (12 files); finish-flow stable 5×
- `npm run build` → ✓
- `npm run test` (full) → 644 passed (58 files)
- Playwright 360×640 / 390×844 / 430×932 / 768×1024 / 1280×720 / 1440×900: no horizontal overflow, exactly one polite+atomic sr-only status, one h1 "Tonight is yours.", 5 posters all `alt=""`. *(Reduced-motion delays→0 is enforced by the `reduced ? 0` guards + the unit structural test; a live framer reduced-motion run needs the gated onboarding flow, which was not reset.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
