### PR TITLE
Clarify Discover fallback data states

### DIFF
--- a/src/features/discover/Discover.jsx
+++ b/src/features/discover/Discover.jsx
@@ -208,7 +208,7 @@ function DiscoverBody() {
   // the same broad-mood films (e.g., Gladiator) win every constellation.
   // Resets naturally when the user leaves /discover and returns.
   const sessionShownIds = useRef(new Set());
-  const { films: liveFilms, profile, baselineMoods, learnedPrefs, recentSaves } = useDiscoverData();
+  const { films: liveFilms, profile, baselineMoods, learnedPrefs, recentSaves, dataSource } = useDiscoverData();
   const { user } = useAuthSession();
   const location = useLocation();
   const fromOnboardingRef = useRef(location.state?.fromOnboarding === true);
@@ -297,9 +297,12 @@ function DiscoverBody() {
   // only when the query hasn't returned anything (offline / empty DB).
   const usingLiveFilms = !!(liveFilms && liveFilms.length > 0);
   const films = usingLiveFilms ? liveFilms : FILMS_FALLBACK;
-  // When the live fetch returned nothing (empty/error), the result is drawn from
-  // the static FILMS_FALLBACK set — labelled honestly to the user via StagePick.
-  const usingFallback = !usingLiveFilms;
+  // Honest fallback state comes from useDiscoverData's explicit dataSource (live
+  // vs fallback + the reason), NOT merely from an empty array — so live_error,
+  // live_empty, and filtered_empty are distinguishable on the result surface.
+  // (Fall back to the length check only before the fetch has resolved.)
+  const isFallback = dataSource ? dataSource.movies === 'fallback' : !usingLiveFilms;
+  const fallbackReason = dataSource?.reason;
 
   const fireBurst = (id, hex) => {
     const t = Date.now();
@@ -439,7 +442,7 @@ function DiscoverBody() {
         {stage === 1   && <StageMood selected={selected} setSelected={setSelected} onNext={()=>setStage(2)} blendHex={blendHex} bursts={bursts} fireBurst={fireBurst} audioToggle={<AudioToggle />} playMoodCue={(id)=>FFAudio.pluck(id)} playContinueCue={()=>FFAudio.whoom()} />}
         {stage === 2   && <StageNightContext time={time} setTime={setTime} who={who} setWho={setWho} energy={energy} setEnergy={setEnergy} intention={intention} setIntention={setIntention} onUserEdit={()=>{ contextTouchedRef.current = true }} onNext={()=>{ handleCommitStage2(); setStage(2.3); }} onBack={()=>setStage(1)} blendHex={blendHex} playOptionCue={()=>FFAudio.pluck('cozy')} playContinueCue={()=>FFAudio.whoom()} />}
         {stage === 2.3 && <StageResolve blendHex={blendHex} onDone={()=>setStage(3)} />}
-        {stage === 3   && <StagePick selected={selected.length>0?selected:['slow','tender']} who={who} energy={energy} intention={intention} time={time} results={allResults} profile={profile} sessionShownIds={sessionShownIds} isFallback={usingFallback} onRestart={()=>{ setStage(1); setSelected([]); contextTouchedRef.current = false; didPredictDefaultsRef.current = false; setIntention('move'); setTime('std'); setWho('alone'); setEnergy('steady'); }} onBack={()=>setStage(2)} blendHex={blendHex} audioToggle={<AudioToggle />} />}
+        {stage === 3   && <StagePick selected={selected.length>0?selected:['slow','tender']} who={who} energy={energy} intention={intention} time={time} results={allResults} profile={profile} sessionShownIds={sessionShownIds} isFallback={isFallback} fallbackReason={fallbackReason} onRestart={()=>{ setStage(1); setSelected([]); contextTouchedRef.current = false; didPredictDefaultsRef.current = false; setIntention('move'); setTime('std'); setWho('alone'); setEnergy('steady'); }} onBack={()=>setStage(2)} blendHex={blendHex} audioToggle={<AudioToggle />} />}
       </div>
     </div>
   );

--- a/src/features/discover/__tests__/DiscoverEntry.test.jsx
+++ b/src/features/discover/__tests__/DiscoverEntry.test.jsx
@@ -13,14 +13,14 @@ import { MemoryRouter } from 'react-router-dom'
 
 const h = vi.hoisted(() => ({
   baselineMoods: [], profile: { affinities: { directors: [] } }, learnedPrefs: null,
-  upserts: [], inserts: [], reduced: false,
+  upserts: [], inserts: [], reduced: false, dataSource: { movies: 'live', reason: 'live_ok' },
 }))
 
 // Keep real motion/AnimatePresence; control useReducedMotion via h.reduced.
 vi.mock('framer-motion', async (orig) => ({ ...(await orig()), useReducedMotion: () => h.reduced }))
 vi.mock('../useDiscoverData', () => ({
   DiscoverDataProvider: ({ children }) => children,
-  useDiscoverData: () => ({ films: [], profile: h.profile, baselineMoods: h.baselineMoods, learnedPrefs: h.learnedPrefs, recentSaves: [] }),
+  useDiscoverData: () => ({ films: [], profile: h.profile, baselineMoods: h.baselineMoods, learnedPrefs: h.learnedPrefs, recentSaves: [], dataSource: h.dataSource }),
 }))
 vi.mock('@/shared/hooks/useAuthSession', () => ({ useAuthSession: () => ({ user: { id: 'u1' } }) }))
 vi.mock('@/shared/hooks/usePageMeta', () => ({ usePageMeta: () => {} }))
@@ -59,7 +59,7 @@ const gotoNight = (mood = 'Cozy') => { fireEvent.click(moodBtn(mood)); fireEvent
 
 beforeEach(() => {
   h.baselineMoods = []; h.profile = { affinities: { directors: [] } }; h.learnedPrefs = null
-  h.upserts = []; h.inserts = []; h.reduced = false
+  h.upserts = []; h.inserts = []; h.reduced = false; h.dataSource = { movies: 'live', reason: 'live_ok' }
   vi.clearAllMocks()
   window.matchMedia = vi.fn().mockImplementation((q) => ({
     matches: false, media: q, onchange: null,
@@ -238,6 +238,65 @@ describe('Discover night context — Tweak Inputs + Start Over (F3.6/F3.7)', () 
       fireEvent.click(screen.getByRole('button', { name: /start over/i }))
       expect(screen.getByRole('heading', { name: /shape.*of your mood/i })).toBeInTheDocument()
       expect(pressedCount()).toBe(0) // moods cleared, seed NOT reapplied
+    } finally { vi.useRealTimers() }
+  })
+})
+
+// ── F3.10: fallback data-source threading (shell → StagePick) ─────────────────
+describe('Discover shell — fallback data-source threading (F3.10)', () => {
+  const gotoResult = async (mood = 'Cozy') => {
+    gotoNight(mood)
+    fireEvent.click(findFilmBtn())
+    await act(async () => { await vi.advanceTimersByTimeAsync(RESOLVE_DURATION_MS) }) // StageResolve → StagePick
+  }
+  it('live_ok → no fallback note (NOT inferred from the empty films array)', async () => {
+    vi.useFakeTimers()
+    try {
+      h.dataSource = { movies: 'live', reason: 'live_ok' }
+      renderDiscover()
+      await gotoResult()
+      expect(screen.queryByText(/Example pick/)).not.toBeInTheDocument()
+    } finally { vi.useRealTimers() }
+  })
+  it('live_error → "live recommendations are unavailable right now."', async () => {
+    vi.useFakeTimers()
+    try {
+      h.dataSource = { movies: 'fallback', reason: 'live_error', errorMessage: 'x' }
+      renderDiscover()
+      await gotoResult()
+      expect(screen.getByText('Example pick — live recommendations are unavailable right now.')).toBeInTheDocument()
+    } finally { vi.useRealTimers() }
+  })
+  it('live_empty → "live recommendations are not ready yet."', async () => {
+    vi.useFakeTimers()
+    try {
+      h.dataSource = { movies: 'fallback', reason: 'live_empty' }
+      renderDiscover()
+      await gotoResult()
+      expect(screen.getByText('Example pick — live recommendations are not ready yet.')).toBeInTheDocument()
+    } finally { vi.useRealTimers() }
+  })
+  it('filtered_empty → "no strong live fit for these details."', async () => {
+    vi.useFakeTimers()
+    try {
+      h.dataSource = { movies: 'fallback', reason: 'filtered_empty' }
+      renderDiscover()
+      await gotoResult()
+      expect(screen.getByText('Example pick — no strong live fit for these details.')).toBeInTheDocument()
+    } finally { vi.useRealTimers() }
+  })
+  it('reaching a fallback result triggers no impression/watchlist/history/interaction writes', async () => {
+    vi.useFakeTimers()
+    try {
+      h.dataSource = { movies: 'fallback', reason: 'live_error' }
+      renderDiscover()
+      await gotoResult()
+      expect(screen.getByText(/Example pick/)).toBeInTheDocument()
+      // The single preference upsert is the normal explicit "Find my film" accept;
+      // fallback mode adds no watchlist/history/interaction writes.
+      expect(h.inserts).toHaveLength(0)
+      expect(updateImpression).not.toHaveBeenCalled()
+      expect(trackInteraction).not.toHaveBeenCalled()
     } finally { vi.useRealTimers() }
   })
 })

--- a/src/features/discover/__tests__/DiscoverResult.test.jsx
+++ b/src/features/discover/__tests__/DiscoverResult.test.jsx
@@ -511,3 +511,50 @@ describe('StagePick — write guards', () => {
     expect(h.inserts).toHaveLength(0)
   })
 })
+
+// ── F3.10: fallback data-truth labelling ──────────────────────────────────────
+describe('StagePick — fallback data-truth labelling (F3.10)', () => {
+  const fb = (reason) => baseProps({ isFallback: true, fallbackReason: reason })
+  it('live_error → unavailable-right-now copy', () => {
+    render(<StagePick {...fb('live_error')} />)
+    expect(screen.getByText('Example pick — live recommendations are unavailable right now.')).toBeInTheDocument()
+  })
+  it('live_empty → not-ready-yet copy', () => {
+    render(<StagePick {...fb('live_empty')} />)
+    expect(screen.getByText('Example pick — live recommendations are not ready yet.')).toBeInTheDocument()
+  })
+  it('filtered_empty → no-strong-fit copy', () => {
+    render(<StagePick {...fb('filtered_empty')} />)
+    expect(screen.getByText('Example pick — no strong live fit for these details.')).toBeInTheDocument()
+  })
+  it('unknown reason → generic safe-fallback copy', () => {
+    render(<StagePick {...fb('mystery')} />)
+    expect(screen.getByText('Example pick — using a safe fallback.')).toBeInTheDocument()
+  })
+  it('no fallback note when isFallback is false (even with a reason present)', () => {
+    render(<StagePick {...baseProps({ isFallback: false, fallbackReason: 'live_error' })} />)
+    expect(screen.queryByText(/Example pick/)).not.toBeInTheDocument()
+  })
+  it('the fallback note is visible + screen-reader reachable (not aria-hidden, no technical wording)', () => {
+    render(<StagePick {...fb('live_error')} />)
+    const note = screen.getByText('Example pick — live recommendations are unavailable right now.')
+    expect(note).toBeVisible()
+    expect(note.closest('[aria-hidden="true"]')).toBeNull()
+    expect(note.textContent).not.toMatch(/supabase|database|query|api|error code|fetch/i)
+  })
+  it('fallback mode renders no fabricated authority (no critic/diary/social proof)', () => {
+    render(<StagePick {...fb('live_error')} />)
+    expect(screen.queryByText(/critics?|reviewers|stars\b|everyone|people are watching|users? love/i)).not.toBeInTheDocument()
+  })
+  it('actions are unchanged under fallback mode', () => {
+    render(<StagePick {...fb('live_error')} />)
+    expect(screen.getByRole('button', { name: /open film file/i })).toBeInTheDocument()
+    for (const name of ['Trailer', 'Save for later', 'Already watched', 'Not tonight']) {
+      expect(screen.getByRole('button', { name })).toBeInTheDocument()
+    }
+  })
+  it('live status remains the normal pick announcement under fallback mode', () => {
+    render(<StagePick {...fb('live_error')} />)
+    expect(screen.getByRole('status')).toHaveTextContent("Tonight's pick: Film1.")
+  })
+})

--- a/src/features/discover/__tests__/useDiscoverData.test.jsx
+++ b/src/features/discover/__tests__/useDiscoverData.test.jsx
@@ -1,0 +1,92 @@
+// src/features/discover/__tests__/useDiscoverData.test.jsx
+// F3.10 — the honest data-source classifier + a light DiscoverDataProvider
+// integration (no user, universal Supabase mock) confirming the fallback reason
+// is wired from the live fetch outcome. Mocks only — no live Supabase, no writes,
+// no ranking/scoring assertions changed.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+
+const h = vi.hoisted(() => ({ user: null, queryError: false }))
+
+// Universal chainable Supabase mock: any builder method returns the chain; awaiting
+// it resolves to { data: [] } (or rejects when h.queryError is set).
+function makeChain() {
+  return new Proxy({}, {
+    get(_t, prop) {
+      if (prop === 'then') return (onF, onR) => (h.queryError ? Promise.reject(new Error('boom')) : Promise.resolve({ data: [], error: null })).then(onF, onR)
+      if (prop === 'catch') return (onR) => (h.queryError ? Promise.reject(new Error('boom')) : Promise.resolve({ data: [], error: null })).catch(onR)
+      if (prop === 'finally') return (cb) => Promise.resolve().finally(cb)
+      return () => makeChain()
+    },
+  })
+}
+
+vi.mock('@/shared/hooks/useAuthSession', () => ({ useAuthSession: () => ({ user: h.user }) }))
+vi.mock('@/shared/lib/supabase/client', () => ({ supabase: { from: () => makeChain() } }))
+vi.mock('@/shared/services/recommendations', () => ({ computeUserProfile: vi.fn(() => Promise.resolve(null)), RECOMMENDATION_CONSTANTS: { GENRE_NAME_TO_ID: {} } }))
+vi.mock('@/shared/services/exclusions', () => ({ filterExclusionsClientSide: (rows) => rows }))
+
+import { classifyDiscoverDataSource, DiscoverDataProvider, useDiscoverData } from '../useDiscoverData'
+
+beforeEach(() => { h.user = null; h.queryError = false; vi.clearAllMocks() })
+
+// ── pure classifier ───────────────────────────────────────────────────────────
+describe('classifyDiscoverDataSource', () => {
+  it('live success with films → live / live_ok', () => {
+    expect(classifyDiscoverDataSource({ filmCount: 5, candidateCount: 12 })).toEqual({ movies: 'live', reason: 'live_ok' })
+  })
+  it('live query empty (no candidates) → fallback / live_empty', () => {
+    expect(classifyDiscoverDataSource({ filmCount: 0, candidateCount: 0 })).toEqual({ movies: 'fallback', reason: 'live_empty' })
+  })
+  it('candidates filtered out → fallback / filtered_empty', () => {
+    expect(classifyDiscoverDataSource({ filmCount: 0, candidateCount: 8 })).toEqual({ movies: 'fallback', reason: 'filtered_empty' })
+  })
+  it('fetch error → fallback / live_error with a safe message (error wins over counts)', () => {
+    const ds = classifyDiscoverDataSource({ errored: true, filmCount: 5, candidateCount: 9 })
+    expect(ds.movies).toBe('fallback')
+    expect(ds.reason).toBe('live_error')
+    expect(ds.errorMessage).toBe('Live recommendations could not be reached.')
+  })
+  it('the error message exposes no raw details (no supabase/query/stack/secrets)', () => {
+    const { errorMessage } = classifyDiscoverDataSource({ errored: true })
+    expect(errorMessage).not.toMatch(/supabase|postgres|query|select|column|relation|permission|stack|at \w|Error:|https?:|key|token/i)
+  })
+  it('defaults to live_empty when called with no args', () => {
+    expect(classifyDiscoverDataSource()).toEqual({ movies: 'fallback', reason: 'live_empty' })
+  })
+})
+
+// ── provider integration (no user, universal mock) ────────────────────────────
+function Probe() {
+  const { loading, dataSource, films, profile, error } = useDiscoverData()
+  return (
+    <div data-testid="probe" data-loading={String(loading)} data-reason={dataSource?.reason}
+         data-movies={dataSource?.movies} data-films={films.length} data-profile={String(profile)} data-error={String(error)} />
+  )
+}
+const probe = () => screen.getByTestId('probe')
+
+describe('DiscoverDataProvider — data-source wiring', () => {
+  it('a live query that returns no candidates → fallback / live_empty (films stay an array)', async () => {
+    render(<DiscoverDataProvider><Probe /></DiscoverDataProvider>)
+    await waitFor(() => expect(probe()).toHaveAttribute('data-loading', 'false'))
+    expect(probe()).toHaveAttribute('data-movies', 'fallback')
+    expect(probe()).toHaveAttribute('data-reason', 'live_empty')
+    expect(probe()).toHaveAttribute('data-films', '0') // empty array, not undefined
+    expect(probe()).toHaveAttribute('data-error', 'null')
+  })
+  it('a failed live query → fallback / live_error (no raw error reaches dataSource)', async () => {
+    h.queryError = true
+    render(<DiscoverDataProvider><Probe /></DiscoverDataProvider>)
+    await waitFor(() => expect(probe()).toHaveAttribute('data-loading', 'false'))
+    expect(probe()).toHaveAttribute('data-movies', 'fallback')
+    expect(probe()).toHaveAttribute('data-reason', 'live_error')
+    expect(probe()).toHaveAttribute('data-films', '0')
+  })
+  it('profile fetch behavior is unchanged with no user (profile stays null)', async () => {
+    render(<DiscoverDataProvider><Probe /></DiscoverDataProvider>)
+    await waitFor(() => expect(probe()).toHaveAttribute('data-loading', 'false'))
+    expect(probe()).toHaveAttribute('data-profile', 'null')
+  })
+})

--- a/src/features/discover/sections/StagePick.jsx
+++ b/src/features/discover/sections/StagePick.jsx
@@ -20,7 +20,7 @@ import StreamingChip from './StreamingChip'
 // promotes the next-best result), never a visible deck, count, or feed. A single
 // polite live region narrates what appeared / succeeded / failed; the queue depth
 // is never announced.
-export default function StagePick({ selected, who, energy, intention, results, profile, sessionShownIds, onRestart, onBack, blendHex, audioToggle, time, isFallback }) {
+export default function StagePick({ selected, who, energy, intention, results, profile, sessionShownIds, onRestart, onBack, blendHex, audioToggle, time, isFallback, fallbackReason }) {
   // Session-only "hidden" set — Not tonight / Already watched add the current
   // top's id here and the next-best result promotes into view. Resets only when
   // `results` changes (the user adjusted inputs or started over).
@@ -146,6 +146,16 @@ export default function StagePick({ selected, who, energy, intention, results, p
   const SAVE_LABEL = { idle: 'Save for later', saving: 'Saving…', saved: 'Saved', error: 'Try again' };
   const watchedLabel = watchedState === 'watched' ? 'Watched' : watchedState === 'error' ? 'Try again' : 'Already watched';
 
+  // Reason-aware fallback copy (F3.10) — quiet + honest, never implying the
+  // fallback was personalized from fresh live data or that a live query
+  // succeeded. No technical wording (no Supabase / database / query / API).
+  const FALLBACK_COPY = {
+    live_error: 'Example pick — live recommendations are unavailable right now.',
+    live_empty: 'Example pick — live recommendations are not ready yet.',
+    filtered_empty: 'Example pick — no strong live fit for these details.',
+  };
+  const fallbackNote = isFallback ? (FALLBACK_COPY[fallbackReason] || 'Example pick — using a safe fallback.') : null;
+
   // One persistent, polite, sr-only status region wraps both states so the
   // exhausted announcement lands on the same live element (no fresh region).
   const liveRegion = (
@@ -214,8 +224,8 @@ export default function StagePick({ selected, who, energy, intention, results, p
               {/* RIGHT — eyebrow, title, meta, chips, the case, synopsis, provider, actions. */}
               <div className="ff-stage3-spread__right">
                 <div className="ff-pick-eyebrow" style={{ color:blendHex }}>Tonight&rsquo;s pick</div>
-                {isFallback && (
-                  <p className="ff-pick-fallback-note">Example pick &mdash; we couldn&rsquo;t reach your live recommendations.</p>
+                {fallbackNote && (
+                  <p className="ff-pick-fallback-note">{fallbackNote}</p>
                 )}
                 <h1 style={{ fontFamily:'Outfit', fontSize:'clamp(44px, 5.6vw, 76px)', lineHeight:0.96, fontWeight:300, letterSpacing:'-0.045em', color:HP.text, margin:'12px 0 0', textWrap:'balance' }}>
                   {titleWords.map((w, i) => <span key={i} className="ff-pick-word" style={{ display:'inline-block', opacity:0, animation:`ff-word-in 0.55s cubic-bezier(.2,.7,.2,1) ${0.1 + i*0.06}s forwards`, marginRight:'0.2em' }}>{w}</span>)}

--- a/src/features/discover/useDiscoverData.jsx
+++ b/src/features/discover/useDiscoverData.jsx
@@ -200,8 +200,27 @@ function shapeFilm(m) {
 
 // === Provider ============================================================
 
+// Pure classifier (F3.10) — maps a fetch outcome to an HONEST data-source
+// descriptor that distinguishes live success from the fallback reasons. The UI
+// copy is driven by `reason`; `errorMessage` is a safe, generic category and never
+// carries raw Supabase errors, query details, secrets, or stack traces.
+//   live_ok        — the live `movies` query returned usable candidates
+//   live_empty     — the live query succeeded but found NO candidates
+//   filtered_empty — candidates existed but exclusions/filters left zero viable
+//   live_error     — the fetch failed
+export function classifyDiscoverDataSource({ errored = false, filmCount = 0, candidateCount = 0 } = {}) {
+  if (errored) return { movies: 'fallback', reason: 'live_error', errorMessage: 'Live recommendations could not be reached.' }
+  if (filmCount > 0) return { movies: 'live', reason: 'live_ok' }
+  if (candidateCount > 0) return { movies: 'fallback', reason: 'filtered_empty' }
+  return { movies: 'fallback', reason: 'live_empty' }
+}
+
 const INITIAL = {
   films: [],
+  // Loading default — the result surface is never shown until the fetch resolves
+  // (the user passes through MoodStage → NightContext → Resolve first), so this
+  // optimistic value is overwritten with the real classification before stage 3.
+  dataSource: { movies: 'live', reason: 'live_ok' },
   diaryQuotes: {},
   profile: null, // computeUserProfile(userId) result — Discover calls scoreMovieForUser inline
   baselineMoods: [], // users.taste_baseline_moods (onboarding mood keys)
@@ -601,11 +620,18 @@ export function DiscoverDataProvider({ children }) {
           } : null)
           .filter(Boolean)
 
-        setState({ films, diaryQuotes, profile, baselineMoods, learnedPrefs, recentSaves, loading: false, error: null })
+        // Honest data-source classification: live_ok when we have films, else
+        // filtered_empty (candidates existed but exclusions removed them all) vs
+        // live_empty (the query itself found nothing). rawMovieRows is the live
+        // candidate set before filterExclusionsClientSide.
+        const dataSource = classifyDiscoverDataSource({ filmCount: films.length, candidateCount: rawMovieRows.length })
+        setState({ films, dataSource, diaryQuotes, profile, baselineMoods, learnedPrefs, recentSaves, loading: false, error: null })
       } catch (e) {
         if (abort) return
+        // Raw error stays in the console + the internal `error` field (never
+        // rendered); the UI sees only the safe classified dataSource.
         console.error('[useDiscoverData]', e)
-        setState(s => ({ ...s, loading: false, error: e?.message || 'Failed to load' }))
+        setState(s => ({ ...s, loading: false, error: e?.message || 'Failed to load', dataSource: classifyDiscoverDataSource({ errored: true }) }))
       }
     })()
     return () => { abort = true }


### PR DESCRIPTION
**F3.10** — make Discover's **data source + fallback reason** explicit and testable, so a live-fetch failure, an empty live pool, exclusion-filtered candidates, and the static fallback set are clearly distinguished. **No journey/ranking/scoring/result-layout change; no write-payload change.**

## Explicit data-source metadata
New **pure exported** `classifyDiscoverDataSource({ errored, filmCount, candidateCount })` → `{ movies: 'live' | 'fallback', reason, errorMessage? }`:
- `live_ok` — the live `movies` query returned usable candidates
- `live_empty` — the live query succeeded but found **no** candidates
- `filtered_empty` — candidates existed but exclusions left zero viable (`films.length === 0` while `rawMovieRows.length > 0`, i.e. **before vs after** `filterExclusionsClientSide`)
- `live_error` — the fetch failed (wins over counts)

`useDiscoverData` now returns `dataSource`: computed on success from `films.length` vs `rawMovieRows.length`, and on error as `live_error`. `INITIAL` carries an optimistic `live_ok` (the result surface is never shown before the fetch resolves). **The raw Supabase error stays only in `console` + the internal, unrendered `error` field**; `dataSource.errorMessage` is a fixed safe string — no query details, secrets, or stack traces reach the UI.

## Fallback reason handling (Discover)
Discover derives `isFallback` from `dataSource.movies === 'fallback'` (**not** merely `liveFilms.length === 0`) and passes `fallbackReason` to StagePick. The `films = usingLiveFilms ? liveFilms : FILMS_FALLBACK` selection is unchanged.

## UI fallback copy by reason (StagePick)
The single F3.9 note becomes reason-aware, quiet, and honest:
| reason | copy |
| --- | --- |
| `live_error` | Example pick — live recommendations are unavailable right now. |
| `live_empty` | Example pick — live recommendations are not ready yet. |
| `filtered_empty` | Example pick — no strong live fit for these details. |
| unknown | Example pick — using a safe fallback. |

Visible + screen-reader reachable, near the eyebrow, never implying personalized-from-live-data or a successful live query, **no technical wording** (no Supabase / database / query / API), no blocking alert.

**Fallback-authority audit:** StagePick already renders no diary/critic/social-proof; the existing `becauseLine` (mood/affinity facts) + runtime-fit line (the user's chosen time + the film's real runtime) remain truthful in fallback mode, so nothing was suppressed and `buildBecauseLine` (`derive.js`) was **not** touched.

## What remains deferred
No reload/refetch helper exists on `useDiscoverData`, so a **"Try live recommendations again"** affordance is **deferred** to a later reliability phase per the brief (adding a refetch path would restructure the provider effect). `filtered_empty` is now implemented (it was distinguishable without a risky refactor).

## Tests
- New **`useDiscoverData.test.jsx`** (9) — the pure classifier (all four reasons + safe error message + errored-precedence) and a light `DiscoverDataProvider` integration (no user, universal Proxy Supabase mock) proving `live_empty` + `live_error` are wired from the fetch outcome, with `films` an array and no raw error in `dataSource`.
- **`DiscoverEntry.test.jsx`** (+5) — shell threads `live_ok` (no note) / `live_error` / `live_empty` / `filtered_empty` copy and reaches a fallback result with **no impression/watchlist/history/interaction writes**.
- **`DiscoverResult.test.jsx`** (+9) — reason-aware copy, no note when `isFallback=false`, the note is visible + SR-reachable + non-technical, no fabricated authority, and actions + live status unchanged under fallback.
- Stable 3×. An **adversarial multi-agent review** (3 dimensions, per-finding verification) found **zero confirmed-real defects**.

## Unchanged (confirmed)
Ranking, `diversifyTop3`, `MAX_PICKS`, the films-selection + element shape, all movie/profile/exclusions/learnedPrefs/recentSaves queries, `shapeFilm`, `diaryQuotes`, every write payload, the Open-Film-File route, trailer + provider behavior (F3.9), the preference-upsert + impression/interaction payloads, Supabase schema/RLS, MoodStage, StageNightContext, StageResolve, and the one-pick result layout. `derive.js`, `constants.js`, `useDiscoverResultActions`, `useStreamingProvider`, `StreamingChip`, `TrailerModal`, StageMood/Night/Resolve are byte-identical. **No live Discover writes triggered** (mocked Supabase).

## Validation
- `npm run lint` → clean · `npm run build` → ✓ · discover suite → **203 passed** (8 files) · `npm run test` → **866 passed** (68 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
