### PR TITLE
Extract Home derivation helpers and remove dead onboarding overlay

### DIFF
--- a/src/features/home/Home.jsx
+++ b/src/features/home/Home.jsx
@@ -5,9 +5,8 @@
 // write to real tables and navigate to /movie/:tmdbId, /profile/:userId,
 // /lists/curated/:slug.
 
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
-import { motion, useReducedMotion } from 'framer-motion'
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 
 import { useAuthSession } from '@/shared/hooks/useAuthSession'
 import { usePageMeta } from '@/shared/hooks/usePageMeta'
@@ -26,23 +25,11 @@ import './home.css'
 function HomeBody() {
   usePageMeta({ title: 'Home — FeelFlick' })
   const navigate = useNavigate()
-  const location = useLocation()
-  const reduced = useReducedMotion()
   const { user: authUser } = useAuthSession()
   const { loading, moods: liveMoods } = useHomeData()
   const [currentMood, setMood] = useState(MOOD_META[0])
   const [userPickedMood, setUserPickedMood] = useState(false)
   const [shuffleSeed, setShuffleSeed] = useState(0)
-  // Snapshot the fromOnboarding flag once on mount — we don't want the
-  // black-handoff overlay to replay if the user later navigates back to /home
-  // from somewhere else. Pairs with Onboarding's fade-out so the seam between
-  // celebration and home reads as a single smooth crossfade.
-  const fromOnboardingRef = useRef(location.state?.fromOnboarding === true)
-  // After the overlay finishes its fade-out we unmount it so it isn't a stale
-  // pointer-events-none div lingering at opacity 0 in the DOM tree.
-  const [handoffOverlayVisible, setHandoffOverlayVisible] = useState(
-    () => fromOnboardingRef.current && !reduced,
-  )
 
   // When the data hook finishes, snap the initial mood tab to the user's first
   // baseline pick from Onboarding Step 1 (useHomeData reorders `moods` so the
@@ -184,24 +171,6 @@ function HomeBody() {
           onDiscover={() => navigate('/discover')}
         />
       </div>
-
-      {/* Black handoff overlay — only on the first arrival from onboarding.
-         Pairs with Onboarding's celebration fade-out (the celebration content
-         dims to 0 over 500ms while the black bg stays); this overlay then
-         covers /home at mount and fades up over 900ms, revealing the page
-         smoothly. delay:0.15s gives React time to commit the first paint
-         before the fade starts, so the user never sees a flash of empty page.
-         Skipped for prefers-reduced-motion. */}
-      {handoffOverlayVisible && (
-        <motion.div
-          aria-hidden="true"
-          className="pointer-events-none fixed inset-0 z-9998 bg-black"
-          initial={{ opacity: 1 }}
-          animate={{ opacity: 0 }}
-          transition={{ duration: 0.9, ease: [0.16, 1, 0.3, 1], delay: 0.15 }}
-          onAnimationComplete={() => setHandoffOverlayVisible(false)}
-        />
-      )}
     </div>
   )
 }

--- a/src/features/home/__tests__/homeDerive.test.js
+++ b/src/features/home/__tests__/homeDerive.test.js
@@ -1,0 +1,160 @@
+// src/features/home/__tests__/homeDerive.test.js
+// F4.2 — pure unit coverage for the extracted Home derivation helpers. No render,
+// no Supabase, no live services. These lock the BEHAVIOR-PRESERVED move from
+// useHomeData.jsx (mood ordering) + sections-top.jsx (seed / shuffle / queue).
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  ONBOARDING_MOOD_TO_BRIEFING,
+  orderBriefingMoodKeys,
+  todaySeed,
+  shuffleBySeed,
+  buildBriefingQueue,
+} from '../homeDerive'
+
+// The Briefing's available mood keys (the keys of MOOD_BRIDGE in useHomeData).
+const AVAILABLE = ['tender', 'thrilled', 'curious', 'cozy', 'melancholy', 'witty']
+
+afterEach(() => { vi.useRealTimers() })
+
+// ── orderBriefingMoodKeys ─────────────────────────────────────────────────────
+describe('orderBriefingMoodKeys', () => {
+  it('empty / non-array baseline preserves the available mood-key order', () => {
+    expect(orderBriefingMoodKeys([], AVAILABLE)).toEqual(AVAILABLE)
+    expect(orderBriefingMoodKeys(undefined, AVAILABLE)).toEqual(AVAILABLE)
+    expect(orderBriefingMoodKeys(null, AVAILABLE)).toEqual(AVAILABLE)
+  })
+  it('a known onboarding mood moves its mapped Briefing mood to the front', () => {
+    // 'cozy' → 'cozy'; expect cozy first, then the rest in original order.
+    expect(orderBriefingMoodKeys(['cozy'], AVAILABLE)).toEqual(['cozy', 'tender', 'thrilled', 'curious', 'melancholy', 'witty'])
+    // 'wired' → 'curious'
+    expect(orderBriefingMoodKeys(['wired'], AVAILABLE)).toEqual(['curious', 'tender', 'thrilled', 'cozy', 'melancholy', 'witty'])
+  })
+  it('multiple known baseline moods keep their mapped order, then the remainder', () => {
+    // tender→tender, fun→witty  →  [tender, witty, ...remaining-in-original-order]
+    expect(orderBriefingMoodKeys(['tender', 'fun'], AVAILABLE)).toEqual(['tender', 'witty', 'thrilled', 'curious', 'cozy', 'melancholy'])
+  })
+  it('unknown onboarding keys are ignored (discarded mappings)', () => {
+    expect(orderBriefingMoodKeys(['nope', 'cozy', 'xyz'], AVAILABLE)).toEqual(['cozy', 'tender', 'thrilled', 'curious', 'melancholy', 'witty'])
+  })
+  it('available moods absent from the baseline are appended in original order', () => {
+    const out = orderBriefingMoodKeys(['fun'], AVAILABLE) // fun→witty first
+    expect(out[0]).toBe('witty')
+    expect(out.slice(1)).toEqual(['tender', 'thrilled', 'curious', 'cozy', 'melancholy'])
+  })
+  it('does not mutate its input arrays', () => {
+    const baseline = ['cozy', 'fun']
+    const available = [...AVAILABLE]
+    const baseSnap = [...baseline]
+    const availSnap = [...available]
+    orderBriefingMoodKeys(baseline, available)
+    expect(baseline).toEqual(baseSnap)
+    expect(available).toEqual(availSnap)
+  })
+  // NOTE: duplicate onboarding mappings (e.g. wired+mythic both → curious) remain
+  // behavior-preserved (NOT deduplicated) — deferred to a later intentional phase.
+  it('preserves the current duplicate-mapping behavior (no dedup in F4.2)', () => {
+    // wired→curious and mythic→curious: 'curious' appears once at the front
+    // (filtered out of the remainder), exactly as the inline block did.
+    expect(ONBOARDING_MOOD_TO_BRIEFING.wired).toBe('curious')
+    expect(ONBOARDING_MOOD_TO_BRIEFING.mythic).toBe('curious')
+    expect(orderBriefingMoodKeys(['wired', 'mythic'], AVAILABLE))
+      .toEqual(['curious', 'curious', 'tender', 'thrilled', 'cozy', 'melancholy', 'witty'])
+  })
+})
+
+// ── todaySeed ─────────────────────────────────────────────────────────────────
+describe('todaySeed', () => {
+  it('returns an 8-digit YYYYMMDD UTC integer', () => {
+    vi.useFakeTimers(); vi.setSystemTime(new Date('2026-02-13T15:00:00Z'))
+    expect(todaySeed()).toBe(20260213)
+    expect(String(todaySeed())).toHaveLength(8)
+  })
+  it('is stable across the same UTC day', () => {
+    vi.useFakeTimers(); vi.setSystemTime(new Date('2026-02-13T00:00:01Z'))
+    const a = todaySeed()
+    vi.setSystemTime(new Date('2026-02-13T23:59:59Z'))
+    expect(todaySeed()).toBe(a)
+  })
+  it('changes at the UTC date rollover, not local midnight', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-02-13T23:30:00Z'))
+    const before = todaySeed()
+    vi.setSystemTime(new Date('2026-02-14T00:30:00Z')) // crossed UTC midnight
+    const after = todaySeed()
+    expect(before).toBe(20260213)
+    expect(after).toBe(20260214)
+    expect(after).not.toBe(before)
+  })
+  it('depends on the UTC date, not the machine timezone (uses getUTC*)', () => {
+    // A fixed UTC instant yields the same UTC date regardless of local TZ.
+    vi.useFakeTimers(); vi.setSystemTime(new Date('2026-12-31T23:59:00Z'))
+    expect(todaySeed()).toBe(20261231)
+  })
+})
+
+// ── shuffleBySeed ─────────────────────────────────────────────────────────────
+describe('shuffleBySeed', () => {
+  const base = () => [1, 2, 3, 4, 5, 6, 7, 8]
+  it('same input + same seed is deterministic', () => {
+    expect(shuffleBySeed(base(), 12345)).toEqual(shuffleBySeed(base(), 12345))
+  })
+  it('different seeds produce different orderings', () => {
+    expect(shuffleBySeed(base(), 111)).not.toEqual(shuffleBySeed(base(), 999))
+  })
+  it('preserves membership — every element exactly once', () => {
+    const out = shuffleBySeed(base(), 4242)
+    expect([...out].sort((a, b) => a - b)).toEqual(base())
+    expect(out).toHaveLength(8)
+  })
+  it('does not mutate the input array', () => {
+    const arr = base()
+    const snap = [...arr]
+    shuffleBySeed(arr, 777)
+    expect(arr).toEqual(snap)
+  })
+  it('seed 0 returns the input order unchanged (current behavior)', () => {
+    const arr = base()
+    expect(shuffleBySeed(arr, 0)).toEqual(arr)
+  })
+})
+
+// ── buildBriefingQueue ────────────────────────────────────────────────────────
+describe('buildBriefingQueue', () => {
+  const films = () => [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }]
+  const SEED = 9999
+
+  it('with no hidden ids returns the seeded order', () => {
+    expect(buildBriefingQueue(films(), SEED, new Set())).toEqual(shuffleBySeed(films(), SEED))
+  })
+  it('removes hidden ids and keeps the deterministic shuffled order', () => {
+    const expected = shuffleBySeed(films(), SEED).filter(f => f.id !== 2 && f.id !== 4)
+    expect(buildBriefingQueue(films(), SEED, new Set([2, 4]))).toEqual(expected)
+  })
+  it('returns an empty queue when all ids are hidden', () => {
+    expect(buildBriefingQueue(films(), SEED, new Set([1, 2, 3, 4, 5]))).toEqual([])
+  })
+  it('ignores unknown hidden ids (keeps all valid films)', () => {
+    expect(buildBriefingQueue(films(), SEED, new Set([99, 100]))).toEqual(shuffleBySeed(films(), SEED))
+  })
+  it('accepts an array form of hidden ids too', () => {
+    expect(buildBriefingQueue(films(), SEED, [2]).every(f => f.id !== 2)).toBe(true)
+  })
+  it('preserves film object identity (no copies)', () => {
+    const src = films()
+    const out = buildBriefingQueue(src, SEED, new Set())
+    expect(out.every(f => src.includes(f))).toBe(true)
+  })
+  it('does not mutate the input films array or the hidden-id Set', () => {
+    const src = films()
+    const srcSnap = src.map(f => ({ ...f }))
+    const hidden = new Set([2])
+    buildBriefingQueue(src, SEED, hidden)
+    expect(src).toEqual(srcSnap)
+    expect([...hidden]).toEqual([2])
+  })
+  it('handles a null/undefined films input safely', () => {
+    expect(buildBriefingQueue(undefined, SEED, new Set())).toEqual([])
+    expect(buildBriefingQueue(null, SEED, new Set())).toEqual([])
+  })
+})

--- a/src/features/home/homeDerive.js
+++ b/src/features/home/homeDerive.js
@@ -1,0 +1,67 @@
+// src/features/home/homeDerive.js
+// F4.2 — pure Home derivation helpers, extracted (behavior-preserving) from
+// useHomeData.jsx (onboarding mood ordering) and sections-top.jsx (daily seed,
+// deterministic shuffle, queue construction). No React, no Supabase, no browser
+// globals beyond Date (used by todaySeed). NO logic changed, NO dedup added.
+
+// Onboarding's 6-key mood vocabulary → the Briefing's 6-key vocabulary.
+// (Moved verbatim from useHomeData.jsx.)
+export const ONBOARDING_MOOD_TO_BRIEFING = {
+  cozy:   'cozy',
+  wired:  'curious',
+  tender: 'tender',
+  fun:    'witty',
+  tense:  'thrilled',
+  mythic: 'curious',
+}
+
+// Order the Briefing mood keys so the user's onboarding-baseline moods appear
+// first, falling back to the original order when there is no baseline. Mechanically
+// equivalent to the inline block in useHomeData (called with availableMoodKeys =
+// Object.keys(MOOD_BRIDGE), where `available.includes(k)` ⟺ the original
+// `k in MOOD_BRIDGE`). Duplicate onboarding mappings are preserved exactly as today
+// (NOT deduplicated) — that is an intentional behavior change deferred to a later
+// product phase.
+export function orderBriefingMoodKeys(baselineKeys, availableMoodKeys) {
+  const baseline = Array.isArray(baselineKeys) ? baselineKeys : []
+  const available = availableMoodKeys || []
+  const baselineBriefingKeys = baseline
+    .map(k => ONBOARDING_MOOD_TO_BRIEFING[k])
+    .filter(Boolean)
+  return [
+    ...baselineBriefingKeys.filter(k => available.includes(k)),
+    ...available.filter(k => !baselineBriefingKeys.includes(k)),
+  ]
+}
+
+// Tiny seeded shuffle so each Reshuffle click reorders deterministically.
+// (Moved verbatim from sections-top.jsx.)
+export function shuffleBySeed(arr, seed) {
+  if (!seed) return arr
+  const out = arr.slice()
+  let s = seed * 9301 + 49297
+  for (let i = out.length - 1; i > 0; i--) {
+    s = (s * 9301 + 49297) % 233280
+    const j = Math.floor((s / 233280) * (i + 1))
+    ;[out[i], out[j]] = [out[j], out[i]]
+  }
+  return out
+}
+
+// Daily seed: current UTC date as YYYYMMDD integer. Stable for a whole UTC day,
+// changes at midnight UTC. (Moved verbatim from sections-top.jsx.)
+export function todaySeed() {
+  const d = new Date()
+  return d.getUTCFullYear() * 10000 + (d.getUTCMonth() + 1) * 100 + d.getUTCDate()
+}
+
+// The remaining Briefing queue for a mood — deterministic shuffle, then drop the
+// skipped/watched ids. Mechanically equivalent to the inline expression in
+// TheBriefing (`shuffleBySeed(moodEntry.films || [], effectiveSeed).filter(f =>
+// !hiddenIds.has(f.id))`). Accepts hiddenIds as the live Set form (or any iterable);
+// does not mutate the inputs and preserves film object identity + ordering.
+export function buildBriefingQueue(films, seed, hiddenIds) {
+  const shuffled = shuffleBySeed(films || [], seed)
+  const hidden = hiddenIds instanceof Set ? hiddenIds : new Set(hiddenIds || [])
+  return shuffled.filter(f => !hidden.has(f.id))
+}

--- a/src/features/home/sections-top.jsx
+++ b/src/features/home/sections-top.jsx
@@ -14,6 +14,7 @@ import Eyebrow from '@/shared/ui/Eyebrow'
 import { HP, MOOD_META } from './data'
 import { SmartImg } from './atoms'
 import WhyThisPick from './WhyThisPick'
+import { todaySeed, buildBriefingQueue } from './homeDerive'
 import { useHomeData } from './useHomeData'
 
 // The Briefing presents ONE confident pick. Its eyebrow is a constant —
@@ -383,28 +384,11 @@ function BriefingSkeleton() {
 }
 
 
-// Tiny seeded shuffle so each Reshuffle click reorders deterministically.
-function shuffleBySeed(arr, seed) {
-  if (!seed) return arr
-  const out = arr.slice()
-  let s = seed * 9301 + 49297
-  for (let i = out.length - 1; i > 0; i--) {
-    s = (s * 9301 + 49297) % 233280
-    const j = Math.floor((s / 233280) * (i + 1))
-    ;[out[i], out[j]] = [out[j], out[i]]
-  }
-  return out
-}
+// shuffleBySeed (deterministic reshuffle) + todaySeed (UTC daily rotation) moved
+// to homeDerive.js in F4.2 (behavior-preserved); imported above. todaySeed still
+// combines with the user's shuffleSeed (Reshuffle) + the mood id (strHash) below
+// to rotate the top-30 pool — same user, same mood, different picks each day.
 
-// Daily seed: current UTC date as YYYYMMDD integer. Stays stable for a
-// whole UTC day, changes at midnight UTC. Combined with the user's
-// shuffleSeed (Reshuffle clicks) and the mood id, this gives the briefing
-// a natural rotation through the top-30 pool — same user, same mood,
-// different picks each day — so /home doesn't feel "static" day-over-day.
-function todaySeed() {
-  const d = new Date()
-  return d.getUTCFullYear() * 10000 + (d.getUTCMonth() + 1) * 100 + d.getUTCDate()
-}
 // Tiny non-cryptographic string-to-int hash. Used to fold the active mood
 // id into the rotation seed so different moods on the same day produce
 // different picks (otherwise switching mood would just refilter the same
@@ -451,8 +435,7 @@ export function TheBriefing({ currentMood, shuffleSeed = 0, user, onWatch, onSki
   // "next slides into the freed slot").
   const queue = useMemo(() => {
     if (!moodEntry) return []
-    const shuffled = shuffleBySeed(moodEntry.films || [], effectiveSeed)
-    return shuffled.filter(f => !hiddenIds.has(f.id))
+    return buildBriefingQueue(moodEntry.films, effectiveSeed, hiddenIds)
   }, [moodEntry, effectiveSeed, hiddenIds])
 
   const hide = useCallback((id) => {

--- a/src/features/home/useHomeData.jsx
+++ b/src/features/home/useHomeData.jsx
@@ -30,6 +30,7 @@ import { computeMatchPercent } from '@/shared/services/matchScore'
 import { MOVIE_ENGINE_COLS } from '@/shared/services/movieFields'
 import { getTasteFingerprint } from '@/shared/services/tasteCache'
 import { buildPersonalLists, MIN_PERSONAL_LISTS, getSeenCandidates, getTasteTwinPulse } from './personalLists'
+import { orderBriefingMoodKeys } from './homeDerive'
 
 const HomeDataContext = createContext(null)
 
@@ -93,19 +94,9 @@ export function resolveEngineReason({ reason, reasonType, seedTitle }, moodId) {
 // === Onboarding mood key → Briefing mood key bridge ======================
 // The onboarding MoodStep uses a 6-key vocabulary (cozy/wired/tender/fun/
 // tense/mythic) — see src/features/onboarding/data.js. The Briefing uses a
-// different 6-key vocabulary above. This map translates the user's baseline
-// picks so we can prioritise the matching Briefing rows on cold-start.
-//
-// 'mythic' has no clean Briefing counterpart yet; we fall back to 'curious'
-// (the closest contemplative/epic register) until a dedicated row exists.
-const ONBOARDING_MOOD_TO_BRIEFING = {
-  cozy:   'cozy',
-  wired:  'curious',
-  tender: 'tender',
-  fun:    'witty',
-  tense:  'thrilled',
-  mythic: 'curious',
-}
+// different 6-key vocabulary above. The translation map + the baseline
+// re-ordering now live (behavior-preserved) in homeDerive.js as
+// ONBOARDING_MOOD_TO_BRIEFING + orderBriefingMoodKeys (F4.2).
 
 // === Engine consistency with onboarding (2026-05-21 audit) ===============
 // Mirrors src/features/onboarding/steps/MoviesStep.jsx — /home applies the
@@ -371,16 +362,10 @@ export function HomeDataProvider({ children }) {
         // Re-order MOOD_BRIDGE so the user's baseline moods (from Onboarding
          //  Step 1) appear first. Falls back to the original order if the user
          //  hasn't picked moods (legacy onboarding, or column null).
-        const baselineKeys = Array.isArray(userRowRes.data?.taste_baseline_moods)
-          ? userRowRes.data.taste_baseline_moods
-          : []
-        const baselineBriefingKeys = baselineKeys
-          .map(k => ONBOARDING_MOOD_TO_BRIEFING[k])
-          .filter(Boolean)
-        const orderedMoodKeys = [
-          ...baselineBriefingKeys.filter(k => k in MOOD_BRIDGE),
-          ...Object.keys(MOOD_BRIDGE).filter(k => !baselineBriefingKeys.includes(k)),
-        ]
+        const orderedMoodKeys = orderBriefingMoodKeys(
+          userRowRes.data?.taste_baseline_moods,
+          Object.keys(MOOD_BRIDGE),
+        )
 
         // Pre-compute the union of tags belonging to OTHER moods — used by
         // the mood-coherence bonus to favor films that fit THIS mood and


### PR DESCRIPTION
**F4.2** — behavior-preserving extraction + dead-code cleanup: the safety net before any `/home` redesign. **No visible Home change, no engine/scoring/ranking change, no payload/event/route/impression-timing change.**

## Pure helpers extracted → new `src/features/home/homeDerive.js`
(no React, no Supabase, no browser globals beyond `Date`)
- **`ONBOARDING_MOOD_TO_BRIEFING` + `orderBriefingMoodKeys(baselineKeys, availableMoodKeys)`** — moved from `useHomeData.jsx`. Mechanically equivalent to the inline block when called with `Object.keys(MOOD_BRIDGE)` (`available.includes(k)` ⟺ the original `k in MOOD_BRIDGE`): non-array baseline → empty; map onboarding keys; discard unknown mappings; mapped available keys first; the rest in original order. **Duplicate onboarding mappings preserved (no dedup)** — deferred to a later intentional phase.
- **`todaySeed()` + `shuffleBySeed(arr, seed)`** — moved verbatim from `sections-top.jsx` (UTC `YYYYMMDD`; the same `9301`/`49297`/`233280` seed arithmetic). `strHash` stays in `sections-top` (it folds the mood id into `effectiveSeed`, unchanged).
- **`buildBriefingQueue(films, seed, hiddenIds)`** — encapsulates the existing `shuffleBySeed(moodEntry.films || [], effectiveSeed).filter(f => !hiddenIds.has(f.id))`. Accepts the live `Set`; no input mutation; preserves film identity + order.

## Mechanical-equivalence evidence
- `useHomeData.jsx` diff = **only** the constant removal + the inline mood-ordering block replaced with `orderBriefingMoodKeys(userRowRes.data?.taste_baseline_moods, Object.keys(MOOD_BRIDGE))`. `MOOD_BRIDGE`, all scoring passes, coherence, pools, reasons, match %, the moods shape, and `resolveEngineReason` (still exported here, unchanged) are untouched.
- `sections-top.jsx` diff = **only** the import + removing the local `shuffleBySeed`/`todaySeed` + the queue `useMemo` calling `buildBriefingQueue`. `effectiveSeed` (`todaySeed + shuffleSeed*7919 + strHash`), `hiddenIds` reset-on-mood-change, reshuffle-preserves-hidden, `queue[0]` as the pick, no-films/exhausted classification, transition keys, and **impression logging (still on the active visible pick)** are unchanged. `BriefingSlide`/`MoodReactor`/`MatchBadge`/actions/provider/animations/copy/styles untouched.
- Seed arithmetic in `homeDerive.js` is byte-identical to the originals.

## Test coverage added
New `homeDerive.test.js` (**24**) — mood ordering (empty/known/multiple/unknown/append/no-mutation **+ the preserved duplicate-mapping behavior**), `todaySeed` (8-digit UTC / stable-within-day / UTC rollover / TZ-independent), `shuffleBySeed` (deterministic / different-seed / membership / no-mutation / seed-0), `buildBriefingQueue` (seeded order / hidden removal / all-hidden / unknown-hidden / array form / identity / no-mutation / null-safe). `WhyThisPick` + `resolveEngineReason` tests still pass. **Stable 3×. Pure tests only — no render, no Supabase, no live Home write.**

## Proof the Home onboarding overlay was unreachable
Onboarding now `navigate('/discover', { state: { fromOnboarding: true } })` (`Onboarding.jsx:241`); **every** `navigate('/home')` passes **no** `fromOnboarding` state (router / `PostAuthGate` / `MovieDetail` / `History` / `Onboarding` lines 104,120), so `location.state?.fromOnboarding` on `/home` was never true → the black `motion.div` overlay never rendered. Removed it + its now-unused imports (`useLocation`, `useRef`, `motion`, `useReducedMotion`). No container/background/heading/MoodReactor/Briefing/section/nav change.

## Confirmations
- **Duplicate mood mappings were not changed** (no dedup).
- **Impression logging remains on the active visible pick** (exposure), unchanged.
- Ranking, scoring, payloads, routes, visible Home behavior, and supporting sections are **unchanged**.
- **No live Home write was triggered** (pure tests; no authenticated render — the active pick would log an impression).

## Validation
- `npm run lint` → clean · `npx vitest run src/features/home/` → **31 passed** (3 files) · `npm run build` → ✓ · `npm run test` → **892 passed** (69 files) · new test stable **3×**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
