### PR TITLE
Extract Film File provenance and add safety-net tests

### DIFF
--- a/src/features/movie/PrimaryCaseCard.jsx
+++ b/src/features/movie/PrimaryCaseCard.jsx
@@ -16,9 +16,7 @@
 import AccentPanel from '@/shared/ui/AccentPanel'
 import Eyebrow from '@/shared/ui/Eyebrow'
 import { HP, RADIUS, SPACE } from './data'
-
-const capitalize = (s) =>
-  s ? s.charAt(0).toUpperCase() + s.slice(1).replace(/_/g, ' ') : ''
+import { derivePrimaryCase } from './derive/primaryCase'
 
 /**
  * @param {object}  props
@@ -33,24 +31,12 @@ const capitalize = (s) =>
 export default function PrimaryCaseCard({
   ffTake, whyHeader, matchPct, moodTags = [], fitProfile, signedIn = false,
 }) {
-  const take = (ffTake?.body || '').trim()
-  const label = take
-    ? (ffTake.byline?.trim() || 'FeelFlick’s read')
-    : (whyHeader?.eyebrow || 'How this reads')
-  const lead = take || (whyHeader?.rationale || '').trim()
-
-  const hasMatch = Number.isFinite(matchPct) && matchPct > 0
-
-  const chips = []
-  if (Array.isArray(moodTags) && moodTags[0]) chips.push(capitalize(moodTags[0]))
-  if (fitProfile) chips.push(capitalize(fitProfile))
-
-  // Nudge anon users toward the personal fit — but only when the lead itself
-  // doesn't already say "sign in" (the anon header rationale does).
-  const showNudge = !signedIn && Boolean(take)
+  // Pure tier-selection decision (extracted F5.2 — same values as before).
+  const { label, lead, hasMatch, chips, showNudge, shouldRender, isTake } =
+    derivePrimaryCase({ ffTake, whyHeader, matchPct, moodTags, fitProfile, signedIn })
 
   // Self-hide only when there is truly no useful case to make.
-  if (!lead && !hasMatch && chips.length === 0) return null
+  if (!shouldRender) return null
 
   return (
     <section
@@ -85,7 +71,7 @@ export default function PrimaryCaseCard({
               lineHeight: 1.5,
               color: HP.text,
               letterSpacing: '-0.01em',
-              fontStyle: take ? 'italic' : 'normal',
+              fontStyle: isTake ? 'italic' : 'normal',
               textWrap: 'pretty',
             }}
           >

--- a/src/features/movie/__tests__/PrimaryCaseCard.test.jsx
+++ b/src/features/movie/__tests__/PrimaryCaseCard.test.jsx
@@ -51,3 +51,55 @@ describe('PrimaryCaseCard — tier-aware lead case (F6B)', () => {
     expect(container).toBeEmptyDOMElement()
   })
 })
+
+// F5.2 render-contract pins (current behavior — F5.4 will change match presentation).
+describe('PrimaryCaseCard — current render contract (pre-F5.4)', () => {
+  it('uses the default byline when ff_take has none', () => {
+    render(<PrimaryCaseCard ffTake={{ body: 'A quiet stunner.' }} whyHeader={HEADER} signedIn />)
+    expect(screen.getByText('FeelFlick’s read')).toBeInTheDocument()
+  })
+
+  it('generated ff_take wins over the adaptive rationale (rationale not shown)', () => {
+    render(<PrimaryCaseCard ffTake={{ body: 'A class war.' }} whyHeader={HEADER} matchPct={90} signedIn />)
+    expect(screen.getByText('A class war.')).toBeInTheDocument()
+    expect(screen.queryByText(HEADER.rationale)).not.toBeInTheDocument()
+  })
+
+  it('renders the exact integer match string — no band/label transformation yet', () => {
+    render(<PrimaryCaseCard ffTake={{ body: 'x' }} whyHeader={HEADER} matchPct={84} signedIn />)
+    expect(screen.getByText('84%')).toBeInTheDocument()
+    // F5.4 will convert this to a band; today it must stay a raw integer %.
+    expect(screen.queryByText(/strong match|good match/i)).not.toBeInTheDocument()
+  })
+
+  it('does not render the match gloss for zero / null / non-finite percentages', () => {
+    for (const matchPct of [0, null, undefined, NaN]) {
+      const { container } = render(
+        <PrimaryCaseCard ffTake={{ body: 'x' }} whyHeader={HEADER} matchPct={matchPct} signedIn />,
+      )
+      expect(container.textContent).not.toMatch(/how it fits your taste so far/i)
+    }
+  })
+
+  it('renders a match-only state (no lead text)', () => {
+    render(<PrimaryCaseCard ffTake={null} whyHeader={{ rationale: '' }} matchPct={77} signedIn />)
+    expect(screen.getByText('77%')).toBeInTheDocument()
+  })
+
+  it('renders a chips-only state (no lead, no match)', () => {
+    render(<PrimaryCaseCard ffTake={null} whyHeader={{ rationale: '' }} matchPct={null} moodTags={['tense']} signedIn />)
+    expect(screen.getByText('Tense')).toBeInTheDocument()
+  })
+
+  it('does not add the sign-in nudge when the signed-out rationale already invites sign-in', () => {
+    render(
+      <PrimaryCaseCard
+        ffTake={null}
+        whyHeader={{ eyebrow: 'Editorial fingerprint', rationale: 'Sign in to see how it lines up with your library.' }}
+        matchPct={null}
+        signedIn={false}
+      />,
+    )
+    expect(screen.queryByText(/sign in and rate a few films/i)).not.toBeInTheDocument()
+  })
+})

--- a/src/features/movie/__tests__/ViewerNotes.test.jsx
+++ b/src/features/movie/__tests__/ViewerNotes.test.jsx
@@ -20,4 +20,55 @@ describe('ViewerNotes — honest framing (F6B)', () => {
     const { container } = render(<ViewerNotes notes={null} />)
     expect(container).toBeEmptyDOMElement()
   })
+
+  it('renders nothing for an empty notes array', () => {
+    const { container } = render(<ViewerNotes notes={[]} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})
+
+// F5.2 — pins TODAY'S pre-F5.4 trust framing EXPLICITLY so the F5.4 change is a
+// visible, reviewable diff. The generated critic_quotes are invented personas, yet
+// the section currently renders them with the *grammar of a real review*: a
+// <blockquote>, quotation marks, an author byline, and an outlet. F5.1 flagged this
+// as the strongest false-authority risk. F5.2 does NOT change it — these assertions
+// document the current reality (and the disclaimer that mitigates it).
+describe('ViewerNotes — current pre-F5.4 trust framing (documented, not endorsed)', () => {
+  const notes = [
+    { quote: 'Tense from frame one.', author: 'A weekend viewer', outlet: 'After one watch' },
+    { quote: 'It lingers.', outlet: 'A second look' }, // no author → fallback
+  ]
+
+  it('keeps the generated-content disclaimer stating these are not real reviews', () => {
+    render(<ViewerNotes notes={notes} />)
+    const disclaimer = screen.getByText(/illustrative impressions feelflick generated/i)
+    expect(disclaimer).toBeInTheDocument()
+    expect(disclaimer.textContent).toMatch(/not real reviews or quotes from real critics/i)
+  })
+
+  it('currently renders each note inside a <blockquote> with quotation marks', () => {
+    const { container } = render(<ViewerNotes notes={notes} />)
+    const blockquotes = container.querySelectorAll('blockquote')
+    expect(blockquotes.length).toBe(2)
+    // The visible text is wrapped in typographic quote marks today.
+    expect(container.textContent).toContain('“Tense from frame one.”')
+  })
+
+  it('currently renders the invented author + outlet byline', () => {
+    render(<ViewerNotes notes={notes} />)
+    expect(screen.getByText('A weekend viewer')).toBeInTheDocument()
+    expect(screen.getByText(/After one watch/)).toBeInTheDocument()
+  })
+
+  it('falls back to "A viewer" when a note has an outlet but no author', () => {
+    render(<ViewerNotes notes={notes} />)
+    expect(screen.getByText('A viewer')).toBeInTheDocument()
+    expect(screen.getByText(/A second look/)).toBeInTheDocument()
+  })
+
+  it('renders multiple notes', () => {
+    render(<ViewerNotes notes={notes} />)
+    expect(screen.getByText(/tense from frame one/i)).toBeInTheDocument()
+    expect(screen.getByText(/it lingers/i)).toBeInTheDocument()
+  })
 })

--- a/src/features/movie/derive/__tests__/matchAvailability.test.js
+++ b/src/features/movie/derive/__tests__/matchAvailability.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+
+import { computeMatchPercent } from '@/shared/services/matchScore'
+
+// F5.2 — pins the Film File's MATCH-AVAILABILITY contract (the rule the hero ring +
+// PrimaryCaseCard depend on to decide whether to show a % at all). It does NOT
+// duplicate the full scoring/calibration suite and does NOT edit computeMatchPercent.
+// F5.4 will change how an available % is PRESENTED (band vs integer); this phase only
+// pins WHEN it is available + that it is an integer today.
+
+describe('computeMatchPercent — Film File availability contract (current)', () => {
+  it('returns null for a missing / non-finite engine score (badge hides)', () => {
+    expect(computeMatchPercent({ engineScore: null })).toBeNull()
+    expect(computeMatchPercent({ engineScore: undefined })).toBeNull()
+    expect(computeMatchPercent({ engineScore: NaN })).toBeNull()
+    expect(computeMatchPercent({})).toBeNull()
+  })
+
+  it('returns null below the confidence floor (engine says poor fit → no % shown)', () => {
+    expect(computeMatchPercent({ engineScore: 49 })).toBeNull()
+    expect(computeMatchPercent({ engineScore: 0 })).toBeNull()
+    expect(computeMatchPercent({ engineScore: -10 })).toBeNull()
+  })
+
+  it('returns a finite integer in 0–99 for an available score', () => {
+    const pct = computeMatchPercent({ engineScore: 120, profile: { meta: { confidence: 'high' } } })
+    expect(Number.isInteger(pct)).toBe(true)
+    expect(pct).toBeGreaterThanOrEqual(0)
+    expect(pct).toBeLessThanOrEqual(99)
+  })
+
+  it('is an integer (no band/label transformation in F5.2)', () => {
+    const pct = computeMatchPercent({ engineScore: 100, profile: { meta: { confidence: 'medium' } } })
+    expect(typeof pct).toBe('number')
+    expect(Number.isInteger(pct)).toBe(true)
+  })
+})

--- a/src/features/movie/derive/__tests__/moodRadar.test.js
+++ b/src/features/movie/derive/__tests__/moodRadar.test.js
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+
+import { deriveMoodAxes } from '../moodRadar'
+
+// F5.2 — pins the CURRENT Mood Radar derivation (no behavior change). Mood Radar's
+// llm_* inputs are GENERATED enrichment; the geometry is derived. These assertions
+// fix today's axis names, order, scaling, clamping, and colours.
+
+const FULL = {
+  llm_intensity: 80, llm_pacing: 60, llm_emotional_depth: 90,
+  llm_dialogue_density: 40, llm_attention_demand: 50,
+  mood_tags: ['tense', 'dark', 'cerebral', 'slow'],
+}
+
+describe('deriveMoodAxes — current contract', () => {
+  it('returns null for null input', () => {
+    expect(deriveMoodAxes(null)).toBeNull()
+    expect(deriveMoodAxes(undefined)).toBeNull()
+  })
+
+  it('returns null when no finite LLM numeric is present', () => {
+    expect(deriveMoodAxes({ mood_tags: ['tense'] })).toBeNull()
+    expect(deriveMoodAxes({ llm_intensity: null, llm_pacing: undefined })).toBeNull()
+  })
+
+  it('creates a correctly named axis for each finite LLM column', () => {
+    const axes = deriveMoodAxes(FULL)
+    const byName = Object.fromEntries(axes.map(a => [a.name, a]))
+    expect(byName.Intensity).toBeTruthy()
+    expect(byName.Pace).toBeTruthy()
+    expect(byName.Depth).toBeTruthy()
+    expect(byName.Dialogue).toBeTruthy()
+    expect(byName.Focus).toBeTruthy()
+  })
+
+  it('divides values by 100', () => {
+    const axes = deriveMoodAxes({ llm_intensity: 80 })
+    expect(axes.find(a => a.name === 'Intensity').weight).toBeCloseTo(0.8, 6)
+  })
+
+  it('clamps values below 0 to 0', () => {
+    const axes = deriveMoodAxes({ llm_intensity: -20 })
+    expect(axes.find(a => a.name === 'Intensity').weight).toBe(0)
+  })
+
+  it('clamps values above 100 to 1', () => {
+    const axes = deriveMoodAxes({ llm_intensity: 150 })
+    expect(axes.find(a => a.name === 'Intensity').weight).toBe(1)
+  })
+
+  it('returns only the available numeric axes plus Range for partial data', () => {
+    const axes = deriveMoodAxes({ llm_intensity: 70, llm_pacing: 30, mood_tags: ['tense'] })
+    expect(axes.map(a => a.name)).toEqual(['Intensity', 'Pace', 'Range'])
+  })
+
+  it('Range uses mood_tags.length / 8', () => {
+    const axes = deriveMoodAxes({ llm_intensity: 50, mood_tags: ['a', 'b', 'c', 'd'] })
+    expect(axes.find(a => a.name === 'Range').weight).toBeCloseTo(4 / 8, 6)
+  })
+
+  it('Range saturates at 1', () => {
+    const tags = Array.from({ length: 12 }, (_, i) => `t${i}`)
+    const axes = deriveMoodAxes({ llm_intensity: 50, mood_tags: tags })
+    expect(axes.find(a => a.name === 'Range').weight).toBe(1)
+  })
+
+  it('missing / non-array mood tags produce Range 0', () => {
+    expect(deriveMoodAxes({ llm_intensity: 50 }).find(a => a.name === 'Range').weight).toBe(0)
+    expect(deriveMoodAxes({ llm_intensity: 50, mood_tags: 'tense' }).find(a => a.name === 'Range').weight).toBe(0)
+  })
+
+  it('does not mutate the original film row', () => {
+    const snap = JSON.stringify(FULL)
+    deriveMoodAxes(FULL)
+    expect(JSON.stringify(FULL)).toBe(snap)
+  })
+
+  it('keeps the axis order Intensity · Pace · Depth · Dialogue · Focus · Range', () => {
+    expect(deriveMoodAxes(FULL).map(a => a.name)).toEqual(
+      ['Intensity', 'Pace', 'Depth', 'Dialogue', 'Focus', 'Range'],
+    )
+  })
+
+  it('keeps the current axis colours', () => {
+    const byName = Object.fromEntries(deriveMoodAxes(FULL).map(a => [a.name, a.hex]))
+    expect(byName).toEqual({
+      Intensity: '#EF4444', Pace: '#A78BFA', Depth: '#34D399',
+      Dialogue: '#7DD3FC', Focus: '#F472B6', Range: '#FBBF24',
+    })
+  })
+})

--- a/src/features/movie/derive/__tests__/primaryCase.test.js
+++ b/src/features/movie/derive/__tests__/primaryCase.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+
+import { derivePrimaryCase } from '../primaryCase'
+
+// F5.2 — pins the CURRENT PrimaryCaseCard tier-selection logic (extracted verbatim
+// from PrimaryCaseCard.jsx). F5.4 will intentionally change this hierarchy; until
+// then these assert today's behavior so any change is a visible, reviewable diff.
+
+const HEADER_WARM = {
+  eyebrow: 'Why this fits you',
+  headline: 'Signals from your last 20 films.',
+  rationale: 'Mood overlap, director history, and runtime patterns.',
+}
+const HEADER_COLD = {
+  eyebrow: 'Editorial fingerprint',
+  headline: 'How this film reads.',
+  rationale: 'Rate 5+ films to unlock personalized matching.',
+}
+
+describe('derivePrimaryCase — current tier hierarchy (pre-F5.4)', () => {
+  it('generated ff_take wins over the adaptive rationale', () => {
+    const r = derivePrimaryCase({
+      ffTake: { body: 'A class war told as a home invasion.', byline: 'FeelFlick take' },
+      whyHeader: HEADER_WARM, matchPct: 94, signedIn: true,
+    })
+    expect(r.tier).toBe('generated_take')
+    expect(r.provenance).toBe('generated')
+    expect(r.isTake).toBe(true)
+    expect(r.lead).toBe('A class war told as a home invasion.')
+    expect(r.label).toBe('FeelFlick take') // custom byline used
+  })
+
+  it('uses the default byline when ff_take has none', () => {
+    const r = derivePrimaryCase({ ffTake: { body: 'A quiet stunner.' }, whyHeader: HEADER_WARM })
+    expect(r.label).toBe('FeelFlick’s read') // current default (typographic apostrophe)
+  })
+
+  it('trims the ff_take body and ignores a whitespace-only take', () => {
+    expect(derivePrimaryCase({ ffTake: { body: '  spaced  ' }, whyHeader: HEADER_WARM }).lead).toBe('spaced')
+    const blank = derivePrimaryCase({ ffTake: { body: '   ' }, whyHeader: HEADER_WARM })
+    expect(blank.isTake).toBe(false)
+    expect(blank.lead).toBe(HEADER_WARM.rationale) // falls through to the rationale
+  })
+
+  it('falls back to the warm whyHeader rationale (adaptive_reason)', () => {
+    const r = derivePrimaryCase({ ffTake: null, whyHeader: HEADER_WARM, matchPct: 80, signedIn: true })
+    expect(r.tier).toBe('adaptive_reason')
+    expect(r.provenance).toBe('derived')
+    expect(r.lead).toBe(HEADER_WARM.rationale)
+    expect(r.label).toBe('Why this fits you') // eyebrow becomes the label
+  })
+
+  it('classifies the cold / signed-out rationale as standalone (static)', () => {
+    const r = derivePrimaryCase({ ffTake: null, whyHeader: HEADER_COLD, signedIn: false })
+    expect(r.tier).toBe('standalone')
+    expect(r.provenance).toBe('static')
+    expect(r.label).toBe('Editorial fingerprint')
+  })
+
+  it('uses the "How this reads" eyebrow fallback when no whyHeader eyebrow', () => {
+    const r = derivePrimaryCase({ ffTake: null, whyHeader: { rationale: '' }, matchPct: 70 })
+    expect(r.label).toBe('How this reads')
+    expect(r.tier).toBe('signals_only') // no lead, but a match exists
+  })
+
+  it('match availability: finite positive → hasMatch; zero/null/NaN → not', () => {
+    expect(derivePrimaryCase({ whyHeader: HEADER_WARM, matchPct: 1 }).hasMatch).toBe(true)
+    expect(derivePrimaryCase({ whyHeader: HEADER_WARM, matchPct: 0 }).hasMatch).toBe(false)
+    expect(derivePrimaryCase({ whyHeader: HEADER_WARM, matchPct: null }).hasMatch).toBe(false)
+    expect(derivePrimaryCase({ whyHeader: HEADER_WARM, matchPct: NaN }).hasMatch).toBe(false)
+  })
+
+  it('builds chips from the first mood tag and the fit profile (capitalized, underscores→spaces)', () => {
+    const r = derivePrimaryCase({ whyHeader: { rationale: '' }, moodTags: ['tense', 'dark'], fitProfile: 'prestige_drama' })
+    expect(r.chips).toEqual(['Tense', 'Prestige drama'])
+  })
+
+  it('shows the sign-in nudge only for a signed-out generated take', () => {
+    expect(derivePrimaryCase({ ffTake: { body: 'x' }, whyHeader: HEADER_WARM, signedIn: false }).showNudge).toBe(true)
+    expect(derivePrimaryCase({ ffTake: { body: 'x' }, whyHeader: HEADER_WARM, signedIn: true }).showNudge).toBe(false)
+    // signed-out without a take (the rationale already says "sign in") → no extra nudge
+    expect(derivePrimaryCase({ ffTake: null, whyHeader: HEADER_COLD, signedIn: false }).showNudge).toBe(false)
+  })
+
+  it('shouldRender: true when any of lead / match / chips exist; signals_only still renders', () => {
+    expect(derivePrimaryCase({ whyHeader: { rationale: '' }, matchPct: 80 }).shouldRender).toBe(true)
+    expect(derivePrimaryCase({ whyHeader: { rationale: '' }, moodTags: ['tense'] }).shouldRender).toBe(true)
+    expect(derivePrimaryCase({ whyHeader: { rationale: '' }, matchPct: 80 }).tier).toBe('signals_only')
+  })
+
+  it('fully empty input → empty tier, does not render', () => {
+    const r = derivePrimaryCase({ ffTake: null, whyHeader: { rationale: '' }, matchPct: null })
+    expect(r.tier).toBe('empty')
+    expect(r.provenance).toBe(null)
+    expect(r.shouldRender).toBe(false)
+    expect(r.chips).toEqual([])
+  })
+})

--- a/src/features/movie/derive/__tests__/sourceClassification.test.js
+++ b/src/features/movie/derive/__tests__/sourceClassification.test.js
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  FILM_FILE_SOURCE_REGISTRY as REG,
+  classifyFilmFileContent,
+} from '../sourceClassification'
+
+// F5.2 — the code-level encoding of the F5.1 provenance matrix. Pins origin +
+// presentation per Film File content surface so F5.4's trust redesign can reason
+// from one source of truth. Pure: no behavior change, no rendering decision.
+
+describe('FILM_FILE_SOURCE_REGISTRY — provenance matrix', () => {
+  const has = (k) => expect(REG[k], k).toBeTruthy()
+
+  it('classifies the real, directly-shown surfaces', () => {
+    for (const k of ['heroFacts', 'friendsLoved', 'tasteTwinReview', 'providers', 'castAndCredits', 'yourTake']) {
+      has(k)
+      expect(REG[k].origin, k).toBe('real')
+      expect(REG[k].presentation, k).toBe('direct')
+    }
+  })
+
+  it('classifies match % and Why-for-you as real-origin / derived-presentation (NOT generated)', () => {
+    expect(REG.matchPercentage.origin).toBe('real')
+    expect(REG.matchPercentage.presentation).toBe('derived')
+    expect(REG.whyForYou.origin).toBe('real')
+    expect(REG.whyForYou.presentation).toBe('derived')
+  })
+
+  it('classifies the generated overlay surfaces as generated', () => {
+    expect(REG.ffTake.origin).toBe('generated')
+    expect(REG.ffTake.presentation).toBe('direct')
+    expect(REG.viewerNotes.origin).toBe('generated') // critic_quotes = invented personas
+    expect(REG.viewerNotes.presentation).toBe('direct')
+    expect(REG.daypartFit.origin).toBe('generated')
+    expect(REG.daypartFit.presentation).toBe('direct')
+  })
+
+  it('classifies Mood Radar as generated-origin (llm_*) / derived-presentation (geometry)', () => {
+    expect(REG.moodRadar.origin).toBe('generated')
+    expect(REG.moodRadar.presentation).toBe('derived')
+  })
+
+  it('classifies cold-start / fallback copy as static', () => {
+    expect(REG.coldStartCopy.origin).toBe('static')
+    expect(REG.coldStartCopy.presentation).toBe('direct')
+  })
+
+  it('never marks a generated surface as real, nor a real user review as generated', () => {
+    const generated = ['ffTake', 'viewerNotes', 'daypartFit', 'moodRadar']
+    for (const k of generated) expect(REG[k].origin, k).toBe('generated')
+    // Friends / Taste-Twin review text is REAL user-authored data, never generated.
+    expect(REG.friendsLoved.origin).toBe('real')
+    expect(REG.tasteTwinReview.origin).toBe('real')
+  })
+
+  it('only uses the three allowed origins and two presentations', () => {
+    for (const [k, v] of Object.entries(REG)) {
+      expect(['real', 'generated', 'static'], k).toContain(v.origin)
+      expect(['direct', 'derived'], k).toContain(v.presentation)
+      expect(typeof v.source, k).toBe('string')
+    }
+  })
+})
+
+describe('classifyFilmFileContent — availability', () => {
+  it('is null-safe with no arguments and returns every element', () => {
+    const c = classifyFilmFileContent()
+    expect(Object.keys(c).sort()).toEqual(Object.keys(REG).sort())
+    // structural surfaces are always available
+    expect(c.heroFacts.available).toBe(true)
+    expect(c.castAndCredits.available).toBe(true)
+    expect(c.coldStartCopy.available).toBe(true)
+    // variable surfaces default to unavailable with no inputs
+    expect(c.ffTake.available).toBe(false)
+    expect(c.viewerNotes.available).toBe(false)
+    expect(c.matchPercentage.available).toBe(false)
+    expect(c.friendsLoved.available).toBe(false)
+  })
+
+  it('reports each spread element with its registry provenance + an available flag', () => {
+    const c = classifyFilmFileContent({ overlay: { ff_take: { body: 'A class war.' } } })
+    expect(c.ffTake).toEqual({ ...REG.ffTake, available: true })
+    expect(c.viewerNotes).toEqual({ ...REG.viewerNotes, available: false })
+  })
+
+  it('marks generated overlay surfaces available only when present', () => {
+    const c = classifyFilmFileContent({
+      overlay: { ff_take: { body: '  ' }, critic_quotes: [{ quote: 'x' }], daypart_fit: 'evening' },
+    })
+    expect(c.ffTake.available).toBe(false)        // whitespace-only body → not available
+    expect(c.viewerNotes.available).toBe(true)
+    expect(c.daypartFit.available).toBe(true)
+  })
+
+  it('marks Mood Radar available only when a finite llm_* signal exists', () => {
+    expect(classifyFilmFileContent({ filmRow: { llm_intensity: 70 } }).moodRadar.available).toBe(true)
+    expect(classifyFilmFileContent({ filmRow: { mood_tags: ['tense'] } }).moodRadar.available).toBe(false)
+    expect(classifyFilmFileContent({ filmRow: { llm_pacing: null } }).moodRadar.available).toBe(false)
+  })
+
+  it('marks match % available only for a finite positive value', () => {
+    expect(classifyFilmFileContent({ matchPct: 84 }).matchPercentage.available).toBe(true)
+    expect(classifyFilmFileContent({ matchPct: 0 }).matchPercentage.available).toBe(false)
+    expect(classifyFilmFileContent({ matchPct: null }).matchPercentage.available).toBe(false)
+    expect(classifyFilmFileContent({ matchPct: NaN }).matchPercentage.available).toBe(false)
+  })
+
+  it('marks providers available only when an offer exists', () => {
+    expect(classifyFilmFileContent({ providers: { flatrate: [{ id: 8 }] } }).providers.available).toBe(true)
+    expect(classifyFilmFileContent({ providers: { flatrate: [], rent: [], buy: [] } }).providers.available).toBe(false)
+    expect(classifyFilmFileContent({ providers: null }).providers.available).toBe(false)
+  })
+
+  it('marks social + rating surfaces available from their own inputs', () => {
+    expect(classifyFilmFileContent({ friends: [{ id: 1 }] }).friendsLoved.available).toBe(true)
+    expect(classifyFilmFileContent({ friends: [] }).friendsLoved.available).toBe(false)
+    expect(classifyFilmFileContent({ twin: { name: 'A' } }).tasteTwinReview.available).toBe(true)
+    expect(classifyFilmFileContent({ twin: null }).tasteTwinReview.available).toBe(false)
+    expect(classifyFilmFileContent({ userRating: { rating: 8 } }).yourTake.available).toBe(true)
+    expect(classifyFilmFileContent({ userRating: null }).yourTake.available).toBe(false)
+  })
+
+  it('does not mutate its inputs', () => {
+    const overlay = { ff_take: { body: 'x' }, critic_quotes: [{ quote: 'y' }] }
+    const filmRow = { llm_intensity: 50, mood_tags: ['tense'] }
+    const providers = { flatrate: [{ id: 8 }] }
+    const snap = JSON.stringify({ overlay, filmRow, providers })
+    classifyFilmFileContent({ overlay, filmRow, providers, matchPct: 80 })
+    expect(JSON.stringify({ overlay, filmRow, providers })).toBe(snap)
+  })
+
+  // F5.2 §2 — useMovieData exposes state.contentSources via classifyFilmFileContent({
+  // overlay, filmRow, matchPct: mv.ffMatch, providers: prov }). This proves the
+  // assembled classification agrees with a representative loaded-film fixture.
+  it('agrees with the useMovieData wiring shape for a representative loaded film', () => {
+    const contentSources = classifyFilmFileContent({
+      overlay: {
+        ff_take: { body: 'A class war told as a home invasion.' },
+        critic_quotes: [{ quote: 'Tense from frame one.' }],
+        daypart_fit: 'Best watched · evening',
+      },
+      filmRow: { llm_intensity: 80, llm_pacing: 60, mood_tags: ['tense', 'dark'], fit_profile: 'prestige_drama' },
+      matchPct: 84,
+      providers: { flatrate: [{ id: 8, name: 'Mock Stream' }], rent: [], buy: [] },
+    })
+    // generated overlay surfaces present + correctly classified
+    expect(contentSources.ffTake).toMatchObject({ origin: 'generated', presentation: 'direct', available: true })
+    expect(contentSources.viewerNotes).toMatchObject({ origin: 'generated', available: true })
+    expect(contentSources.daypartFit).toMatchObject({ origin: 'generated', available: true })
+    expect(contentSources.moodRadar).toMatchObject({ origin: 'generated', presentation: 'derived', available: true })
+    // derived-from-real + real surfaces
+    expect(contentSources.matchPercentage).toMatchObject({ origin: 'real', presentation: 'derived', available: true })
+    expect(contentSources.providers).toMatchObject({ origin: 'real', available: true })
+    expect(contentSources.whyForYou).toMatchObject({ origin: 'real', presentation: 'derived', available: true })
+    // surfaces this data layer doesn't fetch resolve in their own hooks → unavailable here
+    expect(contentSources.friendsLoved.available).toBe(false)
+    expect(contentSources.tasteTwinReview.available).toBe(false)
+    expect(contentSources.yourTake.available).toBe(false)
+  })
+})

--- a/src/features/movie/derive/__tests__/whyForYou.test.js
+++ b/src/features/movie/derive/__tests__/whyForYou.test.js
@@ -51,3 +51,71 @@ describe('deriveWhyHeader — adapts honestly to user state', () => {
     expect(deriveWhyHeader({ fingerprint: { total: 20 }, signedIn: true }).eyebrow).toMatch(/why this fits you/i)
   })
 })
+
+// F5.2 — expand the pins WITHOUT changing wording, thresholds, ranking, or count.
+// (F5.1 flagged the missing signal-strength + exact-match-only fit as F5.4 work;
+// these tests document the CURRENT behavior, they do not "fix" it.)
+describe('deriveWhyReasons — current ordering, caps, and null-safety (pre-F5.4)', () => {
+  it('returns at most 4 cards', () => {
+    const reasons = deriveWhyReasons({
+      mv: { director: 'Bong Joon-ho', runtime: 132 },
+      filmDbRow: { mood_tags: ['tense', 'dark'], tone_tags: ['gritty'], fit_profile: 'prestige_drama' },
+      fingerprint: { total: 30, topMoodTags: [{ key: 'tense' }], topFitProfiles: [{ key: 'prestige_drama', share: 0.4 }] },
+      directorCount: 2,
+    })
+    expect(reasons.length).toBeLessThanOrEqual(4)
+  })
+
+  it('personalized cards win their slot and sort ahead of descriptive ones', () => {
+    const reasons = deriveWhyReasons({
+      mv: { director: 'Bong Joon-ho', runtime: 132 },
+      filmDbRow: { mood_tags: ['tense'], tone_tags: [], fit_profile: 'prestige_drama' },
+      fingerprint: { total: 30, topMoodTags: [{ key: 'tense' }], topFitProfiles: [{ key: 'prestige_drama', share: 0.4 }] },
+      directorCount: 2,
+    })
+    // personalized mood-overlap + fit-match win their slots (descriptive variants drop)
+    expect(reasons.some(r => r.id === 'mood-overlap')).toBe(true)
+    expect(reasons.some(r => r.id === 'mood-film')).toBe(false)
+    expect(reasons.some(r => r.id === 'fit-match')).toBe(true)
+    expect(reasons.some(r => r.id === 'fit-film')).toBe(false)
+    // mood-overlap (priority 1) sorts ahead of fit-match (priority 2)
+    expect(reasons.findIndex(r => r.id === 'mood-overlap')).toBeLessThan(reasons.findIndex(r => r.id === 'fit-match'))
+  })
+
+  it('fit-profile match needs an EXACT match against the user top fit profile', () => {
+    const base = {
+      mv: { director: '—', runtime: 0 },
+      filmDbRow: { mood_tags: [], tone_tags: [], fit_profile: 'arthouse' },
+      fingerprint: { total: 30, topMoodTags: [], topFitProfiles: [{ key: 'prestige_drama', share: 0.5 }] },
+      directorCount: 0,
+    }
+    expect(deriveWhyReasons(base).some(r => r.id === 'fit-match')).toBe(false) // arthouse ≠ prestige_drama
+    const exact = { ...base, filmDbRow: { ...base.filmDbRow, fit_profile: 'prestige_drama' } }
+    expect(deriveWhyReasons(exact).some(r => r.id === 'fit-match')).toBe(true)
+  })
+
+  it('frames a director with library history as a personalized count', () => {
+    const reasons = deriveWhyReasons({
+      mv: { director: 'Bong Joon-ho', runtime: 0 },
+      filmDbRow: { mood_tags: [], tone_tags: [], fit_profile: null },
+      fingerprint: null, directorCount: 3,
+    })
+    const dir = reasons.find(r => r.id === 'director')
+    expect(dir.detail).toMatch(/3 films/i)
+    expect(dir.detail).not.toMatch(/first time/i)
+  })
+
+  it('produces a runtime band card when runtime > 0 and none when runtime is 0', () => {
+    const withTime = deriveWhyReasons({ mv: { director: '—', runtime: 132 }, filmDbRow: { mood_tags: [] }, fingerprint: null, directorCount: 0 })
+    expect(withTime.some(r => r.id === 'time')).toBe(true)
+    const noTime = deriveWhyReasons({ mv: { director: '—', runtime: 0 }, filmDbRow: { mood_tags: [] }, fingerprint: null, directorCount: 0 })
+    expect(noTime.some(r => r.id === 'time')).toBe(false)
+  })
+
+  it('is null-safe with sparse inputs and does not mutate them', () => {
+    const args = { mv: { director: '—', runtime: 0 }, filmDbRow: { mood_tags: ['tense'] }, fingerprint: null, directorCount: 0 }
+    const snap = JSON.stringify(args)
+    expect(Array.isArray(deriveWhyReasons(args))).toBe(true)
+    expect(JSON.stringify(args)).toBe(snap)
+  })
+})

--- a/src/features/movie/derive/primaryCase.js
+++ b/src/features/movie/derive/primaryCase.js
@@ -1,0 +1,82 @@
+// src/features/movie/derive/primaryCase.js
+// Pure tier-selection decision for the Film File's PrimaryCaseCard (F6B).
+//
+// Extracted MECHANICALLY from PrimaryCaseCard.jsx so the current case hierarchy is
+// independently testable before F5.4 intentionally changes the trust hierarchy.
+// F5.2 only EXPOSES and TESTS today's behavior — it does not change which case wins,
+// the labels, the lead text, the match-availability rule, chip selection, the nudge,
+// or the self-hide decision. All of those remain byte-identical to the prior inline
+// logic; `tier`/`provenance` are NEW, non-rendered metadata.
+//
+// Pure: no React, no browser APIs, no side effects, non-mutating.
+
+// Identical to the capitalize previously inline in PrimaryCaseCard.jsx.
+const capitalize = (s) =>
+  s ? s.charAt(0).toUpperCase() + s.slice(1).replace(/_/g, ' ') : ''
+
+/**
+ * @param {object} args
+ * @param {object|null} args.ffTake     overlay.ff_take ({ body, byline, meta }) or null
+ * @param {object|null} args.whyHeader  { eyebrow, headline, rationale } (tier-adaptive)
+ * @param {number|null} args.matchPct   engine match % (0–100) or null
+ * @param {string[]} [args.moodTags]    film mood_tags
+ * @param {string|null} [args.fitProfile] film fit_profile
+ * @param {boolean} [args.signedIn]
+ * @returns {{
+ *   tier: 'generated_take'|'adaptive_reason'|'standalone'|'signals_only'|'empty',
+ *   label: string, lead: string, hasMatch: boolean, chips: string[],
+ *   showNudge: boolean, shouldRender: boolean, isTake: boolean,
+ *   provenance: 'generated'|'derived'|'static'|null
+ * }}
+ */
+export function derivePrimaryCase({
+  ffTake, whyHeader, matchPct, moodTags = [], fitProfile, signedIn = false,
+}) {
+  // --- current PrimaryCaseCard logic, moved verbatim ---
+  const take = (ffTake?.body || '').trim()
+  const isTake = Boolean(take)
+  const label = take
+    ? (ffTake.byline?.trim() || 'FeelFlick’s read')
+    : (whyHeader?.eyebrow || 'How this reads')
+  const lead = take || (whyHeader?.rationale || '').trim()
+
+  const hasMatch = Number.isFinite(matchPct) && matchPct > 0
+
+  const chips = []
+  if (Array.isArray(moodTags) && moodTags[0]) chips.push(capitalize(moodTags[0]))
+  if (fitProfile) chips.push(capitalize(fitProfile))
+
+  // Nudge anon users toward the personal fit — but only when the lead itself
+  // doesn't already say "sign in" (the anon header rationale does).
+  const showNudge = !signedIn && isTake
+
+  // Self-hide only when there is truly no useful case to make.
+  const shouldRender = Boolean(lead) || hasMatch || chips.length > 0
+
+  // --- NEW metadata (not rendered): which case won + its provenance ---
+  let tier
+  let provenance
+  if (isTake) {
+    tier = 'generated_take'   // the generated ff_take editorial hook
+    provenance = 'generated'
+  } else if (lead) {
+    // The adaptive whyHeader rationale. "Why this fits you" = warm, fingerprint-
+    // derived (real-origin/derived). Otherwise it is the cold/signed-out static
+    // standalone copy (deriveWhyHeader's "Editorial fingerprint" branches).
+    if (whyHeader?.eyebrow === 'Why this fits you') {
+      tier = 'adaptive_reason'
+      provenance = 'derived'
+    } else {
+      tier = 'standalone'
+      provenance = 'static'
+    }
+  } else if (hasMatch || chips.length > 0) {
+    tier = 'signals_only'      // only the match % and/or descriptive chips
+    provenance = 'derived'
+  } else {
+    tier = 'empty'
+    provenance = null
+  }
+
+  return { tier, label, lead, hasMatch, chips, showNudge, shouldRender, isTake, provenance }
+}

--- a/src/features/movie/derive/sourceClassification.js
+++ b/src/features/movie/derive/sourceClassification.js
@@ -1,0 +1,152 @@
+// src/features/movie/derive/sourceClassification.js
+// Canonical content-provenance model for the Film File (/movie/:id).
+//
+// This is the code-level encoding of the F5.1 provenance matrix. It records, for
+// every visible content surface, WHERE the content comes from — so later phases
+// (F5.4 trust redesign) can reason about provenance from one source of truth
+// instead of re-deriving it per component.
+//
+// It deliberately distinguishes two independent axes (do NOT collapse them):
+//   origin       — 'real' | 'generated' | 'static'
+//     real       = stored facts or user-authored data (TMDB, user_ratings, …)
+//     generated  = produced by the LLM overlay edge function (ff_take, critic_quotes,
+//                  daypart_fit, and the llm_* enrichment columns)
+//     static     = fixed FeelFlick product copy (cold-start / sign-in prompts)
+//   presentation — 'direct' | 'derived'
+//     direct     = shown roughly as stored/written
+//     derived    = transformed/computed before display (a %, a radar geometry, …)
+//
+// "generated" is NOT a synonym for "computed". The match % is computed from REAL
+// signals (origin: real, presentation: derived). The Mood Radar geometry is computed
+// (derived) from GENERATED llm_* enrichment (origin: generated, presentation: derived).
+//
+// This module is pure: no React, no browser APIs, no Supabase, no network, no side
+// effects. It records provenance only — it does NOT decide whether anything renders
+// and does NOT enforce any trust policy. It contains no user-facing strings.
+
+/**
+ * Stable registry of Film File content elements and their provenance.
+ * @type {Record<string, { origin: 'real'|'generated'|'static', presentation: 'direct'|'derived', source: string }>}
+ */
+export const FILM_FILE_SOURCE_REGISTRY = {
+  // Real, shown directly ------------------------------------------------------
+  heroFacts: {
+    origin: 'real', presentation: 'direct',
+    source: 'TMDB movie details (title, year, runtime, certification, genres, director)',
+  },
+  matchPercentage: {
+    // Computed from stored/user signals + engine inputs — NOT generated prose.
+    origin: 'real', presentation: 'derived',
+    source: 'computeMatchPercent(scoreMovieForUser) over the user profile + film signals',
+  },
+  whyForYou: {
+    origin: 'real', presentation: 'derived',
+    source: 'film attributes (mood_tags, fit_profile, runtime) × available user taste signals',
+  },
+  friendsLoved: {
+    origin: 'real', presentation: 'direct',
+    source: 'followed users (user_follows) × their high user_ratings + user_ratings.review_text',
+  },
+  tasteTwinReview: {
+    origin: 'real', presentation: 'direct',
+    source: 'user_similarity top match × that user’s real user_ratings.review_text',
+  },
+  providers: {
+    origin: 'real', presentation: 'direct',
+    source: 'TMDB watch/providers (region-keyed, third-party)',
+  },
+  castAndCredits: {
+    origin: 'real', presentation: 'direct',
+    source: 'TMDB credits',
+  },
+  yourTake: {
+    origin: 'real', presentation: 'direct',
+    source: 'authenticated user’s own user_ratings + user_movie_feedback',
+  },
+  // Generated (LLM overlay) ---------------------------------------------------
+  ffTake: {
+    origin: 'generated', presentation: 'direct',
+    source: 'movies_editorial_overlay.ff_take (generate-movie-overlay edge function)',
+  },
+  viewerNotes: {
+    origin: 'generated', presentation: 'direct',
+    source: 'movies_editorial_overlay.critic_quotes (invented friend-voice personas)',
+  },
+  daypartFit: {
+    origin: 'generated', presentation: 'direct',
+    source: 'movies_editorial_overlay.daypart_fit (generated)',
+  },
+  moodRadar: {
+    // Geometry is computed (derived) from GENERATED llm_* enrichment columns.
+    origin: 'generated', presentation: 'derived',
+    source: 'movies.llm_* enrichment + mood_tags → deriveMoodAxes geometry',
+  },
+  // Static product copy -------------------------------------------------------
+  coldStartCopy: {
+    origin: 'static', presentation: 'direct',
+    source: 'FeelFlick product copy (cold-start / sign-in prompts, fallback rationale)',
+  },
+}
+
+// The LLM enrichment columns the Mood Radar reads (mirrors deriveMoodAxes).
+const LLM_KEYS = ['llm_intensity', 'llm_pacing', 'llm_emotional_depth', 'llm_dialogue_density', 'llm_attention_demand']
+
+const nonEmptyArray = (v) => Array.isArray(v) && v.length > 0
+const nonEmptyString = (v) => typeof v === 'string' && v.trim().length > 0
+const hasProviderOffers = (p) =>
+  Boolean(p && (nonEmptyArray(p.flatrate) || nonEmptyArray(p.rent) || nonEmptyArray(p.buy)))
+
+/**
+ * Classify the Film File content that is actually present for one (film, user) view.
+ * Pure + null-safe + non-mutating. Returns EVERY registry element spread with an
+ * `available` boolean (the example contract shows both available:true and
+ * available:false entries). `available` reflects ONLY presence of the input data —
+ * it does NOT decide rendering and does NOT change any availability logic elsewhere.
+ *
+ * Structural surfaces that exist on every loaded Film File (hero facts, cast/credits,
+ * static copy) report available:true. Variable surfaces are derived from their input.
+ *
+ * @param {object} [args]
+ * @param {object|null} [args.overlay]    movies_editorial_overlay row ({ ff_take, critic_quotes, daypart_fit, … })
+ * @param {object|null} [args.filmRow]    internal movies row (llm_* columns, mood_tags)
+ * @param {number|null} [args.matchPct]   engine match % (or null)
+ * @param {Array|null}  [args.whyReasons] derived why-for-you cards (or null)
+ * @param {Array|null}  [args.friends]    Friends-Loved entries (or null)
+ * @param {object|null} [args.twin]       Taste-Twin entry (or null)
+ * @param {object|null} [args.providers]  mapped providers ({ flatrate, rent, buy } or null)
+ * @param {object|null} [args.userRating] the user's own rating row (or null)
+ * @returns {Record<string, { origin, presentation, source, available: boolean }>}
+ */
+export function classifyFilmFileContent({
+  overlay = null,
+  filmRow = null,
+  matchPct = null,
+  whyReasons = null,
+  friends = null,
+  twin = null,
+  providers = null,
+  userRating = null,
+} = {}) {
+  const R = FILM_FILE_SOURCE_REGISTRY
+  const withAvail = (key, available) => ({ ...R[key], available: Boolean(available) })
+
+  return {
+    // Structural — present on any loaded Film File.
+    heroFacts: withAvail('heroFacts', true),
+    castAndCredits: withAvail('castAndCredits', true),
+    coldStartCopy: withAvail('coldStartCopy', true),
+    // Generated overlay surfaces.
+    ffTake: withAvail('ffTake', nonEmptyString(overlay?.ff_take?.body)),
+    viewerNotes: withAvail('viewerNotes', nonEmptyArray(overlay?.critic_quotes)),
+    daypartFit: withAvail('daypartFit', Boolean(overlay?.daypart_fit)),
+    moodRadar: withAvail('moodRadar', LLM_KEYS.some(k => Number.isFinite(filmRow?.[k]))),
+    // Derived-from-real surfaces.
+    matchPercentage: withAvail('matchPercentage', Number.isFinite(matchPct) && matchPct > 0),
+    whyForYou: withAvail('whyForYou', nonEmptyArray(whyReasons) || Boolean(filmRow)),
+    // Real social / user / provider surfaces.
+    friendsLoved: withAvail('friendsLoved', nonEmptyArray(friends)),
+    tasteTwinReview: withAvail('tasteTwinReview', Boolean(twin)),
+    providers: withAvail('providers', hasProviderOffers(providers)),
+    yourTake: withAvail('yourTake', Boolean(userRating)),
+  }
+}

--- a/src/features/movie/useMovieData.jsx
+++ b/src/features/movie/useMovieData.jsx
@@ -15,6 +15,7 @@ import { MOVIE_ENGINE_COLS } from '@/shared/services/movieFields'
 import { activeMovieBoundaries, BOUNDARY_LABEL } from '@/shared/services/boundaries'
 import { formatFullDate } from '@/shared/lib/format/date'
 import { deriveMoodAxes } from './derive/moodRadar'
+import { classifyFilmFileContent } from './derive/sourceClassification'
 
 // Pull the full engine column set so the match % on this page matches
 // what /home shows for the same film. Single source of truth in
@@ -499,6 +500,7 @@ const INITIAL_STATE = {
   overlay: null,       // curated editorial overlay (movies_editorial_overlay) when present
   hasOverlay: false,
   boundaryWarnings: [], // [{ id, label }] for /preferences boundaries the user has on AND this film matches
+  contentSources: null, // F5.2 provenance metadata (origin/presentation per content surface); NOT rendered
   loading: true,
   error: null,
 }
@@ -629,6 +631,16 @@ export function useMovieDataFetch(id) {
           overlay,
           hasOverlay: Boolean(overlay),
           boundaryWarnings,
+          // F5.2 provenance metadata — records WHERE each Film File surface comes
+          // from (origin/presentation). Unrendered: no consumer reads it yet. The
+          // social/rating surfaces resolve in their own hooks, so they are classified
+          // from the data this layer has (overlay/filmRow/match/providers).
+          contentSources: classifyFilmFileContent({
+            overlay,
+            filmRow: filmDbRow,
+            matchPct: mv.ffMatch,
+            providers: prov,
+          }),
           loading: false,
           error: null,
         })


### PR DESCRIPTION
**F5.2 — Film File safety net** before the F5.4 trust redesign. **Refactor + tests only.** No visible UI, copy, layout, section-order, scoring, match-%, action, payload, or route change. No live authenticated render; no live user-data mutation.

## Provenance model — `derive/sourceClassification.js` (pure)
`FILM_FILE_SOURCE_REGISTRY` records every Film File surface on **two independent axes**, not flattened to real-vs-derived:
- **origin** `'real' | 'generated' | 'static'` · **presentation** `'direct' | 'derived'`
- `"generated"` is **not** a synonym for `"computed"`: **match %** = real-origin / derived-presentation; **Mood Radar** = generated-origin (`llm_*`) / derived-presentation; **`ff_take` / `critic_quotes` / `daypart_fit`** = generated / direct; cold-start copy = static / direct.
- `classifyFilmFileContent({...})` is deterministic, null-safe, non-mutating, contains no user-facing strings, and **does not decide rendering** — it returns each element spread with an `available` flag (presence only).

**Explicit classification of the generated overlay fields:** `ff_take`, `critic_quotes` (Viewer Notes), and `daypart_fit` are all `origin: 'generated'`. **Explicit confirmation that Friends Loved + Taste Twin review text is REAL user data** (`user_ratings.review_text`) — classified `real/direct`, never generated.

## Wiring
`useMovieData` exposes `state.contentSources` via `classifyFilmFileContent` over the data this layer has (`overlay`/`filmRow`/`matchPct`/`providers`). **Unrendered** — no consumer reads it in F5.2; no new request, write, fetch-order, loading, or error change.

## PrimaryCaseCard pure tier extraction — `derive/primaryCase.js`
`derivePrimaryCase()` moved **verbatim** from `PrimaryCaseCard.jsx` — `label`, `lead`, `hasMatch`, `chips`, `showNudge`, self-hide are **byte-identical**; `tier` (`generated_take` | `adaptive_reason` | `standalone` | `signals_only` | `empty`) + `provenance` are **new, non-rendered** metadata. The component consumes the helper; **JSX / strings / DOM unchanged**.

## Tests — Film File **13 → 76**; full suite **962 → 1025**
- **sourceClassification**: the canonical code-level F5.1 provenance matrix + availability + the useMovieData wiring shape + no-mutation; asserts no generated surface is real and no real review is generated.
- **primaryCase**: current tier hierarchy (ff_take wins, byline default, match availability, chips, nudge, self-hide, empty).
- **moodRadar**: null/empty, `/100` scaling, clamp `0..1`, `Range = tags/8` saturating, axis order Intensity·Pace·Depth·Dialogue·Focus·Range, colours, no mutation.
- **PrimaryCaseCard**: render contract — exact integer `"{n}%"` (**no band/label yet**), gloss hidden for `0/null/NaN`, default byline, generated-take wins, match-only / chips-only.
- **ViewerNotes** — pins **today's pre-F5.4 framing**: `<blockquote>` + quotation marks + invented author/outlet + "A viewer" fallback + the "not real reviews" disclaimer, so F5.4's de-authority change is a visible, reviewable diff. **Production rendering unchanged; disclaimer not weakened.**
- **whyForYou**: ordering/caps (≤4), personalized-wins-slot, fit-profile **exact** match, director-with-count, runtime band, null-safety, no mutation.
- **matchAvailability**: `computeMatchPercent` null-gating + `<50` floor + integer (no band).

## Render-contract equivalence
Extraction is mechanical; the component-level tests assert identical rendered output for the **generated / adaptive / cold / match-only / chips-only / empty** states. There is **no `/movie` visual baseline yet** (F5.8), so this is stated as **render-contract equivalent for the exercised states**, not pixel identity. No fetch / payload / route / score change.

## Validation
`npm run lint` clean · `npx vitest run src/features/movie/` 76 (×3 deterministic) · `npm run test` 1025 · `npm run build` ✓. **No live Film File route or write was triggered** (no profile-cache upsert / Save / Mark Watched / rating / trailer / share / provider / related tracking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
