### PR TITLE
Simplify Home supporting sections

### DIFF
--- a/src/features/home/Home.jsx
+++ b/src/features/home/Home.jsx
@@ -15,10 +15,7 @@ import { updateImpression } from '@/shared/services/recommendations'
 
 import { HP, MOOD_META } from './data'
 import { MoodReactor, TheBriefing } from './sections-top'
-import {
-  ContinueWatching, CinematicDNA, TasteTwinPulse,
-  TasteMatch, CuratedLists, QuickLog, PageEndCard,
-} from './sections-bottom'
+import { QuickLog, PageEndCard } from './sections-bottom'
 import { HomeDataProvider, useHomeData } from './useHomeData'
 import './home.css'
 
@@ -113,38 +110,11 @@ function HomeBody() {
     navigate('/browse')
   }, [navigate])
 
-  // Routes both curated and personal lists. The personal lists carry a
-  // `kind` + `meta` payload that becomes URL params on the destination
-  // route; curated lists keep using the existing slug-based path.
-  const onOpenList = useCallback((slug, list) => {
-    if (list?.kind && list.kind !== 'curated') {
-      const params = new URLSearchParams()
-      const m = list.meta || {}
-      if (list.kind === 'director' && m.directorName) params.set('director', m.directorName)
-      if (list.kind === 'similar' && m.seedId != null) {
-        params.set('seed', String(m.seedId))
-        if (m.seedTitle) params.set('title', m.seedTitle)
-      }
-      if (list.kind === 'genre' && m.dbName) {
-        params.set('genre', m.dbName)
-        if (m.displayName) params.set('display', m.displayName)
-      }
-      if (list.kind === 'fit' && m.fitKey) {
-        params.set('fit', m.fitKey)
-        if (m.label) params.set('label', m.label)
-        if (m.title) params.set('title', m.title)
-      }
-      if (list.kind === 'actor' && m.actorName) params.set('actor', m.actorName)
-      const qs = params.toString()
-      navigate(`/lists/personal/${list.kind}${qs ? `?${qs}` : ''}`)
-      return
-    }
-    navigate(slug ? `/lists/curated/${slug}` : '/lists')
-  }, [navigate])
-
-  const onOpenFriend = useCallback((userId) => {
-    navigate(userId ? `/profile/${userId}` : '/people')
-  }, [navigate])
+  // NOTE: onOpenList (curated/personal lists → /lists) and onOpenFriend
+  // (taste twins → /profile|/people) were removed in F4.5 along with the
+  // CuratedLists / TasteMatch sections they wired. Those components + their
+  // useHomeData logic remain intact; re-add the handlers when the sections
+  // are surfaced on their proper routes (/browse, /lists, /people).
 
   return (
     <div className="ff-home" style={{ minHeight: '100vh', background: HP.bg, color: HP.text, position: 'relative', overflowX: 'hidden' }}>
@@ -176,18 +146,22 @@ function HomeBody() {
               onSkip={onSkip}
             />
             <MoodReactor currentMood={currentMood} setMood={handleSetMood} />
-            <ContinueWatching onResume={onWatch} />
-            {/* Section order — descending actionability:
-                 1. Briefing (tonight's pick — primary recommendation)
-                 2. Adjust-mood strip (secondary control for the pick above)
-                 3. CuratedLists (more picks — alternatives, still actionable)
-                 4. TasteMatch → TasteTwinPulse (social cluster — people then their picks)
-                 5. CinematicDNA (reflective portrait — confidence reveal)
-                 6. QuickLog (utility, lowest priority) */}
-            <CuratedLists onOpenList={onOpenList} />
-            <TasteMatch onOpenFriend={onOpenFriend} />
-            <TasteTwinPulse onWatch={onWatch} />
-            <CinematicDNA />
+            {/* F4.5 — restrained, pick-supporting tail. The one nightly pick leads;
+                the tail stays a quiet trail back into the user's film life, not a
+                dashboard / browse wall / social feed:
+                  • QuickLog — the one concrete repeat-value utility (log films you've
+                    already seen → sharpen tomorrow's pick).
+                  • PageEndCard — a quiet, role-clear close to Discover.
+                Intentionally NOT rendered on Home (components + their useHomeData
+                data logic are preserved for their proper homes / a future return):
+                  • ContinueWatching — has NO real resume-progress data source yet
+                    (continueItem is always null); it should return only once real
+                    watch-progress exists, not as an empty placeholder.
+                  • CuratedLists — a catalog browse wall; belongs to /browse + /lists.
+                  • TasteMatch + TasteTwinPulse — early social; belong to /people once
+                    the similarity data is mature, not a social feed under the pick.
+                  • CinematicDNA — a reflective taste portrait that lives on /profile;
+                    it should not dominate or duplicate Profile on every Home visit. */}
             <QuickLog onLog={onLog} />
             <PageEndCard
               currentMood={currentMood}

--- a/src/features/home/__tests__/HomeSupportingSections.test.jsx
+++ b/src/features/home/__tests__/HomeSupportingSections.test.jsx
@@ -1,0 +1,128 @@
+// src/features/home/__tests__/HomeSupportingSections.test.jsx
+// F4.5 — the Home tail is a restrained, pick-supporting trail, not a dashboard /
+// browse wall / social feed. Renders the REAL QuickLog + PageEndCard (the removed
+// sections are simply absent because Home no longer imports them) over mocked data
+// — no live mount/Supabase/TMDB/impression writes.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+const h = vi.hoisted(() => ({ user: { id: 'u1' }, moods: [], seen: [], loading: false, error: null, navigate: () => {} }))
+
+vi.mock('@/shared/lib/supabase/client', () => ({ supabase: { from: () => { throw new Error('no live supabase in test') } } }))
+vi.mock('@/shared/hooks/usePageMeta', () => ({ usePageMeta: () => {} }))
+vi.mock('@/shared/hooks/useAuthSession', () => ({ useAuthSession: () => ({ user: h.user }) }))
+vi.mock('react-router-dom', async (orig) => ({ ...(await orig()), useNavigate: () => h.navigate }))
+vi.mock('@/shared/services/recommendations', () => ({ logSurfaceImpressions: vi.fn(() => Promise.resolve()), updateImpression: vi.fn(() => Promise.resolve()) }))
+vi.mock('@/shared/services/interactions', () => ({ trackInteraction: vi.fn(() => Promise.resolve()) }))
+vi.mock('@/shared/services/recommendationOutcomes', () => ({ recordRecommendationOutcome: vi.fn(() => Promise.resolve()) }))
+vi.mock('@/shared/api/tmdb', async (orig) => ({ ...(await orig()), getMovieWatchProviders: vi.fn(() => Promise.resolve({ providers: [] })) }))
+vi.mock('@/shared/hooks/useUserMovieStatus', () => ({
+  useUserMovieStatus: () => ({ isWatched: false, isInWatchlist: false, loading: { watchlist: false, watched: false }, toggleWatched: () => {}, toggleWatchlist: () => {}, internalId: 1 }),
+}))
+vi.mock('framer-motion', async () => {
+  const React = await import('react')
+  const cache = {}
+  const strip = (p) => { const { initial, animate, exit, variants, transition, whileHover, whileTap, whileInView, layout, layoutId, ...rest } = p; return rest }
+  const make = (tag) => { if (!cache[tag]) { const C = React.forwardRef((props, ref) => React.createElement(tag, { ...strip(props), ref }, props.children)); C.displayName = `motion.${String(tag)}`; cache[tag] = C } return cache[tag] }
+  return { AnimatePresence: ({ children }) => children, motion: new Proxy({}, { get: (_t, tag) => make(tag) }), useReducedMotion: () => true }
+})
+// Provide all the keys the supporting sections read; the removed ones are NOT
+// rendered by Home, so their (empty) data just confirms nothing leaks through.
+vi.mock('../useHomeData', () => ({
+  HomeDataProvider: ({ children }) => children,
+  useHomeData: () => ({
+    loading: h.loading, error: h.error, moods: h.moods, seenCandidates: h.seen,
+    continueItem: null, dna: null, friends: [], lists: [], twinPulse: [],
+  }),
+}))
+
+import Home from '../Home'
+import { MOOD_META } from '../data'
+
+const MOOD_ID = MOOD_META[0].id
+const renderHome = () => render(<MemoryRouter><Home /></MemoryRouter>)
+const before = (a, b) => !!(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING)
+
+beforeEach(() => {
+  h.user = { id: 'u1' }; h.loading = false; h.error = null; h.navigate = vi.fn()
+  h.moods = [{ id: MOOD_ID, films: [{ id: 1, tmdbId: 1001, title: 'Movie 1', year: 2011, runtime: 110, director: 'Dir 1', engineReason: null, synopsis: null, matchPct: 80, poster: '/p1.jpg' }] }]
+  h.seen = [{ id: 50, title: 'Seen A', poster_path: '/sa.jpg' }, { id: 51, title: 'Seen B', poster_path: '/sb.jpg' }]
+  vi.clearAllMocks()
+  window.matchMedia = window.matchMedia || (() => ({ matches: false, addEventListener() {}, removeEventListener() {} }))
+})
+
+describe('Home supporting sections (F4.5)', () => {
+  it('does not render ContinueWatching (no real resume-progress data)', () => {
+    renderHome()
+    expect(screen.queryByText(/Pick up where you paused/i)).toBeNull()
+    expect(screen.queryByText(/In Progress/i)).toBeNull()
+    expect(screen.queryByText(/continue watching/i)).toBeNull()
+  })
+
+  it('does not render the browse-wall / social / DNA sections on Home', () => {
+    renderHome()
+    expect(screen.queryByText(/Curated edits/i)).toBeNull()
+    expect(screen.queryByText(/Lists, hand-cut/i)).toBeNull()
+    expect(screen.queryByText(/taste twins/i)).toBeNull()        // TasteMatch
+    expect(screen.queryByText(/Taste-twin pulse/i)).toBeNull()   // TasteTwinPulse
+    expect(screen.queryByText(/Cinematic DNA/i)).toBeNull()      // CinematicDNA
+  })
+
+  it('keeps QuickLog as the repeat-value tail utility', () => {
+    renderHome()
+    expect(screen.getByText(/Have you seen any of these\?/i)).toBeTruthy()
+    expect(screen.getByText(/Feed the engine/i)).toBeTruthy()
+  })
+
+  it('keeps QuickLog honest — it logs inline and offers Browse as a secondary jump', () => {
+    renderHome()
+    // The section is explicitly about logging films you have already watched.
+    expect(screen.getByText(/already watched/i)).toBeTruthy()
+    // Browse is a clearly-labelled secondary catalog jump, not the only action.
+    expect(screen.getByRole('button', { name: /Open Browse/i })).toBeTruthy()
+  })
+
+  it('keeps PageEndCard and routes its CTA to /discover', () => {
+    renderHome()
+    const cta = screen.getByRole('button', { name: /Open Discover/i })
+    fireEvent.click(cta)
+    expect(h.navigate).toHaveBeenCalledWith('/discover')
+  })
+
+  it('PageEndCard copy distinguishes Home (already picked) from Discover (deliberate) and drops the "fits better" implication', () => {
+    renderHome()
+    expect(screen.getByText(/already set above/i)).toBeTruthy()
+    expect(screen.getByText(/deliberate path/i)).toBeTruthy()
+    expect(screen.queryByText(/actually fits tonight/i)).toBeNull() // old misleading copy gone
+  })
+
+  it('renders the tail (QuickLog → PageEndCard) AFTER the Briefing pick and Adjust-mood strip', () => {
+    renderHome()
+    const pick = screen.getByRole('heading', { level: 2, name: 'Movie 1' })
+    const moodKicker = screen.getByText('Adjust mood')
+    const quickLog = screen.getByText(/Have you seen any of these\?/i)
+    const discoverCta = screen.getByRole('button', { name: /Open Discover/i })
+    expect(before(pick, moodKicker)).toBe(true)
+    expect(before(moodKicker, quickLog)).toBe(true)
+    expect(before(quickLog, discoverCta)).toBe(true)
+  })
+
+  it('does not leave blank/empty supporting regions or a browse-wall heading dominating the tail', () => {
+    renderHome()
+    // The only catalog reference in the tail is QuickLog's secondary Open Browse.
+    expect(screen.getAllByRole('button', { name: /Open Browse/i })).toHaveLength(1)
+    // No loud browse-wall heading competes with the pick.
+    expect(screen.queryByText(/Curated edits|Lists, hand-cut for you/i)).toBeNull()
+  })
+
+  it('renders only the Briefing + QuickLog + PageEndCard sections (no empty placeholders)', () => {
+    const { container } = renderHome()
+    // Three <section>s remain: TheBriefing, MoodReactor, QuickLog... + PageEndCard.
+    // The removed sections leave no orphaned/empty landmarks.
+    const sections = container.querySelectorAll('section')
+    expect(sections.length).toBeLessThanOrEqual(4)
+    expect(sections.length).toBeGreaterThanOrEqual(3)
+  })
+})

--- a/src/features/home/sections-bottom.jsx
+++ b/src/features/home/sections-bottom.jsx
@@ -701,62 +701,62 @@ export function QuickLog({ onLog }) {
   )
 }
 
-// PageEndCard — closing moment for /home. One focused CTA into Discover
-// (FeelFlick's mood-engine surface). The catalog/Browse remains available
-// from the top nav; here we make the strongest single offer instead of
-// asking the user to choose. Mood-tinted gradient adapts to the active
-// mood so the closer carries the user's current glow.
+// PageEndCard — quiet, role-clear close for /home (F4.5). Home has ALREADY given
+// tonight's pick above; this is just the optional door to Discover for when the
+// user would rather shape a pick deliberately by mood + context. Deliberately
+// calmer than a second hero — and it never implies Discover picks "better" than
+// Home or that tonight's pick is disposable. Mood-tinted so the closer carries the
+// user's current glow.
 export function PageEndCard({ currentMood, onDiscover }) {
   const tint = currentMood?.hex || HP.purple
   return (
-    <section className="border-t px-5 py-16 pb-24 sm:px-8 sm:py-20 sm:pb-28 lg:px-[88px] lg:py-[96px] lg:pb-[112px]" style={{ borderColor: HP.border }}>
+    <section className="border-t px-5 py-12 pb-16 sm:px-8 sm:py-14 sm:pb-20 lg:px-[88px] lg:py-[64px] lg:pb-[80px]" style={{ borderColor: HP.border }}>
       <div
         style={{
           position: 'relative',
           borderRadius: 14,
           overflow: 'hidden',
-          padding: '60px 32px',
+          padding: '40px 28px',
           background: `
-            radial-gradient(ellipse 60% 80% at 20% 100%, ${tint}26, transparent 60%),
-            radial-gradient(ellipse 50% 70% at 100% 0%, rgba(167,139,250,0.14), transparent 55%),
-            linear-gradient(135deg, rgba(8,6,14,0.92) 0%, rgba(8,6,14,0.78) 100%)
+            radial-gradient(ellipse 60% 80% at 20% 100%, ${tint}1a, transparent 62%),
+            linear-gradient(135deg, rgba(8,6,14,0.9) 0%, rgba(8,6,14,0.74) 100%)
           `,
           border: `1px solid ${HP.border}`,
           textAlign: 'center',
         }}
-        className="sm:px-12 lg:py-[88px]"
+        className="sm:px-10"
       >
         <div style={{
-          fontSize: 11, fontWeight: 700, letterSpacing: '0.32em', textTransform: 'uppercase',
-          color: HP.purple, marginBottom: 16, display: 'inline-flex', alignItems: 'center', gap: 12,
+          fontSize: 10, fontWeight: 700, letterSpacing: '0.3em', textTransform: 'uppercase',
+          color: HP.textMuted, marginBottom: 14, display: 'inline-flex', alignItems: 'center', gap: 12,
         }}>
-          <span aria-hidden style={{ height: 1, width: 28, background: HP.purple, opacity: 0.6 }} />
-          Keep exploring
-          <span aria-hidden style={{ height: 1, width: 28, background: HP.purple, opacity: 0.6 }} />
+          <span aria-hidden style={{ height: 1, width: 24, background: HP.textMuted, opacity: 0.5 }} />
+          Or shape your own
+          <span aria-hidden style={{ height: 1, width: 24, background: HP.textMuted, opacity: 0.5 }} />
         </div>
         <h2 style={{
           fontFamily: 'Outfit, Inter, sans-serif',
-          fontSize: 'clamp(32px, 4.4vw, 56px)',
-          lineHeight: 1.02,
+          fontSize: 'clamp(24px, 3vw, 38px)',
+          lineHeight: 1.05,
           fontWeight: 300,
-          letterSpacing: '-0.04em',
+          letterSpacing: '-0.035em',
           color: HP.text,
-          margin: '0 auto 14px auto',
-          maxWidth: 720,
+          margin: '0 auto 12px auto',
+          maxWidth: 620,
           textWrap: 'balance',
         }}>
-          Tonight has more than one <em style={{ fontStyle: 'italic', color: tint, fontWeight: 400 }}>glow.</em>
+          Want to pick by <em style={{ fontStyle: 'italic', color: tint, fontWeight: 400 }}>mood and moment?</em>
         </h2>
         <p style={{
           fontFamily: 'Outfit, Inter, sans-serif',
-          fontSize: 'clamp(14px, 1.1vw, 16px)',
+          fontSize: 'clamp(13px, 1vw, 15px)',
           lineHeight: 1.55,
           color: HP.textMuted,
-          margin: '0 auto 32px auto',
-          maxWidth: 560,
+          margin: '0 auto 26px auto',
+          maxWidth: 520,
           textWrap: 'pretty',
         }}>
-          Let Discover translate your mood into a movie that actually fits tonight.
+          Tonight’s pick is already set above. Discover is the deliberate path — shape a different one around your mood, time, and who you’re with.
         </p>
         <div className="flex items-center justify-center">
           <button
@@ -764,15 +764,15 @@ export function PageEndCard({ currentMood, onDiscover }) {
             onClick={() => onDiscover?.()}
             style={{
               display: 'inline-flex', alignItems: 'center', gap: 10,
-              padding: '14px 24px', borderRadius: 8,
+              padding: '12px 22px', borderRadius: 8,
               background: HP_GRAD, border: 'none', color: '#fff',
               fontFamily: 'Outfit', fontSize: 14, fontWeight: 600, letterSpacing: '0.02em',
               cursor: 'pointer',
-              boxShadow: '0 14px 32px -10px rgba(236,72,153,0.5)',
+              boxShadow: '0 10px 24px -12px rgba(236,72,153,0.42)',
             }}
             className="transition-transform duration-200 active:scale-[0.98]"
           >
-            Discover by mood
+            Open Discover
             <ChevronRight className="h-4 w-4" aria-hidden />
           </button>
         </div>


### PR DESCRIPTION
**F4.5** — reduce + reorganize the Home tail so it **supports** the pick-first nightly briefing instead of turning Home back into a dashboard / browse wall / social feed. **TheBriefing, MoodReactor, the engine, write payloads, routes, and active-pick impression timing are unchanged** (`sections-top.jsx` + `useHomeData.jsx` untouched).

Render tail is now: **TheBriefing → MoodReactor → QuickLog → PageEndCard**.

## ContinueWatching removal
Removed from Home render — it is **dead** (`continueItem` is always null). The component + its `useHomeData` logic are **preserved** (still exported); it should return only when real watch-progress/resume data exists, not as an empty placeholder.

## Supporting-section reorganization / demotion
Removed from Home render (components + data logic **preserved**, for their proper routes / a real return):
- **CuratedLists** — a catalog browse wall → `/browse` + `/lists`.
- **TasteMatch** + **TasteTwinPulse** — early social → `/people` once similarity data is mature (not a social feed under the pick).
- **CinematicDNA** — a reflective portrait that lives on `/profile`; it should not dominate every Home visit or duplicate Profile.

Also removed the now-unused `onOpenList` / `onOpenFriend` Home callbacks (the components they wired are no longer rendered; re-add when those sections surface elsewhere).

## QuickLog preservation
Kept **unchanged** as the one concrete repeat-value utility: it logs films you've already seen **inline** (`user_history` `'home_quicklog'`; `'quick_picks'` impression) with a clearly-labelled secondary **"Open Browse"** → `/browse` jump. It logs inline, so its copy is honest (it does not "say log here but only open Browse").

## PageEndCard revoice (the only `sections-bottom.jsx` change)
Kept but made **quieter + role-clear**. The old copy — *"Let Discover translate your mood into a movie that actually fits tonight"* + *"Tonight has more than one glow"* + *"Keep exploring"* — implied Discover fits **better** than Home and that the pick is disposable. New copy makes the roles parallel: *"Tonight's pick is already set above. Discover is the deliberate path — shape a different one around your mood, time, and who you're with."* Smaller heading/padding/gradient (not a second hero); CTA **"Open Discover"** still routes to `/discover`.

## Honesty & accessibility
Nothing fabricates social/list/DNA content; the removed sections were already return-null-when-empty self-hiders, so removing them loses no real content and leaves **no empty placeholders or orphaned landmarks**. One sr-only `<h1>` retained; the pick stays the first decision surface; keyboard order stays Briefing actions → Adjust mood → QuickLog → closing CTA.

## Tests added/updated
- **`HomeSupportingSections.test.jsx` (9):** ContinueWatching/Curated/social/DNA not rendered; QuickLog kept + honest (logs inline + secondary Browse); PageEndCard kept, routes `/discover`, copy distinguishes Home from Discover (old "actually fits" copy gone); tail after Briefing + Adjust-mood; no blank/orphaned regions; ≤4 `<section>`s.
- F4.4 hierarchy tests + `HomeBriefingActions` + `HomeDataStates` + `homeDerive` + `WhyThisPick` + `resolveEngineReason` all still pass.

## Confirmations
- **TheBriefing behavior, scoring, ranking, payloads, routes, and active-pick impression timing are unchanged** (`sections-top.jsx`/`useHomeData.jsx`/`homeDerive.js`/`WhyThisPick.jsx` untouched; `sections-bottom.jsx` diff is PageEndCard-only).
- **No live Home write was triggered** (mocked component tests; the supabase client mock throws on any access; no authenticated render).
- Reviewed by an adversarial 3-lens panel (frozen-preservation / honesty-copy / a11y-completeness): **zero confirmed defects** (the only a11y note — QuickLog's sub-44px "Open Browse" button — is pre-existing in the frozen QuickLog component, an F4.6 item).

## Validation
- `npm run lint` → clean · `npx vitest run src/features/home/` → **71 passed** (7 files) · `npm run build` → ✓ · `npm run test` → **932 passed** (73 files) · new/changed tests stable **3×**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
