### PR TITLE
Simplify and polish CelebrationReveal

### DIFF
--- a/src/features/onboarding/__tests__/CelebrationReveal.test.jsx
+++ b/src/features/onboarding/__tests__/CelebrationReveal.test.jsx
@@ -1,15 +1,20 @@
 // src/features/onboarding/__tests__/CelebrationReveal.test.jsx
-// F2.20 — CelebrationReveal a11y/semantic foundation. ONE concise sr-only
-// completion status (not a multi-stage live region), a single visible h1, no
-// focus movement, and render-safety across data variants. Reduced-motion VISUAL
-// timing (delays→0) is verified in Playwright; jsdom checks structure only.
+// F2.20 a11y foundation (one sr-only atomic status, single visible h1, no focus
+// movement) + F2.21 visual polish (de-gamified editorial spine, no infinite
+// motion). Reduced-motion VISUAL timing (delays→0) is verified in Playwright;
+// jsdom checks structure + the source-level motion/artifact contracts only.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, within } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 
 vi.mock('@/shared/api/tmdb', () => ({ tmdbImg: (p) => `https://img/${p}` }))
 
 import CelebrationReveal from '../components/CelebrationReveal'
+import { MOODS } from '../data'
+
+const SRC = readFileSync(resolve(import.meta.dirname, '../components/CelebrationReveal.jsx'), 'utf8')
 
 const film = (id, title, poster = `/${id}.jpg`) => ({ id, title, poster_path: poster, release_date: '2014-01-01' })
 const props = (over = {}) => ({
@@ -91,8 +96,12 @@ describe('CelebrationReveal — content + data variants', () => {
   it('renders the apex + coaching copy', () => {
     render(<CelebrationReveal {...props()} />)
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/tonight is\s*yours\./i)
-    expect(screen.getByText(/see films you already know/i)).toBeInTheDocument()
-    expect(screen.getByText(/mark watched/i)).toBeInTheDocument()
+    expect(screen.getByText(/your taste, tuned/i)).toBeInTheDocument()
+    expect(screen.getByText(/your first signals are in/i)).toBeInTheDocument()
+    expect(screen.getByText(/from your picks/i)).toBeInTheDocument()
+    expect(screen.getByText(/next up/i)).toBeInTheDocument()
+    expect(screen.getByText(/tell us how tonight feels/i)).toBeInTheDocument()
+    expect(screen.getByText(/one film for your night/i)).toBeInTheDocument()
   })
 
   it.each([
@@ -123,7 +132,69 @@ describe('CelebrationReveal — reduced motion (structure; visual timing is Play
     render(<CelebrationReveal {...props()} />)
     expect(document.querySelectorAll('[role="status"]')).toHaveLength(1)
     expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1)
-    expect(screen.getByText(/see films you already know/i)).toBeInTheDocument()
+    expect(screen.getByText(/tell us how tonight feels/i)).toBeInTheDocument()
     expect(document.querySelectorAll('img')).toHaveLength(5)
+  })
+})
+
+describe('CelebrationReveal — F2.21 removed artifacts', () => {
+  it('renders no Sparkles/icon svg, no Edition text, no heart, no Mark Watched', () => {
+    const { container } = render(<CelebrationReveal {...props()} />)
+    expect(container.querySelectorAll('svg')).toHaveLength(0)
+    expect(screen.queryByText(/edition/i)).toBeNull()
+    expect(container.textContent).not.toMatch(/♥/)
+    expect(screen.queryByText(/mark watched/i)).toBeNull()
+    expect(screen.queryByText(/sharpens by tomorrow/i)).toBeNull()
+  })
+
+  it('shows no count-receipt stats (no "N films · N genres · N loved")', () => {
+    const { container } = render(<CelebrationReveal {...props()} />)
+    expect(container.textContent).not.toMatch(/\d+\s*(films?|genres?)\b/i)
+    expect(container.textContent).not.toMatch(/\d+\s*(loved|liked)\b/i)
+  })
+
+  it('source contains no Sparkles import, no CelebrationParticles, no Edition №001', () => {
+    expect(SRC).not.toMatch(/lucide-react/)
+    expect(SRC).not.toMatch(/Sparkles/)
+    expect(SRC).not.toMatch(/CelebrationParticles/)
+    expect(SRC).not.toMatch(/Edition №001/)
+    expect(SRC).not.toMatch(/Mark Watched/)
+    expect(SRC).not.toMatch(/sharpens by tomorrow/)
+  })
+})
+
+describe('CelebrationReveal — retained editorial spine', () => {
+  it('renders the kicker, taste line, poster caption, apex, and Next-up coaching', () => {
+    render(<CelebrationReveal {...props()} />)
+    expect(screen.getByText(/your taste, tuned/i)).toBeInTheDocument()
+    expect(screen.getByText(/your first signals are in/i)).toBeInTheDocument()
+    expect(screen.getByText(/from your picks/i)).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/tonight is\s*yours\./i)
+    expect(screen.getByText('Next up')).toBeInTheDocument()
+    expect(screen.getByText(/with the case for why it fits/i)).toBeInTheDocument()
+  })
+
+  it('shows the selected mood pills (by their real labels)', () => {
+    render(<CelebrationReveal {...props({ moods: ['cozy', 'mythic'] })} />)
+    expect(screen.getByText(MOODS.find(m => m.key === 'cozy').label)).toBeInTheDocument()
+    expect(screen.getByText(MOODS.find(m => m.key === 'mythic').label)).toBeInTheDocument()
+  })
+
+  it('taste line degrades cleanly without ratings (uses "the films you chose")', () => {
+    render(<CelebrationReveal {...props({ ratings: {} })} />)
+    expect(screen.getByText(/the films you chose/i)).toBeInTheDocument()
+    expect(screen.queryByText(/how those films landed/i)).toBeNull()
+  })
+})
+
+describe('CelebrationReveal — motion contracts (source-level)', () => {
+  it('contains NO CelebrationReveal-owned infinite loop', () => {
+    expect(SRC).not.toMatch(/repeat:\s*Infinity/)
+  })
+
+  it('preserves the 900ms fade-out and the F2.20 reduced-motion delay guards', () => {
+    expect(SRC).toMatch(/fadingOut \? 0\.9/)          // 900ms fade preserved
+    expect(SRC).toMatch(/reduced \? 0 :/)              // reduced-motion delays → 0
+    expect(SRC).not.toMatch(/scale:\s*\[1, 1\.012, 1\]/) // no whole-stage breathing
   })
 })

--- a/src/features/onboarding/components/CelebrationReveal.jsx
+++ b/src/features/onboarding/components/CelebrationReveal.jsx
@@ -1,8 +1,7 @@
 import { useEffect, useState } from 'react'
 import { motion, useReducedMotion } from 'framer-motion'
-import { Sparkles } from 'lucide-react'
 import { tmdbImg } from '@/shared/api/tmdb'
-import { MOODS, GENRES, SENTIMENT_RATINGS } from '../data'
+import { MOODS } from '../data'
 import AmbientGlow from './AmbientGlow'
 
 // One concise completion sentence for the dedicated sr-only live region — folds
@@ -15,27 +14,40 @@ function buildAnnouncement(titles) {
   return `Your taste is tuned with ${titles[0]}, ${titles[1]}, and more. Opening your first picks.`
 }
 
+// One honest, sentence-case taste line built from the captured signals — no count
+// receipt, no percentages, no inference, no dashboard vocabulary. Degrades
+// gracefully when optional data is sparse (no broken punctuation).
+function buildTasteLine({ hasMoods, hasGenres, hasRatings, hasFilms }) {
+  const parts = []
+  if (hasMoods) parts.push('your moods')
+  if (hasGenres) parts.push('your genres')
+  if (hasRatings) parts.push('how those films landed')
+  else if (hasFilms) parts.push('the films you chose')
+  if (parts.length === 0) return 'Your first signals are in.'
+  const list = parts.length === 1
+    ? parts[0]
+    : `${parts.slice(0, -1).join(', ')}${parts.length > 2 ? ',' : ''} and ${parts[parts.length - 1]}`
+  return `Your first signals are in — ${list}.`
+}
+
 // === Celebration reveal ====================================================
-// Multi-stage immersive reveal that plays after the last rating commits.
-// Designed for calm: gentle easeOut curves, generous overlap between stages,
-// spring physics on the entrances, subtle breathing motion on landed elements.
-// Sentence-case body text + restraint on all-caps for dyslexic readers.
-// AmbientGlow inherits the user's mood picks so the palette is personal.
+// The final onboarding surface + ~12s write-cover before /discover. A calm,
+// personal editorial reveal — mood atmosphere → your mood pills → a taste line →
+// your poster mosaic → "Tonight is yours." → one coaching beat. NO infinite
+// motion: every entrance resolves once and then settles. AmbientGlow + static
+// grain are the only ambient layers. The frozen 12s hold + 900ms fade-out are
+// owned upstream by Onboarding.jsx; this component only reads `fadingOut`.
 //
-// Stages (timeline in seconds from mount; durations overlap by design):
-//   0.0  Sparkles icon eases in + slow rotation
-//   0.4  Brand wordmark fades up — small, warm
-//   1.2  Mood pills spring in (stagger)
-//   2.4  Stats line eases in
-//   3.4  Poster mosaic — gentle cascade with spring landing
-//   5.5  "Tonight is yours." editorial close
-//   7.6  Coaching beat — cold-start expectation-setting + Mark Watched hint
-//        (Stage 5; held until fade-out at ~12s so it has reading time before
-//         /discover takes over — also smooths the transition seam.)
-//
-// `prefers-reduced-motion` users get the complete composition immediately: every
-// stage delay collapses to 0 (no staggered wait), movement is removed, and
-// particles are suppressed. The parent's frozen 12s hold is preserved upstream.
+// Internal stage timeline (NORMAL motion, seconds from mount; every delay
+// collapses to 0 under prefers-reduced-motion, F2.20):
+//   0.4  "Your taste, tuned" kicker
+//   1.1  mood pills (stagger)
+//   2.0  taste line
+//   2.6  poster caption
+//   3.0  poster mosaic (stagger)
+//   4.9  "Tonight is yours."
+//   6.3  coaching beat ("Next up")
+// Settles ~7s, then holds for ~5s reading time until the upstream fade at ~12s.
 const EASE = [0.16, 1, 0.3, 1]                          // quartOut — long settle, no overshoot
 const SPRING = { type: 'spring', stiffness: 70, damping: 18, mass: 0.9 }
 
@@ -47,19 +59,16 @@ export default function CelebrationReveal({ moods, selectedGenres, favoriteMovie
     .map(key => MOODS.find(m => m.key === key))
     .filter(Boolean)
 
-  // Genre labels in the user's selected order.
-  const selectedGenreLabels = (selectedGenres || [])
-    .map(id => GENRES.find(g => g.id === id)?.name)
-    .filter(Boolean)
-
-  // Sentiment breakdown (loved/liked counts).
-  const ratingValues = Object.values(ratings || {})
-  const lovedCount = ratingValues.filter(r => r === SENTIMENT_RATINGS.loved).length
-  const likedCount = ratingValues.filter(r => r === SENTIMENT_RATINGS.liked).length
-  const filmCount  = (favoriteMovies || []).length
-
   // Posters from their picks (truncate to 5 even if more exist).
   const posterFilms = (favoriteMovies || []).slice(0, 5)
+
+  // Honest taste line from the captured signals (no counts).
+  const tasteLine = buildTasteLine({
+    hasMoods: selectedMoods.length > 0,
+    hasGenres: (selectedGenres || []).length > 0,
+    hasRatings: Object.keys(ratings || {}).length > 0,
+    hasFilms: (favoriteMovies || []).length > 0,
+  })
 
   // Single, concise completion announcement. Empty on first render, then set
   // ONCE after mount so assistive tech hears a real content change ("" → text)
@@ -73,16 +82,16 @@ export default function CelebrationReveal({ moods, selectedGenres, favoriteMovie
   }, [announcementText])
 
   return (
-    <div className="onboarding fixed inset-0 z-9999 flex flex-col items-center justify-center bg-black overflow-hidden">
+    <div className="onboarding fixed inset-0 z-9999 overflow-x-hidden overflow-y-auto bg-black">
       {/* The ONLY live region — one concise polite+atomic completion status. */}
       <p className="sr-only" role="status" aria-live="polite" aria-atomic="true">
         {announcement}
       </p>
 
-      {/* Slow, deep ambient glow — mood-tinted */}
+      {/* Slow, deep ambient glow — mood-tinted. The sole ambient layer. */}
       <AmbientGlow moods={moods} />
 
-      {/* Soft grain (very subtle, helps the void feel like a screen) */}
+      {/* Soft grain (very subtle, helps the void feel like a screen) — static. */}
       <div
         aria-hidden="true"
         className="pointer-events-none absolute inset-0 opacity-50"
@@ -92,80 +101,38 @@ export default function CelebrationReveal({ moods, selectedGenres, favoriteMovie
         }}
       />
 
-      {/* Drifting particles — suppressed for reduced-motion. Also fades to 0
-         alongside the main content during fade-out, so they don't pop. */}
-      {!reduced && (
-        <motion.div
-          className="absolute inset-0 z-0"
-          aria-hidden="true"
-          initial={false}
-          animate={{ opacity: fadingOut ? 0 : 1 }}
-          transition={{ duration: 0.9, ease: EASE }}
-        >
-          <CelebrationParticles moods={selectedMoods} />
-        </motion.div>
-      )}
-
-      {/* Background "breathing" — slow scale on the whole stage. Gentle enough
-         to feel like ambient life, not motion. Skipped for reduced-motion.
-         When fadingOut, the entire content tweens to opacity 0 over 900ms;
-         the black backdrop stays so the screen calmly goes dark before
-         navigate fires (/discover's own overlay then fades up over 1.4s to
-         reveal the page). Read together, ~2.3s of cinematic darkness. */}
+      {/* Content — settled (no breathing loop). When fadingOut, the whole stage
+         tweens to opacity 0 over 900ms (hard-matched to Onboarding.jsx's fade
+         wait); the black backdrop stays so the screen calmly goes dark before
+         navigate fires. Scroll-safe on short viewports (no horizontal scroll). */}
       <motion.div
-        className="relative z-10 flex w-full max-w-2xl flex-col items-center px-6 text-center"
+        className="ff-cel-content relative z-10 mx-auto flex min-h-full w-full max-w-2xl flex-col items-center justify-center px-6 text-center"
         initial={false}
-        animate={
-          fadingOut
-            ? { opacity: 0, scale: 1 }
-            : reduced
-              ? { opacity: 1 }
-              : { opacity: 1, scale: [1, 1.012, 1] }
-        }
-        transition={
-          fadingOut
-            ? { duration: 0.9, ease: EASE }
-            : reduced
-              ? { duration: 0 }
-              : { duration: 8, repeat: Infinity, ease: 'easeInOut' }
-        }
+        animate={{ opacity: fadingOut ? 0 : 1 }}
+        transition={{ duration: fadingOut ? 0.9 : 0, ease: EASE }}
       >
-        {/* Sparkles + kicker — Stage 0 */}
-        <motion.div
-          initial={{ opacity: 0, scale: 0.85 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ duration: reduced ? 0.4 : 1.0, ease: EASE }}
-          className="flex flex-col items-center"
+        {/* Kicker — quiet editorial eyebrow (replaces the old icon + edition mark) */}
+        <motion.p
+          initial={{ opacity: 0, y: 6 }}
+          animate={{ opacity: 0.9, y: 0 }}
+          transition={{ duration: reduced ? 0.4 : 0.9, delay: reduced ? 0 : 0.4, ease: EASE }}
+          className="ob-eyebrow inline-flex items-center text-purple-200/80"
         >
-          {/* Slow rotation + breath on the sparkles */}
-          <motion.div
-            animate={reduced ? undefined : { rotate: 360 }}
-            transition={reduced ? undefined : { duration: 22, repeat: Infinity, ease: 'linear' }}
-          >
-            <motion.div
-              animate={reduced ? undefined : { scale: [1, 1.08, 1] }}
-              transition={reduced ? undefined : { duration: 3.4, repeat: Infinity, ease: 'easeInOut' }}
-            >
-              <Sparkles className="h-10 w-10" style={{ color: 'rgb(192, 132, 252)' }} aria-hidden="true" />
-            </motion.div>
-          </motion.div>
-          <motion.p
-            initial={{ opacity: 0, y: 6 }}
-            animate={{ opacity: 0.85, y: 0 }}
-            transition={{ duration: reduced ? 0.4 : 0.9, delay: reduced ? 0 : 0.4, ease: EASE }}
-            className="ob-display mt-6 text-[11px] font-semibold uppercase tracking-[0.32em] text-purple-200/85"
-          >
-            Profile tuned · Edition №001
-          </motion.p>
-        </motion.div>
+          <span
+            aria-hidden="true"
+            className="mr-2.5 inline-block h-px w-5 align-middle"
+            style={{ background: 'rgba(192,132,252,0.5)' }}
+          />
+          Your taste, tuned
+        </motion.p>
 
-        {/* Mood pills — Stage 1, spring in with stagger */}
+        {/* Mood pills — settle once, no breathing loop */}
         {selectedMoods.length > 0 && (
           <motion.div
             initial="hidden"
             animate="visible"
-            variants={{ visible: { transition: { delayChildren: reduced ? 0 : 1.2, staggerChildren: reduced ? 0 : 0.22 } } }}
-            className="mt-9 flex flex-wrap items-center justify-center gap-3"
+            variants={{ visible: { transition: { delayChildren: reduced ? 0 : 1.1, staggerChildren: reduced ? 0 : 0.22 } } }}
+            className="mt-6 flex flex-wrap items-center justify-center gap-2.5 sm:mt-9 sm:gap-3"
           >
             {selectedMoods.map((m) => (
               <motion.span
@@ -175,60 +142,50 @@ export default function CelebrationReveal({ moods, selectedGenres, favoriteMovie
                   visible: { opacity: 1, y: 0, scale: 1 },
                 }}
                 transition={reduced ? { duration: 0.4, ease: EASE } : SPRING}
-                className="ob-display rounded-full px-5 py-2 text-[14px] font-semibold tracking-[0.04em] text-white"
+                className="ob-display rounded-full px-4 py-2 text-[13px] font-semibold tracking-[0.04em] text-white sm:px-5 sm:text-[14px]"
                 style={{
                   background: `rgba(${m.rgb}, 0.18)`,
                   border: `1px solid rgba(${m.rgb}, 0.55)`,
                   boxShadow: `0 0 22px rgba(${m.rgb}, 0.30), inset 0 0 0 1px rgba(${m.rgb}, 0.1)`,
                 }}
               >
-                {/* Breathing tint — very subtle pulse keeps the pill alive */}
-                <motion.span
-                  className="block"
-                  animate={reduced ? undefined : { opacity: [1, 0.78, 1] }}
-                  transition={reduced ? undefined : { duration: 4.5, repeat: Infinity, ease: 'easeInOut' }}
-                >
-                  {m.label}
-                </motion.span>
+                {m.label}
               </motion.span>
             ))}
           </motion.div>
         )}
 
-        {/* Stats line — Stage 2 — sentence case, easier to read */}
+        {/* Taste line — one honest sentence (replaces the count receipt) */}
         <motion.p
           initial={{ opacity: 0, y: 8 }}
           animate={{ opacity: 0.72, y: 0 }}
-          transition={{ duration: reduced ? 0.4 : 0.9, delay: reduced ? 0 : 2.4, ease: EASE }}
-          className="mt-6 text-[13px] tracking-[0.02em] text-white/65"
+          transition={{ duration: reduced ? 0.4 : 0.9, delay: reduced ? 0 : 2.0, ease: EASE }}
+          className="mt-5 max-w-md text-[13px] leading-relaxed tracking-[0.01em] text-white/65 sm:mt-6 sm:text-sm"
+          style={{ textWrap: 'pretty' }}
         >
-          {filmCount} film{filmCount === 1 ? '' : 's'}
-          {selectedGenreLabels.length > 0 && ` · ${selectedGenreLabels.length} genre${selectedGenreLabels.length === 1 ? '' : 's'}`}
-          {lovedCount > 0 && ` · ${lovedCount} loved`}
-          {likedCount > 0 && ` · ${likedCount} liked`}
+          {tasteLine}
         </motion.p>
 
-        {/* Poster mosaic — Stage 3, spring landing with gentle float */}
+        {/* Poster mosaic — the celebration's main visual payoff. Each poster
+           lands once and stays still (no float, no heart badge). */}
         {posterFilms.length > 0 && (
-          <div className="mt-10 w-full">
+          <div className="mt-7 w-full sm:mt-10">
             <motion.p
               initial={{ opacity: 0, y: 8 }}
               animate={{ opacity: 0.55, y: 0 }}
-              transition={{ duration: reduced ? 0.4 : 0.9, delay: reduced ? 0 : 3.0, ease: EASE }}
-              className="mb-5 text-[12px] tracking-[0.02em] text-white/55"
+              transition={{ duration: reduced ? 0.4 : 0.9, delay: reduced ? 0 : 2.6, ease: EASE }}
+              className="mb-4 text-[12px] tracking-[0.02em] text-white/55 sm:mb-5"
             >
-              From the films you’ve loved
+              From your picks
             </motion.p>
             <motion.div
               initial="hidden"
               animate="visible"
-              variants={{ visible: { transition: { delayChildren: reduced ? 0 : 3.4, staggerChildren: reduced ? 0 : 0.18 } } }}
-              className="flex items-end justify-center gap-2.5 sm:gap-3.5"
+              variants={{ visible: { transition: { delayChildren: reduced ? 0 : 3.0, staggerChildren: reduced ? 0 : 0.18 } } }}
+              className="flex items-end justify-center gap-2 sm:gap-3.5"
             >
               {posterFilms.map((film, i) => {
-                const rating = ratings?.[film.id]
-                const wasLoved = rating === SENTIMENT_RATINGS.loved
-                // Slight rotation per poster — gives a hand-laid-out feel.
+                // Subtle hand-laid-out rotation, fanned around centre.
                 const rotate = (i - (posterFilms.length - 1) / 2) * 3.2
                 return (
                   <motion.div
@@ -238,48 +195,20 @@ export default function CelebrationReveal({ moods, selectedGenres, favoriteMovie
                       visible: { opacity: 1, y: 0, scale: 1, rotate },
                     }}
                     transition={reduced ? { duration: 0.4, ease: EASE } : { ...SPRING, stiffness: 60, damping: 16 }}
-                    className="relative h-28 w-[68px] flex-none overflow-hidden rounded-xl shadow-[0_12px_28px_rgba(0,0,0,0.55)] ring-1 ring-white/10 sm:h-36 sm:w-24"
+                    className="ff-cel-poster relative h-[78px] w-[52px] flex-none overflow-hidden rounded-xl shadow-[0_12px_28px_rgba(0,0,0,0.55)] ring-1 ring-white/10 sm:h-36 sm:w-24"
                     style={{ originY: 1 }}
                   >
-                    {/* Gentle float after landing — feels like the posters are breathing */}
-                    <motion.div
-                      className="h-full w-full"
-                      animate={reduced ? undefined : { y: [0, -3, 0] }}
-                      transition={reduced ? undefined : {
-                        duration: 5 + i * 0.4,
-                        repeat: Infinity,
-                        ease: 'easeInOut',
-                        delay: 3.4 + i * 0.18 + 0.6,
-                      }}
-                    >
-                      {film.poster_path ? (
-                        <img
-                          src={tmdbImg(film.poster_path, 'w185')}
-                          alt=""
-                          loading="lazy"
-                          className="h-full w-full object-cover"
-                        />
-                      ) : (
-                        <div className="grid h-full w-full place-items-center bg-white/4 text-[10px] text-white/40">
-                          {film.title?.slice(0, 12) ?? ''}
-                        </div>
-                      )}
-                    </motion.div>
-                    {/* Pink heart for loved films — appears after the poster lands */}
-                    {wasLoved && (
-                      <motion.div
-                        initial={{ opacity: 0, scale: 0.6 }}
-                        animate={{ opacity: 1, scale: 1 }}
-                        transition={{
-                          delay: reduced ? 0 : 3.4 + i * 0.18 + 0.55,
-                          duration: reduced ? 0.3 : 0.6,
-                          ease: EASE,
-                        }}
-                        className="absolute right-1.5 top-1.5 grid h-5 w-5 place-items-center rounded-full bg-pink-500/95 text-[10px] text-white shadow-[0_0_14px_rgba(236,72,153,0.7)]"
-                        aria-hidden="true"
-                      >
-                        ♥
-                      </motion.div>
+                    {film.poster_path ? (
+                      <img
+                        src={tmdbImg(film.poster_path, 'w185')}
+                        alt=""
+                        loading="lazy"
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <div className="grid h-full w-full place-items-center bg-white/4 px-1 text-center text-[10px] leading-tight text-white/40">
+                        {film.title?.slice(0, 14) ?? ''}
+                      </div>
                     )}
                   </motion.div>
                 )
@@ -288,12 +217,12 @@ export default function CelebrationReveal({ moods, selectedGenres, favoriteMovie
           </div>
         )}
 
-        {/* Editorial close — Stage 4 */}
+        {/* Editorial apex — the sole h1, kept verbatim */}
         <motion.div
           initial={{ opacity: 0, y: 16 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: reduced ? 0.5 : 1.2, delay: reduced ? 0 : 5.5, ease: EASE }}
-          className="mt-12"
+          transition={{ duration: reduced ? 0.5 : 1.2, delay: reduced ? 0 : 4.9, ease: EASE }}
+          className="mt-9 sm:mt-12"
         >
           <h1
             className="ob-display text-4xl font-normal leading-[1.05] text-white sm:text-5xl md:text-6xl"
@@ -306,79 +235,31 @@ export default function CelebrationReveal({ moods, selectedGenres, favoriteMovie
           </h1>
         </motion.div>
 
-        {/* Coaching — Stage 5. The lead-out beat before /discover takes
-           over. Sets cold-start expectations (engine will surface films
-           you already know) and frames "Mark Watched" as the corrective
-           signal that sharpens future picks. Held for ~4s before
-           fade-out so the message has reading time + the seam to
-           /discover feels guided rather than abrupt. Replaces the older
-           "Opening your first edition…" stage — the coaching IS the
-           lead-out now. */}
+        {/* Coaching — the lead-out beat, accurate to what /discover opens with
+           (re-asks the night's mood, then reveals one cased pick). No Mark
+           Watched / next-day-cadence promise. Held for reading time before fade. */}
         <motion.div
           initial={{ opacity: 0, y: 14 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: reduced ? 0.5 : 1.4, delay: reduced ? 0 : 7.6, ease: EASE }}
-          className="mt-10 max-w-[460px]"
+          transition={{ duration: reduced ? 0.5 : 1.4, delay: reduced ? 0 : 6.3, ease: EASE }}
+          className="mt-8 max-w-[460px] sm:mt-10"
         >
-          <p className="ob-display text-[10px] font-semibold uppercase tracking-[0.32em] text-purple-200/65">
+          <p className="ob-eyebrow inline-flex items-center text-purple-200/65">
             <span
               aria-hidden="true"
-              className="mr-2 inline-block h-px w-4 align-middle"
-              style={{ background: 'rgba(192,132,252,0.55)' }}
+              className="mr-2.5 inline-block h-px w-5 align-middle"
+              style={{ background: 'rgba(192,132,252,0.5)' }}
             />
-            One last thing
+            Next up
           </p>
           <p
-            className="mt-5 text-[15px] leading-[1.65] text-white/72"
+            className="mt-4 text-[14px] leading-[1.6] text-white/72 sm:mt-5 sm:text-[15px]"
             style={{ textWrap: 'pretty' }}
           >
-            You&rsquo;ll see films you already know &mdash; that&rsquo;s the engine reaching. Tap{' '}
-            <em className="not-italic font-semibold text-purple-100">Mark Watched</em>{' '}
-            on any you&rsquo;ve seen, and FeelFlick sharpens by tomorrow.
+            Tell us how tonight feels. A few quick questions, then one film for your night &mdash; with the case for why it fits.
           </p>
         </motion.div>
       </motion.div>
-    </div>
-  )
-}
-
-// === Celebration particles ================================================
-// 14 drifting points tinted by the user's selected mood colours. Slow upward
-// drift with easeInOut curve — feels like dust in light rather than linear
-// flecks. Suppressed entirely for prefers-reduced-motion.
-function CelebrationParticles({ moods }) {
-  const rgbList = (moods || []).map(m => m.rgb)
-  const fallback = ['192, 132, 252', '236, 72, 153']
-  const palette = rgbList.length > 0 ? rgbList : fallback
-  // Deterministic layout per mount — keys / positions stable from index.
-  const points = Array.from({ length: 14 }, (_, i) => ({
-    i,
-    x: ((i * 73) % 100),
-    y: 70 + ((i * 41) % 30),
-    size: 2 + (i % 3),
-    rgb: palette[i % palette.length],
-    duration: 12 + (i % 5) * 2.4,        // 12-21s — much slower than before
-    delay: (i * 0.42) % 6,
-  }))
-  return (
-    <div className="pointer-events-none absolute inset-0 z-0" aria-hidden="true">
-      {points.map(p => (
-        <motion.span
-          key={p.i}
-          className="absolute rounded-full"
-          style={{
-            left: `${p.x}%`,
-            top: `${p.y}%`,
-            width: p.size,
-            height: p.size,
-            background: `rgba(${p.rgb}, 0.85)`,
-            boxShadow: `0 0 10px rgba(${p.rgb}, 0.6)`,
-          }}
-          initial={{ opacity: 0, y: 0 }}
-          animate={{ opacity: [0, 0.7, 0], y: -360 }}
-          transition={{ duration: p.duration, delay: p.delay, repeat: Infinity, ease: 'easeInOut' }}
-        />
-      ))}
     </div>
   )
 }

--- a/src/features/onboarding/onboarding.css
+++ b/src/features/onboarding/onboarding.css
@@ -71,3 +71,21 @@
 .onboarding .ob-orb-breathe {
   animation: ob-orb-breathe 6s ease-in-out infinite;
 }
+
+/* === CelebrationReveal — short/narrow-viewport hardening ==================
+ * The final reveal lives in a fixed, scroll-safe root (overflow-y-auto, no
+ * horizontal scroll). The content column centres on tall viewports and tightens
+ * its vertical padding on short ones so the h1 + coaching never clip. Tailwind
+ * has no max-height variant, so the height query lives here (CelebrationReveal-
+ * local, not a global selector). */
+.onboarding .ff-cel-content {
+  padding-top: 2.75rem;
+  padding-bottom: 2.75rem;
+}
+@media (max-height: 760px) {
+  .onboarding .ff-cel-content {
+    padding-top: 1.25rem;
+    padding-bottom: 1.25rem;
+    gap: 0;
+  }
+}


### PR DESCRIPTION
Visual/content follow-up to the merged F2.20 a11y foundation (F2.21). **Protect and simplify** — keep the emotional spine, retire the gamified/unsupported/dashboard artifacts.

## Protected emotional spine
Personal mood atmosphere (AmbientGlow), the user's selected **mood pills**, the user's **poster mosaic**, **`Tonight is yours.`**, one concise coaching beat, static grain, and the cinematic fade-to-black handoff.

## Removed unsupported / gamified artifacts
- The generic **Sparkles** hero icon (+ its 22s rotation + 3.4s breath).
- **`Profile tuned · Edition №001`** — a hardcoded edition series that never existed and collided with `/discover`'s "edition" meaning.
- The **count-receipt stats** line (films · genres · loved · liked).
- The **♥ loved-film heart badges** — the symbol F2.18 retired from RatingStep.

## Removed infinite-motion systems
**CelebrationReveal now contains no `repeat: Infinity`.** Deleted `CelebrationParticles` (14 drifting points), the whole-stage breathing (`scale:[1,1.012,1]`), the mood-pill breathing, and the poster float. AmbientGlow + static grain are the only ambient layers; every entrance resolves once and settles.

## New honest taste sentence
Replaced the receipt with one sentence-case line from the captured signals: *"Your first signals are in — your moods, your genres, and how those films landed."* (uses *"…the films you chose."* when ratings are absent; degrades cleanly when sparse). No counts, percentages, scores, or inference.

## Corrected poster caption
*"From the films you've loved"* → **"From your picks"** (the mosaic can include Okay/Liked films, so "loved" wasn't always accurate).

## Accurate `/discover` coaching
The old coaching promised "Mark Watched … sharpens by tomorrow," but `/discover` opens by **re-asking the night's mood**, then revealing one cased pick. Re-voiced to: eyebrow **"Next up"** + *"Tell us how tonight feels. A few quick questions, then one film for your night — with the case for why it fits."* No Mark-Watched / next-day-cadence promise.

## Internal timeline changes
Rebalanced within the frozen 12s envelope: kicker 0.4 → pills 1.1 → taste 2.0 → caption 2.6 → posters 3.0 → "Tonight is yours." 4.9 → coaching 6.3. Settles ~7s with more coaching dwell. **The parent's 12s hold + 900ms fade are unchanged.**

## Short-viewport hardening
CelebrationReveal-local only: scroll-safe root (`overflow-y-auto`, no horizontal scroll), `min-h-full` centered content, a `max-height` padding query (`.ff-cel-content` in `onboarding.css`), responsive stage gaps, and 52px posters at the narrowest so all 5 fit. Verified fit + visible h1/coaching at 360×640.

## Preserved single-live-region model (F2.20)
One `sr-only` `role="status"` `aria-live="polite"` `aria-atomic="true"` completion node (text set once after mount), the sole visible `<h1>`, reduced-motion delays→0, no focus movement, decorative `alt=""`.

## Confirmations
- **The 12-second hold, 900ms fade, finish ordering, Supabase writes, auth timing, and `/discover` destination are unchanged** — `Onboarding.jsx` is untouched; `OnboardingFinishFlow.test.jsx` is kept unchanged and green (asserts `completeOnboarding({markAuthComplete:false})` → `/discover` → `markOnboardingAuthComplete`, not before the 12s hold).
- `AmbientGlow`, `DnaRail`, the steps, services, and `/discover` were not touched. No Skip/Continue control added.

## Validation
- `npm run lint` → clean
- `npx vitest run src/features/onboarding/__tests__/ src/shared/lib/auth/__tests__/onboardingStatus.test.js` → 148 passed (12 files)
- `npm run build` → ✓
- `npm run test` (full) → 652 passed (58 files)
- Playwright 360×640 / 390×844 / 430×932 / 768×1024 / 1280×720 / 1440×900: no horizontal overflow, **0 icon svgs**, 5 posters fit, **h1 + coaching visible** (incl. 360×640 and 1280×720). Source contracts: no `repeat: Infinity`, 900ms fade preserved, reduced-motion delays→0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
