### PR TITLE
Harden Home trust and accessibility

### DIFF
--- a/src/features/home/__tests__/HomeProviderStates.test.jsx
+++ b/src/features/home/__tests__/HomeProviderStates.test.jsx
@@ -1,0 +1,124 @@
+// src/features/home/__tests__/HomeProviderStates.test.jsx
+// F4.6 — honest provider states on the Briefing. Renders Home (desktop provider
+// markup is in the DOM under jsdom) with a controllable getMovieWatchProviders
+// mock. No live TMDB/Supabase/impression writes.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+const h = vi.hoisted(() => ({
+  user: { id: 'u1' }, moods: [], navigate: () => {},
+  providerMode: 'found',
+  providers: [{ name: 'Mock Stream', logoPath: '/ms.png', type: 'flatrate' }],
+  providerOpts: null,
+}))
+
+vi.mock('@/shared/lib/supabase/client', () => ({ supabase: { from: () => { throw new Error('no live supabase in test') } } }))
+vi.mock('@/shared/hooks/usePageMeta', () => ({ usePageMeta: () => {} }))
+vi.mock('@/shared/hooks/useAuthSession', () => ({ useAuthSession: () => ({ user: h.user }) }))
+vi.mock('react-router-dom', async (orig) => ({ ...(await orig()), useNavigate: () => h.navigate }))
+vi.mock('@/shared/services/recommendations', () => ({ logSurfaceImpressions: vi.fn(() => Promise.resolve()), updateImpression: vi.fn(() => Promise.resolve()) }))
+vi.mock('@/shared/services/interactions', () => ({ trackInteraction: vi.fn(() => Promise.resolve()) }))
+vi.mock('@/shared/services/recommendationOutcomes', () => ({ recordRecommendationOutcome: vi.fn(() => Promise.resolve()) }))
+vi.mock('@/shared/hooks/useUserMovieStatus', () => ({
+  useUserMovieStatus: () => ({ isWatched: false, isInWatchlist: false, loading: { watchlist: false, watched: false }, toggleWatched: () => {}, toggleWatchlist: () => {}, internalId: 1 }),
+}))
+vi.mock('@/shared/api/tmdb', async (orig) => ({
+  ...(await orig()),
+  getMovieWatchProviders: vi.fn((id, opts) => {
+    h.providerOpts = opts
+    switch (h.providerMode) {
+      case 'found': return Promise.resolve({ providers: h.providers })
+      case 'empty': return Promise.resolve({ providers: [] })
+      case 'error': return Promise.reject(new Error('tmdb down'))
+      case 'abort': return Promise.reject(Object.assign(new Error('aborted'), { name: 'AbortError' }))
+      case 'loading': return new Promise(() => {}) // never settles
+      default: return Promise.resolve({ providers: [] })
+    }
+  }),
+}))
+vi.mock('framer-motion', async () => {
+  const React = await import('react')
+  const cache = {}
+  const strip = (p) => { const { initial, animate, exit, variants, transition, whileHover, whileTap, whileInView, layout, layoutId, ...rest } = p; return rest }
+  const make = (tag) => { if (!cache[tag]) { const C = React.forwardRef((props, ref) => React.createElement(tag, { ...strip(props), ref }, props.children)); C.displayName = `motion.${String(tag)}`; cache[tag] = C } return cache[tag] }
+  return { AnimatePresence: ({ children }) => children, motion: new Proxy({}, { get: (_t, tag) => make(tag) }), useReducedMotion: () => true }
+})
+vi.mock('../useHomeData', () => ({
+  HomeDataProvider: ({ children }) => children,
+  useHomeData: () => ({ loading: false, error: null, moods: h.moods, seenCandidates: [], continueItem: null, dna: null, friends: [], lists: [], twinPulse: [] }),
+}))
+vi.mock('../sections-bottom', () => ({
+  ContinueWatching: () => null, CinematicDNA: () => null, TasteTwinPulse: () => null,
+  TasteMatch: () => null, CuratedLists: () => null, QuickLog: () => null, PageEndCard: () => null,
+}))
+
+import Home from '../Home'
+import { MOOD_META } from '../data'
+
+const MOOD_ID = MOOD_META[0].id
+const renderHome = () => render(<MemoryRouter><Home /></MemoryRouter>)
+
+beforeEach(() => {
+  h.user = { id: 'u1' }; h.navigate = vi.fn(); h.providerMode = 'found'; h.providerOpts = null
+  h.providers = [{ name: 'Mock Stream', logoPath: '/ms.png', type: 'flatrate' }]
+  h.moods = [{ id: MOOD_ID, films: [{ id: 1, tmdbId: 555, title: 'Movie 1', year: 2011, runtime: 110, director: 'Dir 1', engineReason: null, synopsis: null, poster: '/p1.jpg' }] }]
+  vi.clearAllMocks()
+  window.matchMedia = window.matchMedia || (() => ({ matches: false, addEventListener() {}, removeEventListener() {} }))
+})
+
+describe('Briefing provider states (F4.6)', () => {
+  it('FOUND: renders the provider chip with the first provider', async () => {
+    h.providers = [{ name: 'First Co', logoPath: '/f.png', type: 'flatrate' }, { name: 'Second Co', logoPath: '/s.png', type: 'rent' }]
+    renderHome()
+    await waitFor(() => expect(screen.getByText('First Co')).toBeTruthy()) // providers[0]
+    expect(screen.queryByText('Second Co')).toBeNull()
+    expect(screen.queryByText(/Availability/)).toBeNull()
+  })
+
+  it('FOUND: the logo alt includes "logo"', async () => {
+    renderHome()
+    await waitFor(() => expect(screen.getByAltText('Mock Stream logo')).toBeTruthy())
+  })
+
+  it('passes the unchanged CA → US request options with an abort signal', async () => {
+    renderHome()
+    await waitFor(() => expect(h.providerOpts).toBeTruthy())
+    expect(h.providerOpts.region).toBe('CA')
+    expect(h.providerOpts.fallbackRegion).toBe('US')
+    expect(h.providerOpts.signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('LOADING: renders no provider copy (no layout shift)', async () => {
+    h.providerMode = 'loading'
+    renderHome()
+    await waitFor(() => expect(screen.getByRole('heading', { level: 2 })).toBeTruthy())
+    expect(screen.queryByText(/Availability/)).toBeNull()
+    expect(screen.queryByText('Mock Stream')).toBeNull()
+  })
+
+  it('EMPTY: renders "Availability not found"', async () => {
+    h.providerMode = 'empty'
+    renderHome()
+    await waitFor(() => expect(screen.getByText('Availability not found')).toBeTruthy())
+    expect(screen.queryByText('Availability unavailable')).toBeNull()
+  })
+
+  it('ERROR: renders "Availability unavailable"', async () => {
+    h.providerMode = 'error'
+    renderHome()
+    await waitFor(() => expect(screen.getByText('Availability unavailable')).toBeTruthy())
+    expect(screen.queryByText('Availability not found')).toBeNull()
+  })
+
+  it('ABORT: an aborted/stale request does NOT show an error', async () => {
+    h.providerMode = 'abort'
+    renderHome()
+    await waitFor(() => expect(screen.getByRole('heading', { level: 2 })).toBeTruthy())
+    // give the rejected promise a tick to flush
+    await new Promise(r => setTimeout(r, 0))
+    expect(screen.queryByText('Availability unavailable')).toBeNull()
+    expect(screen.queryByText('Availability not found')).toBeNull()
+  })
+})

--- a/src/features/home/__tests__/HomeTrustA11y.test.jsx
+++ b/src/features/home/__tests__/HomeTrustA11y.test.jsx
@@ -1,0 +1,172 @@
+// src/features/home/__tests__/HomeTrustA11y.test.jsx
+// F4.6 — MoodReactor semantics + reduced-motion, Briefing action focus/icon
+// semantics, WhyThisPick omission when the reason is null, and PageEndCard target/
+// focus. Everything mocked; no live mount/Supabase/TMDB/impression writes.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+const h = vi.hoisted(() => ({ user: { id: 'u1' }, moods: [], reason: null, navigate: () => {}, reduced: false }))
+
+vi.mock('@/shared/lib/supabase/client', () => ({ supabase: { from: () => { throw new Error('no live supabase in test') } } }))
+vi.mock('@/shared/hooks/usePageMeta', () => ({ usePageMeta: () => {} }))
+vi.mock('@/shared/hooks/useAuthSession', () => ({ useAuthSession: () => ({ user: h.user }) }))
+vi.mock('react-router-dom', async (orig) => ({ ...(await orig()), useNavigate: () => h.navigate }))
+vi.mock('@/shared/services/recommendations', () => ({ logSurfaceImpressions: vi.fn(() => Promise.resolve()), updateImpression: vi.fn(() => Promise.resolve()) }))
+vi.mock('@/shared/services/interactions', () => ({ trackInteraction: vi.fn(() => Promise.resolve()) }))
+vi.mock('@/shared/services/recommendationOutcomes', () => ({ recordRecommendationOutcome: vi.fn(() => Promise.resolve()) }))
+vi.mock('@/shared/api/tmdb', async (orig) => ({ ...(await orig()), getMovieWatchProviders: vi.fn(() => Promise.resolve({ providers: [] })) }))
+vi.mock('@/shared/hooks/useUserMovieStatus', () => ({
+  useUserMovieStatus: () => ({ isWatched: false, isInWatchlist: false, loading: { watchlist: false, watched: false }, toggleWatched: () => {}, toggleWatchlist: () => {}, internalId: 1 }),
+}))
+vi.mock('framer-motion', async () => {
+  const React = await import('react')
+  const cache = {}
+  const strip = (p) => { const { initial, animate, exit, variants, transition, whileHover, whileTap, whileInView, layout, layoutId, ...rest } = p; return rest }
+  const make = (tag) => { if (!cache[tag]) { const C = React.forwardRef((props, ref) => React.createElement(tag, { ...strip(props), ref }, props.children)); C.displayName = `motion.${String(tag)}`; cache[tag] = C } return cache[tag] }
+  return { AnimatePresence: ({ children }) => children, motion: new Proxy({}, { get: (_t, tag) => make(tag) }), useReducedMotion: () => h.reduced }
+})
+vi.mock('../useHomeData', () => ({
+  HomeDataProvider: ({ children }) => children,
+  useHomeData: () => ({ loading: false, error: null, moods: h.moods, seenCandidates: [], continueItem: null, dna: null, friends: [], lists: [], twinPulse: [] }),
+}))
+// NOTE: sections-bottom is NOT mocked — we render the REAL QuickLog (null when
+// seenCandidates is empty) + the REAL PageEndCard so its copy/target can be tested.
+
+import Home from '../Home'
+import { MoodReactor } from '../sections-top'
+import { PageEndCard } from '../sections-bottom'
+import { MOOD_META } from '../data'
+
+const MOOD_ID = MOOD_META[0].id
+const renderHome = () => render(<MemoryRouter><Home /></MemoryRouter>)
+
+beforeEach(() => {
+  h.user = { id: 'u1' }; h.navigate = vi.fn(); h.reason = null; h.reduced = false
+  h.moods = [{ id: MOOD_ID, films: [{ id: 1, tmdbId: 555, title: 'Movie 1', year: 2011, runtime: 110, director: 'Dir 1', engineReason: h.reason, synopsis: null, poster: '/p1.jpg' }] }]
+  vi.clearAllMocks()
+  window.matchMedia = window.matchMedia || (() => ({ matches: false, addEventListener() {}, removeEventListener() {} }))
+  // jsdom has no scrollIntoView; default it to a no-op so MoodReactor's effect
+  // never throws when an overflow is (incidentally) present.
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+// ── MoodReactor ───────────────────────────────────────────────────────────────
+describe('MoodReactor semantics (F4.6)', () => {
+  const renderMood = (setMood = vi.fn()) => render(<MoodReactor currentMood={MOOD_META[0]} setMood={setMood} />)
+
+  it('groups the mood options with an accessible label', () => {
+    renderMood()
+    expect(screen.getByRole('group', { name: "Adjust tonight's mood" })).toBeTruthy()
+  })
+
+  it('marks the current mood aria-pressed=true and the rest false', () => {
+    renderMood()
+    const current = screen.getByRole('button', { name: new RegExp(MOOD_META[0].label) })
+    expect(current.getAttribute('aria-pressed')).toBe('true')
+    const other = screen.getByRole('button', { name: new RegExp(MOOD_META[1].label) })
+    expect(other.getAttribute('aria-pressed')).toBe('false')
+  })
+
+  it('keeps visible mood labels and exposes the 44px + focus contract', () => {
+    renderMood()
+    for (const m of MOOD_META) {
+      const btn = screen.getByRole('button', { name: new RegExp(m.label) })
+      expect(btn.textContent).toContain(m.label)
+      expect(btn.style.minHeight).toBe('44px')
+      expect(btn.className).toMatch(/focus-visible:ring/)
+    }
+  })
+
+  it('selecting a mood calls setMood with that mood', () => {
+    const setMood = vi.fn()
+    renderMood(setMood)
+    fireEvent.click(screen.getByRole('button', { name: new RegExp(MOOD_META[1].label) }))
+    expect(setMood).toHaveBeenCalledWith(MOOD_META[1])
+  })
+
+  it('uses smooth active-pill scroll normally and auto under reduced motion', () => {
+    const scrollSpy = vi.fn()
+    const origScroll = Element.prototype.scrollIntoView
+    Element.prototype.scrollIntoView = scrollSpy
+    // Force horizontal overflow so the (otherwise no-op) scroll effect runs.
+    Object.defineProperty(HTMLElement.prototype, 'scrollWidth', { configurable: true, value: 1000 })
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, value: 100 })
+    try {
+      h.reduced = false
+      renderMood()
+      expect(scrollSpy).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'smooth' }))
+      scrollSpy.mockClear()
+      h.reduced = true
+      renderMood()
+      expect(scrollSpy).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'auto' }))
+    } finally {
+      Element.prototype.scrollIntoView = origScroll
+      delete HTMLElement.prototype.scrollWidth
+      delete HTMLElement.prototype.clientWidth
+    }
+  })
+})
+
+// ── Briefing focus / icon semantics ───────────────────────────────────────────
+describe('Briefing action focus + icon semantics (F4.6)', () => {
+  it('gives the primary + secondary actions a visible focus ring', () => {
+    renderHome()
+    for (const name of ['Open Film File', 'Mark Watched', 'Save', 'Not tonight']) {
+      expect(screen.getByRole('button', { name }).className).toMatch(/focus-visible:ring/)
+    }
+  })
+
+  it('marks the action icons decorative (aria-hidden)', () => {
+    const { container } = renderHome()
+    const open = screen.getByRole('button', { name: 'Open Film File' })
+    expect(open.querySelector('svg[aria-hidden="true"]')).toBeTruthy()
+    // every svg inside the action row buttons is decorative
+    const watched = screen.getByRole('button', { name: 'Mark Watched' })
+    expect(watched.querySelector('svg[aria-hidden="true"]')).toBeTruthy()
+    expect(container).toBeTruthy()
+  })
+
+  it('the poster button has an accessible name + focus ring', () => {
+    renderHome()
+    const poster = screen.getByRole('button', { name: 'Open Film File for Movie 1' })
+    expect(poster.className).toMatch(/focus-visible:ring/)
+  })
+})
+
+// ── WhyThisPick omission ──────────────────────────────────────────────────────
+describe('WhyThisPick honesty (F4.6)', () => {
+  it('renders the reason when present', () => {
+    h.moods = [{ id: MOOD_ID, films: [{ id: 1, tmdbId: 555, title: 'Movie 1', engineReason: 'Because you loved Past Lives', poster: '/p1.jpg' }] }]
+    renderHome()
+    expect(screen.getByText(/Because you loved Past Lives/)).toBeTruthy()
+  })
+
+  it('renders no reason panel when the engine reason is null', () => {
+    h.moods = [{ id: MOOD_ID, films: [{ id: 1, tmdbId: 555, title: 'Movie 1', engineReason: null, poster: '/p1.jpg' }] }]
+    renderHome()
+    expect(screen.queryByText(/Because you loved/)).toBeNull()
+    expect(screen.queryByText(/for your .* night/i)).toBeNull() // no fabricated mood sentence
+  })
+})
+
+// ── PageEndCard ───────────────────────────────────────────────────────────────
+describe('PageEndCard target + focus (F4.6)', () => {
+  it('Open Discover retains the callback and the 44px / focus contract', () => {
+    const onDiscover = vi.fn()
+    render(<PageEndCard currentMood={MOOD_META[0]} onDiscover={onDiscover} />)
+    const cta = screen.getByRole('button', { name: /Open Discover/i })
+    expect(cta.style.minHeight).toBe('44px')
+    expect(cta.className).toMatch(/focus-visible:ring/)
+    fireEvent.click(cta)
+    expect(onDiscover).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps role-clear copy (Home already picked; Discover is the deliberate path)', () => {
+    render(<PageEndCard currentMood={MOOD_META[0]} onDiscover={vi.fn()} />)
+    expect(screen.getByText(/already set above/i)).toBeTruthy()
+    expect(screen.getByText(/deliberate path/i)).toBeTruthy()
+    expect(screen.queryByText(/actually fits tonight/i)).toBeNull()
+  })
+})

--- a/src/features/home/__tests__/QuickLog.test.jsx
+++ b/src/features/home/__tests__/QuickLog.test.jsx
@@ -1,0 +1,132 @@
+// src/features/home/__tests__/QuickLog.test.jsx
+// F4.6 — QuickLog write reliability + a11y. Everything mocked; the supabase insert
+// is a test-controlled deferred so busy/pressed/announce/removal timing can be
+// asserted deterministically. No live Supabase/TMDB/impression writes.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+
+const h = vi.hoisted(() => ({
+  user: { id: 'u1' }, seen: [], insertResult: { error: null }, insertDeferred: null,
+  lastTable: null, lastInsert: null, impressionReject: false,
+}))
+
+vi.mock('@/shared/hooks/useAuthSession', () => ({ useAuthSession: () => ({ user: h.user }) }))
+vi.mock('../useHomeData', () => ({ useHomeData: () => ({ seenCandidates: h.seen }) }))
+vi.mock('@/shared/api/tmdb', async (orig) => ({ ...(await orig()), tmdbImg: (p) => `https://image.tmdb.org/img${p}` }))
+vi.mock('@/shared/services/recommendations', () => ({
+  logSurfaceImpressions: vi.fn(() => (h.impressionReject ? Promise.reject(new Error('imp fail')) : Promise.resolve())),
+}))
+vi.mock('@/shared/lib/supabase/client', () => ({
+  supabase: { from: (table) => ({ insert: (row) => {
+    h.lastTable = table; h.lastInsert = row
+    let resolve; const promise = new Promise(r => { resolve = r })
+    h.insertDeferred = { promise, resolve: () => resolve(h.insertResult) }
+    return promise
+  } }) },
+}))
+
+import { QuickLog } from '../sections-bottom'
+import { logSurfaceImpressions } from '@/shared/services/recommendations'
+
+const film = (id, over = {}) => ({ id, title: `Movie ${id}`, poster_path: `/p${id}.jpg`, release_year: 2010 + id, primary_genre: 'Drama', ...over })
+const live = () => document.querySelector('[role="status"][aria-live="polite"]')
+const tileBtn = (title) => screen.getByRole('button', { name: `Mark ${title} as watched` })
+
+beforeEach(() => {
+  h.user = { id: 'u1' }; h.seen = [film(1), film(2)]; h.insertResult = { error: null }; h.insertDeferred = null
+  h.lastTable = null; h.lastInsert = null; h.impressionReject = false
+  vi.clearAllMocks()
+})
+afterEach(() => { vi.useRealTimers() })
+
+describe('QuickLog — impression', () => {
+  it('logs the candidate impression once with the unchanged payload', async () => {
+    render(<QuickLog onLog={vi.fn()} />)
+    await waitFor(() => expect(logSurfaceImpressions).toHaveBeenCalledTimes(1))
+    expect(logSurfaceImpressions.mock.calls[0][0]).toEqual({
+      userId: 'u1', films: h.seen, placement: 'quick_picks',
+      pickReasonType: 'seen_candidates', pickReasonLabel: 'Engine guess: probably seen',
+    })
+  })
+
+  it('contains a rejected candidate impression (no crash, still interactive)', async () => {
+    h.impressionReject = true
+    render(<QuickLog onLog={vi.fn()} />)
+    await waitFor(() => expect(logSurfaceImpressions).toHaveBeenCalled())
+    expect(tileBtn('Movie 1')).toBeTruthy() // still rendered + usable
+  })
+})
+
+describe('QuickLog — SeenTile semantics + write', () => {
+  it('gives each tile an accessible watched-action name + poster alt', () => {
+    render(<QuickLog onLog={vi.fn()} />)
+    expect(tileBtn('Movie 1')).toBeTruthy()
+    expect(screen.getByAltText('Movie 1 poster')).toBeTruthy()
+  })
+
+  it('exposes a busy state while the write is in flight', async () => {
+    render(<QuickLog onLog={vi.fn()} />)
+    fireEvent.click(tileBtn('Movie 1'))
+    await waitFor(() => expect(tileBtn('Movie 1').getAttribute('aria-busy')).toBe('true'))
+    expect(tileBtn('Movie 1')).toBeDisabled()
+  })
+
+  it('writes the byte-equivalent user_history payload', async () => {
+    render(<QuickLog onLog={vi.fn()} />)
+    fireEvent.click(tileBtn('Movie 1'))
+    await waitFor(() => expect(h.lastInsert).toBeTruthy())
+    expect(h.lastTable).toBe('user_history')
+    expect(h.lastInsert).toMatchObject({
+      user_id: 'u1', movie_id: 1, source: 'home_quicklog',
+      watch_duration_minutes: null, mood_session_id: null,
+    })
+    expect(typeof h.lastInsert.watched_at).toBe('string')
+    expect(Object.keys(h.lastInsert).sort()).toEqual(
+      ['mood_session_id', 'movie_id', 'source', 'user_id', 'watch_duration_minutes', 'watched_at'])
+  })
+
+  it('announces success, exposes pressed, then removes the tile after 650ms', async () => {
+    vi.useFakeTimers()
+    render(<QuickLog onLog={vi.fn()} />)
+    fireEvent.click(tileBtn('Movie 1'))
+    await act(async () => { h.insertDeferred.resolve(); await Promise.resolve(); await Promise.resolve() })
+    expect(live().textContent).toBe('Logged Movie 1 as watched.')
+    expect(tileBtn('Movie 1').getAttribute('aria-pressed')).toBe('true') // pressed before removal
+    await act(async () => { vi.advanceTimersByTime(700); await Promise.resolve() })
+    expect(screen.queryByRole('button', { name: 'Mark Movie 1 as watched' })).toBeNull() // removed
+  })
+
+  it('announces a retry on failure and keeps the tile', async () => {
+    h.insertResult = { error: { message: 'db down' } }
+    render(<QuickLog onLog={vi.fn()} />)
+    fireEvent.click(tileBtn('Movie 1'))
+    await act(async () => { h.insertDeferred.resolve(); await Promise.resolve(); await Promise.resolve() })
+    expect(live().textContent).toBe('Could not log Movie 1. Try again.')
+    expect(screen.getByRole('button', { name: 'Mark Movie 1 as watched' })).toBeTruthy() // not removed
+  })
+
+  it('cleans up the removal timer on unmount (no post-unmount state update)', async () => {
+    vi.useFakeTimers()
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { unmount } = render(<QuickLog onLog={vi.fn()} />)
+    fireEvent.click(tileBtn('Movie 1'))
+    await act(async () => { h.insertDeferred.resolve(); await Promise.resolve(); await Promise.resolve() })
+    unmount()
+    await act(async () => { vi.advanceTimersByTime(1000); await Promise.resolve() })
+    expect(errSpy.mock.calls.flat().join(' ')).not.toMatch(/unmounted|memory leak/i)
+    errSpy.mockRestore()
+  })
+})
+
+describe('QuickLog — Open Browse', () => {
+  it('retains the callback and the 44px / focus contract', () => {
+    const onLog = vi.fn()
+    render(<QuickLog onLog={onLog} />)
+    const btn = screen.getByRole('button', { name: /Open Browse/i })
+    expect(btn.className).toMatch(/min-h-\[44px\]/)
+    expect(btn.className).toMatch(/focus-visible:ring/)
+    fireEvent.click(btn)
+    expect(onLog).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/features/home/__tests__/resolveEngineReason.test.js
+++ b/src/features/home/__tests__/resolveEngineReason.test.js
@@ -1,29 +1,57 @@
 import { describe, it, expect } from 'vitest'
 import { resolveEngineReason } from '../useHomeData'
 
-// resolveEngineReason maps the engine's pickReason fields to the hero's
-// displayed "Why this pick" caption. See useHomeData.jsx.
+// resolveEngineReason maps the engine's pickReason fields to the hero's displayed
+// "Why this pick" caption. F4.6 — Home NEVER fabricates the user's current mood:
+// genuine seed/personalized reasons show; generic/missing/unknown → null (no panel),
+// and there is NO "For your … night" fallback. See useHomeData.jsx.
 describe('resolveEngineReason', () => {
-  it('renders a real seed match as "Because you loved X" (any mood)', () => {
-    expect(resolveEngineReason({ reasonType: 'seed_embedding', seedTitle: 'Parasite' }, 'tender'))
+  it('renders a real seed match as "Because you loved X"', () => {
+    expect(resolveEngineReason({ reasonType: 'seed_embedding', seedTitle: 'Parasite' }))
       .toBe('Because you loved Parasite')
-    // Phrasing wins regardless of the pool mood.
-    expect(resolveEngineReason({ reasonType: 'seed_similar', seedTitle: 'Parasite' }, 'cozy'))
+    expect(resolveEngineReason({ reasonType: 'seed_similar', seedTitle: 'Parasite' }))
       .toBe('Because you loved Parasite')
   })
 
-  it('replaces a GENERIC quality label with the session-mood reason', () => {
-    expect(resolveEngineReason({ reason: 'Critically acclaimed', reasonType: 'quality' }, 'thrilled'))
-      .toBe('For your tense night')
-  })
-
-  it('passes through an honest personalized tier verbatim', () => {
-    expect(resolveEngineReason({ reason: 'Matches your taste', reasonType: 'genre_match' }, 'thrilled'))
+  it('passes through a genuine non-generic personalized reason verbatim', () => {
+    expect(resolveEngineReason({ reason: 'Matches your taste', reasonType: 'genre_match' }))
       .toBe('Matches your taste')
+    expect(resolveEngineReason({ reason: 'From a director you love', reasonType: 'director' }))
+      .toBe('From a director you love')
+    expect(resolveEngineReason({ reason: 'A hidden gem for you', reasonType: 'hidden_gem' }))
+      .toBe('A hidden gem for you')
   })
 
-  it('returns null when generic and the mood is unknown (no honest caption)', () => {
-    expect(resolveEngineReason({ reason: 'Critically acclaimed', reasonType: 'quality' }, 'unknownmood'))
-      .toBeNull()
+  it('returns null for every GENERIC reason type (no fabricated caption)', () => {
+    for (const reasonType of ['quality', 'recency', 'default', 'content_match']) {
+      expect(resolveEngineReason({ reason: 'Critically acclaimed', reasonType })).toBeNull()
+    }
+  })
+
+  it('returns null when the reason is missing or the reasonType is absent', () => {
+    expect(resolveEngineReason({ reason: null, reasonType: null, seedTitle: null })).toBeNull()
+    expect(resolveEngineReason({})).toBeNull()
+    expect(resolveEngineReason({ reason: 'Critically acclaimed', reasonType: null })).toBeNull()
+    // A seed type with no seedTitle cannot form a grounded reason → null.
+    expect(resolveEngineReason({ reasonType: 'seed_embedding', seedTitle: null })).toBeNull()
+  })
+
+  it('shows a non-generic reason verbatim but returns null when it is empty', () => {
+    expect(resolveEngineReason({ reason: 'Something specific', reasonType: 'unknown_type' }))
+      .toBe('Something specific')
+    expect(resolveEngineReason({ reason: null, reasonType: 'unknown_type' })).toBeNull()
+  })
+
+  it('NEVER emits a "For your … night" mood-state sentence', () => {
+    const inputs = [
+      { reason: 'Critically acclaimed', reasonType: 'quality' },
+      { reason: null, reasonType: 'default' },
+      { reason: 'Trending now', reasonType: 'recency' },
+      {},
+    ]
+    for (const pick of inputs) {
+      const out = resolveEngineReason(pick)
+      expect(out === null || !/for your .* night/i.test(out)).toBe(true)
+    }
   })
 })

--- a/src/features/home/sections-bottom.jsx
+++ b/src/features/home/sections-bottom.jsx
@@ -509,6 +509,9 @@ export function CuratedLists({ onOpenList }) {
 // the parent removes it from the row.
 function SeenTile({ film, onConfirm }) {
   const [state, setState] = useState('idle') // idle | saving | saved | error
+  const errorTimerRef = useRef(null)
+  // Clear the error-reset timer on unmount so no setState fires after unmount.
+  useEffect(() => () => { if (errorTimerRef.current) clearTimeout(errorTimerRef.current) }, [])
   const handleClick = async () => {
     if (state !== 'idle') return
     setState('saving')
@@ -519,14 +522,18 @@ function SeenTile({ film, onConfirm }) {
     } catch (err) {
       console.error('[SeenTile] confirm error:', err)
       setState('error')
-      setTimeout(() => setState('idle'), 1800)
+      errorTimerRef.current = setTimeout(() => { setState('idle'); errorTimerRef.current = null }, 1800)
     }
   }
   return (
     <button
       type="button"
+      aria-label={`Mark ${film.title} as watched`}
+      aria-busy={state === 'saving'}
+      aria-pressed={state === 'saved'}
       onClick={handleClick}
       disabled={state === 'saving' || state === 'saved'}
+      className="rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
       style={{
         background: 'transparent', border: 'none', padding: 0, cursor: state === 'idle' ? 'pointer' : 'default',
         textAlign: 'left', fontFamily: 'inherit', color: 'inherit', width: '100%',
@@ -542,7 +549,7 @@ function SeenTile({ film, onConfirm }) {
         {film.poster_path ? (
           <img
             src={tmdbImg(film.poster_path, 'w342')}
-            alt={film.title}
+            alt={`${film.title} poster`}
             loading="lazy"
             style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
           />
@@ -563,7 +570,7 @@ function SeenTile({ film, onConfirm }) {
               background: state === 'saved' ? 'rgba(34,197,94,0.92)' : 'rgba(255,255,255,0.18)',
               color: '#fff',
             }}>
-              <Check className="h-5 w-5" />
+              <Check aria-hidden="true" className="h-5 w-5" />
             </div>
           </div>
         )}
@@ -593,6 +600,15 @@ export function QuickLog({ onLog }) {
   // removed immediately. Next /home load picks up the change via the
   // watched_ids query, so this state is just for in-session continuity.
   const [confirmedIds, setConfirmedIds] = useState(() => new Set())
+  // F4.6 — one QuickLog-owned polite live region announces log outcomes.
+  const [statusMsg, setStatusMsg] = useState('')
+  const announce = useCallback((msg) => setStatusMsg(msg), [])
+  // Track the success-hold removal timers so none fire after unmount.
+  const removeTimersRef = useRef(new Set())
+  useEffect(() => {
+    const timers = removeTimersRef.current
+    return () => { timers.forEach(clearTimeout); timers.clear() }
+  }, [])
 
   const handleConfirm = useCallback(async (film) => {
     if (!user?.id) throw new Error('not signed in')
@@ -604,16 +620,22 @@ export function QuickLog({ onLog }) {
       watch_duration_minutes: null,
       mood_session_id: null,
     })
-    if (error) throw error
-    // Remove after a short beat so the user sees the saved checkmark.
-    setTimeout(() => {
+    if (error) {
+      announce(`Could not log ${film.title}. Try again.`)
+      throw error
+    }
+    announce(`Logged ${film.title} as watched.`)
+    // Remove after a 650ms beat so the user sees the saved checkmark.
+    const t = setTimeout(() => {
       setConfirmedIds(prev => {
         const next = new Set(prev)
         next.add(film.id)
         return next
       })
+      removeTimersRef.current.delete(t)
     }, 650)
-  }, [user?.id])
+    removeTimersRef.current.add(t)
+  }, [user?.id, announce])
 
   const visible = useMemo(
     () => (seenCandidates || []).filter(f => !confirmedIds.has(f.id)),
@@ -633,7 +655,7 @@ export function QuickLog({ onLog }) {
       placement: 'quick_picks',
       pickReasonType: 'seen_candidates',
       pickReasonLabel: 'Engine guess: probably seen',
-    })
+    }).catch(() => { /* non-fatal — exposure logging is best-effort */ })
   }, [user?.id, candidateIds, seenCandidates])
 
   // Hidden entirely when there are no candidates AND no user (cold-start
@@ -647,6 +669,8 @@ export function QuickLog({ onLog }) {
 
   return (
     <section className="border-t px-5 py-12 pb-16 sm:px-8 sm:py-14 sm:pb-20 lg:px-[88px] lg:py-[72px] lg:pb-24" style={{ borderColor: HP.border, background: 'rgba(255,255,255,0.008)' }}>
+      {/* QuickLog-owned polite live region — announces log success/failure once. */}
+      <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">{statusMsg}</div>
       <Heading
         kicker="Feed the engine"
         title={allConfirmed ? 'Nice — your taste profile just got sharper.' : 'Have you seen any of these?'}
@@ -690,7 +714,7 @@ export function QuickLog({ onLog }) {
         <button
           type="button"
           onClick={() => onLog?.()}
-          className="group inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/4 px-5 py-2.5 transition-all duration-200 hover:border-white/25 hover:bg-white/8 active:scale-[0.98] focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
+          className="group inline-flex min-h-[44px] items-center gap-2 rounded-full border border-white/10 bg-white/4 px-5 py-2.5 transition-all duration-200 hover:border-white/25 hover:bg-white/8 active:scale-[0.98] focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
           style={{ fontFamily: 'Outfit', fontSize: 13, fontWeight: 500, color: HP.textSoft, letterSpacing: '0.02em' }}
         >
           Open Browse
@@ -763,14 +787,14 @@ export function PageEndCard({ currentMood, onDiscover }) {
             type="button"
             onClick={() => onDiscover?.()}
             style={{
-              display: 'inline-flex', alignItems: 'center', gap: 10,
-              padding: '12px 22px', borderRadius: 8,
+              display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 10,
+              minHeight: 44, padding: '12px 22px', borderRadius: 8,
               background: HP_GRAD, border: 'none', color: '#fff',
               fontFamily: 'Outfit', fontSize: 14, fontWeight: 600, letterSpacing: '0.02em',
               cursor: 'pointer',
               boxShadow: '0 10px 24px -12px rgba(236,72,153,0.42)',
             }}
-            className="transition-transform duration-200 active:scale-[0.98]"
+            className="transition-transform duration-200 active:scale-[0.98] focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
           >
             Open Discover
             <ChevronRight className="h-4 w-4" aria-hidden />

--- a/src/features/home/sections-top.jsx
+++ b/src/features/home/sections-top.jsx
@@ -2,7 +2,7 @@
 // All film data comes from useHomeData (no more imports from data.js for FILMS).
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { AnimatePresence, motion } from 'framer-motion'
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import { ChevronRight, SkipForward } from 'lucide-react'
 import { ActionButton, SecondaryActionButton } from '@/shared/components/ActionButton'
 import { useUserMovieStatus } from '@/shared/hooks/useUserMovieStatus'
@@ -33,6 +33,7 @@ const TONIGHT_LABEL = "Tonight's pick"
 // and the row overflows the viewport.
 export function MoodReactor({ currentMood, setMood }) {
   const pillsRef = useRef(null)
+  const reduced = useReducedMotion()
   useEffect(() => {
     const el = pillsRef.current
     if (!el) return
@@ -40,8 +41,10 @@ export function MoodReactor({ currentMood, setMood }) {
     // desktop the row wraps, so this no-ops.
     if (el.scrollWidth <= el.clientWidth) return
     const active = el.querySelector(`[data-mood-id="${currentMood.id}"]`)
-    if (active) active.scrollIntoView({ inline: 'center', behavior: 'smooth', block: 'nearest' })
-  }, [currentMood.id])
+    // Reduced motion: jump the active pill into view (auto) instead of a smooth
+    // scroll — preserves visibility assistance on narrow screens without animating.
+    if (active) active.scrollIntoView({ inline: 'center', behavior: reduced ? 'auto' : 'smooth', block: 'nearest' })
+  }, [currentMood.id, reduced])
   return (
     <section className="px-5 pt-5 pb-2 sm:px-8 sm:pt-6 sm:pb-4 lg:px-[88px] lg:pt-[12px] lg:pb-5">
       <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:gap-5">
@@ -51,6 +54,8 @@ export function MoodReactor({ currentMood, setMood }) {
         </div>
         <div
           ref={pillsRef}
+          role="group"
+          aria-label="Adjust tonight's mood"
           className="-mx-1 flex w-full min-w-0 gap-2 overflow-x-auto pb-1 scrollbar-none [&::-webkit-scrollbar]:hidden sm:mx-0 sm:w-auto sm:flex-1 sm:flex-wrap sm:justify-end sm:gap-2.5 sm:overflow-visible sm:pb-0"
         >
         {MOOD_META.map(m => {
@@ -60,11 +65,14 @@ export function MoodReactor({ currentMood, setMood }) {
               key={m.id}
               type="button"
               data-mood-id={m.id}
+              aria-pressed={active}
               onClick={() => setMood(m)}
-              className="ff-tap"
+              className="ff-tap focus:outline-none focus-visible:ring-2 focus-visible:ring-white/55"
               style={{
-                display: 'inline-flex', alignItems: 'center', gap: 8,
-                padding: '8px 14px', borderRadius: 999,
+                display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+                minHeight: 44, padding: '8px 14px', borderRadius: 999,
+                // Selected state is carried by background tint + border + text colour
+                // (not only the dot), and is exposed non-visually via aria-pressed.
                 background: active ? `${m.hex}22` : 'transparent',
                 border: `1px solid ${active ? m.hex : HP.border}`,
                 color: active ? HP.text : HP.textSoft,
@@ -73,7 +81,7 @@ export function MoodReactor({ currentMood, setMood }) {
                 flex: 'none',
               }}
             >
-              <span style={{ width: 7, height: 7, borderRadius: 999, background: m.hex, boxShadow: active ? `0 0 10px ${m.hex}` : 'none', transition: 'box-shadow 0.25s ease' }} />
+              <span aria-hidden="true" style={{ width: 7, height: 7, borderRadius: 999, background: m.hex, boxShadow: active ? `0 0 10px ${m.hex}` : 'none', transition: 'box-shadow 0.25s ease' }} />
               {m.label}
             </button>
           )
@@ -88,17 +96,22 @@ export function MoodReactor({ currentMood, setMood }) {
 // (rounded-8, Outfit — shared with /movie so the briefing actions don't feel like a
 // different system). The three below are thin wrappers that add the icon, label, and
 // active state on top of <SecondaryActionButton>; the gradient "Open Film File"
-// primary uses <ActionButton> directly.
+// primary uses <ActionButton> directly. F4.6: a Home-local focus-visible ring is
+// passed via className (without touching the shared component), and the decorative
+// icons are aria-hidden (the text label is the accessible name).
+const FOCUS_RING = 'focus:outline-none focus-visible:ring-2 focus-visible:ring-white/55 focus-visible:ring-offset-0'
+
 function WatchedButton({ isWatched, loading, error, onClick }) {
   return (
     <SecondaryActionButton
       collapse
+      className={FOCUS_RING}
       active={isWatched}
       loading={loading}
       onClick={onClick}
       title={error ? 'Couldn’t mark watched — tap to retry' : isWatched ? 'Watched' : 'Mark as watched'}
       label={isWatched ? 'Watched' : 'Mark Watched'}
-      icon={<svg className="h-4 w-4 lg:h-[13px] lg:w-[13px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12" /></svg>}
+      icon={<svg aria-hidden="true" className="h-4 w-4 lg:h-[13px] lg:w-[13px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12" /></svg>}
     />
   )
 }
@@ -107,14 +120,15 @@ function SaveButton({ isInWatchlist, loading, error, onClick }) {
   return (
     <SecondaryActionButton
       collapse
+      className={FOCUS_RING}
       active={isInWatchlist}
       loading={loading}
       onClick={onClick}
       title={error ? 'Couldn’t save — tap to retry' : isInWatchlist ? 'Saved to watchlist' : 'Save to watchlist'}
       label={isInWatchlist ? 'Saved' : 'Save'}
       icon={isInWatchlist
-        ? <svg className="h-4 w-4 lg:h-[13px] lg:w-[13px]" viewBox="0 0 24 24" fill="currentColor"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" /></svg>
-        : <svg className="h-4 w-4 lg:h-[13px] lg:w-[13px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" /></svg>}
+        ? <svg aria-hidden="true" className="h-4 w-4 lg:h-[13px] lg:w-[13px]" viewBox="0 0 24 24" fill="currentColor"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" /></svg>
+        : <svg aria-hidden="true" className="h-4 w-4 lg:h-[13px] lg:w-[13px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" /></svg>}
     />
   )
 }
@@ -123,35 +137,45 @@ function SkipButton({ onClick }) {
   return (
     <SecondaryActionButton
       collapse
+      className={FOCUS_RING}
       onClick={onClick}
       title="Not tonight"
       label="Not tonight"
-      icon={<SkipForward className="h-4 w-4 lg:h-3.5 lg:w-3.5" />}
+      icon={<SkipForward aria-hidden="true" className="h-4 w-4 lg:h-3.5 lg:w-3.5" />}
     />
   )
 }
 
-// Streaming chip — mirrors HeroTopPick's StreamingBadge. Loads providers
-// via the shared getMovieWatchProviders helper (CA → US fallback), shows
-// the top one as a compact pill (logo + 'Streaming on' / 'Rent on' + name).
-// Returns null when TMDB has no provider data for the title.
+// Streaming provider lookup — loads providers via the shared
+// getMovieWatchProviders helper (CA → US fallback, selecting providers[0]) and
+// exposes an honest { provider, status } model so the UI can distinguish found /
+// empty / error / loading without implying the film is unavailable everywhere.
+//   idle    — no tmdbId
+//   loading — request in flight (render nothing → no layout shift)
+//   found   — a provider was returned
+//   empty   — the request succeeded but TMDB has no provider for this title
+//   error   — a real (non-abort) failure
+// Aborted/stale requests never set error.
 function useStreamingProvider(tmdbId) {
-  const [provider, setProvider] = useState(null)
+  const [state, setState] = useState({ provider: null, status: 'idle' })
   useEffect(() => {
-    if (!tmdbId) { setProvider(null); return }
+    if (!tmdbId) { setState({ provider: null, status: 'idle' }); return }
     const controller = new AbortController()
     let cancelled = false
-    setProvider(null)
+    setState({ provider: null, status: 'loading' })
     getMovieWatchProviders(tmdbId, { region: 'CA', fallbackRegion: 'US', signal: controller.signal })
       .then(data => {
         if (cancelled) return
         const p = data?.providers?.[0]
-        if (p) setProvider(p)
+        setState(p ? { provider: p, status: 'found' } : { provider: null, status: 'empty' })
       })
-      .catch(() => { /* non-fatal */ })
+      .catch(err => {
+        if (cancelled || err?.name === 'AbortError') return // aborted/stale → not an error
+        setState({ provider: null, status: 'error' })
+      })
     return () => { cancelled = true; controller.abort() }
   }, [tmdbId])
-  return provider
+  return state
 }
 
 function StreamingChip({ provider }) {
@@ -166,7 +190,7 @@ function StreamingChip({ provider }) {
     >
       <img
         src={`https://image.tmdb.org/t/p/w92${provider.logoPath}`}
-        alt={provider.name}
+        alt={`${provider.name} logo`}
         className="h-7 w-7 flex-none rounded object-cover"
         loading="lazy"
       />
@@ -192,7 +216,7 @@ function BriefingSlide({ film, user, onWatch, onSkip, onMarkedWatched, announce 
 
   // Fetch streaming providers for this slide (TMDB, region CA→US).
   // Hook handles abort/cancel so switching slides cancels stale fetches.
-  const provider = useStreamingProvider(film?.tmdbId)
+  const { provider, status: providerStatus } = useStreamingProvider(film?.tmdbId)
 
   // F4.3 — Mark Watched / Save reliability. useUserMovieStatus owns the writes
   // (unchanged payloads) and optimistically flips isWatched / isInWatchlist, then
@@ -282,7 +306,7 @@ function BriefingSlide({ film, user, onWatch, onSkip, onMarkedWatched, announce 
         type="button"
         onClick={handleOpen}
         aria-label={`Open Film File for ${film.title}`}
-        className="relative block w-full max-w-[180px] flex-none sm:max-w-[260px] lg:w-[340px] lg:max-w-none"
+        className={`relative block w-full max-w-[180px] flex-none sm:max-w-[260px] lg:w-[340px] lg:max-w-none ${FOCUS_RING}`}
         style={{
           borderRadius: 10, overflow: 'hidden',
           background: 'transparent', border: 'none', padding: 0, cursor: 'pointer',
@@ -353,12 +377,24 @@ function BriefingSlide({ film, user, onWatch, onSkip, onMarkedWatched, announce 
             {film.synopsis}
           </p>
         )}
-        {/* Streaming chip — desktop only. Mobile drops it to keep the
-            slide tight (where-to-watch info is one tap away on /movie/:id). */}
-        {provider && (
+        {/* Provider availability — desktop only (mobile drops it to keep the
+            slide tight; where-to-watch is one tap away on /movie/:id). Honest
+            states: a chip when found; quiet, secondary text for not-found /
+            unavailable (SR-reachable, never a large alert, and neither message
+            implies the film is unavailable everywhere); nothing while loading
+            (no layout shift). */}
+        {providerStatus === 'found' && provider && (
           <div className="hidden lg:mb-5 lg:flex lg:justify-start">
             <StreamingChip provider={provider} />
           </div>
+        )}
+        {(providerStatus === 'empty' || providerStatus === 'error') && (
+          <p
+            className="hidden lg:mb-5 lg:block"
+            style={{ fontSize: 12, color: HP.textFaint, fontFamily: 'Outfit', letterSpacing: '0.04em', margin: 0 }}
+          >
+            {providerStatus === 'empty' ? 'Availability not found' : 'Availability unavailable'}
+          </p>
         )}
         {/* Actions — gradient primary + secondary buttons.
             • mobile: single row — gradient "Open Film File" grows (flex-1)
@@ -366,9 +402,9 @@ function BriefingSlide({ film, user, onWatch, onSkip, onMarkedWatched, announce 
               hidden, icon only).
             • lg+: wrap row of four labeled pills (movie-detail style). */}
         <div className="flex flex-wrap items-center justify-center gap-2.5 pt-4 lg:justify-start" style={{ borderTop: `1px solid ${HP.border}` }}>
-          <ActionButton className="h-11 flex-1 lg:h-auto lg:flex-none" onClick={handleOpen}>
+          <ActionButton className={`h-11 flex-1 lg:h-auto lg:flex-none ${FOCUS_RING}`} onClick={handleOpen}>
             <span>Open Film File</span>
-            <ChevronRight className="h-3.5 w-3.5" />
+            <ChevronRight aria-hidden="true" className="h-3.5 w-3.5" />
           </ActionButton>
           <WatchedButton isWatched={isWatched} loading={watchedState === 'saving'} error={watchedState === 'error'} onClick={handleMarkWatched} />
           <SaveButton isInWatchlist={isInWatchlist} loading={saveState === 'saving'} error={saveState === 'error'} onClick={handleSave} />
@@ -447,6 +483,9 @@ export function TheBriefing({ currentMood, user, onWatch, onSkip }) {
   const [statusMsg, setStatusMsg] = useState('')
   const announce = useCallback((msg) => setStatusMsg(msg), [])
   const pickActionRef = useRef('initial') // 'initial' | 'skip' | 'watched'
+  // Framer-motion isn't covered by the global CSS reduced-motion reset (it drives
+  // JS transforms), so the pick-replacement slide is gated to instant here.
+  const reduced = useReducedMotion()
 
   // Effective seed for the daily rotation through the per-mood pool. Recomputes
   // when the UTC day changes (todaySeed) or the mood changes (strHash folds the
@@ -555,7 +594,7 @@ export function TheBriefing({ currentMood, user, onWatch, onSkip }) {
   }, [isExhausted, announce])
 
   return (
-    <section className="relative px-5 pt-4 pb-10 sm:px-8 sm:pt-6 sm:pb-12 lg:px-[88px] lg:pt-6 lg:pb-6">
+    <section aria-label="Tonight's briefing" className="relative px-5 pt-4 pb-10 sm:px-8 sm:pt-6 sm:pb-12 lg:px-[88px] lg:pt-6 lg:pb-6">
       {/* Single polite live region for Briefing pick progression + action feedback. */}
       <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">{statusMsg}</div>
       {isExhausted ? (
@@ -591,7 +630,7 @@ export function TheBriefing({ currentMood, user, onWatch, onSkip }) {
               initial="enter"
               animate="center"
               exit="exit"
-              transition={{ duration: 0.42, ease: [0.32, 0.72, 0, 1] }}
+              transition={reduced ? { duration: 0 } : { duration: 0.42, ease: [0.32, 0.72, 0, 1] }}
             >
               <BriefingSlide
                 film={pick}

--- a/src/features/home/useHomeData.jsx
+++ b/src/features/home/useHomeData.jsx
@@ -63,32 +63,30 @@ const MOOD_BRIDGE = {
 // production:
 //   • an honest personalized tier (director / genre / perfect_match / hidden_gem)
 //     → passed through verbatim.
-//   • a GENERIC quality/recency/default label → replaced with the session-mood
-//     reason ("For your tender night"), since the film was surfaced for mood fit
-//     — so the hollow "Critically acclaimed" never shows.
+//   • a GENERIC quality/recency/default/content_match label, a missing reason, or
+//     an unknown mood → NO caption (null). Home NEVER fabricates the user's current
+//     emotional state: the auto-selected onboarding-baseline mood is used for
+//     ranking + daily stability internally, but it must not become a visible claim
+//     like "For your tender night" (the user never told us how they feel tonight).
+//     An unsupported explanation is simply omitted — WhyThisPick renders nothing.
 // The seed branch below ("Because you loved X") is retained for contract clarity
 // but does NOT fire on the Briefing — seed-similar reasons live in the
 // because_you_loved list, which fetches its own seed neighbors.
-const MOOD_REASON_LABEL = { tender: 'tender', thrilled: 'tense', curious: 'cerebral', cozy: 'cozy', melancholy: 'melancholic', witty: 'playful' }
 const SEED_REASON_TYPES = new Set(['seed_embedding', 'seed_similarity', 'seed_similar'])
 const GENERIC_REASON_TYPES = new Set(['quality', 'recency', 'default', 'content_match'])
 
 /**
  * Resolve the hero's displayed reason from the engine's pickReason fields.
  * @param {{ reason: string|null, reasonType: string|null, seedTitle: string|null }} pick
- * @param {string} moodId - the Briefing mood key the film was scored under
  * @returns {string|null} the caption to render (null → WhyThisPick renders nothing)
  */
-export function resolveEngineReason({ reason, reasonType, seedTitle }, moodId) {
+export function resolveEngineReason({ reason, reasonType, seedTitle }) {
   if (reasonType && SEED_REASON_TYPES.has(reasonType) && seedTitle) return `Because you loved ${seedTitle}`
   if (reason && reasonType && !GENERIC_REASON_TYPES.has(reasonType)) return reason
-  const mood = MOOD_REASON_LABEL[moodId]
-  // ASSUMPTION: when the reason is generic AND the mood is unknown, render
-  // NOTHING rather than leak the hollow generic label (e.g. "Critically
-  // acclaimed") — the whole point of this fix is to drop it. In practice
-  // moodId is always one of the six MOOD_BRIDGE keys (all mapped above), so
-  // this null branch only ever fires in tests; it never shows in production.
-  return mood ? `For your ${mood} night` : null
+  // Generic / missing / unknown → omit the explanation rather than fabricate a
+  // current-mood claim. The score + film order are unaffected (mood fit still
+  // ranks internally); only the VISIBLE "Why this pick" caption is dropped.
+  return null
 }
 
 // === Onboarding mood key → Briefing mood key bridge ======================
@@ -443,7 +441,7 @@ export function HomeDataProvider({ children }) {
           const top = scored
             .sort((a, b) => b.rankingScore - a.rankingScore)
             .slice(0, 30) // 30-deep pool → ~27 hides of headroom per mood
-            .map(s => ({ ...shapeFilm(s.raw), engineReason: resolveEngineReason(s, moodId), engineScore: s.engineScore }))
+            .map(s => ({ ...shapeFilm(s.raw), engineReason: resolveEngineReason(s), engineScore: s.engineScore }))
           return { moodId, top }
         })
 


### PR DESCRIPTION
**F4.6** — trust / a11y / provider-truth / reduced-motion / QuickLog reliability hardening for the streamlined Home. **No redesign, no hierarchy/tail change, no engine/scoring/ranking/payload/route change.**

## 1. Removed the unsupported generic mood-night explanation
`resolveEngineReason` drops the `"For your {mood} night"` fallback + `MOOD_REASON_LABEL`. Seed (`"Because you loved X"`) + genuine non-generic reasons still show **verbatim**; **generic** (`quality`/`recency`/`default`/`content_match`), **missing**, or **unknown** → `null` (no Why-this-pick panel). Home never fabricates the user's *current* emotional state from the auto-selected onboarding-baseline mood. **Scores + film order are byte-identical** — the helper is caption-only, runs *after* sort+slice, and feeds only the display (verified by data-flow in review). `resolveEngineReason.test.js` rewritten (asserts no `"For your … night"` is ever emitted).

## 2. MoodReactor semantics + reduced motion
`role="group"` `aria-label="Adjust tonight's mood"`; `aria-pressed` per pill; **44px** min-height; focus-visible ring; the colour dot is `aria-hidden`; selected state carried by tint+border+text (not the dot alone). The active-pill `scrollIntoView` uses **smooth normally, auto under reduced motion**. Labels unchanged, still normal buttons (native Tab; no roving focus this phase).

## 3. Briefing action focus + icon semantics
A Home-local `FOCUS_RING` class gives **Open Film File / Mark Watched / Save / Not tonight / the poster** a visible focus-visible ring **without editing the shared `ActionButton`**. Decorative icons (`ChevronRight`/`SkipForward`/the SVGs) are `aria-hidden`; the text labels remain the accessible names. The framer-motion Briefing slide is gated to **instant under reduced motion** (the global CSS reset doesn't cover JS transforms).

## 4. Honest provider states
`useStreamingProvider` now returns `{ provider, status }` with **idle / loading / found / empty / error**; aborted/stale requests **never set error**; **CA region, US fallback, `providers[0]`, and cancellation are preserved**. Found → chip (logo alt `"{name} logo"`); loading → nothing (no layout shift); empty → quiet desktop *"Availability not found"*; error → quiet desktop *"Availability unavailable"* (SR-reachable, never an alert, never implying unavailable-everywhere; mobile keeps provider detail off the tight first screen).

## 5. QuickLog announcements, state, timers, impression containment
One QuickLog-owned `role="status"` live region announces *"Logged {title} as watched."* / *"Could not log {title}. Try again."* (once; the error overlay stays visual to avoid duplicate noise). SeenTile: accessible name *"Mark {title} as watched"*, `aria-busy` while saving, `aria-pressed` after success (before removal), poster alt `"{title} poster"`, decorative `Check` `aria-hidden`, focus ring. **Timers (650ms hold + 1800ms error reset) cleared on unmount** (no post-unmount setState). The `'quick_picks'` impression is now `.catch`-contained (timing/payload unchanged). The `user_history` payload is **byte-identical** (`source: 'home_quicklog'`, the two nulls).

## 6. Target/focus + landmarks
**Open Browse** + **Open Discover** are ≥44px with focus rings (chevrons `aria-hidden`). The Briefing `<section>` is now a labelled region; one sr-only `<h1>` preserved; QuickLog/PageEndCard keep their headings.

## Tests added/updated (+28)
`resolveEngineReason` (6), **QuickLog** (9), **HomeProviderStates** (7), **HomeTrustA11y** (12) — covering reason-null, mood a11y + reduced-motion scroll, provider 5-states + abort + CA/US + selection, QuickLog announce/busy/pressed/timers/byte-payload, and 44px/focus contracts. All mocked — no live mount/Supabase/TMDB/impression writes (the supabase client mock throws on any access). Existing Home tests all still green.

## Confirmations
- **Scoring, ranking, pools, queue behavior, payloads, routes, hierarchy, tail structure, and active-pick impression timing are unchanged** (`homeDerive.js`/`WhyThisPick.jsx`/`data.js`/shared `ActionButton`/`useUserMovieStatus` untouched; provider API + impression payloads preserved & test-verified; the only reason change is the sanctioned generic→null).
- **No live Home write was triggered** (mocked component tests; supabase client mock throws on access). Full browser verification is **blocked-pending-interception** (impression-on-render) and covered by the component tests; intercepted Home E2E deferred to **F4.7**.
- Reviewed by an adversarial 3-lens panel (reason-frozen / provider-quicklog / a11y-motion): **zero confirmed defects**.

## Validation
- `npm run lint` → clean · `npx vitest run src/features/home/` → **101 passed** (10 files) · `npm run build` → ✓ · `npm run test` → **962 passed** (76 files) · new tests stable **3×**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
