### PR TITLE
Harden onboarding completion idempotency

### DIFF
--- a/src/shared/services/__tests__/onboarding.test.js
+++ b/src/shared/services/__tests__/onboarding.test.js
@@ -1,0 +1,169 @@
+// src/shared/services/__tests__/onboarding.test.js
+// F2.24 — completeOnboarding idempotency. Onboarding-sourced history + ratings now
+// use a constraint-agnostic REPLACE-BY-SOURCE strategy (delete source='onboarding'
+// → insert) so a re-run can't duplicate history or hit the (user_id,movie_id)
+// uniqueness conflict, and non-onboarding rows are never touched. Supabase is
+// mocked with a per-table call recorder (no live DB).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const h = vi.hoisted(() => ({ calls: [], errors: {}, usersExists: true, supabase: null }))
+
+vi.mock('@/shared/lib/supabase/client', () => {
+  const result = (table, op) => h.errors[`${table}:${op}`] ?? { data: null, error: null }
+  const supabase = {
+    from(table) {
+      const state = { table, op: null, filters: {}, rows: undefined, vals: undefined }
+      const b = {
+        select(...a) { if (!state.op) state.op = 'select'; state.selectArgs = a; return b },
+        insert(rows) { state.op = 'insert'; state.rows = rows; h.calls.push({ table, op: 'insert', rows }); return b },
+        upsert(rows, opts) { state.op = 'upsert'; state.rows = rows; h.calls.push({ table, op: 'upsert', rows, opts }); return b },
+        update(vals) { state.op = 'update'; state.vals = vals; return b },
+        delete() { state.op = 'delete'; return b },
+        eq(col, val) { state.filters[col] = val; return b },
+        single() { return Promise.resolve(result(table, state.op)) },
+        maybeSingle() {
+          if (table === 'movies' && state.filters.tmdb_id != null) return Promise.resolve({ data: { id: `internal-${state.filters.tmdb_id}` }, error: null })
+          if (table === 'users') return Promise.resolve({ data: h.usersExists ? { id: state.filters.id } : null, error: null })
+          if (table === 'user_profiles_computed') return Promise.resolve({ data: { user_id: state.filters.user_id }, error: null })
+          return Promise.resolve(result(table, 'select'))
+        },
+        then(res, rej) {
+          if (state.op === 'delete') h.calls.push({ table, op: 'delete', filters: { ...state.filters } })
+          if (state.op === 'update') h.calls.push({ table, op: 'update', vals: state.vals, filters: { ...state.filters } })
+          return Promise.resolve(result(table, state.op)).then(res, rej)
+        },
+      }
+      return b
+    },
+    auth: { updateUser: vi.fn().mockResolvedValue({ error: null }) },
+  }
+  h.supabase = supabase
+  return { supabase }
+})
+vi.mock('@/shared/api/tmdb', () => ({ fetchJson: vi.fn().mockResolvedValue({ id: 0, title: 'X' }) }))
+vi.mock('@/shared/services/recommendations', () => ({ computeUserProfileV3: vi.fn().mockResolvedValue(undefined) }))
+vi.mock('@/shared/services/tasteCache', () => ({ getTasteFingerprint: vi.fn().mockResolvedValue({}) }))
+vi.mock('@/shared/services/analytics', () => ({ track: vi.fn() }))
+
+import { completeOnboarding } from '../onboarding'
+import { computeUserProfileV3 } from '@/shared/services/recommendations'
+import { getTasteFingerprint } from '@/shared/services/tasteCache'
+import { track } from '@/shared/services/analytics'
+
+const session = { user: { id: 'u1', email: 'u1@test.dev', user_metadata: {} } }
+const baseArgs = () => ({
+  session,
+  selectedGenres: [18, 28],
+  favoriteMovies: [{ id: 1, title: 'A' }, { id: 2, title: 'B' }, { id: 3, title: 'C' }],
+  ratings: { 1: 9, 2: 7, 3: 5 }, // loved / liked / okay
+  moods: ['cozy'],
+})
+const byTable = (table, op) => h.calls.filter(c => c.table === table && c.op === op)
+const opsFor = (table) => h.calls.filter(c => c.table === table).map(c => c.op)
+
+beforeEach(() => {
+  h.calls = []; h.errors = {}; h.usersExists = true
+  vi.clearAllMocks()
+  h.supabase.auth.updateUser.mockResolvedValue({ error: null })
+})
+
+describe('completeOnboarding — first completion writes', () => {
+  it('saves genres, history, ratings, updates user, computes profile, pre-warms fingerprint, tracks', async () => {
+    await completeOnboarding({ ...baseArgs(), markAuthComplete: false })
+    expect(byTable('user_preferences', 'delete')).toHaveLength(1)
+    expect(byTable('user_preferences', 'upsert')).toHaveLength(1)
+    expect(byTable('user_history', 'insert')).toHaveLength(1)
+    expect(byTable('user_history', 'insert')[0].rows).toHaveLength(3)
+    expect(byTable('user_ratings', 'insert')).toHaveLength(1)
+    expect(byTable('users', 'update')[0].vals).toMatchObject({ onboarding_complete: true })
+    expect(computeUserProfileV3).toHaveBeenCalledWith('u1', { forceRefresh: true })
+    expect(getTasteFingerprint).toHaveBeenCalledWith('u1')
+    expect(track).toHaveBeenCalledWith('onboarding_completed', expect.objectContaining({ movie_count: 3 }))
+  })
+
+  it('inserts the users row when it does not yet exist', async () => {
+    h.usersExists = false
+    await completeOnboarding({ ...baseArgs(), markAuthComplete: false })
+    expect(byTable('users', 'insert')).toHaveLength(1)
+    expect(byTable('users', 'insert')[0].rows).toMatchObject({ id: 'u1' })
+  })
+
+  it('rating numeric mappings flow through unchanged (okay=5, liked=7, loved=9) with source=onboarding', async () => {
+    await completeOnboarding({ ...baseArgs(), markAuthComplete: false })
+    const rows = byTable('user_ratings', 'insert')[0].rows
+    const byMovie = Object.fromEntries(rows.map(r => [r.movie_id, r.rating]))
+    expect(byMovie['internal-1']).toBe(9) // loved
+    expect(byMovie['internal-2']).toBe(7) // liked
+    expect(byMovie['internal-3']).toBe(5) // okay
+    rows.forEach(r => expect(r.source).toBe('onboarding'))
+  })
+
+  it('history rows preserve source/onboarding + null watch_duration + null mood_session', async () => {
+    await completeOnboarding({ ...baseArgs(), markAuthComplete: false })
+    byTable('user_history', 'insert')[0].rows.forEach(r => {
+      expect(r.source).toBe('onboarding')
+      expect(r.watch_duration_minutes).toBeNull()
+      expect(r.mood_session_id).toBeNull()
+    })
+  })
+})
+
+describe('completeOnboarding — idempotency (replace-by-source)', () => {
+  it('replaces onboarding HISTORY (delete source=onboarding → insert)', async () => {
+    await completeOnboarding({ ...baseArgs(), markAuthComplete: false })
+    const del = byTable('user_history', 'delete')
+    expect(del).toHaveLength(1)
+    expect(del[0].filters).toMatchObject({ user_id: 'u1', source: 'onboarding' })
+    expect(opsFor('user_history')).toEqual(['delete', 'insert'])
+  })
+
+  it('replaces onboarding RATINGS (delete source=onboarding → batch insert, no per-row conflict)', async () => {
+    await completeOnboarding({ ...baseArgs(), markAuthComplete: false })
+    const del = byTable('user_ratings', 'delete')
+    expect(del).toHaveLength(1)
+    expect(del[0].filters).toMatchObject({ user_id: 'u1', source: 'onboarding' })
+    expect(opsFor('user_ratings')).toEqual(['delete', 'insert'])
+  })
+
+  it('a re-run keeps the same delete+insert shape (no duplicate accumulation)', async () => {
+    await completeOnboarding({ ...baseArgs(), markAuthComplete: false })
+    h.calls = []
+    await completeOnboarding({ ...baseArgs(), markAuthComplete: false })
+    expect(byTable('user_history', 'delete')).toHaveLength(1)
+    expect(byTable('user_history', 'insert')).toHaveLength(1)
+    expect(byTable('user_ratings', 'delete')).toHaveLength(1)
+    expect(byTable('user_ratings', 'insert')).toHaveLength(1)
+  })
+
+  it('only source=onboarding rows are deleted — non-onboarding rows are never targeted', async () => {
+    await completeOnboarding({ ...baseArgs(), markAuthComplete: false })
+    ;['user_history', 'user_ratings'].forEach(t =>
+      byTable(t, 'delete').forEach(d => expect(d.filters.source).toBe('onboarding')))
+  })
+})
+
+describe('completeOnboarding — auth flip (unchanged)', () => {
+  it('markAuthComplete:false skips auth.updateUser', async () => {
+    await completeOnboarding({ ...baseArgs(), markAuthComplete: false })
+    expect(h.supabase.auth.updateUser).not.toHaveBeenCalled()
+  })
+  it('markAuthComplete:true flips the auth metadata exactly once', async () => {
+    await completeOnboarding({ ...baseArgs(), markAuthComplete: true })
+    expect(h.supabase.auth.updateUser).toHaveBeenCalledTimes(1)
+    expect(h.supabase.auth.updateUser).toHaveBeenCalledWith({ data: { onboarding_complete: true, has_onboarded: true } })
+  })
+})
+
+describe('completeOnboarding — error behavior (unchanged)', () => {
+  it('a history insert failure surfaces a user-facing completion error', async () => {
+    h.errors['user_history:insert'] = { error: { message: 'db down' } }
+    await expect(completeOnboarding({ ...baseArgs(), markAuthComplete: false })).rejects.toThrow(/favorite movies/i)
+  })
+
+  it('a ratings insert failure stays non-fatal (completion resolves; profile still computes)', async () => {
+    h.errors['user_ratings:insert'] = { error: { message: 'conflict' } }
+    await expect(completeOnboarding({ ...baseArgs(), markAuthComplete: false })).resolves.toBeUndefined()
+    expect(computeUserProfileV3).toHaveBeenCalled()
+  })
+})

--- a/src/shared/services/onboarding.js
+++ b/src/shared/services/onboarding.js
@@ -156,29 +156,50 @@ export async function completeOnboarding({ session, selectedGenres, favoriteMovi
 
     const historyRows = movieIdResults.filter(Boolean)
     if (historyRows.length > 0) {
+      // Idempotent re-run: REPLACE this user's onboarding-sourced history (delete
+      // by source + insert) so a re-run can't duplicate rows — the
+      // (user_id, movie_id, watched_at) uniqueness lets a fresh watched_at evade
+      // dedupe. Only source='onboarding' rows are touched; any non-onboarding
+      // history (e.g. later logs) is preserved. No verified onConflict target is
+      // captured in the repo migrations, so we use this conservative replace-by-
+      // source strategy rather than an unverified upsert (F2.24).
+      await supabase.from('user_history').delete().eq('user_id', user_id).eq('source', 'onboarding')
       const { error: historyError } = await supabase.from('user_history').insert(historyRows)
       if (historyError) throw new Error('Could not save your favorite movies')
     }
   }
 
-  // 4. Ratings — one row per rated film (all films the user assigned a sentiment to)
+  // 4. Ratings — one row per rated film. Build the rows (resolving internal IDs),
+  //    then REPLACE this user's onboarding-sourced ratings (delete by source +
+  //    batch insert) so a re-run can't hit the (user_id, movie_id) uniqueness
+  //    conflict (a re-run previously raised 23505). Only source='onboarding' rows
+  //    are touched; non-onboarding ratings are preserved. Persistence stays
+  //    NON-FATAL — the profile computes fine without these rows. Same conservative
+  //    replace-by-source rationale as history (no verified onConflict target in
+  //    the repo migrations) (F2.24).
   const ratingEntries = Object.entries(ratings || {})
   if (ratingEntries.length > 0) {
+    const ratingRows = []
     for (const [tmdbIdStr, rating] of ratingEntries) {
       const tmdbId = Number(tmdbIdStr)
       const movie = favoriteMovies.find(m => m.id === tmdbId)
       if (!movie) continue
       try {
         const internalId = internalIdMap[tmdbId] ?? (movie.internalId || await ensureMovieExists(movie))
-        await supabase.from('user_ratings').insert({
-          user_id,
-          movie_id: internalId,
-          rating,
-          source: 'onboarding',
-        })
+        ratingRows.push({ user_id, movie_id: internalId, rating, source: 'onboarding' })
       } catch (err) {
-        // Non-fatal — profile computes fine without individual rating rows
-        console.warn(`Could not save rating for tmdbId ${tmdbId}:`, err)
+        // Non-fatal — skip a film whose internal id can't be resolved.
+        console.warn(`Could not resolve movie for rating (tmdbId ${tmdbId}):`, err)
+      }
+    }
+    if (ratingRows.length > 0) {
+      try {
+        await supabase.from('user_ratings').delete().eq('user_id', user_id).eq('source', 'onboarding')
+        const { error: ratingError } = await supabase.from('user_ratings').insert(ratingRows)
+        if (ratingError) console.warn('Could not save onboarding ratings:', ratingError)
+      } catch (err) {
+        // Non-fatal — profile computes fine without individual rating rows.
+        console.warn('Could not save onboarding ratings:', err)
       }
     }
   }


### PR DESCRIPTION
Addresses the **F2.22 P2-1** client-side idempotency follow-up: make the onboarding-sourced history + ratings writes safe to re-run. Idempotency/reliability only — **no UI, routing, auth, schema, migration, or RPC change**.

## Schema/constraint inspection
The `user_history` / `user_ratings` table definitions (and their unique constraints) are **not captured in the repo migrations** (`supabase/migrations/` only has indexes/RLS/CHECK alters for them, no `CREATE TABLE`/`UNIQUE`). Both rows already carry a `source: 'onboarding'` column. So a safe `onConflict` target can't be verified, but a constraint-agnostic delete-by-`source` is.

## History idempotency strategy — replace-by-source
Previously `insert(historyRows)`, so a re-run duplicated onboarding rows (the `(user_id, movie_id, watched_at)` uniqueness lets a fresh `watched_at` evade dedupe). Now: **`delete().eq('user_id').eq('source','onboarding')` → `insert(...)`**. Only onboarding-sourced rows are replaced; non-onboarding history is preserved; `source`/`watch_duration_minutes: null`/`mood_session_id: null` kept; a history failure still **throws** the user-facing error.

## Ratings idempotency strategy — replace-by-source (batch)
Previously per-row `insert(...)` in a loop, so a re-run raised the `(user_id, movie_id)` uniqueness conflict (23505). Now: resolve the internal ids, **`delete` this user's `source='onboarding'` ratings → batch `insert`**. Numeric values (`okay=5/liked=7/loved=9`), `source='onboarding'`, and the **non-fatal** behavior (warn + continue; the profile computes fine without these rows) are all preserved. Non-onboarding ratings are never touched.

## Why no migration/RPC
A safe `onConflict` target can't be verified from the repo, and an unverified upsert could fail at runtime. The conservative, constraint-agnostic **delete-by-source + insert** (the same pattern genre preferences already use) guarantees idempotency *and* that only `source='onboarding'` rows are affected, with **zero schema dependency**. The full transactional/RPC path stays the deferred F2.22 **P2-2** follow-up.

## Tests
New `src/shared/services/__tests__/onboarding.test.js` (12) with a per-table supabase call recorder: first-completion writes (genres/history/ratings/user-update/profile/fingerprint/track + the users-insert path), rating numeric mappings + `source`, history null fields, **replace-by-source ordering (`delete`→`insert`) for both tables**, a re-run keeps the same shape (no accumulation), only `source='onboarding'` is deleted, `markAuthComplete` false/true, and history-error-throws + ratings-error-non-fatal. Stable 3×.

## Confirmations
- **Non-onboarding rows are not touched** — both deletes filter `source='onboarding'`.
- **Finish-flow timing/order unchanged** — `completeOnboarding` signature, `markOnboardingAuthComplete`, the `markAuthComplete` default + `markAuthComplete:false` deferred-auth, and the `/discover` ordering (`OnboardingFinishFlow.test.jsx`, kept unchanged + green) are all intact.
- **Auth/routing/UI/Supabase schema unchanged** — only the service file changed; `Onboarding.jsx`, steps, router, gates, migrations, `draft.js`, and `/discover` are untouched; no migration/RPC/SQL added.
- Genre delete+upsert, `ensureMovieExists`/TMDB fallback/movie upsert/shape, `computeUserProfileV3({forceRefresh:true})` + verify/retry, `getTasteFingerprint`, and `track('onboarding_completed')` are unchanged.

## Validation
- `npm run lint` → clean
- `npx vitest run src/features/onboarding/__tests__/ src/shared/lib/auth/__tests__/onboardingStatus.test.js src/shared/services/__tests__/onboarding.test.js` → 174 passed (15 files)
- `npm run build` → ✓
- `npm run test` (full) → 678 passed (61 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
