### PR TITLE
Make Home briefing pick-first

### DIFF
--- a/src/features/home/Home.jsx
+++ b/src/features/home/Home.jsx
@@ -45,7 +45,6 @@ function HomeBody() {
   const { loading, error, moods: liveMoods } = useHomeData()
   const [currentMood, setMood] = useState(MOOD_META[0])
   const [userPickedMood, setUserPickedMood] = useState(false)
-  const [shuffleSeed, setShuffleSeed] = useState(0)
 
   // When the data hook finishes, snap the initial mood tab to the user's first
   // baseline pick from Onboarding Step 1 (useHomeData reorders `moods` so the
@@ -105,10 +104,6 @@ function HomeBody() {
       metadata: { action: 'skip', mood: currentMood?.id ?? null },
     }).catch(() => { /* non-fatal */ })
   }, [currentMood, authUser?.id])
-
-  const onReshuffle = useCallback(() => {
-    setShuffleSeed(s => s + 1)
-  }, [])
 
   // QuickLog's "Open Browse" pill routes to /browse (the catalog).
   // Distinct from the page-end card's "Discover by mood" CTA — that
@@ -171,21 +166,24 @@ function HomeBody() {
           <HomeLoadError />
         ) : (
           <>
-            <MoodReactor currentMood={currentMood} setMood={handleSetMood} onReshuffle={onReshuffle} />
+            {/* F4.4 — pick-first. Home leads with tonight's one pick; the mood
+                control strip sits BELOW it as an optional "adjust mood", not the
+                route's front door (that's Discover's deliberate session). */}
             <TheBriefing
               currentMood={currentMood}
-              shuffleSeed={shuffleSeed}
               user={authUser}
               onWatch={onWatch}
               onSkip={onSkip}
             />
+            <MoodReactor currentMood={currentMood} setMood={handleSetMood} />
             <ContinueWatching onResume={onWatch} />
             {/* Section order — descending actionability:
                  1. Briefing (tonight's pick — primary recommendation)
-                 2. CuratedLists (more picks — alternatives, still actionable)
-                 3. TasteMatch → TasteTwinPulse (social cluster — people then their picks)
-                 4. CinematicDNA (reflective portrait — confidence reveal)
-                 5. QuickLog (utility, lowest priority) */}
+                 2. Adjust-mood strip (secondary control for the pick above)
+                 3. CuratedLists (more picks — alternatives, still actionable)
+                 4. TasteMatch → TasteTwinPulse (social cluster — people then their picks)
+                 5. CinematicDNA (reflective portrait — confidence reveal)
+                 6. QuickLog (utility, lowest priority) */}
             <CuratedLists onOpenList={onOpenList} />
             <TasteMatch onOpenFriend={onOpenFriend} />
             <TasteTwinPulse onWatch={onWatch} />

--- a/src/features/home/__tests__/HomeBriefingActions.test.jsx
+++ b/src/features/home/__tests__/HomeBriefingActions.test.jsx
@@ -168,7 +168,7 @@ describe('Home Briefing — Skip / Not Tonight', () => {
   it('writes skipped-impression BEFORE the dismiss interaction', async () => {
     renderHome()
     await waitFor(() => expect(screen.getByRole('heading', { level: 2 })).toBeTruthy())
-    fireEvent.click(btn('Skip Tonight'))
+    fireEvent.click(btn('Not tonight'))
     await waitFor(() => expect(updateImpression).toHaveBeenCalled())
     expect(trackInteraction).toHaveBeenCalled()
     expect(updateImpression.mock.invocationCallOrder[0]).toBeLessThan(trackInteraction.mock.invocationCallOrder[0])
@@ -181,7 +181,7 @@ describe('Home Briefing — Skip / Not Tonight', () => {
     h.skipReject = true; h.dismissReject = true
     renderHome()
     const t1 = pickTitle()
-    fireEvent.click(btn('Skip Tonight'))
+    fireEvent.click(btn('Not tonight'))
     // No crash; the pick still advances despite both tracking writes rejecting.
     await waitFor(() => expect(pickTitle()).not.toBe(t1))
   })
@@ -189,7 +189,7 @@ describe('Home Briefing — Skip / Not Tonight', () => {
   it('advances the visible pick and announces the new one', async () => {
     renderHome()
     const t1 = pickTitle()
-    fireEvent.click(btn('Skip Tonight'))
+    fireEvent.click(btn('Not tonight'))
     await waitFor(() => expect(pickTitle()).not.toBe(t1))
     expect(liveRegion()?.textContent).toMatch(/^New briefing pick: Movie \d+\.$/)
   })
@@ -219,7 +219,7 @@ describe('Home Briefing — exhausted', () => {
     h.moods = [{ id: MOOD_ID, films: [film(1)] }]
     renderHome()
     await waitFor(() => expect(screen.getByRole('heading', { level: 2 })).toBeTruthy())
-    fireEvent.click(btn('Skip Tonight'))
+    fireEvent.click(btn('Not tonight'))
     await waitFor(() => expect(liveRegion()?.textContent).toBe('No more picks for this mood.'))
   })
 })

--- a/src/features/home/__tests__/HomeBriefingHierarchy.test.jsx
+++ b/src/features/home/__tests__/HomeBriefingHierarchy.test.jsx
@@ -1,0 +1,159 @@
+// src/features/home/__tests__/HomeBriefingHierarchy.test.jsx
+// F4.4 — Home is pick-first. Asserts the redesigned hierarchy: the one pick leads,
+// MoodReactor is a demoted "Adjust mood" strip below it, Reshuffle / slider-dots /
+// match ring are gone, actions are revoiced (Open Film File / Not tonight), the
+// internal queue stays invisible, and supporting sections still follow. Fully
+// mocked — no live mount/Supabase/TMDB/impressions.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+const h = vi.hoisted(() => ({ user: { id: 'u1' }, moods: [], loading: false, error: null, navigate: () => {} }))
+
+vi.mock('@/shared/lib/supabase/client', () => ({ supabase: { from: () => { throw new Error('no live supabase in test') } } }))
+vi.mock('@/shared/hooks/usePageMeta', () => ({ usePageMeta: () => {} }))
+vi.mock('@/shared/hooks/useAuthSession', () => ({ useAuthSession: () => ({ user: h.user }) }))
+vi.mock('react-router-dom', async (orig) => ({ ...(await orig()), useNavigate: () => h.navigate }))
+vi.mock('@/shared/services/recommendations', () => ({ logSurfaceImpressions: vi.fn(() => Promise.resolve()), updateImpression: vi.fn(() => Promise.resolve()) }))
+vi.mock('@/shared/services/interactions', () => ({ trackInteraction: vi.fn(() => Promise.resolve()) }))
+vi.mock('@/shared/services/recommendationOutcomes', () => ({ recordRecommendationOutcome: vi.fn(() => Promise.resolve()) }))
+vi.mock('@/shared/api/tmdb', async (orig) => ({ ...(await orig()), getMovieWatchProviders: vi.fn(() => Promise.resolve({ providers: [] })) }))
+vi.mock('@/shared/hooks/useUserMovieStatus', () => ({
+  useUserMovieStatus: () => ({ isWatched: false, isInWatchlist: false, loading: { watchlist: false, watched: false }, toggleWatched: () => {}, toggleWatchlist: () => {}, internalId: 1 }),
+}))
+vi.mock('framer-motion', async () => {
+  const React = await import('react')
+  const cache = {}
+  const strip = (p) => { const { initial, animate, exit, variants, transition, whileHover, whileTap, whileInView, layout, layoutId, ...rest } = p; return rest }
+  const make = (tag) => { if (!cache[tag]) { const C = React.forwardRef((props, ref) => React.createElement(tag, { ...strip(props), ref }, props.children)); C.displayName = `motion.${String(tag)}`; cache[tag] = C } return cache[tag] }
+  return { AnimatePresence: ({ children }) => children, motion: new Proxy({}, { get: (_t, tag) => make(tag) }), useReducedMotion: () => true }
+})
+vi.mock('../useHomeData', () => ({
+  HomeDataProvider: ({ children }) => children,
+  useHomeData: () => ({ loading: h.loading, error: h.error, moods: h.moods }),
+}))
+// Mark the supporting sections so DOM-order assertions can find them.
+vi.mock('../sections-bottom', () => ({
+  ContinueWatching: () => null,
+  CinematicDNA: () => null,
+  TasteTwinPulse: () => null,
+  TasteMatch: () => null,
+  CuratedLists: () => null,
+  QuickLog: () => null,
+  PageEndCard: () => <div data-testid="page-end-card">end</div>,
+}))
+
+import Home from '../Home'
+import { MOOD_META } from '../data'
+
+const MOOD_ID = MOOD_META[0].id
+const film = (id, over = {}) => ({ id, tmdbId: 1000 + id, title: `Movie ${id}`, year: 2010 + id, runtime: 110, director: `Dir ${id}`, engineReason: null, synopsis: null, matchPct: 80, poster: `/p${id}.jpg`, ...over })
+const renderHome = () => render(<MemoryRouter><Home /></MemoryRouter>)
+// true when `a` comes before `b` in document order
+const before = (a, b) => !!(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING)
+
+beforeEach(() => {
+  h.user = { id: 'u1' }; h.loading = false; h.error = null; h.navigate = vi.fn()
+  h.moods = [{ id: MOOD_ID, films: [film(1), film(2), film(3)] }]
+  vi.clearAllMocks()
+  window.matchMedia = window.matchMedia || (() => ({ matches: false, addEventListener() {}, removeEventListener() {} }))
+})
+
+describe('Home Briefing — pick-first hierarchy (F4.4)', () => {
+  it('renders the Briefing pick BEFORE the mood controls in DOM order', () => {
+    renderHome()
+    const pick = screen.getByRole('heading', { level: 2 })
+    const moodKicker = screen.getByText('Adjust mood')
+    expect(before(pick, moodKicker)).toBe(true)
+  })
+
+  it('labels the mood strip "Adjust mood" (not a front-door prompt)', () => {
+    renderHome()
+    expect(screen.getByText('Adjust mood')).toBeTruthy()
+    expect(screen.queryByText(/tonight i feel/i)).toBeNull()
+  })
+
+  it('has no Reshuffle control', () => {
+    renderHome()
+    expect(screen.queryByRole('button', { name: /reshuffle/i })).toBeNull()
+    expect(screen.queryByTitle(/reshuffle/i)).toBeNull()
+  })
+
+  it('has no visible slider / dot / next-previous navigation', () => {
+    renderHome()
+    for (const name of [/next/i, /previous/i, /slide/i]) {
+      expect(screen.queryByRole('button', { name })).toBeNull()
+    }
+  })
+
+  it('shows exactly one film title (the head) — the rest of the queue is invisible', () => {
+    renderHome()
+    expect(screen.getAllByRole('heading', { level: 2 })).toHaveLength(1)
+    // The other two queued films are not rendered anywhere.
+    const shown = screen.getByRole('heading', { level: 2 }).textContent
+    const others = ['Movie 1', 'Movie 2', 'Movie 3'].filter(t => t !== shown)
+    for (const t of others) expect(screen.queryByText(t)).toBeNull()
+  })
+
+  it('does not render a queue length / "N more" indicator', () => {
+    renderHome()
+    expect(screen.queryByText(/\d+\s*(more|picks|left|remaining)/i)).toBeNull()
+  })
+
+  it('does not show a match ring / visible match percentage', () => {
+    renderHome()
+    expect(screen.queryByText(/\d+\s*%/)).toBeNull()
+  })
+
+  it('advances to the next internal result on Not tonight (and the prior pick disappears)', async () => {
+    renderHome()
+    const first = screen.getByRole('heading', { level: 2 }).textContent
+    // before skip: the next film is not visible
+    expect(screen.getAllByRole('heading', { level: 2 })).toHaveLength(1)
+    fireEvent.click(screen.getByRole('button', { name: 'Not tonight' }))
+    await waitFor(() => expect(screen.getByRole('heading', { level: 2 }).textContent).not.toBe(first))
+    expect(screen.queryByText(first)).toBeNull() // prior pick gone
+  })
+
+  it('revoices the primary action to "Open Film File" and the poster label to match', () => {
+    renderHome()
+    expect(screen.getByRole('button', { name: 'Open Film File' })).toBeTruthy()
+    const shown = screen.getByRole('heading', { level: 2 }).textContent
+    expect(screen.getByRole('button', { name: `Open Film File for ${shown}` })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /see more/i })).toBeNull()
+  })
+
+  it('revoices Skip to "Not tonight"', () => {
+    renderHome()
+    expect(screen.getByRole('button', { name: 'Not tonight' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /skip tonight/i })).toBeNull()
+  })
+
+  it('still renders Save and Mark Watched', () => {
+    renderHome()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Mark Watched' })).toBeTruthy()
+  })
+
+  it('renders WhyThisPick when the engine reason exists', () => {
+    h.moods = [{ id: MOOD_ID, films: [film(1, { engineReason: 'Because you loved Past Lives' })] }]
+    renderHome()
+    expect(screen.getByText(/Because you loved Past Lives/)).toBeTruthy()
+  })
+
+  it('renders the synopsis when present (unchanged)', () => {
+    h.moods = [{ id: MOOD_ID, films: [film(1, { synopsis: 'A quiet, tender story about memory.' })] }]
+    renderHome()
+    expect(screen.getByText('A quiet, tender story about memory.')).toBeTruthy()
+  })
+
+  it('keeps supporting sections after the Briefing + mood controls', () => {
+    renderHome()
+    const pick = screen.getByRole('heading', { level: 2 })
+    const moodKicker = screen.getByText('Adjust mood')
+    const supporting = screen.getByTestId('page-end-card')
+    expect(before(pick, supporting)).toBe(true)
+    expect(before(moodKicker, supporting)).toBe(true)
+  })
+})

--- a/src/features/home/sections-top.jsx
+++ b/src/features/home/sections-top.jsx
@@ -3,8 +3,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
-import { ChevronRight, SkipForward, RefreshCw } from 'lucide-react'
-import MatchBadge from '@/shared/components/MatchBadge'
+import { ChevronRight, SkipForward } from 'lucide-react'
 import { ActionButton, SecondaryActionButton } from '@/shared/components/ActionButton'
 import { useUserMovieStatus } from '@/shared/hooks/useUserMovieStatus'
 import { getMovieWatchProviders } from '@/shared/api/tmdb'
@@ -24,13 +23,15 @@ import { useHomeData } from './useHomeData'
 // head pick with a skip-to-next queue underneath.)
 const TONIGHT_LABEL = "Tonight's pick"
 
-// MoodReactor — pill picker with a "TONIGHT I FEEL" kicker on the left.
-// The active pill already carries the mood color + glow, so the kicker
-// doesn't echo the selected label (would be redundant + cause width jitter
-// on selection). Auto-scrolls the active pill into view on mobile so the
-// user can always see their current pick even when their baseline mood
-// sits at the end of MOOD_META and the row overflows the viewport.
-export function MoodReactor({ currentMood, setMood, onReshuffle }) {
+// MoodReactor — secondary "Adjust mood" control strip (F4.4: demoted BELOW the
+// pick — Home leads with tonight's pick, mood is an optional adjustment, not the
+// front door). Pill picker with an "ADJUST MOOD" kicker on the left. The active
+// pill already carries the mood color + glow, so the kicker doesn't echo the
+// selected label (would be redundant + cause width jitter on selection).
+// Auto-scrolls the active pill into view on mobile so the user can always see
+// their current pick even when their baseline mood sits at the end of MOOD_META
+// and the row overflows the viewport.
+export function MoodReactor({ currentMood, setMood }) {
   const pillsRef = useRef(null)
   useEffect(() => {
     const el = pillsRef.current
@@ -46,7 +47,7 @@ export function MoodReactor({ currentMood, setMood, onReshuffle }) {
       <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:gap-5">
         <div className="flex flex-none items-baseline gap-2.5">
           <span aria-hidden style={{ height: 1, width: 18, background: HP.purple, opacity: 0.6, alignSelf: 'center' }} />
-          <Eyebrow color={HP.textMuted} size={10} style={{ whiteSpace: 'nowrap' }}>Tonight I feel</Eyebrow>
+          <Eyebrow color={HP.textMuted} size={10} style={{ whiteSpace: 'nowrap' }}>Adjust mood</Eyebrow>
         </div>
         <div
           ref={pillsRef}
@@ -77,21 +78,6 @@ export function MoodReactor({ currentMood, setMood, onReshuffle }) {
             </button>
           )
         })}
-        {/* Reshuffle — small icon-only pill at the right end of the row.
-            Took the place of the deleted bottom strip in audit pass-15.
-            On mobile it sits inline with the pills (still tap-accessible). */}
-        {onReshuffle && (
-          <button
-            type="button"
-            onClick={onReshuffle}
-            aria-label="Reshuffle picks"
-            title="Reshuffle"
-            className="ff-tap-hit flex flex-none items-center justify-center rounded-full border border-white/10 transition-all duration-200 hover:border-white/25 hover:bg-white/6 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
-            style={{ width: 32, height: 32, color: HP.textMuted, marginLeft: 4 }}
-          >
-            <RefreshCw className="h-3.5 w-3.5" />
-          </button>
-        )}
         </div>
       </div>
     </section>
@@ -101,8 +87,8 @@ export function MoodReactor({ currentMood, setMood, onReshuffle }) {
 // In-card action buttons are the canonical family in shared/components/ActionButton
 // (rounded-8, Outfit — shared with /movie so the briefing actions don't feel like a
 // different system). The three below are thin wrappers that add the icon, label, and
-// active state on top of <SecondaryActionButton>; the gradient "See More" primary
-// uses <ActionButton> directly.
+// active state on top of <SecondaryActionButton>; the gradient "Open Film File"
+// primary uses <ActionButton> directly.
 function WatchedButton({ isWatched, loading, error, onClick }) {
   return (
     <SecondaryActionButton
@@ -138,8 +124,8 @@ function SkipButton({ onClick }) {
     <SecondaryActionButton
       collapse
       onClick={onClick}
-      title="Skip — not tonight"
-      label="Skip Tonight"
+      title="Not tonight"
+      label="Not tonight"
       icon={<SkipForward className="h-4 w-4 lg:h-3.5 lg:w-3.5" />}
     />
   )
@@ -192,13 +178,13 @@ function StreamingChip({ provider }) {
   )
 }
 
-// BriefingSlide — single-pick hero used inside a Netflix-style slider
-// (audit pass-16). One pick visible at a time; nav lives in TheBriefing
-// (arrows on desktop, swipe + dots on mobile). Layout:
+// BriefingSlide — the one visible nightly pick (F4.4: no slider, no dots, no
+// match ring — a single, stable, pick-first hero; Not-tonight / Mark-Watched draw
+// the next result from the INVISIBLE internal queue). Layout:
 //   • mobile: vertical — poster centered, copy stacked below
 //   • desktop: horizontal — poster left (360×540), copy right column.
 // No background backdrop image — keeps the page surface clean.
-function BriefingSlide({ film, matchPct, user, onWatch, onSkip, onMarkedWatched, announce }) {
+function BriefingSlide({ film, user, onWatch, onSkip, onMarkedWatched, announce }) {
   // source must match the user_watchlist_source_check CHECK constraint —
   // 'mood_recommendation' is the closest of the allowed values.
   const { isInWatchlist, isWatched, loading: statusLoading, toggleWatchlist, toggleWatched, internalId } =
@@ -272,7 +258,7 @@ function BriefingSlide({ film, matchPct, user, onWatch, onSkip, onMarkedWatched,
     }
   }, [statusLoading.watchlist, isInWatchlist, announce])
 
-  // Opening the pick (poster or "See More") is the Briefing's 'clicked' outcome.
+  // Opening the pick (poster or "Open Film File") is the Briefing's 'clicked' outcome.
   // F8B: record it against the fresh hero impression (logged when this slide
   // became active) so shown→clicked is captured, then hand off to onWatch
   // (navigation). Fire-and-forget; recordRecommendationOutcome no-ops if no
@@ -295,7 +281,7 @@ function BriefingSlide({ film, matchPct, user, onWatch, onSkip, onMarkedWatched,
       <button
         type="button"
         onClick={handleOpen}
-        aria-label={`See more about ${film.title}`}
+        aria-label={`Open Film File for ${film.title}`}
         className="relative block w-full max-w-[180px] flex-none sm:max-w-[260px] lg:w-[340px] lg:max-w-none"
         style={{
           borderRadius: 10, overflow: 'hidden',
@@ -304,11 +290,6 @@ function BriefingSlide({ film, matchPct, user, onWatch, onSkip, onMarkedWatched,
         }}
       >
         <SmartImg film={film} big style={{ width: '100%', aspectRatio: '2/3', objectFit: 'cover', display: 'block' }} />
-        {/* Animated match ring — sized to feel proportionate against the
-            smallest poster width (200px mobile); still reads at lg (340px). */}
-        {Number.isFinite(matchPct) && matchPct > 0 && (
-          <MatchBadge variant="ring" pct={matchPct} size={60} style={{ bottom: 14, right: 14 }} />
-        )}
       </button>
 
       {/* Content column */}
@@ -380,13 +361,13 @@ function BriefingSlide({ film, matchPct, user, onWatch, onSkip, onMarkedWatched,
           </div>
         )}
         {/* Actions — gradient primary + secondary buttons.
-            • mobile: single row — gradient "See more" grows (flex-1)
+            • mobile: single row — gradient "Open Film File" grows (flex-1)
               next to three compact 44×44 round icon buttons (label
               hidden, icon only).
             • lg+: wrap row of four labeled pills (movie-detail style). */}
         <div className="flex flex-wrap items-center justify-center gap-2.5 pt-4 lg:justify-start" style={{ borderTop: `1px solid ${HP.border}` }}>
           <ActionButton className="h-11 flex-1 lg:h-auto lg:flex-none" onClick={handleOpen}>
-            <span>See More</span>
+            <span>Open Film File</span>
             <ChevronRight className="h-3.5 w-3.5" />
           </ActionButton>
           <WatchedButton isWatched={isWatched} loading={watchedState === 'saving'} error={watchedState === 'error'} onClick={handleMarkWatched} />
@@ -398,9 +379,9 @@ function BriefingSlide({ film, matchPct, user, onWatch, onSkip, onMarkedWatched,
   )
 }
 
-// Slide-in reveal for the single pick: when the head advances (skip / mark
-// watched / reshuffle / mood change) the new pick enters from the right and
-// the old exits left. Forward-only now — there is no backward browse.
+// Slide-in reveal for the single pick: when the head advances (Not tonight /
+// Mark Watched / mood change) the new pick enters from the right and the old
+// exits left. Forward-only — there is no backward browse.
 const SLIDE_VARIANTS = {
   enter: { x: 56, opacity: 0 },
   center: { x: 0, opacity: 1 },
@@ -439,10 +420,10 @@ function BriefingSkeleton() {
 }
 
 
-// shuffleBySeed (deterministic reshuffle) + todaySeed (UTC daily rotation) moved
-// to homeDerive.js in F4.2 (behavior-preserved); imported above. todaySeed still
-// combines with the user's shuffleSeed (Reshuffle) + the mood id (strHash) below
-// to rotate the top-30 pool — same user, same mood, different picks each day.
+// shuffleBySeed (deterministic shuffle) + todaySeed (UTC daily rotation) moved
+// to homeDerive.js in F4.2 (behavior-preserved); imported above. todaySeed
+// combines with the mood id (strHash) below to rotate the per-mood pool —
+// same user, same mood, a stable pick that changes once per day.
 
 // Tiny non-cryptographic string-to-int hash. Used to fold the active mood
 // id into the rotation seed so different moods on the same day produce
@@ -454,51 +435,44 @@ function strHash(s) {
   return Math.abs(h)
 }
 
-export function TheBriefing({ currentMood, shuffleSeed = 0, user, onWatch, onSkip }) {
+export function TheBriefing({ currentMood, user, onWatch, onSkip }) {
   const { moods, loading } = useHomeData()
   const moodEntry = moods.find(m => m.id === currentMood.id)
 
   // F4.3 — one polite, atomic, screen-reader-only live region owned by the
   // Briefing. It narrates pick progression + action outcomes (never the queue
   // length or match %). pickActionRef records WHY the head last advanced so the
-  // pick-change effect can word the announcement (initial/mood/reshuffle vs skip
-  // vs mark-watched).
+  // pick-change effect can word the announcement (initial/mood vs skip vs
+  // mark-watched).
   const [statusMsg, setStatusMsg] = useState('')
   const announce = useCallback((msg) => setStatusMsg(msg), [])
   const pickActionRef = useRef('initial') // 'initial' | 'skip' | 'watched'
 
-  // Effective seed for picking which 3 of the top 30 are visible today.
-  // Recomputes when the day changes (midnight UTC) or when the user clicks
-  // Reshuffle. Mood id folded in so moods don't share the same rotation.
+  // Effective seed for the daily rotation through the per-mood pool. Recomputes
+  // when the UTC day changes (todaySeed) or the mood changes (strHash folds the
+  // mood id in so different moods don't share a rotation). Value is unchanged
+  // from before — F4.4 just dropped the now-removed Reshuffle term (always 0).
   const effectiveSeed = useMemo(
-    () => todaySeed() + shuffleSeed * 7919 + strHash(currentMood.id || ''),
-    [shuffleSeed, currentMood.id],
+    () => todaySeed() + strHash(currentMood.id || ''),
+    [currentMood.id],
   )
 
-  // Session-only hide list: when a slide is marked watched OR skipped, its
-  // film.id lands here and the picks filter drops it. The engine returns
-  // a deeper pool (15 per mood in useHomeData), so the next-best film
-  // slides into the freed slot — user sees "slide replaced by next
-  // suggestion" instead of an empty hole.
-  //
-  // Resets ONLY on mood change. Previously also reset on shuffleSeed,
-  // which made reshuffle bring back films the user had just skipped —
-  // counter-intuitive ("I skipped this, give me different films").
-  // Reshuffle now re-orders the *remaining* pool; switching moods is the
-  // way to start with a clean slate.
+  // Session-only hide list: when the pick is marked watched OR skipped, its
+  // film.id lands here and the queue filter drops it. The engine returns a
+  // deeper pool (15 per mood in useHomeData), so the next-best film takes the
+  // head slot — user sees the pick replaced by the next suggestion rather than
+  // an empty hole. Resets ONLY on mood change (switching moods is the clean
+  // slate); the internal queue stays invisible.
   const [hiddenIds, setHiddenIds] = useState(() => new Set())
-  // Resets ONLY on mood change. Reshuffle re-orders the *remaining* pool;
-  // switching moods is the way to start with a clean slate.
   useEffect(() => {
     setHiddenIds(new Set())
     // A fresh mood starts a fresh "Tonight's briefing pick" (not skip/watched).
     pickActionRef.current = 'initial'
   }, [currentMood.id])
 
-  // The remaining queue for this mood — daily-seeded + reshuffle-seeded, with
-  // skipped/watched films removed. We render only the HEAD; the rest is the
-  // depth that skip-to-next draws from (the single-pick equivalent of the old
-  // "next slides into the freed slot").
+  // The remaining queue for this mood — daily-seeded, with skipped/watched films
+  // removed. We render only the HEAD; the rest is the invisible depth that
+  // Not-tonight / Mark-Watched draw the next pick from.
   const queue = useMemo(() => {
     if (!moodEntry) return []
     return buildBriefingQueue(moodEntry.films, effectiveSeed, hiddenIds)
@@ -540,7 +514,7 @@ export function TheBriefing({ currentMood, shuffleSeed = 0, user, onWatch, onSki
 
   // Briefing impression — log the one visible pick. Per-day-deduped by
   // recommendation_impressions' unique key, so re-renders write one row per
-  // film per day. Fires whenever the head advances (skip / watched / reshuffle
+  // film per day. Fires whenever the head advances (Not tonight / Mark Watched
   // / mood change).
   const pickId = pick?.id
   const pickReason = pick?.engineReason
@@ -589,7 +563,7 @@ export function TheBriefing({ currentMood, shuffleSeed = 0, user, onWatch, onSki
           <p style={{ fontSize: 15, lineHeight: 1.6, color: HP.textSoft, fontFamily: 'Outfit, Inter, sans-serif', margin: 0, maxWidth: 480 }}>
             You&rsquo;ve reviewed all of tonight&rsquo;s{' '}
             <em style={{ fontStyle: 'italic', color: currentMood.hex, fontWeight: 500 }}>{currentMood.label.toLowerCase()}</em>{' '}
-            picks. Switch moods above, or
+            picks. Switch moods below, or
           </p>
           <button
             type="button"
@@ -602,17 +576,17 @@ export function TheBriefing({ currentMood, shuffleSeed = 0, user, onWatch, onSki
         </div>
       ) : isNoFilms ? (
         <div style={{ padding: '60px 0', textAlign: 'center', fontFamily: 'Outfit, Inter, sans-serif', color: HP.textMuted, fontSize: 14, fontStyle: 'italic' }}>
-          No <span style={{ color: currentMood.hex, fontStyle: 'italic' }}>{currentMood.label.toLowerCase()}</span> picks just yet — try a different mood above.
+          No <span style={{ color: currentMood.hex, fontStyle: 'italic' }}>{currentMood.label.toLowerCase()}</span> picks just yet — try a different mood below.
         </div>
       ) : !pick ? (
         <BriefingSkeleton />
       ) : (
         // Single confident pick. overflow-hidden contains the slide-in reveal
-        // (x-translate) when the head advances on skip / watched / reshuffle.
+        // (x-translate) when the head advances on Not-tonight / Mark-Watched.
         <div className="relative overflow-hidden">
           <AnimatePresence initial={false} mode="wait">
             <motion.div
-              key={`${currentMood.id}-${pick.id}-${shuffleSeed}`}
+              key={`${currentMood.id}-${pick.id}`}
               variants={SLIDE_VARIANTS}
               initial="enter"
               animate="center"
@@ -621,7 +595,6 @@ export function TheBriefing({ currentMood, shuffleSeed = 0, user, onWatch, onSki
             >
               <BriefingSlide
                 film={pick}
-                matchPct={pick.matchPct}
                 user={user}
                 onWatch={onWatch}
                 onSkip={handleSkip}


### PR DESCRIPTION
**F4.4** — first intentional Home redesign: `/home` becomes an **automatic, stable, pick-first nightly briefing** instead of a second Discover. Engine, ranking, queue depth, write payloads, routes, and supporting sections are unchanged.

## Pick-first hierarchy
Render order is now **Masthead → TheBriefing → MoodReactor → supporting sections**. The one pick is the first decision surface after the masthead; mood becomes a secondary adjustment below it. Supporting-section order is otherwise unchanged.

## MoodReactor demotion
Demoted to a secondary **"Adjust mood"** control strip below the pick (kicker "Tonight I feel" → "Adjust mood"). Mood pills, active state, `aria-pressed`, active-pill auto-scroll, mood switching, queue-reset-on-mood-change, and the post-mood initial-pick announcement are all preserved. Still the 6-key `MOOD_META` vocab — no Discover taxonomy, no persistence, no inferred mood, no context controls.

## Reshuffle removed
Removed the Reshuffle button, `onReshuffle`, the `RefreshCw` import, and Home's `shuffleSeed` state/setter. **Daily seed + mood-seed unchanged**: `shuffleSeed` was initialized to 0 and only ever incremented by Reshuffle, so it was always 0 → `effectiveSeed` simplifies from `todaySeed()+shuffleSeed*7919+strHash(mood)` to `todaySeed()+strHash(mood)`, a **byte-identical value** (the daily pick is unchanged). `todaySeed`/`shuffleBySeed`/`buildBriefingQueue`/`strHash` (homeDerive.js) untouched.

## Visible slider/dots removed
The Briefing shows **one pick** (`queue[0]`); there were no real dot/arrow controls left after earlier single-pick refactors, so this removes the misleading "Netflix-style slider" comments + drops `shuffleSeed` from the `AnimatePresence` key. The **internal queue + `hiddenIds` progression stay invisible**; Not-tonight / Mark-Watched still draw the next internal result; exhausted state preserved. No queue length is exposed anywhere.

## MatchBadge removal
Removed the poster match ring, its import, and the now-unused `matchPct` prop. `matchPct` is still computed in `useHomeData` (data layer untouched); it is simply not displayed. **No replacement** badge/percentage/progress/confidence label.

## Action copy updates
Primary action **"See More" → "Open Film File"**; poster accessible name "See more about {title}" → **"Open Film File for {title}"**. Skip **"Skip Tonight" → "Not tonight"** (label + title). `handleOpen`, the `/movie/:tmdbId` route, `recordRecommendationOutcome('clicked')`, `onWatch`, `onSkip`, and Save/Watched payloads are unchanged.

## Internal queue + F4.3 reliability preserved
`queue[0]` is the visible pick; Not-tonight / Mark-Watched advance through the invisible internal queue. Mark Watched still **waits for the write + 600ms hold** before advancing; Skip stays ordered + failure-contained; the **active-pick impression still logs on render** (`placement: 'hero'`, `pickReasonType: 'briefing_active'`, `pickReasonLabel`); the one-pick live region remains. (The exhausted/no-films copy "…above" → "…below" since the mood strip is now below the pick.)

## Tests added/updated
- **`HomeBriefingHierarchy.test.jsx` (14):** pick-before-mood DOM order, "Adjust mood" kicker, no Reshuffle, no slider/dots/next-prev, one visible title (queue invisible), Not-tonight advances + prior pick gone, no queue-length/"N more", no match %, "Open Film File" primary + poster label, "Not tonight" skip, Save+Watched render, WhyThisPick + synopsis render, supporting sections after.
- **`HomeBriefingActions.test.jsx`:** Skip Tonight → Not tonight; the F4.3 reliability + payload + impression-timing assertions are **preserved** (regression-guarded).
- `homeDerive` / `WhyThisPick` / `resolveEngineReason` / `HomeDataStates` still pass.

## Confirmations
- **Ranking, scoring, payloads, routes, supporting sections, and active-pick impression timing are unchanged** (impression/outcome/Skip payloads untouched; `effectiveSeed` value byte-identical; `homeDerive`/`useHomeData`/`sections-bottom`/`WhyThisPick` untouched).
- **No live Home write was triggered** (mocked component tests; the supabase client mock throws on any access). Browser verification is **blocked** by impression-on-render and is covered by component tests, per the phase guidance.
- Reviewed by an adversarial 3-lens panel (frozen-behavior / completeness / a11y-hierarchy): **zero confirmed defects**.

## Validation
- `npm run lint` → clean · `npx vitest run src/features/home/` → **62 passed** (6 files) · `npm run build` → ✓ · `npm run test` → **923 passed** (72 files) · changed tests stable **3×**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
