### PR TITLE
Extract Discover derivation helpers and tests

### DIFF
--- a/src/features/discover/Discover.jsx
+++ b/src/features/discover/Discover.jsx
@@ -12,6 +12,7 @@ import { getMovieWatchProviders } from '@/shared/api/tmdb'
 import { HP as baseHP, HP_GRAD } from '@/shared/lib/tokens'
 import { Play, SkipForward, X, Check, Bookmark } from 'lucide-react'
 import { DiscoverDataProvider, useDiscoverData } from './useDiscoverData'
+import { MOODS, ONBOARDING_TO_DISCOVER, constellationName, buildBecauseLine, diversifyTop3, predictDiscoverDefaults } from './derive'
 import './discover.css'
 
 // /discover v5 — Magazine + the immersion senses
@@ -103,38 +104,6 @@ function AudioToggle() {
 const HP = { ...baseHP, purpleDeep: '#9333ea', surface: '#120d1c', paper: '#0d0b13' }
 const TMDB = (p) => `https://image.tmdb.org/t/p/w500${p}`;
 
-// Hints harmonized to noun-phrase voice — the other 6 already use this
-// register; Tender ("For nights…") and Restless ("When you…") were the
-// two outliers that read like a different writer. Now all 8 line up.
-const MOODS = [
-  { id:'tender',     label:'Tender',      hex:'#F472B6', x:18, y:32, hint:'Nights that ache softly.' },
-  { id:'tense',      label:'Tense',       hex:'#EF4444', x:78, y:24, hint:'Pulse up. Held breath.' },
-  { id:'slow',       label:'Slow-burn',   hex:'#A78BFA', x:34, y:62, hint:'Long takes. Patient escalation.' },
-  { id:'cerebral',   label:'Cerebral',    hex:'#7DD3FC', x:62, y:70, hint:'Big idea, quiet pace.' },
-  { id:'cozy',       label:'Cozy',        hex:'#FBBF24', x:14, y:74, hint:'Low-stakes. Soft landing.' },
-  { id:'bittersweet',label:'Bittersweet', hex:'#FB7185', x:48, y:18, hint:'Sad and beautiful in one breath.' },
-  { id:'mythic',     label:'Mythic',      hex:'#0EA5E9', x:84, y:62, hint:'Epic. Otherworldly.' },
-  { id:'restless',   label:'Restless',    hex:'#34D399', x:52, y:44, hint:'Can’t-sit-still energy.' },
-];
-
-// Onboarding Step 1 uses a 6-mood vocabulary
-// (cozy/wired/tender/fun/tense/mythic — see src/features/onboarding/data.js).
-// /discover uses an 8-axis vocabulary above (the constellation map). This
-// bridge translates baseline-mood keys → Discover mood ids for the
-// first-visit pre-selection in DiscoverBody. Four are direct (cozy,
-// tender, tense, mythic); 'wired' ("cerebral, plot-y, reward focus") maps
-// to the closest Discover hint ("big idea, quiet pace") = cerebral;
-// 'fun' ("light, plot-driven, escapist") maps to restless (the energetic /
-// can't-sit-still axis is the closest entertainment-first register).
-const ONBOARDING_TO_DISCOVER = {
-  cozy:   'cozy',
-  wired:  'cerebral',
-  tender: 'tender',
-  fun:    'restless',
-  tense:  'tense',
-  mythic: 'mythic',
-};
-
 const TIME_OPTIONS = [
   { id:'short', label:'~ 90 min', sub:'A quick one',  v:[60,99] },
   { id:'std',   label:'~ 2 hrs',  sub:'Just right',   v:[100,130] },
@@ -159,31 +128,6 @@ const INTENTIONS = [
   { id:'surprise', label:'Surprise me',    sub:'Show me something new' },
   { id:'comfort',  label:'Comfort me',     sub:'No surprises, please' },
 ];
-
-const CONSTELLATION_NAMES = {
-  'tender':'Soft Focus','tense':'Held Breath','slow':'The Long Take','cerebral':'The Question',
-  'cozy':'Comfort Reel','bittersweet':'Pretty Hurt','mythic':'Big Sky','restless':"Won't Sit Still",
-  'slow,tender':'The Quiet Ache','bittersweet,tender':'The Long Goodbye','cozy,tender':'Home Cinema',
-  'restless,tense':'Live Wire','cerebral,tense':'Cold Logic','bittersweet,tense':'Wound Up',
-  'cerebral,slow':'The Long Question','mythic,slow':'Slow Magic','restless,slow':'Patient Storm',
-  'cerebral,mythic':'The Cathedral','bittersweet,cerebral':'Late Night Math','cerebral,restless':'Mind Adrift',
-  'bittersweet,cozy':'Soft Endings','cozy,mythic':'Fireside Epic','bittersweet,mythic':'Old Light',
-  'mythic,restless':'Quest Mode','bittersweet,restless':'Wired & Wistful',
-  'slow,tense':'Coiled Spring','cozy,tense':'Strange Comfort','mythic,tense':'Dark Myth',
-  'restless,tender':'The Almost','mythic,tender':'Quiet Wonder','cerebral,tender':'The Thinking Heart',
-  'cozy,slow':'Slow Sunday','cozy,cerebral':'Cosy Puzzle','cozy,restless':'Sugar Static',
-  'bittersweet,slow':'The Long Goodbye',
-};
-const constellationName = (selected) => {
-  if (selected.length === 0) return 'Your night';
-  if (selected.length === 1) return CONSTELLATION_NAMES[selected[0]] || 'Your night';
-  if (selected.length === 2) {
-    const k = selected.slice().sort().join(',');
-    return CONSTELLATION_NAMES[k] || selected.map(s => MOODS.find(m=>m.id===s)?.label).join(' × ');
-  }
-  const labels = selected.map(s => MOODS.find(m=>m.id===s)?.label);
-  return `${labels[0]}, ${labels[1]} & ${labels[2]}`;
-};
 
 // M.'s diary lookbacks are sourced live from user_ratings via useDiscoverData
 // (which falls back to a curated default per mood). The hardcoded set below
@@ -788,66 +732,6 @@ function moodFilter(moodId) {
   return {};
 }
 
-// ── "Because…" line — one-line italic proof above the title that names
-// the strongest signal the engine fired for this user × film. Priority:
-// (1) director affinity from the user's rated history, (2) the
-// constellation the user named in Stage 1, (3) the strongest mood as
-// final fallback. Returns null if no signal can be honestly claimed —
-// caller hides the line entirely rather than printing filler. Single
-// line, italic, brand-soft voice. The point of this line is to make
-// "the engine knows you" visible without prose paragraphs.
-// `isAlt` routes alternate cards to FILM-SPECIFIC signals first so the
-// 3 cards on the spread don't all show the same constellation line.
-// Top card uses director-affinity → constellation → mood (the user-
-// connecting hierarchy). Alt cards prefer signals that DIFFER between
-// films — director name + year, or mood/tone tag highlight — making
-// each card carry its own personality. Director affinity still wins
-// for ALT if it fires (rare but valuable signal).
-function buildBecauseLine({ film, profile, selected, isAlt = false }) {
-  if (!film) return null;
-  // Director affinity — strongest signal, works for both slots.
-  const dirAffinity = profile?.affinities?.directors?.find(d =>
-    d?.name && film?.dir && d.name.toLowerCase() === film.dir.toLowerCase()
-  );
-  if (dirAffinity) {
-    return `Because ${film.dir} reads the room the way you do.`;
-  }
-
-  // ALT-only: prefer film-specific signals that vary per card.
-  if (isAlt) {
-    // Highlight the film's strongest mood/tone tag — varies per film,
-    // gives each alt a distinct hook. Skip generic tags ("dark", "tense")
-    // that sound dour; prefer evocative ones.
-    const rawTags = [...(film._raw?.mood_tags || []), ...(film._raw?.tone_tags || [])]
-    const evocative = rawTags.find(t => /heartwarming|whimsical|nostalgic|haunting|exhilarating|melancholic|playful|grandiose|poetic|intimate|gritty|dreamy|wistful|provocative|mysterious/i.test(t || ''))
-    if (evocative) {
-      const pretty = String(evocative).replace(/_/g, ' ').toLowerCase()
-      // "A exhilarating" → "An exhilarating". Cover the common vowel cases.
-      const article = /^[aeiou]/.test(pretty) ? 'An' : 'A'
-      return `${article} ${pretty} take on your night.`
-    }
-    // Director name + year — concrete, varies between films
-    if (film.dir && film.year) {
-      return `${film.dir}'s ${film.year} register.`
-    }
-  }
-
-  // Constellation fallback (for TOP and for ALT when no per-film signal fired).
-  // Skip multi-mood × names ("Bittersweet × Tender") — they read awkwardly
-  // mid-sentence. Strip leading "The " so "The Quiet Ache" doesn't render
-  // as "For your the quiet ache night."
-  const cName = constellationName(selected);
-  if (cName && cName !== 'Your night' && !cName.includes('×') && selected.length <= 2) {
-    const stripped = cName.replace(/^the\s+/i, '').toLowerCase();
-    return `For your ${stripped} night.`;
-  }
-  const topMood = MOODS.find(m => m.id === selected[0]);
-  if (topMood) {
-    return `For your ${topMood.label.toLowerCase()} night.`;
-  }
-  return null;
-}
-
 // ── Alternate card — compact preview of an alternate pick. Click promotes
 // it to the top slot (the page crossfades and this card swaps places with
 // whatever was currently top). Title + meta + because-line; no match %,
@@ -1450,167 +1334,6 @@ function StagePick({ selected, who, energy, intention, results, profile, session
   );
 }
 
-// ── Diversity pass for the Stage 3 swiper.
-// Re-orders the top 3 visible picks so they span 3 distinct primary_genres
-// when the pool allows it. Films 4+ stay in pure rank order. Without this,
-// a mood combo that strongly favors one genre produces a clustered top-3
-// where the user's alternates feel like re-runs of the focused pick.
-//
-// Slot 1 enforces a HARD mood-fit floor (TOP_MOOD_FIT_FLOOR). The headline
-// pick must hit at least this much mood-fit on the user's selected moods.
-// Without it, a film with high taste affinity but poor mood match (e.g.,
-// Chocolat at 15% mood when user asked cerebral+mythic) could be the
-// headline despite not actually fitting what was asked.
-//
-// Slots 2 and 3 enforce a SOFTER floor (ALT_MOOD_FIT_FLOOR). They're
-// framed as alternates so a slightly lower mood threshold is fine, but
-// surfacing a 15% mood film as a "pick from these" alternative to
-// cerebral+mythic still felt wrong in audit. The soft floor protects
-// against that while still leaving room for genre diversity.
-//
-// Fallback chain for slots 2/3:
-//   1. Highest-ranked, NEW genre, above alt floor (best case)
-//   2. Highest-ranked above alt floor (any genre — sacrifice diversity for honesty)
-//   3. Break — surface fewer alts rather than a bad-mood pick. UI handles
-//      0-2 alts gracefully via the alternates row.
-const TOP_MOOD_FIT_FLOOR = 0.35
-const ALT_MOOD_FIT_FLOOR = 0.25
-// Session penalty — films already shown in this /discover session get
-// this many points deducted from their _rankScore before slotting. Soft
-// demotion (not exclusion) so a strongly-mood-matched film can still win
-// if no fresh alternative comes close, but in tight ranks fresh films
-// float to the top. 30 is large enough to flip "broad-mood" films
-// (Gladiator, Chocolat) off the top of every scenario while still
-// allowing them to surface if genuinely the best match.
-const SESSION_SHOWN_PENALTY = 30
-function diversifyTop3(scored, sessionShownIds = new Set()) {
-  if (!Array.isArray(scored) || scored.length < 1) return scored
-  // Re-sort with session penalty: previously-shown films pay 30 pts.
-  // The original _rankScore is preserved on the film; this just changes
-  // sort order. Films past the displayed top 3 still benefit from the
-  // penalty in the queue order so the next skip/watched advance also
-  // surfaces fresh films.
-  const reranked = scored.slice().sort((a, b) => {
-    const aScore = (a._rankScore || 0) - (sessionShownIds.has(a.id) ? SESSION_SHOWN_PENALTY : 0)
-    const bScore = (b._rankScore || 0) - (sessionShownIds.has(b.id) ? SESSION_SHOWN_PENALTY : 0)
-    return bScore - aScore
-  })
-  const used = new Set()
-  const remaining = reranked.slice()
-  const top = []
-
-  // First pick — highest-ranked film that meets the TOP mood-fit floor.
-  // Falls back to overall highest-ranked if nothing meets the floor
-  // (extreme cold-start: pool has zero mood-matching candidates).
-  let firstIdx = remaining.findIndex(f => (f?.moodFitRaw ?? 0) >= TOP_MOOD_FIT_FLOOR)
-  if (firstIdx === -1) firstIdx = 0
-  const first = remaining.splice(firstIdx, 1)[0]
-  if (first) {
-    top.push(first)
-    if (first.primary_genre) used.add(first.primary_genre)
-  }
-
-  // Picks 2 and 3 — apply ALT mood-fit floor with genre-diversity preference.
-  for (let i = 0; i < 2 && remaining.length > 0; i++) {
-    // 1. Try: new genre + above alt floor
-    let idx = remaining.findIndex(f => f?.primary_genre && !used.has(f.primary_genre) && (f?.moodFitRaw ?? 0) >= ALT_MOOD_FIT_FLOOR)
-    // 2. Fall back: above alt floor, any genre (sacrifice diversity over honesty)
-    if (idx === -1) idx = remaining.findIndex(f => (f?.moodFitRaw ?? 0) >= ALT_MOOD_FIT_FLOOR)
-    // 3. Last fallback: break — fewer alts is better than a bad-mood pick
-    if (idx === -1) break
-    const pick = remaining.splice(idx, 1)[0]
-    top.push(pick)
-    if (pick?.primary_genre) used.add(pick.primary_genre)
-  }
-
-  return [...top, ...remaining]
-}
-
-// ── Stage 2 pre-selection — predict the user's likely intention / time /
-// energy from signals we already have, so the page lands on smart
-// defaults instead of the static `move / std / steady / alone` set. The
-// user can always override; this just shifts the starting point so
-// less-engaged users hit Continue faster, and engaged users see the page
-// reflect what they actually tend to pick.
-//
-// Signals used:
-//   • intention ← primary mood from Stage 1 (cerebral → think, cozy →
-//     comfort, tense/restless → distract, tender/bittersweet → move,
-//     mythic → surprise, slow → think). When mood is empty, defaults
-//     to 'move' (broadest appeal).
-//   • time ← profile.preferences.avgRuntime, mapped to the closest
-//     TIME_OPTIONS band. Cold-start users have avgRuntime=120 (the
-//     placeholder default), which lands at 'std' — same as the old
-//     hardcoded default, so no regression.
-//   • energy ← current hour. 22:00-04:00 → 'wiped' (winding down);
-//     14:00-20:00 → 'wired' (active); else 'steady'. Time-of-day is
-//     a privacy-cheap signal that meaningfully shifts the right answer.
-//   • who ← 'alone' (default). Hard to infer honestly without explicit
-//     session signal. Phase 2 will add learned override.
-const INTENTION_FROM_MOOD = {
-  cerebral: 'think',
-  slow:     'think',
-  cozy:     'comfort',
-  tense:    'distract',
-  restless: 'distract',
-  tender:   'move',
-  bittersweet: 'move',
-  mythic:   'surprise',
-}
-
-// Mode-of-counts — returns the most-frequent key in a {key: count} JSONB
-// object, or null when the object is empty/invalid. Used by the hybrid
-// blend to read learned prefs from user_discover_preferences.
-function modeOf(counts) {
-  if (!counts || typeof counts !== 'object') return null
-  const entries = Object.entries(counts)
-  if (entries.length === 0) return null
-  entries.sort((a, b) => b[1] - a[1])
-  return entries[0][0]
-}
-
-// Trust threshold — how many commits the user needs before we prefer
-// their learned mode over the heuristic. 3 is a small-enough sample to
-// adapt quickly but large enough to avoid one-off swings.
-const MIN_COMMITS_TO_TRUST = 3
-
-function predictDiscoverDefaults({ selected, profile, hourOfDay, learnedPrefs }) {
-  // === Heuristic prediction (always computed) ===
-  const primaryMood = selected?.[0]
-  const heuristic = {
-    intention: INTENTION_FROM_MOOD[primaryMood] || 'move',
-    time: 'std',
-    energy: 'steady',
-    who: 'alone',
-  }
-  const avg = profile?.preferences?.avgRuntime
-  if (Number.isFinite(avg)) {
-    if (avg < 100)       heuristic.time = 'short'
-    else if (avg <= 130) heuristic.time = 'std'
-    else if (avg <= 160) heuristic.time = 'long'
-    else                 heuristic.time = 'epic'
-  }
-  if (Number.isFinite(hourOfDay)) {
-    if (hourOfDay >= 22 || hourOfDay < 4) heuristic.energy = 'wiped'
-    else if (hourOfDay >= 14 && hourOfDay < 20) heuristic.energy = 'wired'
-  }
-
-  // === Hybrid blend with learned data ===
-  // Only trust learned prefs after MIN_COMMITS_TO_TRUST. Below that, the
-  // heuristic carries the prediction. Per-dimension fallback: if the
-  // learned mode for a dimension is null (no signal yet for that field),
-  // fall back to heuristic for THAT field — even if total_commits >= 3.
-  if ((learnedPrefs?.total_commits || 0) >= MIN_COMMITS_TO_TRUST) {
-    return {
-      intention: modeOf(learnedPrefs.intention_counts) || heuristic.intention,
-      time:      modeOf(learnedPrefs.time_counts)      || heuristic.time,
-      energy:    modeOf(learnedPrefs.energy_counts)    || heuristic.energy,
-      who:       modeOf(learnedPrefs.who_counts)       || heuristic.who,
-    }
-  }
-  return heuristic
-}
-
 // Commit the user's Stage 2 selections to user_discover_preferences —
 // increments the count for each selected option in each dimension, plus
 // total_commits. Uses an upsert path: read current row (or default to
@@ -1951,4 +1674,3 @@ export default function Discover() {
     </DiscoverDataProvider>
   );
 }
-

--- a/src/features/discover/__tests__/derive.test.js
+++ b/src/features/discover/__tests__/derive.test.js
@@ -1,0 +1,325 @@
+// src/features/discover/__tests__/derive.test.js
+// F3.2 — contract tests for the pure Discover derivation helpers extracted from
+// Discover.jsx. These lock the TRUST-CRITICAL behaviour before the F3 redesign:
+// the honest "Because…" line (null-not-fabricate), the Stage-3 mood-fit floors +
+// session-shown demotion, the onboarding→Discover mood bridge, the constellation
+// naming, and the Stage-2 predicted defaults. Values asserted here are FROZEN
+// product contracts (F3.2 brief).
+
+import { describe, it, expect } from 'vitest'
+import {
+  MOODS,
+  ONBOARDING_TO_DISCOVER,
+  constellationName,
+  buildBecauseLine,
+  diversifyTop3,
+  predictDiscoverDefaults,
+  TOP_MOOD_FIT_FLOOR,
+  ALT_MOOD_FIT_FLOOR,
+  SESSION_SHOWN_PENALTY,
+} from '../derive'
+
+// ── frozen floor/penalty values ───────────────────────────────────────────────
+describe('frozen ranking constants', () => {
+  it('floors + session penalty match the documented contract', () => {
+    expect(TOP_MOOD_FIT_FLOOR).toBe(0.35)
+    expect(ALT_MOOD_FIT_FLOOR).toBe(0.25)
+    expect(SESSION_SHOWN_PENALTY).toBe(30)
+  })
+})
+
+// ── MOODS model ───────────────────────────────────────────────────────────────
+describe('MOODS — the 8-axis mood vocabulary', () => {
+  it('exposes the eight documented mood ids', () => {
+    expect(MOODS.map(m => m.id)).toEqual(
+      ['tender', 'tense', 'slow', 'cerebral', 'cozy', 'bittersweet', 'mythic', 'restless'],
+    )
+  })
+  it('every mood carries id/label/hex/x/y/hint', () => {
+    MOODS.forEach(m => {
+      expect(m).toMatchObject({
+        id: expect.any(String), label: expect.any(String), hex: expect.stringMatching(/^#/),
+        x: expect.any(Number), y: expect.any(Number), hint: expect.any(String),
+      })
+    })
+  })
+})
+
+// ── constellationName ─────────────────────────────────────────────────────────
+describe('constellationName', () => {
+  it('empty selection → "Your night"', () => {
+    expect(constellationName([])).toBe('Your night')
+  })
+  it('one known mood → its documented single name', () => {
+    expect(constellationName(['tender'])).toBe('Soft Focus')
+    expect(constellationName(['cozy'])).toBe('Comfort Reel')
+  })
+  it('two known moods are order-independent', () => {
+    expect(constellationName(['slow', 'tender'])).toBe('The Quiet Ache')
+    expect(constellationName(['tender', 'slow'])).toBe('The Quiet Ache')
+  })
+  it('two moods without a named combination use the "label × label" fallback (input order)', () => {
+    expect(constellationName(['tender', 'tense'])).toBe('Tender × Tense')
+  })
+  it('three moods use the "A, B & C" label-list format', () => {
+    expect(constellationName(['tender', 'tense', 'slow'])).toBe('Tender, Tense & Slow-burn')
+  })
+  it('does not mutate the input array', () => {
+    const sel = ['tender', 'slow']
+    const snapshot = [...sel]
+    constellationName(sel)
+    expect(sel).toEqual(snapshot)
+  })
+})
+
+// ── ONBOARDING_TO_DISCOVER ────────────────────────────────────────────────────
+describe('ONBOARDING_TO_DISCOVER bridge', () => {
+  it('locks all six onboarding→Discover mood mappings', () => {
+    expect(ONBOARDING_TO_DISCOVER).toEqual({
+      cozy: 'cozy',
+      wired: 'cerebral',
+      tender: 'tender',
+      fun: 'restless',
+      tense: 'tense',
+      mythic: 'mythic',
+    })
+  })
+})
+
+// ── buildBecauseLine ──────────────────────────────────────────────────────────
+const dir = (name) => ({ affinities: { directors: [{ name }] } })
+
+describe('buildBecauseLine — honest "Because…" proof', () => {
+  it('no film → null', () => {
+    expect(buildBecauseLine({ film: null, profile: {}, selected: ['tender'] })).toBeNull()
+  })
+
+  it('rated director affinity wins (top slot)', () => {
+    const film = { dir: 'Bong Joon-ho' }
+    expect(buildBecauseLine({ film, profile: dir('bong joon-ho'), selected: ['tender'] }))
+      .toBe('Because Bong Joon-ho reads the room the way you do.')
+  })
+
+  it('focused pick uses a valid constellation when no director affinity', () => {
+    const film = { dir: 'Nobody' }
+    expect(buildBecauseLine({ film, profile: {}, selected: ['tender'] }))
+      .toBe('For your soft focus night.')
+  })
+
+  it('focused pick falls back to the primary selected mood (× constellation skipped)', () => {
+    const film = { dir: 'Nobody' }
+    // ['tender','tense'] has no named combo → "Tender × Tense" → skipped → primary mood
+    expect(buildBecauseLine({ film, profile: {}, selected: ['tender', 'tense'] }))
+      .toBe('For your tender night.')
+  })
+
+  it('no supported signal → null', () => {
+    const film = { dir: 'Nobody' }
+    expect(buildBecauseLine({ film, profile: {}, selected: [] })).toBeNull()
+  })
+
+  it('alternate uses an evocative real film tag', () => {
+    const film = { dir: 'X', year: 2000, _raw: { mood_tags: ['haunting'], tone_tags: [] } }
+    expect(buildBecauseLine({ film, profile: {}, selected: ['tender'], isAlt: true }))
+      .toBe('A haunting take on your night.')
+  })
+
+  it('alternate article handles "A" vs "An"', () => {
+    const film = { dir: 'X', year: 2000, _raw: { mood_tags: ['exhilarating'] } }
+    expect(buildBecauseLine({ film, profile: {}, selected: ['tender'], isAlt: true }))
+      .toBe('An exhilarating take on your night.')
+  })
+
+  it('alternate falls back to concrete director + year', () => {
+    const film = { dir: 'Celine Song', year: 2023, _raw: { mood_tags: ['dark'] } }
+    expect(buildBecauseLine({ film, profile: {}, selected: ['tender'], isAlt: true }))
+      .toBe("Celine Song's 2023 register.")
+  })
+
+  it('generic tags do NOT generate fabricated evocative language', () => {
+    const film = { dir: 'Celine Song', year: 2023, _raw: { mood_tags: ['dark', 'tense'] } }
+    const line = buildBecauseLine({ film, profile: {}, selected: ['tender'], isAlt: true })
+    expect(line).toBe("Celine Song's 2023 register.")
+    expect(line).not.toMatch(/take on your night/)
+  })
+
+  it('director affinity still outranks alternate-specific signals', () => {
+    const film = { dir: 'Bong Joon-ho', year: 2019, _raw: { mood_tags: ['haunting'] } }
+    expect(buildBecauseLine({ film, profile: dir('Bong Joon-ho'), selected: ['tender'], isAlt: true }))
+      .toBe('Because Bong Joon-ho reads the room the way you do.')
+  })
+
+  it('does not mutate the fixture data', () => {
+    const film = { dir: 'X', year: 2000, _raw: { mood_tags: ['haunting'], tone_tags: [] } }
+    const snap = JSON.parse(JSON.stringify(film))
+    const selected = ['tender']
+    buildBecauseLine({ film, profile: {}, selected, isAlt: true })
+    expect(film).toEqual(snap)
+    expect(selected).toEqual(['tender'])
+  })
+})
+
+// ── diversifyTop3 ─────────────────────────────────────────────────────────────
+const film = (id, rank, moodFit, genre) => ({ id, _rankScore: rank, moodFitRaw: moodFit, primary_genre: genre })
+
+describe('diversifyTop3 — mood-fit floors + diversity + session demotion', () => {
+  it('null/empty input is returned unchanged', () => {
+    expect(diversifyTop3(null)).toBeNull()
+    expect(diversifyTop3([])).toEqual([])
+  })
+
+  it('a high-rank but below-TOP-floor film cannot become #1 when a qualifying film exists', () => {
+    const a = film('a', 100, 0.10, 'Drama')   // top rank, below 0.35 floor
+    const b = film('b', 50, 0.50, 'Comedy')    // lower rank, above floor
+    const out = diversifyTop3([a, b])
+    expect(out[0].id).toBe('b')
+  })
+
+  it('top falls back to the overall highest-ranked film when none meet the floor', () => {
+    const a = film('a', 100, 0.10, 'Drama')
+    const b = film('b', 80, 0.20, 'Comedy')
+    const out = diversifyTop3([a, b])
+    expect(out[0].id).toBe('a') // highest rank, since nothing clears 0.35
+  })
+
+  it('alternates prefer distinct genres among qualifying candidates', () => {
+    const a = film('a', 100, 0.9, 'Drama')
+    const b = film('b', 90, 0.9, 'Drama')   // same genre as a — should be skipped for slot 2
+    const c = film('c', 80, 0.9, 'Comedy')  // new genre — preferred for slot 2
+    const out = diversifyTop3([a, b, c])
+    expect(out.slice(0, 3).map(f => f.id)).toEqual(['a', 'c', 'b'])
+    expect(out[0].primary_genre).toBe('Drama')
+    expect(out[1].primary_genre).toBe('Comedy')
+  })
+
+  it('never uses a below-ALT-floor film merely to fill a slot', () => {
+    const a = film('a', 100, 0.9, 'Drama')
+    const b = film('b', 90, 0.10, 'Comedy') // below 0.25 alt floor
+    const out = diversifyTop3([a, b])
+    // a is the protected top; b stays in the queue tail, NOT promoted into an alt slot
+    expect(out[0].id).toBe('a')
+    expect(out.indexOf(out.find(f => f.id === 'b'))).toBe(1) // b is just the next queue item, not a "chosen" alt
+  })
+
+  it('can return fewer than three protected picks', () => {
+    const a = film('a', 100, 0.9, 'Drama')
+    const b = film('b', 90, 0.10, 'Comedy') // below alt floor → not a protected alt
+    const out = diversifyTop3([a, b])
+    expect(out).toHaveLength(2) // all films still present, just no forced 3rd
+  })
+
+  it('the session-shown penalty can demote a previously-shown film', () => {
+    const a = film('a', 100, 0.9, 'Drama')  // shown → 100 - 30 = 70
+    const b = film('b', 80, 0.9, 'Comedy')  // 80
+    const out = diversifyTop3([a, b], new Set(['a']))
+    expect(out[0].id).toBe('b')
+  })
+
+  it('original _rankScore values are not modified', () => {
+    const a = film('a', 100, 0.9, 'Drama')
+    const b = film('b', 80, 0.9, 'Comedy')
+    diversifyTop3([a, b], new Set(['a']))
+    expect(a._rankScore).toBe(100)
+    expect(b._rankScore).toBe(80)
+  })
+
+  it('does not duplicate ids', () => {
+    const films = [film('a', 100, 0.9, 'Drama'), film('b', 90, 0.8, 'Comedy'), film('c', 80, 0.7, 'Sci-Fi'), film('d', 70, 0.6, 'Drama')]
+    const out = diversifyTop3(films)
+    const ids = out.map(f => f.id)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(ids).toHaveLength(4)
+  })
+
+  it('remaining films preserve the reranked queue order after the protected picks', () => {
+    const a = film('a', 100, 0.9, 'Drama')
+    const b = film('b', 90, 0.9, 'Drama')
+    const c = film('c', 80, 0.9, 'Comedy')
+    const d = film('d', 70, 0.9, 'Sci-Fi')
+    const out = diversifyTop3([a, b, c, d])
+    // top: a (Drama), c (Comedy new genre), d (Sci-Fi new genre); tail: b
+    expect(out.map(f => f.id)).toEqual(['a', 'c', 'd', 'b'])
+  })
+
+  it('does not mutate the input array', () => {
+    const films = [film('a', 50, 0.9, 'Drama'), film('b', 100, 0.9, 'Comedy')]
+    const snapshot = films.slice()
+    diversifyTop3(films)
+    expect(films).toEqual(snapshot) // same elements, same order
+  })
+})
+
+// ── predictDiscoverDefaults ───────────────────────────────────────────────────
+describe('predictDiscoverDefaults — heuristic + learned blend', () => {
+  it('empty/cold input returns the documented defaults', () => {
+    expect(predictDiscoverDefaults({})).toEqual({ intention: 'move', time: 'std', energy: 'steady', who: 'alone' })
+  })
+
+  it('every mood maps to its documented intention', () => {
+    const map = { cerebral: 'think', slow: 'think', cozy: 'comfort', tense: 'distract', restless: 'distract', tender: 'move', bittersweet: 'move', mythic: 'surprise' }
+    for (const [mood, intention] of Object.entries(map)) {
+      expect(predictDiscoverDefaults({ selected: [mood] }).intention).toBe(intention)
+    }
+  })
+
+  it('runtime boundaries map to the correct time band', () => {
+    const time = (avg) => predictDiscoverDefaults({ profile: { preferences: { avgRuntime: avg } } }).time
+    expect(time(99)).toBe('short')
+    expect(time(100)).toBe('std')
+    expect(time(130)).toBe('std')
+    expect(time(131)).toBe('long')
+    expect(time(160)).toBe('long')
+    expect(time(161)).toBe('epic')
+  })
+
+  it('hour-of-day boundaries map to the correct energy', () => {
+    const energy = (h) => predictDiscoverDefaults({ hourOfDay: h }).energy
+    expect(energy(3)).toBe('wiped')
+    expect(energy(4)).toBe('steady')
+    expect(energy(13)).toBe('steady')
+    expect(energy(14)).toBe('wired')
+    expect(energy(19)).toBe('wired')
+    expect(energy(20)).toBe('steady')
+    expect(energy(21)).toBe('steady')
+    expect(energy(22)).toBe('wiped')
+  })
+
+  it('learned data below the trust threshold (3 commits) is ignored', () => {
+    const out = predictDiscoverDefaults({ selected: ['tender'], learnedPrefs: { total_commits: 2, intention_counts: { think: 5 } } })
+    expect(out.intention).toBe('move') // heuristic (tender→move), NOT learned 'think'
+  })
+
+  it('learned data at exactly 3 commits is used', () => {
+    const out = predictDiscoverDefaults({
+      selected: ['tender'],
+      learnedPrefs: { total_commits: 3, intention_counts: { think: 5 }, time_counts: { long: 2 }, energy_counts: { wired: 1 }, who_counts: { partner: 1 } },
+    })
+    expect(out).toEqual({ intention: 'think', time: 'long', energy: 'wired', who: 'partner' })
+  })
+
+  it('learned preferences fall back independently per dimension', () => {
+    const out = predictDiscoverDefaults({
+      selected: ['tender'],
+      hourOfDay: 15, // → wired heuristic
+      learnedPrefs: { total_commits: 3, intention_counts: { think: 5 }, time_counts: {}, energy_counts: null, who_counts: {} },
+    })
+    expect(out.intention).toBe('think')  // learned
+    expect(out.time).toBe('std')         // empty learned → heuristic
+    expect(out.energy).toBe('wired')     // null learned → heuristic (hour 15)
+    expect(out.who).toBe('alone')        // empty learned → heuristic
+  })
+
+  it('invalid/empty count objects fall back to the heuristic', () => {
+    const out = predictDiscoverDefaults({ selected: ['cozy'], learnedPrefs: { total_commits: 3, intention_counts: {} } })
+    expect(out.intention).toBe('comfort') // cozy→comfort heuristic
+  })
+
+  it('does not mutate the input objects', () => {
+    const learnedPrefs = { total_commits: 3, intention_counts: { think: 5 } }
+    const snap = JSON.parse(JSON.stringify(learnedPrefs))
+    const selected = ['tender']
+    predictDiscoverDefaults({ selected, profile: { preferences: { avgRuntime: 120 } }, hourOfDay: 15, learnedPrefs })
+    expect(learnedPrefs).toEqual(snap)
+    expect(selected).toEqual(['tender'])
+  })
+})

--- a/src/features/discover/derive.js
+++ b/src/features/discover/derive.js
@@ -1,0 +1,295 @@
+// src/features/discover/derive.js
+// F3.2 — pure derivation helpers extracted VERBATIM from Discover.jsx (the
+// trust-critical, side-effect-free core of /discover): the mood model + mappings,
+// the honest "Because…" explanation, the Stage-3 diversity pass, and the Stage-2
+// predicted defaults. NO React, NO Supabase, NO navigation/localStorage/analytics,
+// NO FFAudio — every function is pure (same inputs → same output, no external
+// mutation). That purity is exactly why this is the unit-test boundary protecting
+// the F3 redesign. Behaviour + values are unchanged from the pre-extraction source.
+
+
+// === Mood model + mappings ===
+
+// Hints harmonized to noun-phrase voice — the other 6 already use this
+// register; Tender ("For nights…") and Restless ("When you…") were the
+// two outliers that read like a different writer. Now all 8 line up.
+export const MOODS = [
+  { id:'tender',     label:'Tender',      hex:'#F472B6', x:18, y:32, hint:'Nights that ache softly.' },
+  { id:'tense',      label:'Tense',       hex:'#EF4444', x:78, y:24, hint:'Pulse up. Held breath.' },
+  { id:'slow',       label:'Slow-burn',   hex:'#A78BFA', x:34, y:62, hint:'Long takes. Patient escalation.' },
+  { id:'cerebral',   label:'Cerebral',    hex:'#7DD3FC', x:62, y:70, hint:'Big idea, quiet pace.' },
+  { id:'cozy',       label:'Cozy',        hex:'#FBBF24', x:14, y:74, hint:'Low-stakes. Soft landing.' },
+  { id:'bittersweet',label:'Bittersweet', hex:'#FB7185', x:48, y:18, hint:'Sad and beautiful in one breath.' },
+  { id:'mythic',     label:'Mythic',      hex:'#0EA5E9', x:84, y:62, hint:'Epic. Otherworldly.' },
+  { id:'restless',   label:'Restless',    hex:'#34D399', x:52, y:44, hint:'Can’t-sit-still energy.' },
+];
+
+// Onboarding Step 1 uses a 6-mood vocabulary
+// (cozy/wired/tender/fun/tense/mythic — see src/features/onboarding/data.js).
+// /discover uses an 8-axis vocabulary above (the constellation map). This
+// bridge translates baseline-mood keys → Discover mood ids for the
+// first-visit pre-selection in DiscoverBody. Four are direct (cozy,
+// tender, tense, mythic); 'wired' ("cerebral, plot-y, reward focus") maps
+// to the closest Discover hint ("big idea, quiet pace") = cerebral;
+// 'fun' ("light, plot-driven, escapist") maps to restless (the energetic /
+// can't-sit-still axis is the closest entertainment-first register).
+export const ONBOARDING_TO_DISCOVER = {
+  cozy:   'cozy',
+  wired:  'cerebral',
+  tender: 'tender',
+  fun:    'restless',
+  tense:  'tense',
+  mythic: 'mythic',
+};
+
+const CONSTELLATION_NAMES = {
+  'tender':'Soft Focus','tense':'Held Breath','slow':'The Long Take','cerebral':'The Question',
+  'cozy':'Comfort Reel','bittersweet':'Pretty Hurt','mythic':'Big Sky','restless':"Won't Sit Still",
+  'slow,tender':'The Quiet Ache','bittersweet,tender':'The Long Goodbye','cozy,tender':'Home Cinema',
+  'restless,tense':'Live Wire','cerebral,tense':'Cold Logic','bittersweet,tense':'Wound Up',
+  'cerebral,slow':'The Long Question','mythic,slow':'Slow Magic','restless,slow':'Patient Storm',
+  'cerebral,mythic':'The Cathedral','bittersweet,cerebral':'Late Night Math','cerebral,restless':'Mind Adrift',
+  'bittersweet,cozy':'Soft Endings','cozy,mythic':'Fireside Epic','bittersweet,mythic':'Old Light',
+  'mythic,restless':'Quest Mode','bittersweet,restless':'Wired & Wistful',
+  'slow,tense':'Coiled Spring','cozy,tense':'Strange Comfort','mythic,tense':'Dark Myth',
+  'restless,tender':'The Almost','mythic,tender':'Quiet Wonder','cerebral,tender':'The Thinking Heart',
+  'cozy,slow':'Slow Sunday','cozy,cerebral':'Cosy Puzzle','cozy,restless':'Sugar Static',
+  'bittersweet,slow':'The Long Goodbye',
+};
+export const constellationName = (selected) => {
+  if (selected.length === 0) return 'Your night';
+  if (selected.length === 1) return CONSTELLATION_NAMES[selected[0]] || 'Your night';
+  if (selected.length === 2) {
+    const k = selected.slice().sort().join(',');
+    return CONSTELLATION_NAMES[k] || selected.map(s => MOODS.find(m=>m.id===s)?.label).join(' × ');
+  }
+  const labels = selected.map(s => MOODS.find(m=>m.id===s)?.label);
+  return `${labels[0]}, ${labels[1]} & ${labels[2]}`;
+};
+
+// === Honest "Because…" explanation ===
+
+// ── "Because…" line — one-line italic proof above the title that names
+// the strongest signal the engine fired for this user × film. Priority:
+// (1) director affinity from the user's rated history, (2) the
+// constellation the user named in Stage 1, (3) the strongest mood as
+// final fallback. Returns null if no signal can be honestly claimed —
+// caller hides the line entirely rather than printing filler. Single
+// line, italic, brand-soft voice. The point of this line is to make
+// "the engine knows you" visible without prose paragraphs.
+// `isAlt` routes alternate cards to FILM-SPECIFIC signals first so the
+// 3 cards on the spread don't all show the same constellation line.
+// Top card uses director-affinity → constellation → mood (the user-
+// connecting hierarchy). Alt cards prefer signals that DIFFER between
+// films — director name + year, or mood/tone tag highlight — making
+// each card carry its own personality. Director affinity still wins
+// for ALT if it fires (rare but valuable signal).
+export function buildBecauseLine({ film, profile, selected, isAlt = false }) {
+  if (!film) return null;
+  // Director affinity — strongest signal, works for both slots.
+  const dirAffinity = profile?.affinities?.directors?.find(d =>
+    d?.name && film?.dir && d.name.toLowerCase() === film.dir.toLowerCase()
+  );
+  if (dirAffinity) {
+    return `Because ${film.dir} reads the room the way you do.`;
+  }
+
+  // ALT-only: prefer film-specific signals that vary per card.
+  if (isAlt) {
+    // Highlight the film's strongest mood/tone tag — varies per film,
+    // gives each alt a distinct hook. Skip generic tags ("dark", "tense")
+    // that sound dour; prefer evocative ones.
+    const rawTags = [...(film._raw?.mood_tags || []), ...(film._raw?.tone_tags || [])]
+    const evocative = rawTags.find(t => /heartwarming|whimsical|nostalgic|haunting|exhilarating|melancholic|playful|grandiose|poetic|intimate|gritty|dreamy|wistful|provocative|mysterious/i.test(t || ''))
+    if (evocative) {
+      const pretty = String(evocative).replace(/_/g, ' ').toLowerCase()
+      // "A exhilarating" → "An exhilarating". Cover the common vowel cases.
+      const article = /^[aeiou]/.test(pretty) ? 'An' : 'A'
+      return `${article} ${pretty} take on your night.`
+    }
+    // Director name + year — concrete, varies between films
+    if (film.dir && film.year) {
+      return `${film.dir}'s ${film.year} register.`
+    }
+  }
+
+  // Constellation fallback (for TOP and for ALT when no per-film signal fired).
+  // Skip multi-mood × names ("Bittersweet × Tender") — they read awkwardly
+  // mid-sentence. Strip leading "The " so "The Quiet Ache" doesn't render
+  // as "For your the quiet ache night."
+  const cName = constellationName(selected);
+  if (cName && cName !== 'Your night' && !cName.includes('×') && selected.length <= 2) {
+    const stripped = cName.replace(/^the\s+/i, '').toLowerCase();
+    return `For your ${stripped} night.`;
+  }
+  const topMood = MOODS.find(m => m.id === selected[0]);
+  if (topMood) {
+    return `For your ${topMood.label.toLowerCase()} night.`;
+  }
+  return null;
+}
+
+// === Stage-3 diversity / ranking post-processing ===
+
+// ── Diversity pass for the Stage 3 swiper.
+// Re-orders the top 3 visible picks so they span 3 distinct primary_genres
+// when the pool allows it. Films 4+ stay in pure rank order. Without this,
+// a mood combo that strongly favors one genre produces a clustered top-3
+// where the user's alternates feel like re-runs of the focused pick.
+//
+// Slot 1 enforces a HARD mood-fit floor (TOP_MOOD_FIT_FLOOR). The headline
+// pick must hit at least this much mood-fit on the user's selected moods.
+// Without it, a film with high taste affinity but poor mood match (e.g.,
+// Chocolat at 15% mood when user asked cerebral+mythic) could be the
+// headline despite not actually fitting what was asked.
+//
+// Slots 2 and 3 enforce a SOFTER floor (ALT_MOOD_FIT_FLOOR). They're
+// framed as alternates so a slightly lower mood threshold is fine, but
+// surfacing a 15% mood film as a "pick from these" alternative to
+// cerebral+mythic still felt wrong in audit. The soft floor protects
+// against that while still leaving room for genre diversity.
+//
+// Fallback chain for slots 2/3:
+//   1. Highest-ranked, NEW genre, above alt floor (best case)
+//   2. Highest-ranked above alt floor (any genre — sacrifice diversity for honesty)
+//   3. Break — surface fewer alts rather than a bad-mood pick. UI handles
+//      0-2 alts gracefully via the alternates row.
+export const TOP_MOOD_FIT_FLOOR = 0.35
+export const ALT_MOOD_FIT_FLOOR = 0.25
+// Session penalty — films already shown in this /discover session get
+// this many points deducted from their _rankScore before slotting. Soft
+// demotion (not exclusion) so a strongly-mood-matched film can still win
+// if no fresh alternative comes close, but in tight ranks fresh films
+// float to the top. 30 is large enough to flip "broad-mood" films
+// (Gladiator, Chocolat) off the top of every scenario while still
+// allowing them to surface if genuinely the best match.
+export const SESSION_SHOWN_PENALTY = 30
+export function diversifyTop3(scored, sessionShownIds = new Set()) {
+  if (!Array.isArray(scored) || scored.length < 1) return scored
+  // Re-sort with session penalty: previously-shown films pay 30 pts.
+  // The original _rankScore is preserved on the film; this just changes
+  // sort order. Films past the displayed top 3 still benefit from the
+  // penalty in the queue order so the next skip/watched advance also
+  // surfaces fresh films.
+  const reranked = scored.slice().sort((a, b) => {
+    const aScore = (a._rankScore || 0) - (sessionShownIds.has(a.id) ? SESSION_SHOWN_PENALTY : 0)
+    const bScore = (b._rankScore || 0) - (sessionShownIds.has(b.id) ? SESSION_SHOWN_PENALTY : 0)
+    return bScore - aScore
+  })
+  const used = new Set()
+  const remaining = reranked.slice()
+  const top = []
+
+  // First pick — highest-ranked film that meets the TOP mood-fit floor.
+  // Falls back to overall highest-ranked if nothing meets the floor
+  // (extreme cold-start: pool has zero mood-matching candidates).
+  let firstIdx = remaining.findIndex(f => (f?.moodFitRaw ?? 0) >= TOP_MOOD_FIT_FLOOR)
+  if (firstIdx === -1) firstIdx = 0
+  const first = remaining.splice(firstIdx, 1)[0]
+  if (first) {
+    top.push(first)
+    if (first.primary_genre) used.add(first.primary_genre)
+  }
+
+  // Picks 2 and 3 — apply ALT mood-fit floor with genre-diversity preference.
+  for (let i = 0; i < 2 && remaining.length > 0; i++) {
+    // 1. Try: new genre + above alt floor
+    let idx = remaining.findIndex(f => f?.primary_genre && !used.has(f.primary_genre) && (f?.moodFitRaw ?? 0) >= ALT_MOOD_FIT_FLOOR)
+    // 2. Fall back: above alt floor, any genre (sacrifice diversity over honesty)
+    if (idx === -1) idx = remaining.findIndex(f => (f?.moodFitRaw ?? 0) >= ALT_MOOD_FIT_FLOOR)
+    // 3. Last fallback: break — fewer alts is better than a bad-mood pick
+    if (idx === -1) break
+    const pick = remaining.splice(idx, 1)[0]
+    top.push(pick)
+    if (pick?.primary_genre) used.add(pick.primary_genre)
+  }
+
+  return [...top, ...remaining]
+}
+
+// === Stage-2 predicted defaults ===
+
+// ── Stage 2 pre-selection — predict the user's likely intention / time /
+// energy from signals we already have, so the page lands on smart
+// defaults instead of the static `move / std / steady / alone` set. The
+// user can always override; this just shifts the starting point so
+// less-engaged users hit Continue faster, and engaged users see the page
+// reflect what they actually tend to pick.
+//
+// Signals used:
+//   • intention ← primary mood from Stage 1 (cerebral → think, cozy →
+//     comfort, tense/restless → distract, tender/bittersweet → move,
+//     mythic → surprise, slow → think). When mood is empty, defaults
+//     to 'move' (broadest appeal).
+//   • time ← profile.preferences.avgRuntime, mapped to the closest
+//     TIME_OPTIONS band. Cold-start users have avgRuntime=120 (the
+//     placeholder default), which lands at 'std' — same as the old
+//     hardcoded default, so no regression.
+//   • energy ← current hour. 22:00-04:00 → 'wiped' (winding down);
+//     14:00-20:00 → 'wired' (active); else 'steady'. Time-of-day is
+//     a privacy-cheap signal that meaningfully shifts the right answer.
+//   • who ← 'alone' (default). Hard to infer honestly without explicit
+//     session signal. Phase 2 will add learned override.
+const INTENTION_FROM_MOOD = {
+  cerebral: 'think',
+  slow:     'think',
+  cozy:     'comfort',
+  tense:    'distract',
+  restless: 'distract',
+  tender:   'move',
+  bittersweet: 'move',
+  mythic:   'surprise',
+}
+
+// Mode-of-counts — returns the most-frequent key in a {key: count} JSONB
+// object, or null when the object is empty/invalid. Used by the hybrid
+// blend to read learned prefs from user_discover_preferences.
+function modeOf(counts) {
+  if (!counts || typeof counts !== 'object') return null
+  const entries = Object.entries(counts)
+  if (entries.length === 0) return null
+  entries.sort((a, b) => b[1] - a[1])
+  return entries[0][0]
+}
+
+// Trust threshold — how many commits the user needs before we prefer
+// their learned mode over the heuristic. 3 is a small-enough sample to
+// adapt quickly but large enough to avoid one-off swings.
+const MIN_COMMITS_TO_TRUST = 3
+
+export function predictDiscoverDefaults({ selected, profile, hourOfDay, learnedPrefs }) {
+  // === Heuristic prediction (always computed) ===
+  const primaryMood = selected?.[0]
+  const heuristic = {
+    intention: INTENTION_FROM_MOOD[primaryMood] || 'move',
+    time: 'std',
+    energy: 'steady',
+    who: 'alone',
+  }
+  const avg = profile?.preferences?.avgRuntime
+  if (Number.isFinite(avg)) {
+    if (avg < 100)       heuristic.time = 'short'
+    else if (avg <= 130) heuristic.time = 'std'
+    else if (avg <= 160) heuristic.time = 'long'
+    else                 heuristic.time = 'epic'
+  }
+  if (Number.isFinite(hourOfDay)) {
+    if (hourOfDay >= 22 || hourOfDay < 4) heuristic.energy = 'wiped'
+    else if (hourOfDay >= 14 && hourOfDay < 20) heuristic.energy = 'wired'
+  }
+
+  // === Hybrid blend with learned data ===
+  // Only trust learned prefs after MIN_COMMITS_TO_TRUST. Below that, the
+  // heuristic carries the prediction. Per-dimension fallback: if the
+  // learned mode for a dimension is null (no signal yet for that field),
+  // fall back to heuristic for THAT field — even if total_commits >= 3.
+  if ((learnedPrefs?.total_commits || 0) >= MIN_COMMITS_TO_TRUST) {
+    return {
+      intention: modeOf(learnedPrefs.intention_counts) || heuristic.intention,
+      time:      modeOf(learnedPrefs.time_counts)      || heuristic.time,
+      energy:    modeOf(learnedPrefs.energy_counts)    || heuristic.energy,
+      who:       modeOf(learnedPrefs.who_counts)       || heuristic.who,
+    }
+  }
+  return heuristic
+}


### PR DESCRIPTION
**F3.2** — the first, smallest, safest code phase of the `/discover` redesign (per the F3.1 audit). **Behavior-preserving decomposition only** — mechanically extract `Discover.jsx`'s pure, trust-critical derivation logic into a module and lock it under unit test. **No UI, copy, styling, state-machine, scoring, ranking, persistence, queue, audio, ceremony, or fallback change.**

## Helpers/constants extracted → `src/features/discover/derive.js`
- **Mood model + mappings:** `MOODS`, `ONBOARDING_TO_DISCOVER`, `CONSTELLATION_NAMES` (module-private), `constellationName`.
- **Honest explanation:** `buildBecauseLine` — the full top/alt priority order + the **null-not-fabricate** discipline preserved exactly; `isAlt` branch intact.
- **Stage-3 diversity:** `TOP_MOOD_FIT_FLOOR=0.35`, `ALT_MOOD_FIT_FLOOR=0.25`, `SESSION_SHOWN_PENALTY=30`, `diversifyTop3` (mood-fit floors, genre diversity, fewer-alts-over-bad-mood, session demotion, original `_rankScore` preserved).
- **Stage-2 defaults:** `INTENTION_FROM_MOOD`, `modeOf`, `MIN_COMMITS_TO_TRUST` (all module-private), `predictDiscoverDefaults` (runtime/hour heuristics + the ≥3-commit learned blend with per-dimension fallback).

**Exports** = only what `Discover.jsx` imports back (`MOODS`, `ONBOARDING_TO_DISCOVER`, `constellationName`, `buildBecauseLine`, `diversifyTop3`, `predictDiscoverDefaults`) + the three frozen floor/penalty constants for the tests. The other four moved symbols stay module-private.

## Why this is the trust-critical test boundary
These are the pure, side-effect-free heart of the experience — the **honest because-line**, the **mood-fit floors**, and the **onboarding→Discover mood bridge**. They had **zero coverage**. Locking them first makes the later decomposition + UX cuts (F3.3+) reviewable without risking the honesty layer.

## Test contracts added (`__tests__/derive.test.js`, 41)
`MOODS` 8-axis shape · `constellationName` order-independence + label fallback + no-mutation · the six `ONBOARDING_TO_DISCOVER` mappings · `buildBecauseLine` null-not-fabricate + director-affinity-priority + alt evocative-tag/article/dir-year + **no-fabrication on generic tags** · `diversifyTop3` floor enforcement + genre diversity + session demotion + `_rankScore` preservation + no-mutation · `predictDiscoverDefaults` runtime/hour boundaries + the 3-commit learned blend + per-dimension fallback. Stable across 3 runs.

## Mechanical-equivalence evidence
All **263 non-empty moved lines are byte-identical** to the pre-extraction `Discover.jsx` (verified by diff vs `main`); the only syntactic change is the added `export ` prefixes. `Discover.jsx` changed by exactly **one added import line + removal of the moved blocks** — zero JSX, handler, write, or scoring edits. **No logic changed.**

## Confirmations
- **`computeFit` and `useDiscoverData.jsx` untouched** — `computeFit` stays in the data provider (explicitly deferred).
- **UI, state machine, scoring, queue, writes, audio, ceremony, and fallback content untouched** — `commitDiscoverPreferences` (writes) and `FILMS_FALLBACK` both stay in `Discover.jsx`; no recommendations.js/scoringV3.js/matchScore.js/interactions.js/onboarding/home/movie/router/schema/RLS/migration/snapshot change.
- **No live Discover write was triggered** — unit tests only; no authenticated render (loading live Discover would log impressions).

## Validation
- `npm run lint` → clean
- `npx vitest run src/features/discover/__tests__/derive.test.js` → 41 passed (3× stable)
- `npx vitest run src/features/discover/ src/shared/services/__tests__/discoverEngine.test.js` → 55 passed (2 files)
- `npm run build` → ✓ (the `./derive` import resolves; no dangling reference)
- `npm run test` (full) → 719 passed (62 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
