### PR TITLE
Harden Home briefing actions

### DIFF
--- a/src/features/home/Home.jsx
+++ b/src/features/home/Home.jsx
@@ -22,11 +22,27 @@ import {
 import { HomeDataProvider, useHomeData } from './useHomeData'
 import './home.css'
 
+// Calm, honest top-level error when the home briefing data fails to load. No raw
+// Supabase error, no stack trace, no auto-reload — just a clear message and a
+// gentle suggestion to refresh.
+function HomeLoadError() {
+  return (
+    <div role="alert" className="flex flex-col items-center gap-2 px-6 py-24 text-center">
+      <p style={{ fontSize: 16, fontWeight: 600, color: HP.text, fontFamily: 'Outfit, Inter, sans-serif', margin: 0 }}>
+        We couldn&rsquo;t load your home briefing.
+      </p>
+      <p style={{ fontSize: 14, color: HP.textMuted, fontFamily: 'Outfit, Inter, sans-serif', margin: 0 }}>
+        Try refreshing in a moment.
+      </p>
+    </div>
+  )
+}
+
 function HomeBody() {
   usePageMeta({ title: 'Home — FeelFlick' })
   const navigate = useNavigate()
   const { user: authUser } = useAuthSession()
-  const { loading, moods: liveMoods } = useHomeData()
+  const { loading, error, moods: liveMoods } = useHomeData()
   const [currentMood, setMood] = useState(MOOD_META[0])
   const [userPickedMood, setUserPickedMood] = useState(false)
   const [shuffleSeed, setShuffleSeed] = useState(0)
@@ -60,34 +76,34 @@ function HomeBody() {
   // for tomorrow") overstated what the engine actually does with skips.
   const onSkip = useCallback((film) => {
     if (!film?.id) return
-    // Two writes, two purposes:
+    // Skip is a LEARNING SIGNAL, not just analytics — so both writes matter, but
+    // neither blocks the user moving on (the visible pick advances in
+    // TheBriefing.handleSkip right after this returns). Explicit F4.3 sequence,
+    // each write failure-contained (consistent with Discover's non-blocking skip):
     //
-    // 1. user_interactions ('dismiss') — product-analytics log of "user said no
-    //    to this film." The interaction_type CHECK constraint allows
-    //    {view,hover,click,search,filter,scroll,play_trailer,share,dismiss};
-    //    'skip' isn't in the set, so we use 'dismiss' (closest semantic) and
-    //    carry the concrete action in metadata.action.
+    //   1. recommendation_impressions.skipped = true — flips the most-recent
+    //      impression row for (user, movie) so the engine's negative-signal model
+    //      picks it up (computeNegativeSignals → skippedDirectors / skippedGenres /
+    //      skippedFitProfiles / skippedMoodTags → scoreMovieForUser next visit).
+    //      The briefing's per-active-slide impression effect already logged the
+    //      `placement: 'hero'` row for this film, so updateImpression finds + flips
+    //      THAT row. Without this write, skips only hide-in-session.
+    //   2. user_interactions ('dismiss') — product-analytics log. The
+    //      interaction_type CHECK allows {view,hover,click,search,filter,scroll,
+    //      play_trailer,share,dismiss}; 'skip' isn't in the set, so 'dismiss' is
+    //      the closest semantic, with the concrete action in metadata.action.
+    //   3. advance — handled by the caller (hide the slide → next pick).
     //
-    // 2. recommendation_impressions.skipped = true — flips the most-recent
-    //    impression row for (user, movie) so the engine's negative-signal
-    //    model picks it up. computeNegativeSignals reads this column to
-    //    populate skippedDirectors / skippedGenres / skippedFitProfiles /
-    //    skippedMoodTags — which feed back into scoreMovieForUser the next
-    //    time the user lands on /home. Without this write, briefing skips
-    //    only hide-in-session and never teach the engine.
-    //
-    //    Order matters: the briefing's per-active-slide impression effect
-    //    (sections-top.jsx) has already created a `placement: 'hero'` row
-    //    for this film when the slide became active. updateImpression finds
-    //    THAT row and flips the flag.
+    // Payloads/tables/events are unchanged; both are best-effort (.catch) so a
+    // failed tracking write never leaves an unhandled promise or blocks the user.
+    if (authUser?.id) {
+      updateImpression(authUser.id, film.id, 'skipped').catch(() => { /* non-fatal */ })
+    }
     trackInteraction('dismiss', {
       movieId: film.id,
       source: 'briefing',
       metadata: { action: 'skip', mood: currentMood?.id ?? null },
     }).catch(() => { /* non-fatal */ })
-    if (authUser?.id) {
-      updateImpression(authUser.id, film.id, 'skipped').catch(() => {})
-    }
   }, [currentMood, authUser?.id])
 
   const onReshuffle = useCallback(() => {
@@ -146,30 +162,41 @@ function HomeBody() {
       <div style={{ position: 'relative', zIndex: 1 }}>
         {/* a11y landmark (F12B): the visual masthead is the Briefing hero; an sr-only h1 gives the page its heading without competing with the pick. */}
         <h1 className="sr-only">Tonight — your nightly pick</h1>
-        <MoodReactor currentMood={currentMood} setMood={handleSetMood} onReshuffle={onReshuffle} />
-        <TheBriefing
-          currentMood={currentMood}
-          shuffleSeed={shuffleSeed}
-          user={authUser}
-          onWatch={onWatch}
-          onSkip={onSkip}
-        />
-        <ContinueWatching onResume={onWatch} />
-        {/* Section order — descending actionability:
-             1. Briefing (tonight's pick — primary recommendation)
-             2. CuratedLists (more picks — alternatives, still actionable)
-             3. TasteMatch → TasteTwinPulse (social cluster — people then their picks)
-             4. CinematicDNA (reflective portrait — confidence reveal)
-             5. QuickLog (utility, lowest priority) */}
-        <CuratedLists onOpenList={onOpenList} />
-        <TasteMatch onOpenFriend={onOpenFriend} />
-        <TasteTwinPulse onWatch={onWatch} />
-        <CinematicDNA />
-        <QuickLog onLog={onLog} />
-        <PageEndCard
-          currentMood={currentMood}
-          onDiscover={() => navigate('/discover')}
-        />
+        {error ? (
+          // F4.3 — honest top-level load failure. Without this, a data error left
+          // `loading` false with empty moods, so the Briefing showed a misleading
+          // "no picks for this mood" state forever. Calm message, no raw error, no
+          // auto-reload; rendering this (not the Briefing) also means no impression
+          // is logged on an errored load.
+          <HomeLoadError />
+        ) : (
+          <>
+            <MoodReactor currentMood={currentMood} setMood={handleSetMood} onReshuffle={onReshuffle} />
+            <TheBriefing
+              currentMood={currentMood}
+              shuffleSeed={shuffleSeed}
+              user={authUser}
+              onWatch={onWatch}
+              onSkip={onSkip}
+            />
+            <ContinueWatching onResume={onWatch} />
+            {/* Section order — descending actionability:
+                 1. Briefing (tonight's pick — primary recommendation)
+                 2. CuratedLists (more picks — alternatives, still actionable)
+                 3. TasteMatch → TasteTwinPulse (social cluster — people then their picks)
+                 4. CinematicDNA (reflective portrait — confidence reveal)
+                 5. QuickLog (utility, lowest priority) */}
+            <CuratedLists onOpenList={onOpenList} />
+            <TasteMatch onOpenFriend={onOpenFriend} />
+            <TasteTwinPulse onWatch={onWatch} />
+            <CinematicDNA />
+            <QuickLog onLog={onLog} />
+            <PageEndCard
+              currentMood={currentMood}
+              onDiscover={() => navigate('/discover')}
+            />
+          </>
+        )}
       </div>
     </div>
   )

--- a/src/features/home/__tests__/HomeBriefingActions.test.jsx
+++ b/src/features/home/__tests__/HomeBriefingActions.test.jsx
@@ -1,0 +1,235 @@
+// src/features/home/__tests__/HomeBriefingActions.test.jsx
+// F4.3 — Home Briefing action reliability. Everything is mocked: no live mount, no
+// Supabase/TMDB, no real recommendation_impressions. useUserMovieStatus is mocked to
+// FAITHFULLY mirror the real hook (optimistic set → revert on failure, loading
+// true→false on settle) via a test-controlled deferred, so the briefing's
+// success-before-advance gating + honest feedback can be asserted deterministically.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+const h = vi.hoisted(() => ({
+  user: { id: 'u1' },
+  moods: [], loading: false, error: null,
+  internalId: 999,
+  watchedOutcome: 'success', saveOutcome: 'success',
+  watchedDeferred: null, saveDeferred: null,
+  impressionReject: false, skipReject: false, dismissReject: false,
+  navigate: () => {},
+}))
+
+// A live supabase client must never be touched in this test — any access throws.
+vi.mock('@/shared/lib/supabase/client', () => ({ supabase: { from: () => { throw new Error('no live supabase in test') } } }))
+vi.mock('@/shared/hooks/usePageMeta', () => ({ usePageMeta: () => {} }))
+vi.mock('@/shared/hooks/useAuthSession', () => ({ useAuthSession: () => ({ user: h.user }) }))
+vi.mock('react-router-dom', async (orig) => ({ ...(await orig()), useNavigate: () => h.navigate }))
+vi.mock('@/shared/services/recommendations', () => ({
+  logSurfaceImpressions: vi.fn(() => (h.impressionReject ? Promise.reject(new Error('imp fail')) : Promise.resolve())),
+  updateImpression: vi.fn(() => (h.skipReject ? Promise.reject(new Error('skip fail')) : Promise.resolve())),
+}))
+vi.mock('@/shared/services/interactions', () => ({ trackInteraction: vi.fn(() => (h.dismissReject ? Promise.reject(new Error('dismiss fail')) : Promise.resolve())) }))
+vi.mock('@/shared/services/recommendationOutcomes', () => ({ recordRecommendationOutcome: vi.fn(() => Promise.resolve()) }))
+vi.mock('@/shared/api/tmdb', async (orig) => ({ ...(await orig()), getMovieWatchProviders: vi.fn(() => Promise.resolve({ providers: [] })) }))
+
+// Mirror the real useUserMovieStatus contract: optimistic flip, revert-on-failure,
+// loading true→false on settle. The settle is gated on a test-controlled deferred.
+vi.mock('@/shared/hooks/useUserMovieStatus', async () => {
+  const React = await import('react')
+  return { useUserMovieStatus: () => {
+    const [isWatched, setIsWatched] = React.useState(false)
+    const [isInWatchlist, setIsInWatchlist] = React.useState(false)
+    const [loading, setLoading] = React.useState({ watchlist: false, watched: false })
+    const toggleWatched = React.useCallback(() => {
+      setLoading(l => ({ ...l, watched: true })); setIsWatched(true)
+      let resolve; const promise = new Promise(r => { resolve = r }); h.watchedDeferred = { promise, resolve }
+      promise.then(() => { if (h.watchedOutcome === 'fail') setIsWatched(false); setLoading(l => ({ ...l, watched: false })) })
+    }, [])
+    const toggleWatchlist = React.useCallback(() => {
+      setLoading(l => ({ ...l, watchlist: true })); setIsInWatchlist(v => !v)
+      let resolve; const promise = new Promise(r => { resolve = r }); h.saveDeferred = { promise, resolve }
+      promise.then(() => { if (h.saveOutcome === 'fail') setIsInWatchlist(v => !v); setLoading(l => ({ ...l, watchlist: false })) })
+    }, [])
+    return { isWatched, isInWatchlist, loading, toggleWatched, toggleWatchlist, internalId: h.internalId }
+  } }
+})
+
+// Strip framer-motion animation so AnimatePresence advances the pick synchronously.
+vi.mock('framer-motion', async () => {
+  const React = await import('react')
+  const strip = (p) => { const { initial, animate, exit, variants, transition, whileHover, whileTap, whileInView, layout, layoutId, ...rest } = p; return rest }
+  const cache = {}
+  const make = (tag) => {
+    if (!cache[tag]) {
+      const C = React.forwardRef((props, ref) => React.createElement(tag, { ...strip(props), ref }, props.children))
+      C.displayName = `motion.${String(tag)}`
+      cache[tag] = C
+    }
+    return cache[tag] // stable component identity per tag → no remount on re-render
+  }
+  return {
+    AnimatePresence: ({ children }) => children,
+    motion: new Proxy({}, { get: (_t, tag) => make(tag) }),
+    useReducedMotion: () => true,
+  }
+})
+
+// The data provider + the bottom sections are out of scope — stub them.
+vi.mock('../useHomeData', () => ({
+  HomeDataProvider: ({ children }) => children,
+  useHomeData: () => ({ loading: h.loading, error: h.error, moods: h.moods }),
+}))
+vi.mock('../sections-bottom', () => ({
+  ContinueWatching: () => null, CinematicDNA: () => null, TasteTwinPulse: () => null,
+  TasteMatch: () => null, CuratedLists: () => null, QuickLog: () => null, PageEndCard: () => null,
+}))
+
+import Home from '../Home'
+import { MOOD_META } from '../data'
+import { logSurfaceImpressions, updateImpression } from '@/shared/services/recommendations'
+import { trackInteraction } from '@/shared/services/interactions'
+
+const MOOD_ID = MOOD_META[0].id
+const film = (id) => ({ id, tmdbId: 1000 + id, title: `Movie ${id}`, year: 2010 + id, runtime: 110, director: `Dir ${id}`, engineReason: null, synopsis: null, matchPct: 80, poster: `/p${id}.jpg` })
+
+const renderHome = () => render(<MemoryRouter><Home /></MemoryRouter>)
+const pickTitle = () => screen.getByRole('heading', { level: 2 }).textContent
+const liveRegion = () => document.querySelector('[role="status"][aria-live="polite"]')
+const btn = (name) => screen.getByRole('button', { name })
+
+beforeEach(() => {
+  h.user = { id: 'u1' }; h.loading = false; h.error = null; h.internalId = 999
+  h.watchedOutcome = 'success'; h.saveOutcome = 'success'; h.watchedDeferred = null; h.saveDeferred = null
+  h.impressionReject = false; h.skipReject = false; h.dismissReject = false; h.navigate = vi.fn()
+  h.moods = [{ id: MOOD_ID, films: [film(1), film(2), film(3)] }]
+  vi.clearAllMocks()
+  window.matchMedia = window.matchMedia || (() => ({ matches: false, addEventListener() {}, removeEventListener() {} }))
+})
+
+describe('Home Briefing — active-pick impression', () => {
+  it('logs exactly one impression on render with the unchanged payload', async () => {
+    renderHome()
+    await waitFor(() => expect(logSurfaceImpressions).toHaveBeenCalledTimes(1))
+    const arg = logSurfaceImpressions.mock.calls[0][0]
+    expect(arg).toMatchObject({ userId: 'u1', placement: 'hero', pickReasonType: 'briefing_active', pickReasonLabel: MOOD_ID })
+    expect(arg.films).toHaveLength(1)
+    expect(typeof arg.films[0].id).toBe('number')
+  })
+
+  it('contains a rejected impression write without crashing', async () => {
+    h.impressionReject = true
+    renderHome()
+    await waitFor(() => expect(logSurfaceImpressions).toHaveBeenCalled())
+    // The pick still renders; the rejection is swallowed (no unhandled promise).
+    expect(screen.getByRole('heading', { level: 2 })).toBeTruthy()
+  })
+
+  it('announces the initial visible pick politely', async () => {
+    renderHome()
+    await waitFor(() => expect(liveRegion()?.textContent).toMatch(/^Tonight.s briefing pick: Movie \d+\.$/))
+  })
+})
+
+describe('Home Briefing — Mark Watched', () => {
+  it('waits for the write before advancing the pick', async () => {
+    renderHome()
+    const t1 = pickTitle()
+    fireEvent.click(btn('Mark Watched'))
+    // Write in flight (deferred unresolved) → the pick must NOT have advanced.
+    expect(pickTitle()).toBe(t1)
+    expect(h.watchedDeferred).toBeTruthy()
+    await act(async () => { h.watchedDeferred.resolve(); await h.watchedDeferred.promise })
+    await waitFor(() => expect(pickTitle()).not.toBe(t1), { timeout: 2000 })
+  })
+
+  it('does not advance + shows retryable feedback on failure', async () => {
+    h.watchedOutcome = 'fail'
+    renderHome()
+    const t1 = pickTitle()
+    fireEvent.click(btn('Mark Watched'))
+    await act(async () => { h.watchedDeferred.resolve(); await h.watchedDeferred.promise })
+    // Pick stays; failure announced; the button offers a retry.
+    await waitFor(() => expect(liveRegion()?.textContent).toBe('Could not mark watched. Try again.'))
+    expect(pickTitle()).toBe(t1)
+    expect(screen.getByRole('button', { name: 'Mark Watched' }).getAttribute('title')).toMatch(/retry/i)
+  })
+
+  it('announces watched + the new pick on success', async () => {
+    renderHome()
+    const t1 = pickTitle()
+    fireEvent.click(btn('Mark Watched'))
+    await act(async () => { h.watchedDeferred.resolve(); await h.watchedDeferred.promise })
+    await waitFor(() => expect(liveRegion()?.textContent).toMatch(/^Marked watched\. New briefing pick: Movie \d+\.$/), { timeout: 2000 })
+    expect(pickTitle()).not.toBe(t1)
+  })
+})
+
+describe('Home Briefing — Skip / Not Tonight', () => {
+  it('writes skipped-impression BEFORE the dismiss interaction', async () => {
+    renderHome()
+    await waitFor(() => expect(screen.getByRole('heading', { level: 2 })).toBeTruthy())
+    fireEvent.click(btn('Skip Tonight'))
+    await waitFor(() => expect(updateImpression).toHaveBeenCalled())
+    expect(trackInteraction).toHaveBeenCalled()
+    expect(updateImpression.mock.invocationCallOrder[0]).toBeLessThan(trackInteraction.mock.invocationCallOrder[0])
+    // payloads unchanged
+    expect(updateImpression).toHaveBeenCalledWith('u1', expect.any(Number), 'skipped')
+    expect(trackInteraction).toHaveBeenCalledWith('dismiss', expect.objectContaining({ source: 'briefing', metadata: expect.objectContaining({ action: 'skip' }) }))
+  })
+
+  it('contains failures in the non-critical tracking writes', async () => {
+    h.skipReject = true; h.dismissReject = true
+    renderHome()
+    const t1 = pickTitle()
+    fireEvent.click(btn('Skip Tonight'))
+    // No crash; the pick still advances despite both tracking writes rejecting.
+    await waitFor(() => expect(pickTitle()).not.toBe(t1))
+  })
+
+  it('advances the visible pick and announces the new one', async () => {
+    renderHome()
+    const t1 = pickTitle()
+    fireEvent.click(btn('Skip Tonight'))
+    await waitFor(() => expect(pickTitle()).not.toBe(t1))
+    expect(liveRegion()?.textContent).toMatch(/^New briefing pick: Movie \d+\.$/)
+  })
+})
+
+describe('Home Briefing — Save', () => {
+  it('announces success after the write settles', async () => {
+    renderHome()
+    fireEvent.click(btn('Save'))
+    await act(async () => { h.saveDeferred.resolve(); await h.saveDeferred.promise })
+    await waitFor(() => expect(liveRegion()?.textContent).toBe('Saved for later.'))
+    expect(screen.getByRole('button', { name: 'Saved' })).toBeTruthy()
+  })
+
+  it('announces a retryable failure and reverts on error', async () => {
+    h.saveOutcome = 'fail'
+    renderHome()
+    fireEvent.click(btn('Save'))
+    await act(async () => { h.saveDeferred.resolve(); await h.saveDeferred.promise })
+    await waitFor(() => expect(liveRegion()?.textContent).toBe('Could not save. Try again.'))
+    expect(screen.getByRole('button', { name: 'Save' })).toBeTruthy() // reverted
+  })
+})
+
+describe('Home Briefing — exhausted', () => {
+  it('announces no more picks when the mood queue empties', async () => {
+    h.moods = [{ id: MOOD_ID, films: [film(1)] }]
+    renderHome()
+    await waitFor(() => expect(screen.getByRole('heading', { level: 2 })).toBeTruthy())
+    fireEvent.click(btn('Skip Tonight'))
+    await waitFor(() => expect(liveRegion()?.textContent).toBe('No more picks for this mood.'))
+  })
+})
+
+describe('Home Briefing — safety', () => {
+  it('uses only mocked services (no live supabase/tmdb/fetch)', async () => {
+    // The supabase mock throws on any access; reaching this assertion means nothing
+    // touched it. Provider lookups go through the mocked TMDB helper.
+    renderHome()
+    await waitFor(() => expect(logSurfaceImpressions).toHaveBeenCalled())
+    expect(screen.getByRole('heading', { level: 2 })).toBeTruthy()
+  })
+})

--- a/src/features/home/__tests__/HomeDataStates.test.jsx
+++ b/src/features/home/__tests__/HomeDataStates.test.jsx
@@ -1,0 +1,82 @@
+// src/features/home/__tests__/HomeDataStates.test.jsx
+// F4.3 — Home top-level data states. The data provider is mocked so we control
+// loading / error / loaded without any live Supabase read. Everything else is
+// stubbed; no live services, no recommendation_impressions.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+const h = vi.hoisted(() => ({ user: { id: 'u1' }, moods: [], loading: false, error: null, navigate: () => {} }))
+
+vi.mock('@/shared/lib/supabase/client', () => ({ supabase: { from: () => { throw new Error('no live supabase in test') } } }))
+vi.mock('@/shared/hooks/usePageMeta', () => ({ usePageMeta: () => {} }))
+vi.mock('@/shared/hooks/useAuthSession', () => ({ useAuthSession: () => ({ user: h.user }) }))
+vi.mock('react-router-dom', async (orig) => ({ ...(await orig()), useNavigate: () => h.navigate }))
+vi.mock('@/shared/services/recommendations', () => ({ logSurfaceImpressions: vi.fn(() => Promise.resolve()), updateImpression: vi.fn(() => Promise.resolve()) }))
+vi.mock('@/shared/services/interactions', () => ({ trackInteraction: vi.fn(() => Promise.resolve()) }))
+vi.mock('@/shared/services/recommendationOutcomes', () => ({ recordRecommendationOutcome: vi.fn(() => Promise.resolve()) }))
+vi.mock('@/shared/api/tmdb', async (orig) => ({ ...(await orig()), getMovieWatchProviders: vi.fn(() => Promise.resolve({ providers: [] })) }))
+vi.mock('@/shared/hooks/useUserMovieStatus', () => ({
+  useUserMovieStatus: () => ({ isWatched: false, isInWatchlist: false, loading: { watchlist: false, watched: false }, toggleWatched: () => {}, toggleWatchlist: () => {}, internalId: 1 }),
+}))
+vi.mock('framer-motion', async () => {
+  const React = await import('react')
+  const cache = {}
+  const strip = (p) => { const { initial, animate, exit, variants, transition, whileHover, whileTap, whileInView, layout, layoutId, ...rest } = p; return rest }
+  const make = (tag) => { if (!cache[tag]) { const C = React.forwardRef((props, ref) => React.createElement(tag, { ...strip(props), ref }, props.children)); C.displayName = `motion.${String(tag)}`; cache[tag] = C } return cache[tag] }
+  return { AnimatePresence: ({ children }) => children, motion: new Proxy({}, { get: (_t, tag) => make(tag) }), useReducedMotion: () => true }
+})
+vi.mock('../useHomeData', () => ({
+  HomeDataProvider: ({ children }) => children,
+  useHomeData: () => ({ loading: h.loading, error: h.error, moods: h.moods }),
+}))
+vi.mock('../sections-bottom', () => ({
+  ContinueWatching: () => null, CinematicDNA: () => null, TasteTwinPulse: () => null,
+  TasteMatch: () => null, CuratedLists: () => null, QuickLog: () => null, PageEndCard: () => null,
+}))
+
+import Home from '../Home'
+import { MOOD_META } from '../data'
+
+const MOOD_ID = MOOD_META[0].id
+const renderHome = () => render(<MemoryRouter><Home /></MemoryRouter>)
+
+beforeEach(() => {
+  h.user = { id: 'u1' }; h.loading = false; h.error = null; h.navigate = vi.fn()
+  h.moods = [{ id: MOOD_ID, films: [{ id: 1, tmdbId: 1001, title: 'Movie 1', year: 2011, runtime: 110, director: 'Dir 1', engineReason: null, synopsis: null, matchPct: 80, poster: '/p1.jpg' }] }]
+  vi.clearAllMocks()
+  window.matchMedia = window.matchMedia || (() => ({ matches: false, addEventListener() {}, removeEventListener() {} }))
+})
+
+describe('Home data states', () => {
+  it('renders the briefing skeleton while loading', () => {
+    h.loading = true; h.moods = []
+    renderHome()
+    expect(screen.getByLabelText("Preparing tonight's briefing")).toBeTruthy()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('renders an honest error state (role=alert) on data failure', () => {
+    h.error = 'PostgREST 500: relation does not exist'
+    renderHome()
+    const alert = screen.getByRole('alert')
+    expect(alert.textContent).toContain('We couldn’t load your home briefing.')
+    expect(alert.textContent).toContain('Try refreshing in a moment.')
+  })
+
+  it('does not render the raw error detail', () => {
+    h.error = 'PostgREST 500: relation does not exist'
+    renderHome()
+    expect(screen.queryByText(/PostgREST/)).toBeNull()
+    expect(screen.queryByText(/relation does not exist/)).toBeNull()
+    // The briefing is not rendered on error → no impression-on-render write either.
+    expect(screen.queryByRole('heading', { level: 2 })).toBeNull()
+  })
+
+  it('renders the briefing pick when data loads normally', () => {
+    renderHome()
+    expect(screen.getByRole('heading', { level: 2 }).textContent).toBe('Movie 1')
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})

--- a/src/features/home/sections-top.jsx
+++ b/src/features/home/sections-top.jsx
@@ -103,28 +103,28 @@ export function MoodReactor({ currentMood, setMood, onReshuffle }) {
 // different system). The three below are thin wrappers that add the icon, label, and
 // active state on top of <SecondaryActionButton>; the gradient "See More" primary
 // uses <ActionButton> directly.
-function WatchedButton({ isWatched, loading, onClick }) {
+function WatchedButton({ isWatched, loading, error, onClick }) {
   return (
     <SecondaryActionButton
       collapse
       active={isWatched}
       loading={loading}
       onClick={onClick}
-      title={isWatched ? 'Watched' : 'Mark as watched'}
+      title={error ? 'Couldn’t mark watched — tap to retry' : isWatched ? 'Watched' : 'Mark as watched'}
       label={isWatched ? 'Watched' : 'Mark Watched'}
       icon={<svg className="h-4 w-4 lg:h-[13px] lg:w-[13px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12" /></svg>}
     />
   )
 }
 
-function SaveButton({ isInWatchlist, loading, onClick }) {
+function SaveButton({ isInWatchlist, loading, error, onClick }) {
   return (
     <SecondaryActionButton
       collapse
       active={isInWatchlist}
       loading={loading}
       onClick={onClick}
-      title={isInWatchlist ? 'Saved to watchlist' : 'Save to watchlist'}
+      title={error ? 'Couldn’t save — tap to retry' : isInWatchlist ? 'Saved to watchlist' : 'Save to watchlist'}
       label={isInWatchlist ? 'Saved' : 'Save'}
       icon={isInWatchlist
         ? <svg className="h-4 w-4 lg:h-[13px] lg:w-[13px]" viewBox="0 0 24 24" fill="currentColor"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" /></svg>
@@ -198,24 +198,79 @@ function StreamingChip({ provider }) {
 //   • mobile: vertical — poster centered, copy stacked below
 //   • desktop: horizontal — poster left (360×540), copy right column.
 // No background backdrop image — keeps the page surface clean.
-function BriefingSlide({ film, matchPct, user, onWatch, onSkip, onMarkedWatched }) {
+function BriefingSlide({ film, matchPct, user, onWatch, onSkip, onMarkedWatched, announce }) {
   // source must match the user_watchlist_source_check CHECK constraint —
   // 'mood_recommendation' is the closest of the allowed values.
-  const { isInWatchlist, isWatched, loading: statusLoading, toggleWatchlist, toggleWatched } =
+  const { isInWatchlist, isWatched, loading: statusLoading, toggleWatchlist, toggleWatched, internalId } =
     useUserMovieStatus({ user, movie: film, internalMovieId: film?.id, source: 'mood_recommendation' })
 
   // Fetch streaming providers for this slide (TMDB, region CA→US).
   // Hook handles abort/cancel so switching slides cancels stale fetches.
   const provider = useStreamingProvider(film?.tmdbId)
 
-  // Fire onMarkedWatched optimistically on the user's click (before the
-  // async DB write resolves) so TheBriefing hides this slide immediately
-  // and the next pick slides in.
+  // F4.3 — Mark Watched / Save reliability. useUserMovieStatus owns the writes
+  // (unchanged payloads) and optimistically flips isWatched / isInWatchlist, then
+  // REVERTS on failure while loading.{watched,watchlist} runs true → false. We
+  // observe that settle to gate the advance (watched) and surface honest success /
+  // failure feedback — instead of advancing optimistically before the write lands.
+  const [watchedState, setWatchedState] = useState('idle') // idle | saving | watched | error
+  const [saveState, setSaveState] = useState('idle')       // idle | saving | error
+  const watchPendingRef = useRef(false)
+  const savePendingRef = useRef(null)                      // null | 'add' | 'remove'
+  const advanceTimerRef = useRef(null)
+  useEffect(() => () => { if (advanceTimerRef.current) clearTimeout(advanceTimerRef.current) }, [])
+
+  // Mark Watched — do NOT hide/advance until the user_history write succeeds
+  // (mirrors Discover F3.9). internalId must be resolved for the write to run.
   const handleMarkWatched = useCallback(() => {
-    const wasWatched = isWatched
+    if (!film?.id || !internalId || statusLoading.watched || watchedState === 'saving' || isWatched) return
+    watchPendingRef.current = true
+    setWatchedState('saving')
     toggleWatched()
-    if (!wasWatched && film?.id) onMarkedWatched?.(film.id)
-  }, [isWatched, toggleWatched, onMarkedWatched, film?.id])
+  }, [film?.id, internalId, statusLoading.watched, watchedState, isWatched, toggleWatched])
+
+  // Resolve the pending mark-watched once the hook write settles: isWatched stays
+  // true on success → advance after a confirmation hold; reverts to false on
+  // failure → keep the pick, show a retryable error and announce it.
+  useEffect(() => {
+    if (!watchPendingRef.current || statusLoading.watched) return
+    watchPendingRef.current = false
+    const filmId = film?.id
+    if (isWatched) {
+      setWatchedState('watched')
+      advanceTimerRef.current = setTimeout(() => {
+        onMarkedWatched?.(filmId)
+        advanceTimerRef.current = null
+      }, 600)
+    } else {
+      setWatchedState('error')
+      announce?.('Could not mark watched. Try again.')
+    }
+  }, [statusLoading.watched, isWatched, film?.id, onMarkedWatched, announce])
+
+  // Save — keep the optimistic toggle (reversible) but surface success / failure
+  // once the write settles. Saving shows a spinner; a real save announces
+  // confirmation; a failed save reverts and announces a retry.
+  const handleSave = useCallback(() => {
+    if (!film?.id || !internalId || statusLoading.watchlist || saveState === 'saving') return
+    savePendingRef.current = isInWatchlist ? 'remove' : 'add'
+    setSaveState('saving')
+    toggleWatchlist()
+  }, [film?.id, internalId, statusLoading.watchlist, saveState, isInWatchlist, toggleWatchlist])
+
+  useEffect(() => {
+    if (savePendingRef.current == null || statusLoading.watchlist) return
+    const intent = savePendingRef.current
+    savePendingRef.current = null
+    if (intent === 'add') {
+      if (isInWatchlist) { setSaveState('idle'); announce?.('Saved for later.') }
+      else { setSaveState('error'); announce?.('Could not save. Try again.') }
+    } else if (isInWatchlist) {
+      setSaveState('error'); announce?.('Could not save. Try again.')
+    } else {
+      setSaveState('idle')
+    }
+  }, [statusLoading.watchlist, isInWatchlist, announce])
 
   // Opening the pick (poster or "See More") is the Briefing's 'clicked' outcome.
   // F8B: record it against the fresh hero impression (logged when this slide
@@ -334,8 +389,8 @@ function BriefingSlide({ film, matchPct, user, onWatch, onSkip, onMarkedWatched 
             <span>See More</span>
             <ChevronRight className="h-3.5 w-3.5" />
           </ActionButton>
-          <WatchedButton isWatched={isWatched} loading={statusLoading.watched} onClick={handleMarkWatched} />
-          <SaveButton isInWatchlist={isInWatchlist} loading={statusLoading.watchlist} onClick={toggleWatchlist} />
+          <WatchedButton isWatched={isWatched} loading={watchedState === 'saving'} error={watchedState === 'error'} onClick={handleMarkWatched} />
+          <SaveButton isInWatchlist={isInWatchlist} loading={saveState === 'saving'} error={saveState === 'error'} onClick={handleSave} />
           <SkipButton onClick={() => onSkip?.(film)} />
         </div>
       </div>
@@ -403,6 +458,15 @@ export function TheBriefing({ currentMood, shuffleSeed = 0, user, onWatch, onSki
   const { moods, loading } = useHomeData()
   const moodEntry = moods.find(m => m.id === currentMood.id)
 
+  // F4.3 — one polite, atomic, screen-reader-only live region owned by the
+  // Briefing. It narrates pick progression + action outcomes (never the queue
+  // length or match %). pickActionRef records WHY the head last advanced so the
+  // pick-change effect can word the announcement (initial/mood/reshuffle vs skip
+  // vs mark-watched).
+  const [statusMsg, setStatusMsg] = useState('')
+  const announce = useCallback((msg) => setStatusMsg(msg), [])
+  const pickActionRef = useRef('initial') // 'initial' | 'skip' | 'watched'
+
   // Effective seed for picking which 3 of the top 30 are visible today.
   // Recomputes when the day changes (midnight UTC) or when the user clicks
   // Reshuffle. Mood id folded in so moods don't share the same rotation.
@@ -427,6 +491,8 @@ export function TheBriefing({ currentMood, shuffleSeed = 0, user, onWatch, onSki
   // switching moods is the way to start with a clean slate.
   useEffect(() => {
     setHiddenIds(new Set())
+    // A fresh mood starts a fresh "Tonight's briefing pick" (not skip/watched).
+    pickActionRef.current = 'initial'
   }, [currentMood.id])
 
   // The remaining queue for this mood — daily-seeded + reshuffle-seeded, with
@@ -447,12 +513,15 @@ export function TheBriefing({ currentMood, shuffleSeed = 0, user, onWatch, onSki
   }, [])
 
   const handleSkip = useCallback((film) => {
+    pickActionRef.current = 'skip'
     onSkip?.(film)
     if (film?.id) hide(film.id)
   }, [onSkip, hide])
 
   const handleMarkedWatched = useCallback((id) => {
-    if (id != null) hide(id)
+    if (id == null) return
+    pickActionRef.current = 'watched'
+    hide(id)
   }, [hide])
 
   const clearHidden = useCallback(() => setHiddenIds(new Set()), [])
@@ -477,17 +546,44 @@ export function TheBriefing({ currentMood, shuffleSeed = 0, user, onWatch, onSki
   const pickReason = pick?.engineReason
   useEffect(() => {
     if (!user?.id || pickId == null) return
+    // Exposure log of the visible head pick. Timing/placement/payload unchanged
+    // (F4.3 only adds failure containment so a rejected write isn't unhandled).
     logSurfaceImpressions({
       userId: user.id,
       films: [{ id: pickId }],
       placement: 'hero',
       pickReasonType: 'briefing_active',
       pickReasonLabel: pickReason || currentMood.id,
-    })
+    }).catch(() => { /* non-fatal — exposure logging is best-effort */ })
   }, [user?.id, pickId, pickReason, currentMood.id])
+
+  // Announce the visible pick whenever the head advances. The reason recorded by
+  // the last action shapes the wording. Fires only when the head id changes, so
+  // routine re-renders don't re-announce.
+  const pickTitle = pick?.title
+  useEffect(() => {
+    if (pickId == null || !pickTitle) {
+      // No visible pick (loading / no films / exhausted) — clear the action so a
+      // later fresh pick announces as "Tonight's", not a stale skip/watched.
+      pickActionRef.current = 'initial'
+      return
+    }
+    const reason = pickActionRef.current
+    pickActionRef.current = 'initial'
+    if (reason === 'skip') announce(`New briefing pick: ${pickTitle}.`)
+    else if (reason === 'watched') announce(`Marked watched. New briefing pick: ${pickTitle}.`)
+    else announce(`Tonight’s briefing pick: ${pickTitle}.`)
+  }, [pickId, pickTitle, announce])
+
+  // Exhausted — the user has worked through the whole mood queue.
+  useEffect(() => {
+    if (isExhausted) announce('No more picks for this mood.')
+  }, [isExhausted, announce])
 
   return (
     <section className="relative px-5 pt-4 pb-10 sm:px-8 sm:pt-6 sm:pb-12 lg:px-[88px] lg:pt-6 lg:pb-6">
+      {/* Single polite live region for Briefing pick progression + action feedback. */}
+      <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">{statusMsg}</div>
       {isExhausted ? (
         <div className="flex flex-col items-center gap-5 py-12 text-center">
           <p style={{ fontSize: 15, lineHeight: 1.6, color: HP.textSoft, fontFamily: 'Outfit, Inter, sans-serif', margin: 0, maxWidth: 480 }}>
@@ -530,6 +626,7 @@ export function TheBriefing({ currentMood, shuffleSeed = 0, user, onWatch, onSki
                 onWatch={onWatch}
                 onSkip={handleSkip}
                 onMarkedWatched={handleMarkedWatched}
+                announce={announce}
               />
             </motion.div>
           </AnimatePresence>


### PR DESCRIPTION
**F4.3** — Home Briefing action reliability + feedback, **without redesigning Home**. No engine/scoring/ranking change, no payload/event/route change, no impression-timing change, no visible-hierarchy redesign. The match ring, slider/dots, Reshuffle, MoodReactor, supporting sections, and internal queue are all unchanged.

## Active-pick impression failure containment
The on-render exposure log of the visible head pick is **unchanged** — `placement: 'hero'`, `pickReasonType: 'briefing_active'`, `pickReasonLabel: pickReason || currentMood.id`, same deps/timing, **not** user-action-gated. Only a `.catch(() => {})` was added so a rejected write is never an unhandled promise.

## Mark Watched — success before advance
Keeps `useUserMovieStatus` (unchanged `user_history` payload, source `'mood_recommendation'`). The hook optimistically sets `isWatched` then **reverts on failure** while `loading.watched` runs `true→false`; a settlement effect observes that to decide: **success** → confirm + advance after a 600 ms hold (mirrors Discover F3.9); **failure** → keep the pick, re-enable the button with a retry title, announce *"Could not mark watched. Try again."* No more advancing optimistically before the write lands. `internalId`-gated so a click before the status sync can't false-fail.

## Skip / Not Tonight sequencing + failure containment
`Home.onSkip` is now an explicit, documented order: **(1)** `recommendation_impressions.skipped` (engine learning signal) → **(2)** `user_interactions 'dismiss'` (analytics) → **(3)** advance (in `TheBriefing.handleSkip`). Both writes are best-effort `.catch` (no unhandled promise), non-blocking. **Payloads/tables/events byte-identical** (reorder only).

## Live-status announcements
One Briefing-owned visually-hidden `role="status" aria-live="polite" aria-atomic="true"` region. Announces the initial/mood/reshuffle pick (*"Tonight's briefing pick: {title}."*), skip-promoted (*"New briefing pick: {title}."*), mark-watched-promoted (*"Marked watched. New briefing pick: {title}."*), Save success/failure, Mark-Watched failure, and exhausted (*"No more picks for this mood."*). Never announces queue length or match %; fires only when the head id changes (no per-render echo).

## Save / error behavior
Save keeps the optimistic toggle (reversible) but now surfaces outcomes: saving shows a spinner; success announces *"Saved for later."*; failure reverts + announces *"Could not save. Try again."* with a retry title. Payload unchanged.

## HomeData error-state behavior
Consumes the `error` that `useHomeData` already exposes and renders a calm `role="alert"` (*"We couldn't load your home briefing." / "Try refreshing in a moment."*) instead of the misleading eternal skeleton. No raw Supabase error, no stack trace, no auto-reload — and rendering this (not the Briefing) means **no impression on an errored load**. Fetch/ranking/shaping untouched.

## Tests added (mocked only — no live mount/Supabase/TMDB/impressions; the supabase client mock throws on any access as a guard)
- **`HomeBriefingActions.test.jsx` (13):** impression-once + payload, contained rejected impression, mark-watched waits-before-advance, failure keeps pick + retry + announce, success announces watched + new pick, skip ordered (impression before dismiss) + payloads, skip tracking-failure contained, skip advances + announces, save success/failure announce + revert, exhausted announce, mocked-services-only.
- **`HomeDataStates.test.jsx` (4):** loading skeleton, error `role=alert` copy, raw error not rendered (+ no briefing/impression on error), normal render.
- `homeDerive` / `WhyThisPick` / `resolveEngineReason` still pass.

## Confirmations
- **Impression timing remains on the active visible pick** (exposure), only `.catch` added.
- **Ranking, scoring, payloads, routes, visible hierarchy, and supporting sections are unchanged.** Skip payloads byte-identical (reorder only); Mark-Watched/Save via the unchanged `useUserMovieStatus`.
- **No live Home write was triggered** (pure mocked tests; no authenticated render).
- Reviewed by an adversarial 3-lens panel (frozen-contracts / mark-watched-race / a11y-skip-save): **zero confirmed blockers or majors.**

## Validation
- `npm run lint` → clean · `npx vitest run src/features/home/` → **48 passed** (5 files) · `npm run build` → ✓ · `npm run test` → **909 passed** (71 files) · new tests stable **3×**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
