### PR TITLE
Harden Discover for private beta

### DIFF
--- a/docs/discover/beta-readiness-f312.md
+++ b/docs/discover/beta-readiness-f312.md
@@ -1,0 +1,58 @@
+# `/discover` — Private-Beta Readiness (F3.12)
+
+**Status:** READY FOR PRIVATE/BETA TESTING — no P0, no functional P1 blocker.
+**Not yet:** public-production readiness (pending a real intercepted-backend e2e — see Deferred).
+**Date:** 2026-06 · supersedes nothing; closes the F3.2–F3.12 `/discover` redesign arc.
+
+This note records the final state of the redesigned `/discover` journey after F3.2–F3.12, the F3.11 production-readiness verdict, and the trust + accessibility posture for inviting private-beta testers.
+
+## Final journey
+
+1. **MoodStage** — the front door. Direct visits start with **no mood selected**; arriving from onboarding seeds the mapped baseline moods only (deduped, order-preserved, **max 3**). `Continue` is gated on ≥1 mood. No hero, no "Surprise Me".
+2. **StageNightContext** — a **summary-first** view of the predicted context (intention / time / who / energy). The primary CTA `Find my film →` is available immediately; all editing is behind one optional **Adjust details** disclosure. The Discover preference is written **only** when the user explicitly accepts via `Find my film` (`commitDiscoverPreferences`, `onConflict: 'user_id'`).
+3. **StageResolve** — one short, honest transition: **900ms** normal motion, **0ms** under `prefers-reduced-motion` (immediate result). No progress bar, no "analyzing", no fake AI theatre.
+4. **StagePick** — **one** evidence-backed recommendation. No visible alternates, no queue count, no mood/taste percentages, no parallax or infinite poster motion. The ranked list stays internal (`MAX_PICKS = 15`, `hiddenTopIds`) as a controlled **Not tonight** / **Already watched** fallback. An honest **"Why this one"** case (a real `becauseLine` and/or an in-band runtime-fit line) renders only when supportable. Reason-aware fallback labels distinguish `live_ok` / `live_empty` / `filtered_empty` / `live_error`.
+
+## F3.11 verdict
+
+A read-only, multi-dimension audit (journey, trust/data-truth, a11y, mobile, motion/audio, writes, loading/error, testing, architecture), cross-checked against source:
+
+- **Journey:** 16/16 checkpoints PASS.
+- **No P0.** No crash, data-loss, secret/raw-error exposure, double-write, lost-data, or broken-primary-action path.
+- **No functional P1 blocker** for private beta. The remaining findings are test-coverage breadth and a11y/polish, addressed here (F3.12) or deferred.
+- **Public-production is NOT claimed:** the audit and all 203 Discover tests are code-level with mocked Supabase/TMDB/YouTube; there is no live-backend evidence and (until F3.13) no Playwright e2e on `/discover`.
+
+## Data-truth posture
+
+Every user-facing claim is real-source-backed or derived-but-honest:
+
+- Mood labels / context summary — the user's own selections.
+- "Because…" line — derived from real mood/affinity signals; **returns null (section omitted) when unsupported**, including in fallback mode. No fabrication.
+- Runtime-fit line — shown **only** when the film's runtime is genuinely inside the chosen band (no tolerance).
+- Synopsis — real TMDB overview; hidden when absent (never templated).
+- Provider — found chip, or quiet honest "Availability not found" / "Availability unavailable"; **never implies the film is unavailable everywhere**.
+- Save / Already-watched / Not-tonight — confirmations reflect the real write; **Mark Watched awaits the write before confirming** and surfaces a retryable error on failure (no false "Watched").
+- Fallback static films — now **labelled** by reason; the static set is never presented as a fresh live personalization.
+
+## Accessibility posture (after F3.12)
+
+- One polite, atomic `role="status"` live region on the result; reason-aware fallback note carries `role="note"`.
+- Actions expose `aria-busy` / `aria-pressed` / disabled with text-named states; trailer dialog has a focus trap + restore + `aria-modal`.
+- Decorative grain/vignette/glow + button icons are `aria-hidden`; poster alt is `"{title} poster"`, provider logo alt `"{name} logo"`.
+- Touch targets: all result actions ≥44px via `.ff-pick-actions__*`; the **AudioToggle is now 44×44px with an accessible name** (F3.12).
+- Heading hierarchy: every stage-3 state now has a single top-level `<h1>` (the exhausted state was promoted from `<h2>` in F3.12).
+- Reduced motion is fully respected: the global `@media (prefers-reduced-motion: reduce)` reset neutralizes the ambient starfield / mood-orb / ceremony animations, and StageResolve resolves to 0ms.
+
+## Deferred (not blocking private beta)
+
+- **F3.13 — real e2e + visual coverage for `/discover`** (intercepted backend, **no live writes**): happy path + reduced-motion + a fallback state, plus a visual-regression baseline for the four stages (mobile + desktop). **Required before public-production sign-off.**
+- **Reducer / state-machine extraction** of `Discover.jsx` — deferred; the numeric-stage + refs are readable and well-tested. Revisit only when a new stage or branch appears.
+- **`FILMS_FALLBACK` cleanup** — the static fallback films carry latent `criticLine` / `twin` / `arc` fields that are **never rendered** by the current StagePick; harmless, but worth removing/commenting.
+- Minor polish: mood-button `aria-label` combining label + hint; `overflow-wrap` hardening for long labels at 360px; lock-tests for `MOOD_BRIDGE` + `FILMS_FALLBACK`.
+
+## Beta safety rules
+
+- **Mocked-data testing only** for automated checks — do not exercise the live authenticated `/discover` route in CI.
+- **No destructive resets** — do not reset the dev/test user, do not use `/account` reset, do not run service-role mutations.
+- Save / Mark-watched / Not-tonight / Open-Film-File log impressions and write to user tables — **only** trigger them against intercepted/mocked backends in tests, never against a live account during verification.
+- No secrets in logs, screenshots, or commits.

--- a/src/features/discover/Discover.jsx
+++ b/src/features/discover/Discover.jsx
@@ -78,7 +78,7 @@ const FFAudio = (() => {
 function AudioToggle() {
   const [muted, setMuted] = useState(FFAudio.isMuted());
   return (
-    <button onClick={() => { const n = !muted; FFAudio.setMuted(n); setMuted(n); }} title={muted?'Sound off':'Sound on'} style={{ position:'fixed', bottom:24, left:24, width:40, height:40, borderRadius:999, background:'rgba(18,11,28,0.85)', backdropFilter:'blur(12px)', border:`1px solid rgba(255,255,255,0.14)`, color:muted?'rgba(255,255,255,0.45)':'#A78BFA', cursor:'pointer', zIndex:60, display:'inline-flex', alignItems:'center', justifyContent:'center' }}>
+    <button onClick={() => { const n = !muted; FFAudio.setMuted(n); setMuted(n); }} title={muted?'Sound off':'Sound on'} aria-label={muted?'Sound off':'Sound on'} style={{ position:'fixed', bottom:24, left:24, width:44, height:44, borderRadius:999, background:'rgba(18,11,28,0.85)', backdropFilter:'blur(12px)', border:`1px solid rgba(255,255,255,0.14)`, color:muted?'rgba(255,255,255,0.45)':'#A78BFA', cursor:'pointer', zIndex:60, display:'inline-flex', alignItems:'center', justifyContent:'center' }}>
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
         <path d="M11 5L6 9H2v6h4l5 4V5z"/>
         {!muted && <><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14"/></>}

--- a/src/features/discover/__tests__/DiscoverEntry.test.jsx
+++ b/src/features/discover/__tests__/DiscoverEntry.test.jsx
@@ -133,6 +133,27 @@ describe('Discover night context — summary-first (F3.6)', () => {
     } finally { vi.useRealTimers() }
   })
 
+  it('Find my film writes exactly one preference upsert with the full count payload (onConflict user_id)', async () => {
+    vi.useFakeTimers()
+    try {
+      renderDiscover()
+      gotoNight('Cozy') // predicted: intention=comfort, time=std, who=alone, energy=hour-based
+      fireEvent.click(findFilmBtn())
+      await act(async () => { await vi.advanceTimersByTimeAsync(0) }) // flush the fire-and-forget commit
+      const ups = prefUpserts()
+      expect(ups).toHaveLength(1)
+      expect(ups[0].opts).toEqual({ onConflict: 'user_id' })
+      const row = ups[0].row
+      expect(row.user_id).toBe('u1')
+      expect(row.total_commits).toBe(1)
+      // existing row is null → each count map starts at the accepted value with count 1
+      expect(row.intention_counts).toEqual({ comfort: 1 }) // cozy → comfort
+      expect(row.time_counts).toEqual({ std: 1 })
+      expect(row.who_counts).toEqual({ alone: 1 })
+      expect(Object.values(row.energy_counts)).toEqual([1]) // hour-dependent key, count 1
+    } finally { vi.useRealTimers() }
+  })
+
   it('the result appears after exactly 900ms — not before', async () => {
     vi.useFakeTimers()
     try {

--- a/src/features/discover/sections/StagePick.jsx
+++ b/src/features/discover/sections/StagePick.jsx
@@ -131,7 +131,7 @@ export default function StagePick({ selected, who, energy, intention, results, p
       placement: 'discover',
       pickReasonType: 'discover_reveal',
       pickReasonLabel: `Discover · ${cName}`,
-    })
+    }).catch(() => {}) // fire-and-forget — an impression-log failure must never surface to the user
     // top.id pins the impression — when Not tonight / Already watched advance the
     // pick we log the new top as its own row.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -175,9 +175,9 @@ export default function StagePick({ selected, who, energy, intention, results, p
             <span aria-hidden="true" style={{ height:1, width:22, background:blendHex, opacity:0.6 }} />
             No more strong fits
           </div>
-          <h2 style={{ fontFamily:'Outfit', fontSize:'clamp(32px, 4.6vw, 56px)', lineHeight:1.04, fontWeight:200, letterSpacing:'-0.04em', color:HP.text, margin:0, maxWidth:760, textWrap:'balance' }}>
+          <h1 style={{ fontFamily:'Outfit', fontSize:'clamp(32px, 4.6vw, 56px)', lineHeight:1.04, fontWeight:200, letterSpacing:'-0.04em', color:HP.text, margin:0, maxWidth:760, textWrap:'balance' }}>
             That&rsquo;s the honest edge of tonight&rsquo;s list.
-          </h2>
+          </h1>
           <p style={{ marginTop:18, fontFamily:'Outfit, Inter, sans-serif', fontSize:14, color:HP.textMuted, fontStyle:'italic', maxWidth:480, lineHeight:1.6 }}>
             Adjust tonight&rsquo;s details, or start again with a different mood.
           </p>
@@ -225,7 +225,7 @@ export default function StagePick({ selected, who, energy, intention, results, p
               <div className="ff-stage3-spread__right">
                 <div className="ff-pick-eyebrow" style={{ color:blendHex }}>Tonight&rsquo;s pick</div>
                 {fallbackNote && (
-                  <p className="ff-pick-fallback-note">{fallbackNote}</p>
+                  <p className="ff-pick-fallback-note" role="note" aria-label="Recommendation source note">{fallbackNote}</p>
                 )}
                 <h1 style={{ fontFamily:'Outfit', fontSize:'clamp(44px, 5.6vw, 76px)', lineHeight:0.96, fontWeight:300, letterSpacing:'-0.045em', color:HP.text, margin:'12px 0 0', textWrap:'balance' }}>
                   {titleWords.map((w, i) => <span key={i} className="ff-pick-word" style={{ display:'inline-block', opacity:0, animation:`ff-word-in 0.55s cubic-bezier(.2,.7,.2,1) ${0.1 + i*0.06}s forwards`, marginRight:'0.2em' }}>{w}</span>)}


### PR DESCRIPTION
**F3.12** — final beta-readiness hardening of the redesigned `/discover` journey: the small, verified accessibility + robustness touch-ups from the F3.11 audit + a beta-readiness note. **No journey redesign, no ranking/scoring change, no write-payload change, no result-layout change** beyond the heading level + fallback-note attributes.

## The six fixes
1. **AudioToggle touch target** — `40×40` → **`44×44px`** (`Discover.jsx`); position, icon, muted-default, title, and localStorage persistence unchanged.
2. **Exhausted-state heading** — StagePick exhausted branch `<h2>` → **`<h1>`** (copy + styles unchanged), so every stage-3 state has a single top-level heading.
3. **Fallback note semantics** — the reason-aware fallback `<p>` gains **`role="note"`** + `aria-label="Recommendation source note"`; visible copy unchanged.
4. **AudioToggle accessible name** — added **`aria-label`** ("Sound on"/"Sound off") alongside the existing `title`.
5. **Non-blocking impression log** — `logSurfaceImpressions` on StagePick mount now ends in **`.catch(() => {})`** (matching `updateImpression`/`trackInteraction`), so an analytics failure can never surface to the user. The impression **payload is unchanged**.
6. **Direct preference-commit test** — DiscoverEntry asserts that **"Find my film" writes exactly one `user_discover_preferences` upsert** with `onConflict: 'user_id'` and the full payload shape (`intention_counts {comfort:1}` / `time_counts {std:1}` / `who_counts {alone:1}` / `energy_counts {<hour>:1}` / `total_commits:1`).

## Beta-readiness doc
`docs/discover/beta-readiness-f312.md` — the final journey, the F3.11 verdict (**private/beta ready, no P0/P1; public-production pending a real e2e**), the data-truth + a11y posture, the deferred items (**F3.13** e2e/visual coverage; reducer extraction; `FILMS_FALLBACK` cleanup), and the beta safety rules (mocked-data testing only, no destructive resets).

## Unchanged (confirmed byte-identical)
StageMood, StageNightContext, StageResolve, `useDiscoverData`, `useDiscoverResultActions`, `useStreamingProvider`, TrailerModal, StreamingChip, `derive.js`, `constants.js`, `resultPresentation.js`, `discover.css`; **ranking/scoring**, `diversifyTop3`, `MAX_PICKS`, **every write payload + event name**, the dataSource/fallback logic, provider/trailer behavior, onboarding handoff, and the **`/discover` route**. `commitDiscoverPreferences` is untouched (the new test only reads its output). **No live Discover writes triggered** (mocked Supabase/TMDB/YouTube).

## Validation
- `npm run lint` → clean · `npm run build` → ✓ · discover suite → **204 passed** (8 files) · `npm run test` → **868 passed** (68 files) · changed tests stable **3×**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
