### PR TITLE
Scope onboarding draft to signed-in user

### DIFF
--- a/src/app/header/Header.jsx
+++ b/src/app/header/Header.jsx
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react'
 
 import { supabase } from '@/shared/lib/supabase/client'
+import { clearDraft } from '@/features/onboarding/draft'
 import { useAuthSession } from '@/shared/hooks/useAuthSession'
 import { useGoogleAuth } from '@/shared/hooks/useGoogleAuth'
 
@@ -285,6 +286,9 @@ export default function Header({ onOpenSearch }) {
   }, [])
 
   const handleSignOut = async () => {
+    // Drop this user's onboarding draft (+ the legacy global key) before the
+    // session is gone, so it can't rehydrate into the next user on a shared browser.
+    clearDraft(user?.id)
     await supabase.auth.signOut()
     navigate('/')
   }

--- a/src/features/onboarding/Onboarding.jsx
+++ b/src/features/onboarding/Onboarding.jsx
@@ -32,22 +32,13 @@ import MoviesStep from './steps/MoviesStep'
 import RatingStep from './steps/RatingStep'
 
 import { MOODS_LS_KEY, SENTIMENT_RATINGS } from './data'
+import { loadDraft, saveDraft, clearDraft } from './draft'
 import './onboarding.css'
 
-// Drafts the in-flight onboarding so a refresh doesn't wipe selections.
-// Cleared by completeOnboarding once data is persisted to Supabase.
-const ONBOARDING_DRAFT_KEY = 'ff_onboarding_draft_v1'
-
-function loadDraft() {
-  try {
-    const raw = localStorage.getItem(ONBOARDING_DRAFT_KEY)
-    if (!raw) return null
-    const draft = JSON.parse(raw)
-    return draft && typeof draft === 'object' ? draft : null
-  } catch {
-    return null
-  }
-}
+// Drafts the in-flight onboarding (per signed-in user) so a refresh doesn't wipe
+// selections. Keyed/loaded/cleared via ./draft — user-scoped so one account's
+// draft can't leak into another on a shared browser (F2.23). Cleared on
+// completion, sign-out, and the already-onboarded redirect.
 
 export default function Onboarding() {
   const navigate = useNavigate()
@@ -67,26 +58,39 @@ export default function Onboarding() {
   const [, setLoading] = useState(false)
   const [error, setError] = useState('')
 
-  // Step state — hydrate from localStorage draft so a mid-flow refresh doesn't
-  // wipe selections. The draft is cleared in handleFinish on success.
-  const draft = loadDraft()
-  const [step, setStep] = useState(draft?.step ?? 0)
-  const [moods, setMoods] = useState(draft?.moods ?? [])
-  const [selectedGenres, setSelectedGenres] = useState(draft?.selectedGenres ?? [])
-  const [favoriteMovies, setFavoriteMovies] = useState(draft?.favoriteMovies ?? [])
-  const [ratings, setRatings] = useState(draft?.ratings ?? {})
+  // Step state — starts empty and hydrates from the SIGNED-IN USER's scoped draft
+  // once their id is known (deferred so we never read another user's draft, and
+  // never a global default). Cleared on completion / sign-out / redirect.
+  const userId = session?.user?.id ?? null
+  const [hydrated, setHydrated] = useState(false)
+  const [step, setStep] = useState(0)
+  const [moods, setMoods] = useState([])
+  const [selectedGenres, setSelectedGenres] = useState([])
+  const [favoriteMovies, setFavoriteMovies] = useState([])
+  const [ratings, setRatings] = useState({})
 
-  // Persist draft on every change. Best-effort — quota/private-mode failures are non-fatal.
+  // Hydrate the user's scoped draft once their id is available (runs once).
   useEffect(() => {
-    try {
-      localStorage.setItem(
-        ONBOARDING_DRAFT_KEY,
-        JSON.stringify({ step, moods, selectedGenres, favoriteMovies, ratings }),
-      )
-    } catch {
-      // localStorage unavailable — flow still works, just no refresh persistence.
+    if (!userId || hydrated) return
+    const draft = loadDraft(userId)
+    if (draft) {
+      if (typeof draft.step === 'number') setStep(draft.step)
+      if (Array.isArray(draft.moods)) setMoods(draft.moods)
+      if (Array.isArray(draft.selectedGenres)) setSelectedGenres(draft.selectedGenres)
+      if (Array.isArray(draft.favoriteMovies)) setFavoriteMovies(draft.favoriteMovies)
+      if (draft.ratings && typeof draft.ratings === 'object') setRatings(draft.ratings)
     }
-  }, [step, moods, selectedGenres, favoriteMovies, ratings])
+    setHydrated(true)
+  }, [userId, hydrated])
+
+  // Persist the user's scoped draft on every change — only AFTER hydration (so the
+  // empty initial state can't clobber a just-loaded draft) and only once the gate
+  // has settled to render the steps (`!checking`), so a completed user being
+  // redirected can't re-write the draft the gate just cleared. Best-effort.
+  useEffect(() => {
+    if (!userId || !hydrated || checking) return
+    saveDraft(userId, { step, moods, selectedGenres, favoriteMovies, ratings })
+  }, [userId, hydrated, checking, step, moods, selectedGenres, favoriteMovies, ratings])
 
   // Auth gate (same logic as legacy)
   useEffect(() => {
@@ -96,6 +100,7 @@ export default function Onboarding() {
     ;(async () => {
       try {
         if (deriveOnboardingStatus(session.user).isComplete) {
+          clearDraft(session.user.id) // already onboarded → drop any stale draft
           navigate('/home', { replace: true })
           return
         }
@@ -110,8 +115,10 @@ export default function Onboarding() {
         // path or a partial wipe), the OR caused a redirect-loop with
         // PostAuthGate: this gate said complete, PostAuthGate said not. The
         // rerunOnboarding flow now nulls both, so the OR is unnecessary.
-        if (data?.onboarding_complete) navigate('/home', { replace: true })
-        else setChecking(false)
+        if (data?.onboarding_complete) {
+          clearDraft(session.user.id) // already onboarded → drop any stale draft
+          navigate('/home', { replace: true })
+        } else setChecking(false)
       } catch {
         setChecking(false)
       }
@@ -184,7 +191,7 @@ export default function Onboarding() {
         }) : Promise.resolve(),
       ])
 
-      try { localStorage.removeItem(ONBOARDING_DRAFT_KEY) } catch { /* noop */ }
+      clearDraft(userId) // completion → drop this user's scoped draft + legacy key
 
       // Hold for the remainder of the celebration min duration so the reveal
       // animation always has room to land.
@@ -247,7 +254,9 @@ export default function Onboarding() {
   }
 
   // Loading — uses the shared BrandSplash (delayed 200ms so fast checks never flash).
-  if (checking) {
+  // Also hold the splash until the user's scoped draft has hydrated, so the steps
+  // never flash at an empty step 0 before a same-user draft restores.
+  if (checking || (userId && !hydrated)) {
     return <BrandSplash />
   }
 

--- a/src/features/onboarding/__tests__/OnboardingDraft.test.jsx
+++ b/src/features/onboarding/__tests__/OnboardingDraft.test.jsx
@@ -1,0 +1,66 @@
+// src/features/onboarding/__tests__/OnboardingDraft.test.jsx
+// F2.23 — Onboarding-level draft isolation: a different user does NOT hydrate
+// another user's scoped draft, the same user DOES restore theirs, and an
+// already-onboarded user's stale draft is cleared on the redirect. (The progressbar
+// aria-valuenow = step + 1 is the stable proxy for the restored step.)
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+
+import { saveDraft, loadDraft } from '../draft'
+
+const h = vi.hoisted(() => ({ session: { user: { id: 'B' } }, isComplete: false, dbComplete: false, navigate: () => {} }))
+
+vi.mock('@/shared/hooks/useAuthSession', () => ({ useAuthSession: () => ({ ready: true, session: h.session }) }))
+vi.mock('@/shared/lib/auth/onboardingStatus', () => ({ deriveOnboardingStatus: () => ({ hasAny: true, isComplete: h.isComplete }) }))
+vi.mock('@/shared/lib/supabase/client', () => ({
+  supabase: { from: () => ({ select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: { onboarding_complete: h.dbComplete } }) }) }) }) },
+}))
+vi.mock('react-router-dom', async (orig) => ({ ...(await orig()), useNavigate: () => h.navigate }))
+vi.mock('@/shared/hooks/usePageMeta', () => ({ usePageMeta: () => {} }))
+vi.mock('@/shared/services/onboarding', () => ({ completeOnboarding: vi.fn().mockResolvedValue(), markOnboardingAuthComplete: vi.fn().mockResolvedValue() }))
+vi.mock('@/features/home/useHomeData', () => ({ prefetchHomeData: vi.fn().mockResolvedValue() }))
+vi.mock('@/shared/api/tmdb', () => ({ tmdbImg: (p) => `https://img/${p}`, searchMovies: vi.fn().mockResolvedValue({ results: [] }) }))
+
+import Onboarding from '../Onboarding'
+
+beforeEach(() => {
+  localStorage.clear()
+  h.session = { user: { id: 'B' } }
+  h.isComplete = false
+  h.dbComplete = false
+  h.navigate = vi.fn()
+  window.matchMedia = vi.fn().mockImplementation((q) => ({
+    matches: false, media: q, onchange: null,
+    addEventListener: vi.fn(), removeEventListener: vi.fn(),
+    addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(),
+  }))
+})
+
+describe('Onboarding — user-scoped draft isolation', () => {
+  it('does NOT hydrate another user’s draft — user B starts fresh, user A is untouched', async () => {
+    saveDraft('A', { step: 3, moods: ['cozy'], selectedGenres: [18], favoriteMovies: [{ id: 1, title: 'X' }], ratings: { 1: 9 } })
+    h.session = { user: { id: 'B' } }
+    render(<Onboarding />)
+    const bar = await screen.findByRole('progressbar')
+    expect(bar).toHaveAttribute('aria-valuenow', '1') // step 0, not A's step 3
+    expect(loadDraft('A')).toMatchObject({ step: 3 })  // A's draft untouched
+  })
+
+  it('restores the SAME user’s scoped draft on mount', async () => {
+    saveDraft('A', { step: 1, moods: ['cozy'], selectedGenres: [18], favoriteMovies: [], ratings: {} })
+    h.session = { user: { id: 'A' } }
+    render(<Onboarding />)
+    const bar = await screen.findByRole('progressbar')
+    expect(bar).toHaveAttribute('aria-valuenow', '2') // step 1 restored
+  })
+
+  it('clears the user’s stale draft and redirects to /home when already onboarded', async () => {
+    saveDraft('A', { step: 2, moods: ['cozy'] })
+    h.session = { user: { id: 'A' } }
+    h.isComplete = true
+    render(<Onboarding />)
+    await waitFor(() => expect(h.navigate).toHaveBeenCalledWith('/home', { replace: true }))
+    expect(loadDraft('A')).toBeNull()
+  })
+})

--- a/src/features/onboarding/__tests__/draft.test.js
+++ b/src/features/onboarding/__tests__/draft.test.js
@@ -1,0 +1,93 @@
+// src/features/onboarding/__tests__/draft.test.js
+// F2.23 — user-scoped onboarding draft: cross-account isolation, same-user restore,
+// clear (scoped + legacy), the one-time legacy-global migration, and safe parsing.
+// Plus wiring assertions that Header (sign-out) + Onboarding clear the draft.
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { draftKey, loadDraft, saveDraft, clearDraft, LEGACY_DRAFT_KEY } from '../draft'
+
+beforeEach(() => { localStorage.clear() })
+
+describe('onboarding draft — user scoping', () => {
+  it('keys are per-user', () => {
+    expect(draftKey('A')).toBe('ff_onboarding_draft_v1_A')
+    expect(draftKey('A')).not.toBe(draftKey('B'))
+  })
+
+  it('User A draft is NOT loaded for User B', () => {
+    saveDraft('A', { step: 3, moods: ['cozy'], selectedGenres: [18], favoriteMovies: [{ id: 1 }], ratings: { 1: 9 } })
+    expect(loadDraft('B')).toBeNull()
+    expect(loadDraft('A')).toMatchObject({ step: 3, moods: ['cozy'] })
+  })
+
+  it('same user restores their scoped draft (with version stamp)', () => {
+    saveDraft('A', { step: 2, moods: ['wired'], selectedGenres: [], favoriteMovies: [], ratings: {} })
+    const d = loadDraft('A')
+    expect(d.step).toBe(2)
+    expect(d.moods).toEqual(['wired'])
+    expect(d.version).toBe(1)
+  })
+
+  it('clearDraft removes the user scoped key AND the legacy global key', () => {
+    saveDraft('A', { step: 1 })
+    localStorage.setItem(LEGACY_DRAFT_KEY, JSON.stringify({ step: 9 }))
+    clearDraft('A')
+    expect(loadDraft('A')).toBeNull()
+    expect(localStorage.getItem(LEGACY_DRAFT_KEY)).toBeNull()
+  })
+
+  it('null/undefined userId is a no-op (no crash, never a global default)', () => {
+    expect(loadDraft(null)).toBeNull()
+    expect(loadDraft(undefined)).toBeNull()
+    expect(() => saveDraft(null, { step: 1 })).not.toThrow()
+    expect(() => clearDraft(null)).not.toThrow()
+  })
+})
+
+describe('onboarding draft — legacy global-key migration', () => {
+  it('adopts the legacy global draft ONCE for the first user, then deletes the global key', () => {
+    localStorage.setItem(LEGACY_DRAFT_KEY, JSON.stringify({ step: 4, moods: ['mythic'] }))
+    const adopted = loadDraft('A')
+    expect(adopted).toMatchObject({ step: 4, moods: ['mythic'] })
+    expect(localStorage.getItem(draftKey('A'))).not.toBeNull() // copied to A's scoped key
+    expect(localStorage.getItem(LEGACY_DRAFT_KEY)).toBeNull()   // global key deleted
+    expect(loadDraft('B')).toBeNull()                           // no future user can read it
+  })
+
+  it('a user with their own scoped draft ignores the legacy key', () => {
+    saveDraft('A', { step: 2 })
+    localStorage.setItem(LEGACY_DRAFT_KEY, JSON.stringify({ step: 9 }))
+    expect(loadDraft('A').step).toBe(2)
+  })
+})
+
+describe('onboarding draft — safe parsing', () => {
+  it('invalid scoped draft JSON returns null (no crash)', () => {
+    localStorage.setItem(draftKey('A'), '{not valid json')
+    expect(loadDraft('A')).toBeNull()
+  })
+  it('non-object JSON returns null', () => {
+    localStorage.setItem(draftKey('A'), '42')
+    expect(loadDraft('A')).toBeNull()
+  })
+})
+
+describe('onboarding draft — wiring', () => {
+  const read = (p) => readFileSync(resolve(import.meta.dirname, p), 'utf8')
+
+  it('Header sign-out clears this user’s draft (scoped + legacy)', () => {
+    const header = read('../../../app/header/Header.jsx')
+    expect(header).toMatch(/import \{ clearDraft \} from '@\/features\/onboarding\/draft'/)
+    expect(header).toMatch(/clearDraft\(user\?\.id\)/)
+  })
+
+  it('Onboarding uses the scoped helper (no global key) and clears on redirect + completion', () => {
+    const ob = read('../Onboarding.jsx')
+    expect(ob).not.toMatch(/ONBOARDING_DRAFT_KEY/)        // global key removed
+    expect(ob).toMatch(/from '\.\/draft'/)
+    expect((ob.match(/clearDraft\(/g) || []).length).toBeGreaterThanOrEqual(2) // gate(s) + completion
+  })
+})

--- a/src/features/onboarding/draft.js
+++ b/src/features/onboarding/draft.js
@@ -1,0 +1,71 @@
+// src/features/onboarding/draft.js
+// User-scoped onboarding draft persistence (F2.23). The draft lets a mid-flow
+// refresh restore selections — but it is keyed PER signed-in user so one account's
+// in-progress moods/genres/films/ratings can never rehydrate into another account
+// on a shared browser. The pre-F2.23 GLOBAL key (the leak source) is migrated once
+// — adopted by the first signed-in user to mount, then deleted — and never read
+// again. All access is best-effort (private-mode / quota safe).
+
+const DRAFT_PREFIX = 'ff_onboarding_draft_v1_'
+// The pre-F2.23 un-scoped key — every account shared it (the cross-account leak).
+export const LEGACY_DRAFT_KEY = 'ff_onboarding_draft_v1'
+
+/** localStorage key for a given user's onboarding draft. */
+export function draftKey(userId) {
+  return `${DRAFT_PREFIX}${userId}`
+}
+
+function safeGet(key) {
+  try { return localStorage.getItem(key) } catch { return null }
+}
+function safeRemove(key) {
+  try { localStorage.removeItem(key) } catch { /* private mode / quota — non-fatal */ }
+}
+
+/**
+ * Load a user's onboarding draft. Reads the SCOPED key first; if it's absent,
+ * adopts a legacy global draft ONCE for this user (then deletes the global key so
+ * no future user can ever read it). Returns null on absence or malformed JSON.
+ *
+ * @param {string|null|undefined} userId
+ * @returns {object|null}
+ */
+export function loadDraft(userId) {
+  if (!userId) return null
+  const key = draftKey(userId)
+  let raw = safeGet(key)
+  if (raw == null) {
+    // One-time migration: a draft left under the old global key is adopted by the
+    // first signed-in user to mount across the F2.23 upgrade, then the global key
+    // is removed for good. Trade-off: on a shared browser the very first signer-in
+    // after the deploy could adopt a stranger's single in-flight legacy draft —
+    // a one-time, deploy-window-only edge, after which all drafts are user-scoped.
+    const legacy = safeGet(LEGACY_DRAFT_KEY)
+    if (legacy != null) {
+      try { localStorage.setItem(key, legacy) } catch { /* non-fatal */ }
+      safeRemove(LEGACY_DRAFT_KEY)
+      raw = legacy
+    }
+  }
+  if (raw == null) return null
+  try {
+    const draft = JSON.parse(raw)
+    return draft && typeof draft === 'object' ? draft : null
+  } catch {
+    return null
+  }
+}
+
+/** Persist a user's onboarding draft (carries a `version` stamp). Best-effort. */
+export function saveDraft(userId, draft) {
+  if (!userId) return
+  try {
+    localStorage.setItem(draftKey(userId), JSON.stringify({ version: 1, ...draft }))
+  } catch { /* private mode / quota — flow still works, just no refresh persistence */ }
+}
+
+/** Remove a user's scoped draft AND the legacy global key (sign-out / completion). */
+export function clearDraft(userId) {
+  if (userId) safeRemove(draftKey(userId))
+  safeRemove(LEGACY_DRAFT_KEY)
+}


### PR DESCRIPTION
Fixes the **F2.22-ranked P1 cross-account onboarding-draft leak**. Privacy/state-isolation only — no UI, validation, completion-write, routing-destination, or finish-flow change.

## The leak
The onboarding draft used a single **global** localStorage key (`ff_onboarding_draft_v1`). On a shared browser: User A starts onboarding → doesn't finish → signs out → User B signs in → B inherited A's unfinished moods/genres/films/ratings.

## New user-scoped key
New `src/features/onboarding/draft.js`: the draft is keyed **per user** — `ff_onboarding_draft_v1_${userId}` — via `draftKey`/`loadDraft`/`saveDraft`/`clearDraft`. A different user can never read another's draft. `saveDraft` carries a `version` stamp; a `null` userId is a no-op (never a global default); malformed JSON returns `null` (no crash); all access is private-mode/quota safe.

## Legacy global-key migration (adopt-then-delete)
If a scoped key is absent and the old global key exists, the **first signed-in user adopts it once**, then the global key is **deleted** so no future user can ever read it. *(Documented trade-off: a one-time deploy-window edge where a different first-signer could adopt a single in-flight legacy draft; after that, all drafts are user-scoped.)*

## Onboarding.jsx
State now **starts empty and hydrates** from the user's scoped draft in a deferred effect once `session.user.id` is known (so we never read another user's draft, and never a global default); BrandSplash holds until hydrated so the steps never flash at step 0. **Persist is gated on `!checking`** (in addition to `hydrated`) so a completed user being redirected can't re-write the draft the gate just cleared. The **already-onboarded redirect now clears that user's stale draft**, and **completion clears via `clearDraft(userId)`** (replacing the global `removeItem`).

## Sign-out cleanup
`Header.jsx` (the canonical sign-out): `clearDraft(user?.id)` before `signOut()`, removing the scoped key **and** the legacy global key. *(Account-page/router sign-outs are secondary; the user-scoped key already makes the leak impossible regardless of path, so a scoped orphan there is harmless — confirmed Header is the canonical handler.)*

## Tests
- `draft.test.js`: cross-user isolation, same-user restore (with version stamp), clear scoped+legacy, null no-op, migration adopt-then-delete, safe JSON parsing, and Header+Onboarding wiring.
- `OnboardingDraft.test.jsx`: User B does **not** hydrate User A's draft (A untouched), same-user restore (verified via the DnaRail progressbar step), and the already-onboarded redirect clears the stale draft + routes to `/home`.
- `OnboardingFinishFlow.test.jsx` kept **unchanged and green** (finish ordering unchanged).

## Confirmations
- **Finish-flow timing/order unchanged** — `CELEBRATION_MIN_MS=12000`, the 900ms fade, `completeOnboarding({markAuthComplete:false})` + parallel prefetch, `navigate('/discover')` before `markOnboardingAuthComplete()`, auth timing — all intact (only the draft-clear line in `handleFinish` changed).
- **Step UI, Supabase writes, routing destination, and completion payload unchanged** — no step / CelebrationReveal / DnaRail / AmbientGlow / `data.js` / onboarding-service edits.

## Validation
- `npm run lint` → clean
- `npx vitest run src/features/onboarding/__tests__/ src/shared/lib/auth/__tests__/onboardingStatus.test.js` → 162 passed (14 files); new tests stable 3×
- `npm run build` → ✓
- `npm run test` (full) → 666 passed (60 files)
- jsdom localStorage proof: cross-user isolation / same-user restore / sign-out clear / migration adopt+delete all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
