### PR TITLE
Harden Discover result trust and accessibility

### DIFF
--- a/src/features/discover/Discover.jsx
+++ b/src/features/discover/Discover.jsx
@@ -295,7 +295,11 @@ function DiscoverBody() {
 
   // Use live candidates from `movies`; fall back to the editorial seed set
   // only when the query hasn't returned anything (offline / empty DB).
-  const films = (liveFilms && liveFilms.length > 0) ? liveFilms : FILMS_FALLBACK;
+  const usingLiveFilms = !!(liveFilms && liveFilms.length > 0);
+  const films = usingLiveFilms ? liveFilms : FILMS_FALLBACK;
+  // When the live fetch returned nothing (empty/error), the result is drawn from
+  // the static FILMS_FALLBACK set — labelled honestly to the user via StagePick.
+  const usingFallback = !usingLiveFilms;
 
   const fireBurst = (id, hex) => {
     const t = Date.now();
@@ -435,7 +439,7 @@ function DiscoverBody() {
         {stage === 1   && <StageMood selected={selected} setSelected={setSelected} onNext={()=>setStage(2)} blendHex={blendHex} bursts={bursts} fireBurst={fireBurst} audioToggle={<AudioToggle />} playMoodCue={(id)=>FFAudio.pluck(id)} playContinueCue={()=>FFAudio.whoom()} />}
         {stage === 2   && <StageNightContext time={time} setTime={setTime} who={who} setWho={setWho} energy={energy} setEnergy={setEnergy} intention={intention} setIntention={setIntention} onUserEdit={()=>{ contextTouchedRef.current = true }} onNext={()=>{ handleCommitStage2(); setStage(2.3); }} onBack={()=>setStage(1)} blendHex={blendHex} playOptionCue={()=>FFAudio.pluck('cozy')} playContinueCue={()=>FFAudio.whoom()} />}
         {stage === 2.3 && <StageResolve blendHex={blendHex} onDone={()=>setStage(3)} />}
-        {stage === 3   && <StagePick selected={selected.length>0?selected:['slow','tender']} who={who} energy={energy} intention={intention} time={time} results={allResults} profile={profile} sessionShownIds={sessionShownIds} onRestart={()=>{ setStage(1); setSelected([]); contextTouchedRef.current = false; didPredictDefaultsRef.current = false; setIntention('move'); setTime('std'); setWho('alone'); setEnergy('steady'); }} onBack={()=>setStage(2)} blendHex={blendHex} audioToggle={<AudioToggle />} />}
+        {stage === 3   && <StagePick selected={selected.length>0?selected:['slow','tender']} who={who} energy={energy} intention={intention} time={time} results={allResults} profile={profile} sessionShownIds={sessionShownIds} isFallback={usingFallback} onRestart={()=>{ setStage(1); setSelected([]); contextTouchedRef.current = false; didPredictDefaultsRef.current = false; setIntention('move'); setTime('std'); setWho('alone'); setEnergy('steady'); }} onBack={()=>setStage(2)} blendHex={blendHex} audioToggle={<AudioToggle />} />}
       </div>
     </div>
   );

--- a/src/features/discover/__tests__/DiscoverEntry.test.jsx
+++ b/src/features/discover/__tests__/DiscoverEntry.test.jsx
@@ -141,9 +141,9 @@ describe('Discover night context — summary-first (F3.6)', () => {
       fireEvent.click(findFilmBtn())
       await act(async () => { await vi.advanceTimersByTimeAsync(899) })
       expect(screen.getByText('Bringing tonight into focus.')).toBeInTheDocument() // still resolving
-      expect(screen.queryByText(/Tonight.s pick/)).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Not tonight' })).not.toBeInTheDocument()
       await act(async () => { await vi.advanceTimersByTimeAsync(1) })
-      expect(screen.getByText(/Tonight.s pick/)).toBeInTheDocument() // StagePick reached
+      expect(screen.getByRole('button', { name: 'Not tonight' })).toBeInTheDocument() // StagePick reached
     } finally { vi.useRealTimers() }
   })
 
@@ -155,7 +155,7 @@ describe('Discover night context — summary-first (F3.6)', () => {
       gotoNight('Cozy')
       fireEvent.click(findFilmBtn())
       await act(async () => { await vi.advanceTimersByTimeAsync(0) }) // 0ms resolve under reduced motion
-      expect(screen.getByText(/Tonight.s pick/)).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Not tonight' })).toBeInTheDocument()
     } finally { vi.useRealTimers() }
   })
 

--- a/src/features/discover/__tests__/DiscoverResult.test.jsx
+++ b/src/features/discover/__tests__/DiscoverResult.test.jsx
@@ -6,9 +6,10 @@
 // sections are unchanged. Everything mocked — no live mount/Supabase/TMDB/YouTube.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, act, renderHook } from '@testing-library/react'
+import { useState } from 'react'
 
-const h = vi.hoisted(() => ({ user: { id: 'u1' }, navigate: () => {}, inserts: [], insertError: null, providers: [] }))
+const h = vi.hoisted(() => ({ user: { id: 'u1' }, navigate: () => {}, inserts: [], insertError: null, providers: [], providerError: false }))
 
 vi.mock('@/shared/hooks/useAuthSession', () => ({ useAuthSession: () => ({ user: h.user }) }))
 vi.mock('react-router-dom', async (orig) => ({ ...(await orig()), useNavigate: () => h.navigate }))
@@ -17,11 +18,12 @@ vi.mock('@/shared/lib/supabase/client', () => ({
 }))
 vi.mock('@/shared/services/recommendations', () => ({ updateImpression: vi.fn().mockResolvedValue(), logSurfaceImpressions: vi.fn().mockResolvedValue() }))
 vi.mock('@/shared/services/interactions', () => ({ trackInteraction: vi.fn().mockResolvedValue() }))
-vi.mock('@/shared/api/tmdb', () => ({ getMovieWatchProviders: vi.fn(() => Promise.resolve({ providers: h.providers })) }))
+vi.mock('@/shared/api/tmdb', () => ({ getMovieWatchProviders: vi.fn(() => h.providerError ? Promise.reject(new Error('tmdb down')) : Promise.resolve({ providers: h.providers })) }))
 
 import StagePick from '../sections/StagePick'
 import StreamingChip from '../sections/StreamingChip'
 import TrailerModal from '../sections/TrailerModal'
+import { useStreamingProvider } from '../hooks/useStreamingProvider'
 import { buildRuntimeFitLine } from '../resultPresentation'
 import { updateImpression, logSurfaceImpressions } from '@/shared/services/recommendations'
 import { trackInteraction } from '@/shared/services/interactions'
@@ -42,7 +44,7 @@ const baseProps = (over = {}) => ({
 const titleHeading = (name) => screen.getByRole('heading', { level: 1, name })
 
 beforeEach(() => {
-  h.user = { id: 'u1' }; h.navigate = vi.fn(); h.inserts = []; h.insertError = null; h.providers = []
+  h.user = { id: 'u1' }; h.navigate = vi.fn(); h.inserts = []; h.insertError = null; h.providers = []; h.providerError = false
   vi.clearAllMocks()
   window.matchMedia = window.matchMedia || (() => ({ matches: false, addEventListener() {}, removeEventListener() {} }))
 })
@@ -92,7 +94,7 @@ describe('StagePick — one-pick render', () => {
   })
   it('renders the "Tonight’s pick" eyebrow + the "Why this one" case with the because + runtime lines', () => {
     render(<StagePick {...baseProps()} />)
-    expect(screen.getByText(/Tonight.s pick/)).toBeInTheDocument()
+    expect(screen.getByText(/^Tonight.s pick$/)).toBeInTheDocument()
     expect(screen.getByText('Why this one')).toBeInTheDocument()
     expect(screen.getByText('For your soft focus night.')).toBeInTheDocument() // becauseLine
     expect(screen.getByText('Within your ~ 2 hrs window.')).toBeInTheDocument() // runtime fit (101 ∈ std)
@@ -244,28 +246,212 @@ describe('StagePick — actions', () => {
   })
 })
 
-// ── unchanged sections (StreamingChip + TrailerModal) ─────────────────────────
-describe('StreamingChip (unchanged)', () => {
-  it('renders nothing without a provider', () => {
-    const { container } = render(<StreamingChip provider={null} />)
-    expect(container).toBeEmptyDOMElement()
+// ── F3.9: single live-status region ───────────────────────────────────────────
+const liveRegion = () => screen.getByRole('status')
+describe('StagePick — live status (F3.9)', () => {
+  it('exposes exactly one polite, atomic status region', () => {
+    render(<StagePick {...baseProps()} />)
+    const regions = screen.getAllByRole('status')
+    expect(regions).toHaveLength(1)
+    expect(regions[0]).toHaveAttribute('aria-live', 'polite')
+    expect(regions[0]).toHaveAttribute('aria-atomic', 'true')
   })
-  it('maps provider type to the priority label', () => {
-    const { rerender } = render(<StreamingChip provider={{ type: 'flatrate', name: 'Netflix', logoPath: '/n.png' }} />)
-    expect(screen.getByText('Streaming on')).toBeInTheDocument()
-    rerender(<StreamingChip provider={{ type: 'rent', name: 'Apple TV', logoPath: '/a.png' }} />)
-    expect(screen.getByText('Rent on')).toBeInTheDocument()
-    rerender(<StreamingChip provider={{ type: 'buy', name: 'Amazon', logoPath: '/z.png' }} />)
-    expect(screen.getByText('Buy on')).toBeInTheDocument()
+  it('announces the first pick with its title', () => {
+    render(<StagePick {...baseProps()} />)
+    expect(liveRegion()).toHaveTextContent("Tonight's pick: Film1.")
+  })
+  it('announces save success', async () => {
+    render(<StagePick {...baseProps()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Save for later' }))
+    await waitFor(() => expect(liveRegion()).toHaveTextContent('Saved for later.'))
+  })
+  it('announces save failure as a retry', async () => {
+    h.insertError = { code: '500' }
+    render(<StagePick {...baseProps()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Save for later' }))
+    await waitFor(() => expect(liveRegion()).toHaveTextContent('Could not save. Try again.'))
+  })
+  it('announces the promoted pick after Not tonight', async () => {
+    render(<StagePick {...baseProps()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Not tonight' }))
+    await waitFor(() => expect(liveRegion()).toHaveTextContent('New pick: Film2.'))
+  })
+  it('announces marked-watched then the promoted pick', async () => {
+    render(<StagePick {...baseProps()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Already watched' }))
+    await waitFor(() => expect(liveRegion()).toHaveTextContent('Marked watched. New pick: Film2.'), { timeout: 2000 })
+  })
+  it('announces the exhausted state', () => {
+    render(<StagePick {...baseProps({ results: [] })} />)
+    expect(liveRegion()).toHaveTextContent('No more strong fits for this set of details.')
+  })
+  it('never announces a queue count', () => {
+    render(<StagePick {...baseProps({ results: [film(1), film(2), film(3), film(4), film(5)] })} />)
+    expect(liveRegion().textContent).not.toMatch(/\d+\s*(more|queued|left|remaining)/i)
   })
 })
 
-describe('TrailerModal (unchanged)', () => {
+// ── F3.9: action-state semantics ──────────────────────────────────────────────
+describe('StagePick — action-state semantics (F3.9)', () => {
+  it('Save exposes pressed + disabled once saved', async () => {
+    render(<StagePick {...baseProps()} />)
+    const save = screen.getByRole('button', { name: 'Save for later' })
+    expect(save).toHaveAttribute('aria-pressed', 'false')
+    fireEvent.click(save)
+    const saved = await screen.findByRole('button', { name: 'Saved' })
+    expect(saved).toHaveAttribute('aria-pressed', 'true')
+    expect(saved).toBeDisabled()
+  })
+  it('Already watched exposes pressed + disabled on success', async () => {
+    render(<StagePick {...baseProps()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Already watched' }))
+    const done = await screen.findByRole('button', { name: 'Watched' })
+    expect(done).toHaveAttribute('aria-pressed', 'true')
+    expect(done).toBeDisabled()
+  })
+  it('Not tonight stays available', () => {
+    render(<StagePick {...baseProps()} />)
+    expect(screen.getByRole('button', { name: 'Not tonight' })).toBeEnabled()
+  })
+  it('shows a film-file-unavailable note instead of a dead button when tmdbId is missing', () => {
+    render(<StagePick {...baseProps({ results: [film(1, { tmdbId: null })] })} />)
+    expect(screen.queryByRole('button', { name: /open film file/i })).not.toBeInTheDocument()
+    expect(screen.getByText('Film file unavailable for this title.')).toBeInTheDocument()
+  })
+  it('all action controls keep accessible names', () => {
+    render(<StagePick {...baseProps()} />)
+    expect(screen.getByRole('button', { name: /open film file/i })).toBeInTheDocument()
+    for (const name of ['Trailer', 'Save for later', 'Already watched', 'Not tonight']) {
+      expect(screen.getByRole('button', { name })).toBeInTheDocument()
+    }
+  })
+})
+
+// ── F3.9: write-error behavior ────────────────────────────────────────────────
+describe('StagePick — write-error behavior (F3.9)', () => {
+  it('Save treats 23505 (already saved) as success', async () => {
+    h.insertError = { code: '23505' }
+    render(<StagePick {...baseProps()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Save for later' }))
+    expect(await screen.findByText('Saved')).toBeInTheDocument()
+  })
+  it('Save surfaces a non-23505 failure as Try again', async () => {
+    h.insertError = { code: '500' }
+    render(<StagePick {...baseProps()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Save for later' }))
+    expect(await screen.findByText('Try again')).toBeInTheDocument()
+  })
+  it('Mark Watched does NOT falsely confirm Watched when the write fails', async () => {
+    h.insertError = { code: '500' }
+    render(<StagePick {...baseProps()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Already watched' }))
+    expect(await screen.findByRole('button', { name: 'Try again' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Watched' })).not.toBeInTheDocument()
+    expect(updateImpression).not.toHaveBeenCalledWith('u1', 1, 'watched') // failed write is not credited
+    await waitFor(() => expect(liveRegion()).toHaveTextContent('Could not mark watched. Try again.'))
+  })
+  it('a non-critical impression failure does not block a successful save', async () => {
+    updateImpression.mockRejectedValueOnce(new Error('analytics down'))
+    render(<StagePick {...baseProps()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Save for later' }))
+    expect(await screen.findByText('Saved')).toBeInTheDocument() // save still confirms
+  })
+})
+
+// ── F3.9: streaming-provider honesty ──────────────────────────────────────────
+describe('Streaming provider honesty (F3.9)', () => {
+  it('StreamingChip renders nothing without a provider (idle/loading)', () => {
+    const { container } = render(<StreamingChip provider={null} status="loading" />)
+    expect(container).toBeEmptyDOMElement()
+  })
+  it('StreamingChip maps provider type to the label + a logo alt', () => {
+    const { rerender } = render(<StreamingChip provider={{ type: 'flatrate', name: 'Netflix', logoPath: '/n.png' }} status="found" />)
+    expect(screen.getByText('Streaming on')).toBeInTheDocument()
+    expect(screen.getByAltText('Netflix logo')).toBeInTheDocument()
+    rerender(<StreamingChip provider={{ type: 'rent', name: 'Apple TV', logoPath: '/a.png' }} status="found" />)
+    expect(screen.getByText('Rent on')).toBeInTheDocument()
+    rerender(<StreamingChip provider={{ type: 'buy', name: 'Amazon', logoPath: '/z.png' }} status="found" />)
+    expect(screen.getByText('Buy on')).toBeInTheDocument()
+  })
+  it('StreamingChip renders an honest empty state', () => {
+    render(<StreamingChip provider={null} status="empty" />)
+    expect(screen.getByText('Availability not found')).toBeInTheDocument()
+  })
+  it('StreamingChip renders an honest error state', () => {
+    render(<StreamingChip provider={null} status="error" />)
+    expect(screen.getByText('Availability unavailable')).toBeInTheDocument()
+  })
+  it('useStreamingProvider keeps flatrate → rent → buy priority (providers[0])', async () => {
+    h.providers = [{ type: 'flatrate', name: 'Netflix', logoPath: '/n.png' }, { type: 'rent', name: 'Apple', logoPath: '/a.png' }]
+    const { result } = renderHook(() => useStreamingProvider(101))
+    await waitFor(() => expect(result.current.status).toBe('found'))
+    expect(result.current.provider.type).toBe('flatrate')
+  })
+  it('useStreamingProvider reports empty when TMDB has no provider', async () => {
+    h.providers = []
+    const { result } = renderHook(() => useStreamingProvider(101))
+    await waitFor(() => expect(result.current.status).toBe('empty'))
+  })
+  it('useStreamingProvider reports error when the fetch fails', async () => {
+    h.providerError = true
+    const { result } = renderHook(() => useStreamingProvider(101))
+    await waitFor(() => expect(result.current.status).toBe('error'))
+  })
+  it('StagePick shows the honest no-availability note after an empty fetch', async () => {
+    h.providers = []
+    render(<StagePick {...baseProps()} />)
+    expect(await screen.findByText('Availability not found')).toBeInTheDocument()
+  })
+})
+
+// ── F3.9: image + decorative semantics ────────────────────────────────────────
+describe('StagePick — image + decorative semantics (F3.9)', () => {
+  it('the main poster has a meaningful alt', () => {
+    render(<StagePick {...baseProps()} />)
+    expect(screen.getByAltText('Film1 poster')).toBeInTheDocument()
+  })
+  it('decorative overlays are aria-hidden', () => {
+    const { container } = render(<StagePick {...baseProps()} />)
+    expect(container.querySelectorAll('[aria-hidden="true"]').length).toBeGreaterThan(0)
+  })
+  it('button icons are aria-hidden (the text already names the action)', () => {
+    render(<StagePick {...baseProps()} />)
+    const trailerBtn = screen.getByRole('button', { name: /trailer/i })
+    expect(trailerBtn.querySelector('svg')).toHaveAttribute('aria-hidden', 'true')
+  })
+})
+
+// ── F3.9: trailer dialog accessibility ────────────────────────────────────────
+function TrailerHarness({ title = 'Parasite' }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <button data-testid="opener" onClick={() => setOpen(true)}>Open trailer</button>
+      <TrailerModal open={open} youtubeKey="abc" title={title} onClose={() => setOpen(false)} />
+    </>
+  )
+}
+const closeBtn = () => screen.getByRole('button', { name: 'Close trailer' })
+describe('TrailerModal — accessibility (F3.9)', () => {
   it('renders nothing when closed', () => {
     render(<TrailerModal open={false} youtubeKey="abc" title="X" onClose={() => {}} />)
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
-  it('Escape closes the trailer', () => {
+  it('is a modal dialog whose name includes the film title', () => {
+    render(<TrailerModal open youtubeKey="abc" title="Parasite" onClose={() => {}} />)
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    expect(dialog).toHaveAccessibleName('Parasite trailer')
+  })
+  it('moves initial focus into the dialog (close button)', () => {
+    vi.useFakeTimers()
+    try {
+      render(<TrailerModal open youtubeKey="abc" title="X" onClose={() => {}} />)
+      act(() => { vi.advanceTimersByTime(0) })
+      expect(closeBtn()).toHaveFocus()
+    } finally { vi.useRealTimers() }
+  })
+  it('Escape closes', () => {
     const onClose = vi.fn()
     render(<TrailerModal open youtubeKey="abc" title="X" onClose={onClose} />)
     fireEvent.keyDown(window, { key: 'Escape' })
@@ -281,9 +467,41 @@ describe('TrailerModal (unchanged)', () => {
     fireEvent.click(dialog.lastElementChild)
     expect(onClose).not.toHaveBeenCalled()
   })
+  it('returns focus to the opener on close', () => {
+    vi.useFakeTimers()
+    try {
+      render(<TrailerHarness />)
+      const opener = screen.getByTestId('opener')
+      opener.focus()
+      fireEvent.click(opener)
+      act(() => { vi.advanceTimersByTime(0) })
+      expect(closeBtn()).toHaveFocus()
+      fireEvent.keyDown(window, { key: 'Escape' })
+      expect(opener).toHaveFocus()
+    } finally { vi.useRealTimers() }
+  })
+  it('keeps Tab and Shift+Tab inside the dialog', () => {
+    vi.useFakeTimers()
+    try {
+      render(<TrailerModal open youtubeKey="abc" title="X" onClose={() => {}} />)
+      act(() => { vi.advanceTimersByTime(0) })
+      const btn = closeBtn()
+      expect(btn).toHaveFocus()
+      fireEvent.keyDown(window, { key: 'Tab' })
+      expect(document.activeElement).toBe(btn) // stayed inside
+      fireEvent.keyDown(window, { key: 'Tab', shiftKey: true })
+      expect(document.activeElement).toBe(btn)
+    } finally { vi.useRealTimers() }
+  })
+  it('locks body scroll while open and restores on unmount', () => {
+    const { unmount } = render(<TrailerModal open youtubeKey="abc" title="X" onClose={() => {}} />)
+    expect(document.body.style.overflow).toBe('hidden')
+    unmount()
+    expect(document.body.style.overflow).toBe('')
+  })
 })
 
-// no write occurs when there is no user
+// ── existing contracts kept green ─────────────────────────────────────────────
 describe('StagePick — write guards', () => {
   it('does not write to the watchlist when there is no user', async () => {
     h.user = null

--- a/src/features/discover/discover.css
+++ b/src/features/discover/discover.css
@@ -345,6 +345,20 @@
   .ff-pick-actions__secondary { flex: 1 1 auto; }
 }
 
+/* F3.9 — quiet, honest trust notes (provider absence, missing film file,
+ * fallback/static result). Secondary by design: small, muted, never an alert. */
+.ff-provider-note,
+.ff-pick-unavailable,
+.ff-pick-fallback-note {
+  font-family: 'Outfit', 'Inter', sans-serif;
+  font-size: 12px;
+  color: var(--text-muted, #8f8883);
+  letter-spacing: 0.01em;
+}
+.ff-provider-note { display: inline-block; }
+.ff-pick-unavailable { align-self: center; }
+.ff-pick-fallback-note { margin: 8px 0 0; font-style: italic; }
+
 /* Stage 3 — "Almost got" + anti-rec block becomes a single column on
  * mobile so each card has reading room. */
 .ff-stage3-aftercards {

--- a/src/features/discover/hooks/useDiscoverResultActions.js
+++ b/src/features/discover/hooks/useDiscoverResultActions.js
@@ -12,7 +12,7 @@ import { trackInteraction } from '@/shared/services/interactions'
 
 export function useDiscoverResultActions({ top, user, selected, intention, energy, who, setHiddenTopIds, setSelectedTopId, navigate }) {
   const [savedState, setSavedState] = useState('idle'); // idle | saving | saved | error
-  const [watchedState, setWatchedState] = useState('idle'); // idle | watched
+  const [watchedState, setWatchedState] = useState('idle'); // idle | saving | watched | error
   // Per-film Saved + Watched state — when the user clicks Save or Mark
   // Watched, the button confirms success ("Saved", "Watched"). On
   // auto-advance to a new film, both reset to idle so the new top can be
@@ -104,9 +104,11 @@ export function useDiscoverResultActions({ top, user, selected, intention, energ
     if (markWatchedTimeoutRef.current) clearTimeout(markWatchedTimeoutRef.current);
   }, []);
   const handleMarkWatched = async () => {
-    if (!top?.id || !user?.id || watchedState !== 'idle') return;
+    // Re-entrant only from 'idle' or 'error' (retry); blocked while saving or
+    // already confirmed. Payload + impression/interaction shapes are unchanged.
+    if (!top?.id || !user?.id || watchedState === 'saving' || watchedState === 'watched') return;
     const filmId = top.id;
-    setWatchedState('watched');
+    setWatchedState('saving');
     try {
       // 23505 (unique violation) = already in history; treat as success
       const { error } = await supabase
@@ -115,13 +117,19 @@ export function useDiscoverResultActions({ top, user, selected, intention, energ
       if (error && error.code !== '23505') throw error;
     } catch (e) {
       console.error('[Discover.markWatched]', e);
-      // Even on insert failure, hide locally so the user can move on
+      // A real write failure must NOT falsely confirm "Watched" or advance —
+      // surface a retryable error instead (F3.9 honesty).
+      setWatchedState('error');
+      return;
     }
+    setWatchedState('watched');
+    // Engine learning fires only after the history write succeeds, so a failed
+    // mark-watched isn't credited.
     updateImpression(user.id, filmId, 'watched').catch(() => {});
     trackInteraction('watch', interactionContext('mark_watched')).catch(() => {});
     // 600ms holds "Watched ✓" long enough to register as confirmation
     // before the crossfade swap (180ms) carries the next pick in. Cleared
-    // on unmount so a quick Tweak inputs / Start over click during the
+    // on unmount so a quick Adjust tonight / Start over click during the
     // hold doesn't fire a setState on an unmounted component.
     markWatchedTimeoutRef.current = setTimeout(() => {
       setHiddenTopIds(prev => new Set([...prev, filmId]));

--- a/src/features/discover/hooks/useStreamingProvider.js
+++ b/src/features/discover/hooks/useStreamingProvider.js
@@ -1,25 +1,30 @@
 import { useState, useEffect } from 'react'
 import { getMovieWatchProviders } from '@/shared/api/tmdb'
 
-// ── Streaming provider chip (single best provider) ──────────────────────────
-// Borrowed from home-v2/sections-top.jsx — same compact chip with logo +
-// "Streaming on Netflix" / "Rent on Apple TV+" label. Returns null when TMDB
-// has no provider for the title; the chip then doesn't render.
+// ── Streaming provider (single best provider) + honest fetch status ──────────
+// Returns { provider, status } where status is one of:
+//   'idle'    — no tmdbId yet
+//   'loading' — fetch in flight
+//   'found'   — a provider was returned
+//   'empty'   — fetch succeeded but TMDB has no provider for this title/region
+//   'error'   — fetch failed
+// Provider priority is whatever getMovieWatchProviders already returns
+// (flatrate → rent → buy); we take providers[0] and do NOT re-order it.
 export function useStreamingProvider(tmdbId) {
-  const [provider, setProvider] = useState(null);
+  const [state, setState] = useState({ provider: null, status: 'idle' });
   useEffect(() => {
-    if (!tmdbId) { setProvider(null); return; }
+    if (!tmdbId) { setState({ provider: null, status: 'idle' }); return; }
     const controller = new AbortController();
     let cancelled = false;
-    setProvider(null);
+    setState({ provider: null, status: 'loading' });
     getMovieWatchProviders(tmdbId, { region: 'CA', fallbackRegion: 'US', signal: controller.signal })
       .then(data => {
         if (cancelled) return;
         const p = data?.providers?.[0];
-        if (p) setProvider(p);
+        setState(p ? { provider: p, status: 'found' } : { provider: null, status: 'empty' });
       })
-      .catch(() => { /* non-fatal */ });
+      .catch(() => { if (!cancelled) setState({ provider: null, status: 'error' }); });
     return () => { cancelled = true; controller.abort(); };
   }, [tmdbId]);
-  return provider;
+  return state;
 }

--- a/src/features/discover/sections/StagePick.jsx
+++ b/src/features/discover/sections/StagePick.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from 'react'
+import { useState, useMemo, useEffect, useRef } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useNavigate } from 'react-router-dom'
 import { Play, Bookmark } from 'lucide-react'
@@ -13,13 +13,14 @@ import { useDiscoverResultActions } from '../hooks/useDiscoverResultActions'
 import TrailerModal from './TrailerModal'
 import StreamingChip from './StreamingChip'
 
-// ── Stage 3 — one confident pick (F3.8) ──
+// ── Stage 3 — one confident pick (F3.8) + trust/a11y hardening (F3.9) ──
 // ONE film on the decision surface: FeelFlick's considered recommendation for
 // tonight, with an honest "Why this one" case. The ranked `results` list stays
 // INTERNAL — a controlled "Not tonight" / "Already watched" fallback (hiddenTopIds
-// promotes the next-best result), never a visible deck, count, or feed. No
-// alternates, no match percentages, no parallax, no infinite poster motion.
-export default function StagePick({ selected, who, energy, intention, results, profile, sessionShownIds, onRestart, onBack, blendHex, audioToggle, time }) {
+// promotes the next-best result), never a visible deck, count, or feed. A single
+// polite live region narrates what appeared / succeeded / failed; the queue depth
+// is never announced.
+export default function StagePick({ selected, who, energy, intention, results, profile, sessionShownIds, onRestart, onBack, blendHex, audioToggle, time, isFallback }) {
   // Session-only "hidden" set — Not tonight / Already watched add the current
   // top's id here and the next-best result promotes into view. Resets only when
   // `results` changes (the user adjusted inputs or started over).
@@ -41,8 +42,9 @@ export default function StagePick({ selected, who, energy, intention, results, p
   const [trailerOpen, setTrailerOpen] = useState(false);
   const navigate = useNavigate();
   const { user } = useAuthSession();
-  // Streaming provider — hides cleanly when TMDB has nothing for this title.
-  const provider = useStreamingProvider(top?.tmdbId);
+  // Streaming availability — { provider, status } so we can be honest about
+  // found / no-data / couldn't-check (never implying the film is unavailable).
+  const { provider, status: providerStatus } = useStreamingProvider(top?.tmdbId);
   // "Because…" line — the one honest signal that proves the engine knows the user;
   // null when no signal can be claimed (the case section then omits it).
   const becauseLine = useMemo(
@@ -73,6 +75,43 @@ export default function StagePick({ selected, who, energy, intention, results, p
   const { savedState, watchedState, handleSeeMore, handleSaveForLater, handleMarkWatched, handleSkip } =
     useDiscoverResultActions({ top, user, selected, intention, energy, who, setHiddenTopIds, setSelectedTopId: () => {}, navigate });
 
+  // ── Single polite live region ───────────────────────────────────────────────
+  // One status string, updated only on meaningful changes (pick appeared /
+  // promoted, write succeeded / failed, exhausted). promotionReasonRef records
+  // WHY the next top-change happens so we can phrase it honestly; the queue
+  // count is never spoken.
+  const [liveStatus, setLiveStatus] = useState('');
+  const promotionReasonRef = useRef(null); // null | 'skip' | 'watched'
+  const announcedTopRef = useRef(null);
+
+  // Pick appearance / promotion / exhausted.
+  useEffect(() => {
+    if (exhausted) { setLiveStatus('No more strong fits for this set of details.'); return; }
+    if (!top?.id || announcedTopRef.current === top.id) return;
+    announcedTopRef.current = top.id;
+    const reason = promotionReasonRef.current;
+    promotionReasonRef.current = null;
+    if (reason === 'skip') setLiveStatus(`New pick: ${top.title}.`);
+    else if (reason === 'watched') setLiveStatus(`Marked watched. New pick: ${top.title}.`);
+    else setLiveStatus(`Tonight's pick: ${top.title}.`);
+  }, [top?.id, top?.title, exhausted]);
+
+  // Save success / failure.
+  useEffect(() => {
+    if (savedState === 'saved') setLiveStatus('Saved for later.');
+    else if (savedState === 'error') setLiveStatus('Could not save. Try again.');
+  }, [savedState]);
+
+  // Already-watched success / failure. Success also marks the next top-change as a
+  // watched-promotion so it reads "Marked watched. New pick: …".
+  useEffect(() => {
+    if (watchedState === 'watched') { setLiveStatus('Marked watched.'); promotionReasonRef.current = 'watched'; }
+    else if (watchedState === 'error') setLiveStatus('Could not mark watched. Try again.');
+  }, [watchedState]);
+
+  // Not tonight — flag the promotion reason before the synchronous advance.
+  const onNotTonight = () => { promotionReasonRef.current = 'skip'; handleSkip(); };
+
   // Session-shown tracking — record ONLY the film the user actually saw (the
   // current top). Queued films are never marked shown. diversifyTop3 reads this
   // ref on the NEXT input change to demote genuinely-seen films.
@@ -100,184 +139,205 @@ export default function StagePick({ selected, who, energy, intention, results, p
 
   const filter = moodFilter(selected[0]);
 
+  // Computed only when a pick exists (guarded so the exhausted branch is safe).
+  const synopsis = top && top.overview && top.overview.trim().length > 20 ? top.overview.trim() : null;
+  const titleWords = top ? top.title.split(' ') : [];
+  const hasCase = Boolean(becauseLine || runtimeFitLine);
+  const SAVE_LABEL = { idle: 'Save for later', saving: 'Saving…', saved: 'Saved', error: 'Try again' };
+  const watchedLabel = watchedState === 'watched' ? 'Watched' : watchedState === 'error' ? 'Try again' : 'Already watched';
+
+  // One persistent, polite, sr-only status region wraps both states so the
+  // exhausted announcement lands on the same live element (no fresh region).
+  const liveRegion = (
+    <p className="sr-only" role="status" aria-live="polite" aria-atomic="true">{liveStatus}</p>
+  );
+
   // Exhausted — the internal ranked list is consumed. No automatic refill (that
   // would read as an infinite feed). Two honest doors: adjust tonight's details,
   // or start over with a different mood.
   if (exhausted) {
     return (
-      <section className="ff-discover-section" style={{ position:'relative', minHeight:'70vh', display:'flex', flexDirection:'column', alignItems:'center', justifyContent:'center', padding:'80px 24px', textAlign:'center', animation:'ff-fade 0.5s ease' }}>
-        {audioToggle}
-        <div className="ff-pick-eyebrow" style={{ color:blendHex, marginBottom:18, display:'inline-flex', alignItems:'center', gap:10 }}>
-          <span style={{ height:1, width:22, background:blendHex, opacity:0.6 }} />
-          No more strong fits
-        </div>
-        <h2 style={{ fontFamily:'Outfit', fontSize:'clamp(32px, 4.6vw, 56px)', lineHeight:1.04, fontWeight:200, letterSpacing:'-0.04em', color:HP.text, margin:0, maxWidth:760, textWrap:'balance' }}>
-          That&rsquo;s the honest edge of tonight&rsquo;s list.
-        </h2>
-        <p style={{ marginTop:18, fontFamily:'Outfit, Inter, sans-serif', fontSize:14, color:HP.textMuted, fontStyle:'italic', maxWidth:480, lineHeight:1.6 }}>
-          Adjust tonight&rsquo;s details, or start again with a different mood.
-        </p>
-        <div style={{ marginTop:32, display:'flex', gap:10, flexWrap:'wrap', justifyContent:'center' }}>
-          <button onClick={onBack} style={{ minHeight:44, display:'inline-flex', alignItems:'center', justifyContent:'center', padding:'12px 22px', borderRadius:10, background:HP_GRAD, border:'none', color:'#fff', fontFamily:'Outfit', fontSize:13, fontWeight:700, letterSpacing:'0.01em', cursor:'pointer', boxShadow:'0 10px 26px -10px rgba(236,72,153,0.55)' }}>Adjust tonight</button>
-          <button onClick={onRestart} style={{ minHeight:44, display:'inline-flex', alignItems:'center', justifyContent:'center', padding:'12px 18px', borderRadius:10, background:HP.surface, border:`1px solid ${HP.borderStrong}`, color:HP.text, fontFamily:'Outfit', fontSize:13, fontWeight:500, cursor:'pointer' }}>Start over</button>
-        </div>
-      </section>
+      <>
+        {liveRegion}
+        <section className="ff-discover-section" style={{ position:'relative', minHeight:'70vh', display:'flex', flexDirection:'column', alignItems:'center', justifyContent:'center', padding:'80px 24px', textAlign:'center', animation:'ff-fade 0.5s ease' }}>
+          {audioToggle}
+          <div className="ff-pick-eyebrow" style={{ color:blendHex, marginBottom:18, display:'inline-flex', alignItems:'center', gap:10 }}>
+            <span aria-hidden="true" style={{ height:1, width:22, background:blendHex, opacity:0.6 }} />
+            No more strong fits
+          </div>
+          <h2 style={{ fontFamily:'Outfit', fontSize:'clamp(32px, 4.6vw, 56px)', lineHeight:1.04, fontWeight:200, letterSpacing:'-0.04em', color:HP.text, margin:0, maxWidth:760, textWrap:'balance' }}>
+            That&rsquo;s the honest edge of tonight&rsquo;s list.
+          </h2>
+          <p style={{ marginTop:18, fontFamily:'Outfit, Inter, sans-serif', fontSize:14, color:HP.textMuted, fontStyle:'italic', maxWidth:480, lineHeight:1.6 }}>
+            Adjust tonight&rsquo;s details, or start again with a different mood.
+          </p>
+          <div style={{ marginTop:32, display:'flex', gap:10, flexWrap:'wrap', justifyContent:'center' }}>
+            <button onClick={onBack} style={{ minHeight:44, display:'inline-flex', alignItems:'center', justifyContent:'center', padding:'12px 22px', borderRadius:10, background:HP_GRAD, border:'none', color:'#fff', fontFamily:'Outfit', fontSize:13, fontWeight:700, letterSpacing:'0.01em', cursor:'pointer', boxShadow:'0 10px 26px -10px rgba(236,72,153,0.55)' }}>Adjust tonight</button>
+            <button onClick={onRestart} style={{ minHeight:44, display:'inline-flex', alignItems:'center', justifyContent:'center', padding:'12px 18px', borderRadius:10, background:HP.surface, border:`1px solid ${HP.borderStrong}`, color:HP.text, fontFamily:'Outfit', fontSize:13, fontWeight:500, cursor:'pointer' }}>Start over</button>
+          </div>
+        </section>
+      </>
     );
   }
 
-  // Synopsis — real TMDB overview; hidden when absent rather than templated.
-  const synopsis = top.overview && top.overview.trim().length > 20 ? top.overview.trim() : null;
-  const titleWords = top.title.split(' ');
-  const hasCase = Boolean(becauseLine || runtimeFitLine);
-
-  const SAVE_LABEL = { idle: 'Save for later', saving: 'Saving…', saved: 'Saved', error: 'Try again' };
-
   return (
-    <section className="ff-discover-section" style={{ position:'relative', animation:'ff-fade 0.7s ease' }}>
-      {audioToggle}
-      {/* Static film grain + vignette (no animated movement). */}
-      <div aria-hidden style={{ position:'fixed', inset:0, pointerEvents:'none', zIndex:2, opacity:0.045, mixBlendMode:'overlay', backgroundImage:'url("data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%22220%22 height=%22220%22><filter id=%22n%22><feTurbulence type=%22fractalNoise%22 baseFrequency=%220.9%22 numOctaves=%222%22 stitchTiles=%22stitch%22/></filter><rect width=%22100%25%22 height=%22100%25%22 filter=%22url(%23n)%22/></svg>")' }} />
-      <div aria-hidden style={{ position:'fixed', inset:0, pointerEvents:'none', zIndex:2, background:'radial-gradient(ellipse at center, transparent 50%, rgba(0,0,0,0.55) 100%)' }} />
+    <>
+      {liveRegion}
+      <section className="ff-discover-section" style={{ position:'relative', animation:'ff-fade 0.7s ease' }}>
+        {audioToggle}
+        {/* Static film grain + vignette (decorative, no animated movement). */}
+        <div aria-hidden="true" style={{ position:'fixed', inset:0, pointerEvents:'none', zIndex:2, opacity:0.045, mixBlendMode:'overlay', backgroundImage:'url("data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%22220%22 height=%22220%22><filter id=%22n%22><feTurbulence type=%22fractalNoise%22 baseFrequency=%220.9%22 numOctaves=%222%22 stitchTiles=%22stitch%22/></filter><rect width=%22100%25%22 height=%22100%25%22 filter=%22url(%23n)%22/></svg>")' }} />
+        <div aria-hidden="true" style={{ position:'fixed', inset:0, pointerEvents:'none', zIndex:2, background:'radial-gradient(ellipse at center, transparent 50%, rgba(0,0,0,0.55) 100%)' }} />
 
-      {/* AnimatePresence keyed on top.id — the only result motion: a short
-          crossfade when Not tonight / Already watched advance the pick. */}
-      <AnimatePresence mode="wait" initial={false}>
-        <motion.div
-          key={top.id}
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={{ duration: 0.18, ease: 'easeOut' }}
-        >
-          <div className="ff-stage3-spread">
-            {/* LEFT — poster (static mood-coloured glow, no parallax, no ken burns). */}
-            <div className="ff-stage3-spread__left" style={{ position:'relative' }}>
-              <div style={{ position:'relative' }}>
-                <div aria-hidden style={{ position:'absolute', inset:-14, borderRadius:14, background:`radial-gradient(ellipse at center, ${blendHex}55, transparent 70%)`, filter:'blur(30px)' }} />
-                <div style={{ position:'relative', overflow:'hidden', borderRadius:8, boxShadow:`0 30px 60px -20px rgba(0,0,0,0.8), 0 0 0 1px ${blendHex}33` }}>
-                  <img className="ff-pick-poster" src={top.poster} alt={top.title} style={{ width:'100%', aspectRatio:'2/3', objectFit:'cover', display:'block', filter: filter.cardFilter || 'none', animation:'ff-poster-in 1s cubic-bezier(.2,.7,.2,1)' }} />
-                  {filter.overlay && <div aria-hidden style={{ position:'absolute', inset:0, background:filter.overlay, pointerEvents:'none', mixBlendMode:'overlay' }} />}
+        {/* AnimatePresence keyed on top.id — the only result motion: a short
+            crossfade when Not tonight / Already watched advance the pick. */}
+        <AnimatePresence mode="wait" initial={false}>
+          <motion.div
+            key={top.id}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.18, ease: 'easeOut' }}
+          >
+            <div className="ff-stage3-spread">
+              {/* LEFT — poster (static mood-coloured glow, no parallax, no ken burns). */}
+              <div className="ff-stage3-spread__left" style={{ position:'relative' }}>
+                <div style={{ position:'relative' }}>
+                  <div aria-hidden="true" style={{ position:'absolute', inset:-14, borderRadius:14, background:`radial-gradient(ellipse at center, ${blendHex}55, transparent 70%)`, filter:'blur(30px)' }} />
+                  <div style={{ position:'relative', overflow:'hidden', borderRadius:8, boxShadow:`0 30px 60px -20px rgba(0,0,0,0.8), 0 0 0 1px ${blendHex}33` }}>
+                    <img className="ff-pick-poster" src={top.poster} alt={`${top.title} poster`} style={{ width:'100%', aspectRatio:'2/3', objectFit:'cover', display:'block', filter: filter.cardFilter || 'none', animation:'ff-poster-in 1s cubic-bezier(.2,.7,.2,1)' }} />
+                    {filter.overlay && <div aria-hidden="true" style={{ position:'absolute', inset:0, background:filter.overlay, pointerEvents:'none', mixBlendMode:'overlay' }} />}
+                  </div>
                 </div>
               </div>
-            </div>
 
-            {/* RIGHT — eyebrow, title, meta, chips, the case, synopsis, provider, actions. */}
-            <div className="ff-stage3-spread__right">
-              <div className="ff-pick-eyebrow" style={{ color:blendHex }}>Tonight&rsquo;s pick</div>
-              <h1 style={{ fontFamily:'Outfit', fontSize:'clamp(44px, 5.6vw, 76px)', lineHeight:0.96, fontWeight:300, letterSpacing:'-0.045em', color:HP.text, margin:'12px 0 0', textWrap:'balance' }}>
-                {titleWords.map((w, i) => <span key={i} className="ff-pick-word" style={{ display:'inline-block', opacity:0, animation:`ff-word-in 0.55s cubic-bezier(.2,.7,.2,1) ${0.1 + i*0.06}s forwards`, marginRight:'0.2em' }}>{w}</span>)}
-              </h1>
-
-              {/* Meta — director · year · runtime (no percentages). */}
-              <div style={{ marginTop:14, display:'flex', alignItems:'center', gap:10, flexWrap:'wrap', fontFamily:'Outfit', fontSize:13, color:HP.textMuted, letterSpacing:'0.04em' }}>
-                <span>{top.dir}</span>
-                <span style={{ color:HP.textFaint }}>·</span>
-                <span>{top.year}</span>
-                <span style={{ color:HP.textFaint }}>·</span>
-                <span>{top.runtime} min</span>
-              </div>
-
-              {chips.length > 0 && (
-                <div style={{ marginTop:14, display:'flex', flexWrap:'wrap', gap:7 }}>
-                  {chips.map((c, i) => (
-                    <span key={`${c}-${i}`} style={{ display:'inline-flex', alignItems:'center', padding:'4px 10px', borderRadius:999, border:`1px solid ${HP.border}`, fontFamily:'Outfit', fontSize:11, fontWeight:500, color:HP.textSoft, letterSpacing:'0.02em' }}>
-                      {c}
-                    </span>
-                  ))}
-                </div>
-              )}
-
-              {/* Why this one — the honest case. Renders only when at least one
-                  true line exists; never a generic fallback sentence. */}
-              {hasCase && (
-                <div className="ff-pick-case" style={{ marginTop:22 }}>
-                  <div className="ff-pick-case__label" style={{ color:HP.textMuted }}>Why this one</div>
-                  {becauseLine && (
-                    <p className="ff-pick-case__line" style={{ margin:'10px 0 0', fontFamily:'Outfit, Inter, sans-serif', fontSize:14, fontStyle:'italic', color:blendHex, letterSpacing:'0.01em', textWrap:'balance' }}>{becauseLine}</p>
-                  )}
-                  {runtimeFitLine && (
-                    <p className="ff-pick-case__line" style={{ margin:'6px 0 0', fontFamily:'Outfit, Inter, sans-serif', fontSize:13, color:HP.textSoft }}>{runtimeFitLine}</p>
-                  )}
-                </div>
-              )}
-
-              {synopsis && (
-                <p style={{ marginTop:22, marginBottom:0, fontFamily:'Inter, sans-serif', fontSize:14.5, color:HP.textMuted, lineHeight:1.7, textWrap:'pretty', maxWidth:580, opacity:0, animation:'ff-fade 0.7s ease 0.6s forwards' }}>
-                  {synopsis}
-                </p>
-              )}
-
-              {provider && (
-                <div style={{ marginTop:18 }}>
-                  <StreamingChip provider={provider} />
-                </div>
-              )}
-
-              {/* Actions — one primary, two secondary, two quiet tertiary. */}
-              <div className="ff-pick-actions" role="group" aria-label="Film actions" style={{ marginTop:26 }}>
-                {top.tmdbId && (
-                  <button
-                    type="button"
-                    className="ff-pick-actions__primary"
-                    onClick={handleSeeMore}
-                    style={{ display:'inline-flex', alignItems:'center', justifyContent:'center', padding:'12px 22px', borderRadius:10, background:HP_GRAD, border:'none', color:'#fff', fontFamily:'Outfit', fontSize:13, fontWeight:700, letterSpacing:'0.01em', cursor:'pointer', boxShadow:'0 10px 26px -10px rgba(236,72,153,0.55)' }}
-                  >
-                    Open Film File &rarr;
-                  </button>
+              {/* RIGHT — eyebrow, title, meta, chips, the case, synopsis, provider, actions. */}
+              <div className="ff-stage3-spread__right">
+                <div className="ff-pick-eyebrow" style={{ color:blendHex }}>Tonight&rsquo;s pick</div>
+                {isFallback && (
+                  <p className="ff-pick-fallback-note">Example pick &mdash; we couldn&rsquo;t reach your live recommendations.</p>
                 )}
-                {top.trailerKey && (
+                <h1 style={{ fontFamily:'Outfit', fontSize:'clamp(44px, 5.6vw, 76px)', lineHeight:0.96, fontWeight:300, letterSpacing:'-0.045em', color:HP.text, margin:'12px 0 0', textWrap:'balance' }}>
+                  {titleWords.map((w, i) => <span key={i} className="ff-pick-word" style={{ display:'inline-block', opacity:0, animation:`ff-word-in 0.55s cubic-bezier(.2,.7,.2,1) ${0.1 + i*0.06}s forwards`, marginRight:'0.2em' }}>{w}</span>)}
+                </h1>
+
+                {/* Meta — director · year · runtime (no percentages). */}
+                <div style={{ marginTop:14, display:'flex', alignItems:'center', gap:10, flexWrap:'wrap', fontFamily:'Outfit', fontSize:13, color:HP.textMuted, letterSpacing:'0.04em' }}>
+                  <span>{top.dir}</span>
+                  <span aria-hidden="true" style={{ color:HP.textFaint }}>·</span>
+                  <span>{top.year}</span>
+                  <span aria-hidden="true" style={{ color:HP.textFaint }}>·</span>
+                  <span>{top.runtime} min</span>
+                </div>
+
+                {chips.length > 0 && (
+                  <div style={{ marginTop:14, display:'flex', flexWrap:'wrap', gap:7 }}>
+                    {chips.map((c, i) => (
+                      <span key={`${c}-${i}`} style={{ display:'inline-flex', alignItems:'center', padding:'4px 10px', borderRadius:999, border:`1px solid ${HP.border}`, fontFamily:'Outfit', fontSize:11, fontWeight:500, color:HP.textSoft, letterSpacing:'0.02em' }}>
+                        {c}
+                      </span>
+                    ))}
+                  </div>
+                )}
+
+                {/* Why this one — the honest case. Renders only when at least one
+                    true line exists; never a generic fallback sentence. */}
+                {hasCase && (
+                  <div className="ff-pick-case" style={{ marginTop:22 }}>
+                    <div className="ff-pick-case__label" style={{ color:HP.textMuted }}>Why this one</div>
+                    {becauseLine && (
+                      <p className="ff-pick-case__line" style={{ margin:'10px 0 0', fontFamily:'Outfit, Inter, sans-serif', fontSize:14, fontStyle:'italic', color:blendHex, letterSpacing:'0.01em', textWrap:'balance' }}>{becauseLine}</p>
+                    )}
+                    {runtimeFitLine && (
+                      <p className="ff-pick-case__line" style={{ margin:'6px 0 0', fontFamily:'Outfit, Inter, sans-serif', fontSize:13, color:HP.textSoft }}>{runtimeFitLine}</p>
+                    )}
+                  </div>
+                )}
+
+                {synopsis && (
+                  <p style={{ marginTop:22, marginBottom:0, fontFamily:'Inter, sans-serif', fontSize:14.5, color:HP.textMuted, lineHeight:1.7, textWrap:'pretty', maxWidth:580, opacity:0, animation:'ff-fade 0.7s ease 0.6s forwards' }}>
+                    {synopsis}
+                  </p>
+                )}
+
+                {(provider || providerStatus === 'empty' || providerStatus === 'error') && (
+                  <div style={{ marginTop:18 }}>
+                    <StreamingChip provider={provider} status={providerStatus} />
+                  </div>
+                )}
+
+                {/* Actions — one primary, two secondary, two quiet tertiary. */}
+                <div className="ff-pick-actions" role="group" aria-label="Film actions" style={{ marginTop:26 }}>
+                  {top.tmdbId ? (
+                    <button
+                      type="button"
+                      className="ff-pick-actions__primary"
+                      onClick={handleSeeMore}
+                      style={{ display:'inline-flex', alignItems:'center', justifyContent:'center', padding:'12px 22px', borderRadius:10, background:HP_GRAD, border:'none', color:'#fff', fontFamily:'Outfit', fontSize:13, fontWeight:700, letterSpacing:'0.01em', cursor:'pointer', boxShadow:'0 10px 26px -10px rgba(236,72,153,0.55)' }}
+                    >
+                      Open Film File &rarr;
+                    </button>
+                  ) : (
+                    <span className="ff-pick-unavailable">Film file unavailable for this title.</span>
+                  )}
+                  {top.trailerKey && (
+                    <button
+                      type="button"
+                      className="ff-pick-actions__secondary"
+                      onClick={() => setTrailerOpen(true)}
+                      title="Watch the trailer"
+                      style={{ display:'inline-flex', alignItems:'center', gap:8, padding:'12px 18px', borderRadius:10, background:HP.surface, border:`1px solid ${HP.borderStrong}`, color:HP.text, fontFamily:'Outfit', fontSize:13, fontWeight:500, cursor:'pointer' }}
+                    >
+                      <Play size={14} fill="currentColor" aria-hidden="true" />
+                      <span>Trailer</span>
+                    </button>
+                  )}
                   <button
                     type="button"
                     className="ff-pick-actions__secondary"
-                    onClick={() => setTrailerOpen(true)}
-                    title="Watch the trailer"
-                    style={{ display:'inline-flex', alignItems:'center', gap:8, padding:'12px 18px', borderRadius:10, background:HP.surface, border:`1px solid ${HP.borderStrong}`, color:HP.text, fontFamily:'Outfit', fontSize:13, fontWeight:500, cursor:'pointer' }}
+                    onClick={handleSaveForLater}
+                    disabled={savedState === 'saving' || savedState === 'saved'}
+                    aria-busy={savedState === 'saving'}
+                    aria-pressed={savedState === 'saved'}
+                    style={{ display:'inline-flex', alignItems:'center', gap:8, padding:'12px 18px', borderRadius:10, background: savedState === 'saved' ? `${HP.green}14` : HP.surface, border:`1px solid ${savedState === 'saved' ? HP.green + '66' : HP.borderStrong}`, color: savedState === 'saved' ? HP.green : HP.text, fontFamily:'Outfit', fontSize:13, fontWeight:500, cursor: (savedState === 'idle' || savedState === 'error') ? 'pointer' : 'default' }}
                   >
-                    <Play size={14} fill="currentColor" />
-                    <span>Trailer</span>
+                    <Bookmark size={14} fill={savedState === 'saved' ? 'currentColor' : 'none'} strokeWidth={2} aria-hidden="true" />
+                    <span>{SAVE_LABEL[savedState]}</span>
                   </button>
-                )}
-                <button
-                  type="button"
-                  className="ff-pick-actions__secondary"
-                  onClick={handleSaveForLater}
-                  disabled={savedState === 'saving' || savedState === 'saved'}
-                  style={{ display:'inline-flex', alignItems:'center', gap:8, padding:'12px 18px', borderRadius:10, background: savedState === 'saved' ? `${HP.green}14` : HP.surface, border:`1px solid ${savedState === 'saved' ? HP.green + '66' : HP.borderStrong}`, color: savedState === 'saved' ? HP.green : HP.text, fontFamily:'Outfit', fontSize:13, fontWeight:500, cursor: savedState === 'idle' ? 'pointer' : 'default' }}
-                >
-                  <Bookmark size={14} fill={savedState === 'saved' ? 'currentColor' : 'none'} strokeWidth={2} />
-                  <span>{SAVE_LABEL[savedState]}</span>
-                </button>
-                <button
-                  type="button"
-                  className="ff-pick-actions__tertiary"
-                  onClick={handleMarkWatched}
-                  disabled={watchedState === 'watched'}
-                  title="I've already seen this one"
-                  style={{ background:'transparent', border:'none', color: watchedState === 'watched' ? HP.green : HP.textMuted, fontFamily:'Outfit', fontSize:12, fontWeight:500, letterSpacing:'0.01em', cursor: watchedState === 'idle' ? 'pointer' : 'default', padding:'0 8px' }}
-                >
-                  {watchedState === 'watched' ? 'Watched' : 'Already watched'}
-                </button>
-                <button
-                  type="button"
-                  className="ff-pick-actions__tertiary"
-                  onClick={handleSkip}
-                  style={{ background:'transparent', border:'none', color:HP.textMuted, fontFamily:'Outfit', fontSize:12, fontWeight:500, letterSpacing:'0.01em', cursor:'pointer', padding:'0 8px' }}
-                >
-                  Not tonight
-                </button>
+                  <button
+                    type="button"
+                    className="ff-pick-actions__tertiary"
+                    onClick={handleMarkWatched}
+                    disabled={watchedState === 'saving' || watchedState === 'watched'}
+                    aria-busy={watchedState === 'saving'}
+                    aria-pressed={watchedState === 'watched'}
+                    title="I've already seen this one"
+                    style={{ background:'transparent', border:'none', color: watchedState === 'watched' ? HP.green : watchedState === 'error' ? HP.text : HP.textMuted, fontFamily:'Outfit', fontSize:12, fontWeight:500, letterSpacing:'0.01em', cursor: (watchedState === 'saving' || watchedState === 'watched') ? 'default' : 'pointer', padding:'0 8px' }}
+                  >
+                    {watchedLabel}
+                  </button>
+                  <button
+                    type="button"
+                    className="ff-pick-actions__tertiary"
+                    onClick={onNotTonight}
+                    style={{ background:'transparent', border:'none', color:HP.textMuted, fontFamily:'Outfit', fontSize:12, fontWeight:500, letterSpacing:'0.01em', cursor:'pointer', padding:'0 8px' }}
+                  >
+                    Not tonight
+                  </button>
+                </div>
               </div>
             </div>
-          </div>
 
-          {/* Footer — quiet ways back into the flow. */}
-          <div className="ff-pick-footer">
-            <button onClick={onBack}    style={{ minHeight:44, padding:'9px 14px', borderRadius:8, background:'transparent', border:`1px solid ${HP.border}`, color:HP.textMuted, fontFamily:'Outfit', fontSize:11, fontWeight:500, cursor:'pointer' }}>Adjust tonight</button>
-            <button onClick={onRestart} style={{ minHeight:44, padding:'9px 14px', borderRadius:8, background:'transparent', border:`1px solid ${HP.border}`, color:HP.textMuted, fontFamily:'Outfit', fontSize:11, fontWeight:500, cursor:'pointer' }}>Start over</button>
-          </div>
-        </motion.div>
-      </AnimatePresence>
+            {/* Footer — quiet ways back into the flow. */}
+            <div className="ff-pick-footer">
+              <button onClick={onBack}    style={{ minHeight:44, padding:'9px 14px', borderRadius:8, background:'transparent', border:`1px solid ${HP.border}`, color:HP.textMuted, fontFamily:'Outfit', fontSize:11, fontWeight:500, cursor:'pointer' }}>Adjust tonight</button>
+              <button onClick={onRestart} style={{ minHeight:44, padding:'9px 14px', borderRadius:8, background:'transparent', border:`1px solid ${HP.border}`, color:HP.textMuted, fontFamily:'Outfit', fontSize:11, fontWeight:500, cursor:'pointer' }}>Start over</button>
+            </div>
+          </motion.div>
+        </AnimatePresence>
 
-      <TrailerModal open={trailerOpen} youtubeKey={top.trailerKey} title={top.title} onClose={() => setTrailerOpen(false)} />
-    </section>
+        <TrailerModal open={trailerOpen} youtubeKey={top.trailerKey} title={top.title} onClose={() => setTrailerOpen(false)} />
+      </section>
+    </>
   );
 }

--- a/src/features/discover/sections/StreamingChip.jsx
+++ b/src/features/discover/sections/StreamingChip.jsx
@@ -1,22 +1,30 @@
 import { HP } from '../constants'
 
-export default function StreamingChip({ provider }) {
-  if (!provider) return null;
-  const label = provider.type === 'flatrate' ? 'Streaming on'
-    : provider.type === 'rent' ? 'Rent on'
-    : 'Buy on';
-  return (
-    <div style={{ display:'inline-flex', alignItems:'center', gap:10, padding:'8px 12px 8px 8px', borderRadius:8, background:'rgba(255,255,255,0.04)', border:`1px solid ${HP.border}`, maxWidth:'100%' }}>
-      <img
-        src={`https://image.tmdb.org/t/p/w92${provider.logoPath}`}
-        alt={provider.name}
-        style={{ width:28, height:28, borderRadius:5, objectFit:'cover', flex:'none' }}
-        loading="lazy"
-      />
-      <div style={{ minWidth:0 }}>
-        <div style={{ fontSize:9, fontWeight:600, letterSpacing:'0.18em', textTransform:'uppercase', color:HP.textFaint, fontFamily:'Outfit', lineHeight:1 }}>{label}</div>
-        <div style={{ fontSize:12, fontWeight:600, color:HP.text, fontFamily:'Outfit', lineHeight:1.2, marginTop:3 }}>{provider.name}</div>
+// Streaming availability — honest about what we know. `status` (F3.9) lets us
+// distinguish a found provider from "no data" / "couldn't check" without
+// implying the film is unavailable everywhere or that our data is complete.
+export default function StreamingChip({ provider, status }) {
+  if (provider) {
+    const label = provider.type === 'flatrate' ? 'Streaming on'
+      : provider.type === 'rent' ? 'Rent on'
+      : 'Buy on';
+    return (
+      <div style={{ display:'inline-flex', alignItems:'center', gap:10, padding:'8px 12px 8px 8px', borderRadius:8, background:'rgba(255,255,255,0.04)', border:`1px solid ${HP.border}`, maxWidth:'100%' }}>
+        <img
+          src={`https://image.tmdb.org/t/p/w92${provider.logoPath}`}
+          alt={`${provider.name} logo`}
+          style={{ width:28, height:28, borderRadius:5, objectFit:'cover', flex:'none' }}
+          loading="lazy"
+        />
+        <div style={{ minWidth:0 }}>
+          <div style={{ fontSize:9, fontWeight:600, letterSpacing:'0.18em', textTransform:'uppercase', color:HP.textFaint, fontFamily:'Outfit', lineHeight:1 }}>{label}</div>
+          <div style={{ fontSize:12, fontWeight:600, color:HP.text, fontFamily:'Outfit', lineHeight:1.2, marginTop:3 }}>{provider.name}</div>
+        </div>
       </div>
-    </div>
-  );
+    );
+  }
+  // Quiet, secondary, honest. Not an alert; not a claim of unavailability.
+  if (status === 'empty') return <span className="ff-provider-note">Availability not found</span>;
+  if (status === 'error') return <span className="ff-provider-note">Availability unavailable</span>;
+  return null; // idle / loading → render nothing (no layout shift)
 }

--- a/src/features/discover/sections/TrailerModal.jsx
+++ b/src/features/discover/sections/TrailerModal.jsx
@@ -39,24 +39,52 @@ export default function TrailerModal({ open, youtubeKey, title, onClose }) {
   const closeBtnRef = useRef(null);
   const playerRef = useRef(null);
   const playerSlotRef = useRef(null);
+  const dialogRef = useRef(null);
+  // Element focused before the dialog opened, so we can restore focus on close.
+  const openerRef = useRef(null);
   // Latest onClose held in a ref so the player effect's deps stay stable —
   // otherwise the parent's inline `() => setTrailerOpen(false)` would
   // re-create the player on every parent re-render.
   const onCloseRef = useRef(onClose);
   useEffect(() => { onCloseRef.current = onClose; }, [onClose]);
 
-  // Body scroll lock + Escape + initial focus
+  // Body scroll lock + Escape + Tab containment + initial/return focus
   useEffect(() => {
     if (!open) return;
+    // Remember the opener so focus can return to it on close (e.g. the Trailer
+    // button). Guarded on restore in case it was unmounted while the modal was open.
+    openerRef.current = document.activeElement;
     const prevOverflow = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
-    const onKey = (e) => { if (e.key === 'Escape') onCloseRef.current?.(); };
+    const onKey = (e) => {
+      if (e.key === 'Escape') { onCloseRef.current?.(); return; }
+      if (e.key !== 'Tab') return;
+      // Focus trap — keep Tab / Shift+Tab inside the dialog.
+      const root = dialogRef.current;
+      if (!root) return;
+      const focusables = root.querySelectorAll(
+        'a[href], button:not([disabled]), iframe, [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusables.length === 0) { e.preventDefault(); return; }
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement;
+      if (e.shiftKey) {
+        if (active === first || !root.contains(active)) { e.preventDefault(); last.focus(); }
+      } else if (active === last || !root.contains(active)) {
+        e.preventDefault(); first.focus();
+      }
+    };
     window.addEventListener('keydown', onKey);
     const t = setTimeout(() => closeBtnRef.current?.focus(), 0);
     return () => {
       window.removeEventListener('keydown', onKey);
       document.body.style.overflow = prevOverflow;
       clearTimeout(t);
+      const opener = openerRef.current;
+      if (opener && typeof opener.focus === 'function' && document.contains(opener)) {
+        opener.focus();
+      }
     };
   }, [open]);
 
@@ -115,6 +143,7 @@ export default function TrailerModal({ open, youtubeKey, title, onClose }) {
     // accessibility intent.
     // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events
     <div
+      ref={dialogRef}
       role="dialog" aria-modal="true" aria-label={`${title} trailer`}
       onClick={onOverlayClick}
       style={{ position:'fixed', inset:0, zIndex:300, background:'rgba(0,0,0,0.92)', backdropFilter:'blur(20px)', display:'flex', alignItems:'center', justifyContent:'center', padding:'24px', cursor:'pointer' }}


### PR DESCRIPTION
**F3.9** — trust/error/accessibility hardening of the one-pick Discover result. **No journey redesign, no ranking change, no result-layout change.** Every write payload, event name, table, route, and `useDiscoverData` fetch/ranking is unchanged.

## Live-status model
One persistent `sr-only` `role="status"` (`aria-live="polite"`, `aria-atomic`) wrapping both the normal and exhausted branches, updated **only on meaningful changes** (guarded by `announcedTopRef` + `promotionReasonRef`):
- first appearance → `Tonight's pick: {title}.`
- Not tonight → `New pick: {title}.`
- Already watched → `Marked watched. New pick: {title}.`
- Save → `Saved for later.` / `Could not save. Try again.`
- Already watched → `Marked watched.` / `Could not mark watched. Try again.`
- exhausted → `No more strong fits for this set of details.`

The **queue depth is never announced**; no focus is moved.

## Action-state semantics
- **Save**: `aria-busy` while saving, `aria-pressed` when saved, disabled understandable.
- **Already watched**: `aria-busy` while saving, `aria-pressed` + disabled when complete.
- **Not tonight** stays available. **Open Film File** renders only with a `tmdbId` — when absent it shows a quiet *"Film file unavailable for this title."* note, never a dead button. **Trailer** renders only when a key exists. All controls keep accessible names, 44px targets, and focus-visible.

## Result write-error feedback
**Mark Watched now awaits the `user_history` write before confirming**: a real failure shows a retryable "Try again" + the polite error and does **not** falsely show "Watched", advance the pick, or fire the `'watched'` impression. 23505 stays a success. Save's 23505=success / other=error unchanged. Analytics (`updateImpression`/`trackInteraction`) stay fire-and-forget (`.catch`) and never block the primary action. **Payload shapes + event names identical.**

## Streaming-provider honesty
`useStreamingProvider` returns `{ provider, status }` (idle/loading/found/empty/error; aborts never set `'error'`); priority is still `providers[0]` (flatrate→rent→buy), TMDB call unchanged. `StreamingChip` renders the found chip, a quiet *"Availability not found"* (empty) or *"Availability unavailable"* (error), or nothing while loading — **never implying the film is unavailable everywhere**.

## Trailer dialog focus hardening
Added a **Tab/Shift+Tab focus trap** (wraps within the dialog) and **focus restore to the opener on close** (guarded with `document.contains` so it can't throw if the opener unmounted). Kept `role=dialog`, `aria-modal`, the title in the accessible name, Escape, overlay-click close, initial focus to the close button, scroll-lock restore, and the YouTube cleanup.

## Image/decorative semantics + fallback labelling
Poster alt is `{title} poster`; grain/vignette/glow + button icons are `aria-hidden`; provider logo alt is `{name} logo`. Discover passes `isFallback` (true only when the live fetch returned nothing) so StagePick honestly labels a static `FILMS_FALLBACK` result (*"Example pick — we couldn't reach your live recommendations."*) instead of presenting it as authoritative. **`useDiscoverData` fetch/ranking untouched** — the flag is derived from the existing `films` length, not a data-provider refactor. (A deeper fallback-source refactor remains deferred to F3.10 per the brief.)

## Tests
`DiscoverResult.test.jsx` **34 → 65**: live status (one region, first pick, save ok/fail, skip/watched promotion, exhausted, no queue count), action semantics (busy/pressed/disabled, unavailable note, names), write errors (23505 ok, non-23505 error, watched-failure **not** confirmed, non-blocking analytics), provider honesty (found/empty/error chip + `useStreamingProvider` priority/empty/error), image semantics (poster/logo alt, decorative + icon aria-hidden), and trailer a11y (aria-modal, named, initial focus, Escape, overlay, **focus-return**, **Tab/Shift+Tab containment**, scroll-lock restore). `DiscoverEntry` stage-3 detection re-pointed to the "Not tonight" button (the new live region also matched the eyebrow text). **Stable 6×.**

An **adversarial multi-agent review** (3 dimensions × per-finding verification) found **zero confirmed-real defects**.

## Unchanged (confirmed)
Ranking, result order, queue depth (`MAX_PICKS=15`/`hiddenTopIds`), all Supabase tables + payloads, impression/interaction event names + metadata keys, Open-Film-File route, trailer-open logic, provider fetch source + priority, duplicate-save (23505) handling, saved/watched reset on top change, MoodStage, StageNightContext, StageResolve, and `useDiscoverData.jsx`. **No live Discover writes triggered** (mocked Supabase/TMDB/YouTube).

## Responsive / a11y verification
Mocked-data only (the live authenticated `/discover` route was not used). One film; 44px targets via `.ff-pick-*` CSS; focus-visible on all controls; trailer focus trap + Escape restore covered by tests; live status present but not noisy (ref-guarded); provider absence/error copy quiet + honest; action error states visible; `/discover` is not in the visual-regression baseline.

## Validation
- `npm run lint` → clean · `npm run build` → ✓ · discover suite → **180 passed** (7 files) · `npm run test` → **844 passed** (67 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
