### PR TITLE
Harden Film File actions and accessibility

### DIFF
--- a/src/features/movie/MovieDetail.jsx
+++ b/src/features/movie/MovieDetail.jsx
@@ -8,6 +8,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import { useReducedMotion } from 'framer-motion'
 
 import { useAuthSession } from '@/shared/hooks/useAuthSession'
 import { useUserMovieStatus } from '@/shared/hooks/useUserMovieStatus'
@@ -21,9 +22,10 @@ import { useFriendsLoved } from './hooks/useFriendsLoved'
 import { useTasteTwin } from './hooks/useTasteTwin'
 
 import {
-  ScrollProgress, FilmGrain, TrailerModal, MovieHero, StickyActionBar,
+  ScrollProgress, FilmGrain, MovieHero, StickyActionBar,
   WhyForYou, Synopsis, MoodRadar,
 } from './sections-top'
+import AccessibleMediaDialog from './components/AccessibleMediaDialog'
 import PrimaryCaseCard from './PrimaryCaseCard'
 import ViewerNotes from './ViewerNotes'
 import {
@@ -116,19 +118,71 @@ export default function MovieDetail() {
   const [hoveredReason, setHoveredReason] = useState(null)
   const [hoveredAxis, setHoveredAxis] = useState(null)
 
-  // When Mark Watched flips from false → true, gently scroll the YourTake
-  // card into view so the rating UI is the obvious next thing. We skip the
-  // scroll on initial mount (e.g. opening an already-watched film) so we
-  // only react to in-session transitions.
+  // F5.4 — one Film File-owned polite live region for concise action outcomes.
+  const reduced = useReducedMotion()
+  const [announcement, setAnnouncement] = useState('')
+  const announce = useCallback((msg) => setAnnouncement(msg), [])
+
+  // F5.4 settlement model (mirrors Home F4.3). The shared status hook flips state
+  // optimistically and reverts on failure WITHOUT returning a result, so we observe
+  // each `loading.{watched,watchlist}` true→false transition and compare the settled
+  // state against the intent the user clicked. An intent ref (set only on a real
+  // click) guards against the first-render DB sync being mistaken for a user op.
   const yourTakeRef = useRef(null)
-  const prevWatchedRef = useRef(isWatched)
+  const watchedIntentRef = useRef(null)
+  const watchlistIntentRef = useRef(null)
+  const prevWatchedLoadingRef = useRef(false)
+  const prevWatchlistLoadingRef = useRef(false)
+  const confettiTimerRef = useRef(null)
+  const [celebrate, setCelebrate] = useState(false)
+  useEffect(() => () => { if (confettiTimerRef.current) clearTimeout(confettiTimerRef.current) }, [])
+
+  const handleMarkWatched = useCallback(() => {
+    if (actionLoading.watched) return
+    watchedIntentRef.current = !isWatched   // the value the user intends to settle to
+    toggleWatched()
+  }, [actionLoading.watched, isWatched, toggleWatched])
+
+  const handleToggleWatchlist = useCallback(() => {
+    if (actionLoading.watchlist) return
+    watchlistIntentRef.current = !isInWatchlist
+    toggleWatchlist()
+  }, [actionLoading.watchlist, isInWatchlist, toggleWatchlist])
+
+  // Mark Watched: announce / unlock / scroll / celebrate ONLY on settled success.
   useEffect(() => {
-    const wasWatched = prevWatchedRef.current
-    if (!wasWatched && isWatched && yourTakeRef.current) {
-      yourTakeRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    const settled = prevWatchedLoadingRef.current && !actionLoading.watched
+    prevWatchedLoadingRef.current = actionLoading.watched
+    if (!settled || watchedIntentRef.current === null) return
+    const intent = watchedIntentRef.current
+    watchedIntentRef.current = null
+    if (isWatched !== intent) { announce('Could not update watched status. Try again.'); return }
+    if (intent) {
+      announce(`Marked ${movieTitle} as watched. Your Take is now available.`)
+      if (!reduced) {
+        setCelebrate(true)
+        if (confettiTimerRef.current) clearTimeout(confettiTimerRef.current)
+        confettiTimerRef.current = setTimeout(() => setCelebrate(false), 1800)
+      }
+      yourTakeRef.current?.scrollIntoView({ behavior: reduced ? 'auto' : 'smooth', block: 'start' })
+    } else {
+      announce(`Removed watched status for ${movieTitle}.`)
     }
-    prevWatchedRef.current = isWatched
-  }, [isWatched])
+  }, [actionLoading.watched, isWatched, reduced, movieTitle, announce])
+
+  // Save: announce success / removal / failure ONLY on settlement.
+  useEffect(() => {
+    const settled = prevWatchlistLoadingRef.current && !actionLoading.watchlist
+    prevWatchlistLoadingRef.current = actionLoading.watchlist
+    if (!settled || watchlistIntentRef.current === null) return
+    const intent = watchlistIntentRef.current
+    watchlistIntentRef.current = null
+    if (isInWatchlist !== intent) { announce('Could not update saved films. Try again.'); return }
+    announce(intent ? `Saved ${movieTitle} for later.` : `Removed ${movieTitle} from saved films.`)
+  }, [actionLoading.watchlist, isInWatchlist, movieTitle, announce])
+
+  const onRatingSaved = useCallback(() => announce(`Your take on ${movieTitle} was saved.`), [announce, movieTitle])
+  const onRatingError = useCallback(() => announce('Could not save your take. Try again.'), [announce])
 
   // Two-way mood ↔ Why card highlight, now keyed off dynamic whyReasons.
   const reasonMood = whyReasons.find(r => r.id === hoveredReason)?.moodKey ?? null
@@ -160,19 +214,31 @@ export default function MovieDetail() {
   const handleBack = useCallback(() => navigate(-1), [navigate])
 
   const handleShare = useCallback(async () => {
+    // Analytics first + non-blocking (unchanged event/metadata). The canonical clean
+    // Film File URL is shared/copied — never the raw location (no query/auth material).
     if (internalId) trackShare(internalId, 'movie_detail_v2')
     if (navigator.share && mv) {
       try {
-        await navigator.share({
-          title: mv.title,
-          text: mv.tagline || mv.overview,
-          url: window.location.href,
-        })
-      } catch {
-        // user cancelled — silent
+        await navigator.share({ title: mv.title, text: mv.tagline || mv.overview, url: movieUrl })
+        announce(`Shared ${movieTitle}.`)
+      } catch (err) {
+        // user cancelled (AbortError) → silent; never claim success on real failure.
+        if (err?.name !== 'AbortError') announce('Could not share this film.')
       }
+      return
     }
-  }, [internalId, mv])
+    // No native share → clipboard fallback.
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(movieUrl)
+        announce(`Link copied for ${movieTitle}.`)
+      } else {
+        announce('Could not share this film.')
+      }
+    } catch {
+      announce('Could not share this film.')
+    }
+  }, [internalId, mv, movieUrl, movieTitle, announce])
 
   if (loading) return <PageSkeleton />
   if (error || !mv) return <PageError error={error} onBack={handleBack} />
@@ -185,12 +251,19 @@ export default function MovieDetail() {
       }}>
         <ScrollProgress />
         <FilmGrain />
-        <TrailerModal
+        <AccessibleMediaDialog
           open={trailerOpen}
           onClose={() => setTrailerOpen(false)}
-          videoKey={selectedVideo?.key}
-          videoTitle={selectedVideo?.title}
+          youtubeKey={selectedVideo?.key || mv.trailerYouTubeId}
+          title={selectedVideo?.title
+            ? `${mv.title} · ${selectedVideo.title}`
+            : `${mv.title} · Official Trailer`}
         />
+
+        {/* One Film File-owned polite live region for action outcomes. */}
+        <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+          {announcement}
+        </div>
 
         <div style={{ maxWidth: 1440, margin: '0 auto' }}>
           <MovieHero
@@ -199,10 +272,11 @@ export default function MovieDetail() {
             onShare={handleShare}
             isInWatchlist={isInWatchlist}
             isWatched={isWatched}
-            onToggleWatchlist={toggleWatchlist}
-            onToggleWatched={toggleWatched}
+            onToggleWatchlist={handleToggleWatchlist}
+            onToggleWatched={handleMarkWatched}
             loading={actionLoading}
             canAct={Boolean(user)}
+            celebrate={celebrate}
           />
 
           {/* The case leads: one consolidated, tier-aware statement of why this
@@ -231,7 +305,7 @@ export default function MovieDetail() {
               land. When unwatched, the locked card stays small and nudges
               them to mark watched — a quiet inline prompt, not a billboard. */}
           <div ref={yourTakeRef}>
-            <YourTake isWatched={isWatched} userId={user?.id} internalId={internalId} />
+            <YourTake isWatched={isWatched} userId={user?.id} internalId={internalId} onSaved={onRatingSaved} onError={onRatingError} />
           </div>
 
           <ViewerNotes notes={viewerNotes} />
@@ -262,7 +336,7 @@ export default function MovieDetail() {
         <StickyActionBar
           onPlayTrailer={handlePlayTrailer}
           onBack={handleBack}
-          onToggleWatchlist={toggleWatchlist}
+          onToggleWatchlist={handleToggleWatchlist}
           isInWatchlist={isInWatchlist}
           loading={actionLoading}
           canAct={Boolean(user)}

--- a/src/features/movie/__tests__/FilmFileReducedMotion.test.jsx
+++ b/src/features/movie/__tests__/FilmFileReducedMotion.test.jsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+
+let reduced = false
+vi.mock('framer-motion', () => ({ useReducedMotion: () => reduced }))
+
+import { MovieHero, StickyActionBar } from '../sections-top'
+import { MovieDataProvider } from '../useMovieData'
+
+const MV = { id: 1, title: 'Parasite', year: 2019, runtime: 132, director: 'Bong Joon-ho', genres: ['Drama'], language: 'KO', poster: 'p.jpg', backdrop: 'b.jpg', tmdbRating: 8.5, ffCritic: 91, ffAudience: 90, daypartFit: 'evening', trailerYouTubeId: 'abc' }
+const withData = (value, node) => render(<MovieDataProvider value={value}>{node}</MovieDataProvider>)
+const heroProps = { onPlayTrailer() {}, onBack() {}, onShare() {}, isInWatchlist: false, isWatched: false, onToggleWatchlist() {}, onToggleWatched() {}, loading: { watched: false, watchlist: false }, canAct: true, celebrate: false }
+
+beforeEach(() => { cleanup(); document.body.innerHTML = ''; reduced = false; vi.stubGlobal('IntersectionObserver', class { observe() {} unobserve() {} disconnect() {} }) })
+afterEach(() => { vi.unstubAllGlobals() })
+
+describe('Sticky action bar — inert / tab order (F5.4)', () => {
+  it('59/60. hidden bar is aria-hidden + inert (controls leave the tab order)', () => {
+    const { container } = withData({ mv: MV }, <StickyActionBar onPlayTrailer={() => {}} onBack={() => {}} onToggleWatchlist={() => {}} isInWatchlist={false} loading={{}} canAct />)
+    const bar = container.querySelector('.ff-movie-sticky-bar')
+    expect(bar).toHaveAttribute('aria-hidden', 'true')
+    expect(bar).toHaveAttribute('inert')
+    expect(bar.style.pointerEvents).toBe('none')
+  })
+
+  it('61. scrolled bar becomes interactive (no aria-hidden/inert)', () => {
+    const { container } = withData({ mv: MV }, <StickyActionBar onPlayTrailer={() => {}} onBack={() => {}} onToggleWatchlist={() => {}} isInWatchlist={false} loading={{}} canAct />)
+    Object.defineProperty(window, 'scrollY', { value: 200, configurable: true })
+    fireEvent.scroll(window)
+    const bar = container.querySelector('.ff-movie-sticky-bar')
+    expect(bar.getAttribute('aria-hidden')).toBeNull()
+    expect(bar.hasAttribute('inert')).toBe(false)
+    expect(bar.style.pointerEvents).toBe('auto')
+    Object.defineProperty(window, 'scrollY', { value: 0, configurable: true })
+  })
+})
+
+describe('Reduced motion — JS-driven motion suppressed (F5.4)', () => {
+  it('70. poster pointer-tilt does not change under reduced motion', () => {
+    reduced = true
+    const { container } = withData({ mv: MV, boundaryWarnings: [] }, <MovieHero {...heroProps} />)
+    const poster = container.querySelector('[style*="rotateX"]')
+    expect(poster).toBeTruthy()
+    fireEvent.mouseMove(poster.parentElement || poster, { clientX: 200, clientY: 300 })
+    // tilt stays at rotateX(0deg) rotateY(0deg)
+    expect(poster.style.transform).toMatch(/rotateX\(0deg\)\s*rotateY\(0deg\)/)
+  })
+
+  it('71. backdrop parallax stays put under reduced motion', () => {
+    reduced = true
+    const { container } = withData({ mv: MV, boundaryWarnings: [] }, <MovieHero {...heroProps} />)
+    Object.defineProperty(window, 'scrollY', { value: 400, configurable: true })
+    fireEvent.scroll(window)
+    const parallax = container.querySelector('[style*="translateY"]')
+    expect(parallax.style.transform).toMatch(/translateY\(0px\)/)
+    Object.defineProperty(window, 'scrollY', { value: 0, configurable: true })
+  })
+
+})
+
+describe('Decorative icons hidden (F5.4)', () => {
+  it('Mark Watched / Save icons are aria-hidden', () => {
+    withData({ mv: MV, boundaryWarnings: [] }, <MovieHero {...heroProps} />)
+    const watched = screen.getByRole('button', { name: 'Mark Watched' })
+    expect(watched.querySelector('svg')).toHaveAttribute('aria-hidden', 'true')
+  })
+})

--- a/src/features/movie/__tests__/FilmFileWatchedFlow.test.jsx
+++ b/src/features/movie/__tests__/FilmFileWatchedFlow.test.jsx
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { useEffect, useState } from 'react'
+import { render, screen, fireEvent, act, cleanup } from '@testing-library/react'
+
+// ── Controllable shared-status mock ───────────────────────────────────────────
+// Drives the optimistic flip + settle/revert that the Movie-local settlement effect
+// observes (loading.{watched,watchlist} true→false + the resulting state).
+const status = { isInWatchlist: false, isWatched: false, loading: { watchlist: false, watched: false }, internalId: 7 }
+const forces = new Set()
+const toggleWatched = vi.fn()
+const toggleWatchlist = vi.fn()
+function bump() { act(() => { forces.forEach((f) => f()) }) }
+
+vi.mock('@/shared/hooks/useUserMovieStatus', () => ({
+  useUserMovieStatus: () => {
+    const [, f] = useState(0)
+    useEffect(() => { const fn = () => f((n) => n + 1); forces.add(fn); return () => forces.delete(fn) }, [])
+    return { isInWatchlist: status.isInWatchlist, isWatched: status.isWatched, loading: status.loading, toggleWatchlist, toggleWatched, internalId: status.internalId }
+  },
+}))
+vi.mock('@/shared/hooks/useAuthSession', () => ({ useAuthSession: () => ({ user: { id: 'u1' } }) }))
+vi.mock('@/shared/hooks/usePageMeta', () => ({ usePageMeta: () => {} }))
+vi.mock('@/shared/services/interactions', () => ({ trackShare: vi.fn(), trackTrailerPlay: vi.fn() }))
+vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn(), useParams: () => ({ id: '496243' }) }))
+const MV = { id: 496243, title: 'Parasite', year: 2019, tagline: 'Act like you own the place.', overview: 'A class war.', trailerYouTubeId: 'abc', ffMatch: 88, runtime: 132, director: 'Bong Joon-ho', genres: ['Drama'], language: 'KO', poster: '', backdrop: '', tmdbRating: 8.5, ffCritic: 91, ffAudience: 90, daypartFit: 'evening' }
+vi.mock('../useMovieData', () => ({
+  useMovieDataFetch: () => ({ mv: MV, filmDbRow: null, moodAxes: null, overlay: null, cast: [], videos: [], similar: [], dirShelf: [], providers: { flatrate: [], rent: [], buy: [] }, boundaryWarnings: [], loading: false, error: null }),
+  MovieDataProvider: ({ children }) => children,
+  useMovieData: () => ({ mv: MV, boundaryWarnings: [] }),
+}))
+vi.mock('../hooks/useTasteFingerprint', () => ({ useTasteFingerprint: () => ({ fingerprint: null }) }))
+vi.mock('../hooks/useDirectorAffinity', () => ({ useDirectorAffinity: () => ({ count: 0 }) }))
+vi.mock('../hooks/useFriendsLoved', () => ({ useFriendsLoved: () => ({ friends: [] }) }))
+vi.mock('../hooks/useTasteTwin', () => ({ useTasteTwin: () => ({ twin: null }) }))
+// Mock the heavy tail so the test focuses on the hero actions + the live region.
+vi.mock('../sections-bottom', () => {
+  const Stub = () => null
+  return { CastSection: Stub, VideosSection: Stub, ProvidersSection: Stub, PairsWith: Stub, FriendsLoved: Stub, TasteTwinReview: Stub, TimelineSection: Stub, DirectorShelf: Stub, YourTake: () => <div data-testid="your-take" />, DetailsSection: Stub, MovieFooter: Stub }
+})
+let reduced = false
+vi.mock('framer-motion', () => ({ useReducedMotion: () => reduced }))
+
+import MovieDetail from '../MovieDetail'
+
+const live = () => document.querySelector('[role="status"][aria-live="polite"]')
+
+beforeEach(() => {
+  cleanup(); document.body.innerHTML = ''
+  status.isInWatchlist = false; status.isWatched = false; status.loading = { watchlist: false, watched: false }
+  reduced = false
+  toggleWatched.mockClear(); toggleWatchlist.mockClear()
+  vi.stubGlobal('IntersectionObserver', class { observe() {} unobserve() {} disconnect() {} })
+  Element.prototype.scrollIntoView = vi.fn()
+})
+afterEach(() => { vi.unstubAllGlobals(); vi.clearAllMocks() })
+
+// Simulate the shared hook's optimistic flip then settle (success) or revert (fail).
+function startWatched(targetTrue) { status.loading.watched = true; status.isWatched = targetTrue; bump() }
+function settleWatched(success, targetTrue) { status.loading.watched = false; status.isWatched = success ? targetTrue : !targetTrue; bump() }
+
+describe('Film File — watched settlement + live region (F5.4)', () => {
+  it('22/23. exactly one polite/atomic live region, initially empty', () => {
+    render(<MovieDetail />)
+    const regions = document.querySelectorAll('[role="status"][aria-live="polite"][aria-atomic="true"]')
+    expect(regions.length).toBe(1)
+    expect(regions[0].textContent).toBe('')
+  })
+
+  it('1/2/3/4/5/6. settled success announces, no scroll/confetti before success', () => {
+    render(<MovieDetail />)
+    fireEvent.click(screen.getByRole('button', { name: 'Mark Watched' }))
+    expect(toggleWatched).toHaveBeenCalledTimes(1)
+    startWatched(true)
+    // optimistic only — not settled yet → no announce, no scroll, no confetti
+    expect(live().textContent).toBe('')
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled()
+    expect(document.querySelector('[aria-hidden] [style*="mv-confetti"]')).toBeNull()
+    settleWatched(true, true)
+    expect(live().textContent).toMatch(/Marked Parasite as watched\. Your Take is now available\./)
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled()
+  })
+
+  it('8. normal motion scrolls with smooth behavior', () => {
+    render(<MovieDetail />)
+    fireEvent.click(screen.getByRole('button', { name: 'Mark Watched' }))
+    startWatched(true); settleWatched(true, true)
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'smooth' }))
+  })
+
+  it('7/9. reduced motion uses auto scroll + renders no confetti', () => {
+    reduced = true
+    render(<MovieDetail />)
+    fireEvent.click(screen.getByRole('button', { name: 'Mark Watched' }))
+    startWatched(true); settleWatched(true, true)
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'auto' }))
+    expect(document.querySelector('[style*="mv-confetti"]')).toBeNull()
+  })
+
+  it('10/11/12/13. failure/revert announces failure, no scroll, retryable', () => {
+    render(<MovieDetail />)
+    fireEvent.click(screen.getByRole('button', { name: 'Mark Watched' }))
+    startWatched(true)               // optimistic
+    settleWatched(false, true)        // revert → isWatched back to false
+    expect(live().textContent).toMatch(/Could not update watched status\. Try again\./)
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: 'Mark Watched' })).toBeEnabled() // still retryable
+  })
+
+  it('14. initial hydration (no click) does not announce or scroll', () => {
+    render(<MovieDetail />)
+    // simulate the mount sync flipping isWatched WITHOUT a loading transition
+    status.isWatched = true; bump()
+    expect(live().textContent).toBe('')
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled()
+  })
+})
+
+describe('Film File — Save settlement (F5.4)', () => {
+  it('16/20. Save success announces after settlement + button exposes pressed/busy', () => {
+    render(<MovieDetail />)
+    const save = screen.getByRole('button', { name: 'Save' })
+    fireEvent.click(save)
+    expect(toggleWatchlist).toHaveBeenCalledTimes(1)
+    status.loading.watchlist = true; status.isInWatchlist = true; bump()
+    expect(screen.getByRole('button', { name: 'Saved' })).toHaveAttribute('aria-busy', 'true')
+    expect(live().textContent).toBe('') // not settled yet
+    status.loading.watchlist = false; bump()
+    expect(live().textContent).toMatch(/Saved Parasite for later\./)
+    expect(screen.getByRole('button', { name: 'Saved' })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('18/19. Save failure/revert announces failure, no false success', () => {
+    render(<MovieDetail />)
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    status.loading.watchlist = true; status.isInWatchlist = true; bump()  // optimistic
+    status.loading.watchlist = false; status.isInWatchlist = false; bump() // revert
+    expect(live().textContent).toMatch(/Could not update saved films\. Try again\./)
+    expect(live().textContent).not.toMatch(/Saved Parasite for later/)
+  })
+})
+
+describe('Film File — Share fallback (F5.4)', () => {
+  it('63/64. native share success announces shared', async () => {
+    const share = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { ...navigator, share, clipboard: undefined })
+    render(<MovieDetail />)
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /share/i })) })
+    expect(share).toHaveBeenCalledWith(expect.objectContaining({ url: 'https://app.feelflick.com/movie/496243' }))
+    expect(live().textContent).toMatch(/Shared Parasite\./)
+  })
+
+  it('65/66/69. no native share → clipboard copy of the canonical URL announces copied', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { ...navigator, share: undefined, clipboard: { writeText } })
+    render(<MovieDetail />)
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /share/i })) })
+    expect(writeText).toHaveBeenCalledWith('https://app.feelflick.com/movie/496243')
+    expect(live().textContent).toMatch(/Link copied for Parasite\./)
+  })
+
+  it('67. total failure announces failure', async () => {
+    vi.stubGlobal('navigator', { ...navigator, share: undefined, clipboard: { writeText: vi.fn().mockRejectedValue(new Error('x')) } })
+    render(<MovieDetail />)
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /share/i })) })
+    expect(live().textContent).toMatch(/Could not share this film\./)
+  })
+})

--- a/src/features/movie/components/AccessibleMediaDialog.jsx
+++ b/src/features/movie/components/AccessibleMediaDialog.jsx
@@ -1,0 +1,150 @@
+// src/features/movie/components/AccessibleMediaDialog.jsx
+// F5.4 — the hardened, accessible media (trailer / featurette) dialog for the Film
+// File. Replaces the inline TrailerModal. Generic over any YouTube key + caption so
+// the hero trailer, the sticky trailer, and featurette tiles can all reuse it.
+//
+// Accessibility (mirrors the hardened Discover dialog pattern, Movie-local):
+//   • role="dialog" + aria-modal="true" + accessible name via aria-labelledby
+//   • initial focus → the close control (≥44×44)
+//   • Escape closes · backdrop click closes · inside clicks do NOT close
+//   • COMPLETE Tab / Shift+Tab focus containment (wraps last↔first; if only the
+//     close control is focusable, Tab stays on it)
+//   • focus restores to the exact opener element
+//   • body scroll lock + cleanup on unmount AND on media-key change
+//   • the backdrop is a non-focusable element (NOT a second Close button) — only one
+//     accessible Close control exists
+//   • the iframe title honestly names the film + video; only one iframe at a time
+//   • no autoplay before the dialog is open (the iframe only mounts while open)
+//   • decorative curtains are aria-hidden; the entrance animation is CSS-driven and
+//     is neutralised under prefers-reduced-motion by the global reduced-motion reset
+//
+// Video analytics stay at the trigger (not in this generic dialog).
+
+import { useRef, useEffect } from 'react'
+import { createPortal } from 'react-dom'
+
+const CAPTION_ID = 'ff-media-dialog-caption'
+
+/**
+ * @param {object} props
+ * @param {boolean} props.open
+ * @param {() => void} props.onClose
+ * @param {string|null|undefined} props.youtubeKey
+ * @param {string} props.title  full caption, e.g. "Parasite · Official Trailer"
+ */
+export default function AccessibleMediaDialog({ open, onClose, youtubeKey, title }) {
+  const dialogRef = useRef(null)
+  const closeBtnRef = useRef(null)
+  const openerRef = useRef(null)
+  // Hold the latest onClose in a ref so the effect deps stay stable (a parent's
+  // inline `() => setOpen(false)` would otherwise re-run the whole effect).
+  const onCloseRef = useRef(onClose)
+  useEffect(() => { onCloseRef.current = onClose }, [onClose])
+
+  // Scroll lock + Escape + focus trap + initial/return focus. Re-runs when the media
+  // key changes so a featurette → trailer swap re-locks/re-focuses cleanly.
+  useEffect(() => {
+    if (!open || !youtubeKey) return
+    openerRef.current = document.activeElement
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+
+    const focusables = () => {
+      const root = dialogRef.current
+      if (!root) return []
+      return Array.from(root.querySelectorAll(
+        'a[href], button:not([disabled]), iframe, [tabindex]:not([tabindex="-1"])',
+      ))
+    }
+    const onKey = (e) => {
+      if (e.key === 'Escape') { onCloseRef.current?.(); return }
+      if (e.key !== 'Tab') return
+      const items = focusables()
+      if (items.length === 0) { e.preventDefault(); return }
+      const first = items[0]
+      const last = items[items.length - 1]
+      const active = document.activeElement
+      const root = dialogRef.current
+      if (e.shiftKey) {
+        if (active === first || !root?.contains(active)) { e.preventDefault(); last.focus() }
+      } else if (active === last || !root?.contains(active)) {
+        e.preventDefault(); first.focus()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    const focusTimer = setTimeout(() => closeBtnRef.current?.focus(), 0)
+
+    return () => {
+      window.removeEventListener('keydown', onKey)
+      document.body.style.overflow = prevOverflow
+      clearTimeout(focusTimer)
+      const opener = openerRef.current
+      if (opener && typeof opener.focus === 'function' && document.contains(opener)) {
+        opener.focus()
+      }
+    }
+  }, [open, youtubeKey])
+
+  if (!open || !youtubeKey) return null
+
+  const caption = title || 'Trailer'
+
+  return createPortal(
+    <div
+      ref={dialogRef}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={CAPTION_ID}
+      className="ff-media-dialog"
+      style={{ position: 'fixed', inset: 0, zIndex: 300, animation: 'mv-fade-in 0.4s ease both' }}
+    >
+      {/* Non-focusable backdrop — click to dismiss. aria-hidden + not a button, so it
+          is NOT a second accessible Close control. Keyboard equivalent is Escape + the
+          focused X close button. */}
+      <div
+        aria-hidden="true"
+        onClick={() => onCloseRef.current?.()}
+        style={{ position: 'absolute', inset: 0, background: 'rgba(0,0,0,0.92)', backdropFilter: 'blur(20px)', cursor: 'pointer' }}
+      />
+      {/* Decorative curtains — hidden from assistive tech; CSS entrance is neutralised
+          under reduced motion by the global reset. */}
+      <div aria-hidden="true" className="ff-media-dialog__curtain-l" style={{ position: 'absolute', top: 0, bottom: 0, left: 0, width: '50%', background: 'linear-gradient(90deg, rgba(167,139,250,0.25) 0%, transparent 100%)', opacity: 0.6, animation: 'mv-curtain-l 0.6s cubic-bezier(0.2,0.8,0.2,1) both', pointerEvents: 'none' }} />
+      <div aria-hidden="true" className="ff-media-dialog__curtain-r" style={{ position: 'absolute', top: 0, bottom: 0, right: 0, width: '50%', background: 'linear-gradient(-90deg, rgba(167,139,250,0.25) 0%, transparent 100%)', opacity: 0.6, animation: 'mv-curtain-r 0.6s cubic-bezier(0.2,0.8,0.2,1) both', pointerEvents: 'none' }} />
+
+      <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', pointerEvents: 'none' }}>
+        <button
+          ref={closeBtnRef}
+          type="button"
+          onClick={() => onCloseRef.current?.()}
+          aria-label="Close trailer"
+          className="ff-media-dialog__close"
+          style={{ position: 'absolute', top: 22, right: 22, width: 44, height: 44, borderRadius: 999, background: 'rgba(0,0,0,0.75)', border: '1px solid rgba(255,255,255,0.28)', color: '#fff', cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: 22, lineHeight: 1, zIndex: 5, pointerEvents: 'auto' }}
+        >×</button>
+
+        {/* Clicks inside the player must NOT close the dialog. Pure click-intercept;
+            no keyboard action expected (the dialog's a11y is the X + Escape). */}
+        {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
+        <div
+          onClick={(e) => e.stopPropagation()}
+          style={{ position: 'relative', width: 'min(1120px, 90vw)', aspectRatio: '16/9', borderRadius: 12, overflow: 'hidden', pointerEvents: 'auto', boxShadow: '0 40px 120px -20px rgba(0,0,0,0.9), 0 0 0 1px rgba(255,255,255,0.08)', animation: 'mv-zoom-in 0.5s cubic-bezier(0.2,0.8,0.2,1) both' }}
+        >
+          <iframe
+            key={youtubeKey}
+            src={`https://www.youtube.com/embed/${youtubeKey}?autoplay=1&rel=0&modestbranding=1&playsinline=1`}
+            title={caption}
+            frameBorder="0"
+            allow="autoplay; encrypted-media; picture-in-picture"
+            allowFullScreen
+            style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }}
+          />
+        </div>
+
+        <div id={CAPTION_ID} style={{ position: 'absolute', bottom: 32, left: '50%', transform: 'translateX(-50%)', textAlign: 'center', pointerEvents: 'none' }}>
+          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.28em', textTransform: 'uppercase', color: '#A78BFA', marginBottom: 6 }}>Now Playing</div>
+          <div style={{ fontFamily: 'Outfit', fontSize: 18, fontWeight: 500, color: '#FAFAFA', letterSpacing: '-0.015em' }}>{caption}</div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/src/features/movie/components/__tests__/TrailerDialog.test.jsx
+++ b/src/features/movie/components/__tests__/TrailerDialog.test.jsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useState } from 'react'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+
+import AccessibleMediaDialog from '../AccessibleMediaDialog'
+
+// F5.4 — the hardened accessible media dialog (replaces the inline TrailerModal).
+
+// A stable opener whose DOM node is preserved across open/close so focus
+// restoration is observable.
+function Controlled({ youtubeKey = 'abc123', title = 'Parasite · Official Trailer' }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div>
+      <button type="button" id="opener" onClick={() => setOpen(true)}>Open trailer</button>
+      <AccessibleMediaDialog open={open} onClose={() => setOpen(false)} youtubeKey={youtubeKey} title={title} />
+    </div>
+  )
+}
+
+beforeEach(() => { cleanup(); document.body.innerHTML = ''; document.body.style.overflow = '' })
+
+describe('AccessibleMediaDialog', () => {
+  it('42. is a named modal dialog', () => {
+    render(<AccessibleMediaDialog open onClose={() => {}} youtubeKey="k" title="Parasite · Official Trailer" />)
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    const labelId = dialog.getAttribute('aria-labelledby')
+    expect(labelId).toBeTruthy()
+    expect(document.getElementById(labelId).textContent).toMatch(/Parasite · Official Trailer/)
+  })
+
+  it('43/44. initial focus is the close control, which is ≥44×44', async () => {
+    render(<AccessibleMediaDialog open onClose={() => {}} youtubeKey="k" title="t" />)
+    const close = screen.getByRole('button', { name: /close trailer/i })
+    await waitFor(() => expect(close).toHaveFocus())
+    expect(close.style.width).toBe('44px')
+    expect(close.style.height).toBe('44px')
+  })
+
+  it('45. Escape closes', () => {
+    const onClose = vi.fn()
+    render(<AccessibleMediaDialog open onClose={onClose} youtubeKey="k" title="t" />)
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('46. backdrop click closes', () => {
+    const onClose = vi.fn()
+    const { container } = render(<AccessibleMediaDialog open onClose={onClose} youtubeKey="k" title="t" />)
+    const backdrop = document.querySelector('.ff-media-dialog [aria-hidden="true"]')
+    fireEvent.click(backdrop)
+    expect(onClose).toHaveBeenCalled()
+    void container
+  })
+
+  it('47. clicking inside the player does NOT close', () => {
+    const onClose = vi.fn()
+    render(<AccessibleMediaDialog open onClose={onClose} youtubeKey="k" title="t" />)
+    const iframe = document.querySelector('iframe')
+    fireEvent.click(iframe.parentElement)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('48/49. Tab and Shift+Tab wrap inside the dialog (close ↔ iframe)', () => {
+    render(<AccessibleMediaDialog open onClose={() => {}} youtubeKey="k" title="t" />)
+    const close = screen.getByRole('button', { name: /close trailer/i })
+    const iframe = document.querySelector('iframe')
+    // from the last focusable (iframe) Tab wraps to first (close)
+    iframe.focus()
+    fireEvent.keyDown(window, { key: 'Tab' })
+    expect(close).toHaveFocus()
+    // from the first (close) Shift+Tab wraps to last (iframe)
+    close.focus()
+    fireEvent.keyDown(window, { key: 'Tab', shiftKey: true })
+    expect(iframe).toHaveFocus()
+  })
+
+  it('50/51/52. focus restores to the exact opener on close', async () => {
+    render(<Controlled />)
+    const opener = screen.getByText('Open trailer')
+    opener.focus()
+    fireEvent.click(opener)                       // opens → effect captures the opener
+    await screen.findByRole('dialog')
+    fireEvent.keyDown(window, { key: 'Escape' })  // closes
+    await waitFor(() => expect(opener).toHaveFocus())
+  })
+
+  it('53. body scroll locks while open and restores on close', () => {
+    const { rerender } = render(<AccessibleMediaDialog open onClose={() => {}} youtubeKey="k" title="t" />)
+    expect(document.body.style.overflow).toBe('hidden')
+    rerender(<AccessibleMediaDialog open={false} onClose={() => {}} youtubeKey="k" title="t" />)
+    expect(document.body.style.overflow).toBe('')
+  })
+
+  it('55. the iframe is removed after close (no duplicate player)', () => {
+    const { rerender } = render(<AccessibleMediaDialog open onClose={() => {}} youtubeKey="k" title="t" />)
+    expect(document.querySelectorAll('iframe').length).toBe(1)
+    rerender(<AccessibleMediaDialog open={false} onClose={() => {}} youtubeKey="k" title="t" />)
+    expect(document.querySelectorAll('iframe').length).toBe(0)
+  })
+
+  it('56. the iframe title honestly names the film + video, with the expected URL params', () => {
+    render(<AccessibleMediaDialog open onClose={() => {}} youtubeKey="xyz" title="Parasite · Behind the scenes" />)
+    const iframe = document.querySelector('iframe')
+    expect(iframe).toHaveAttribute('title', 'Parasite · Behind the scenes')
+    expect(iframe.getAttribute('src')).toBe('https://www.youtube.com/embed/xyz?autoplay=1&rel=0&modestbranding=1&playsinline=1')
+  })
+
+  it('57/58. decorative curtains are hidden + only ONE accessible Close exists', () => {
+    render(<AccessibleMediaDialog open onClose={() => {}} youtubeKey="k" title="t" />)
+    document.querySelectorAll('.ff-media-dialog__curtain-l, .ff-media-dialog__curtain-r').forEach(
+      (c) => expect(c).toHaveAttribute('aria-hidden', 'true'),
+    )
+    expect(screen.getAllByRole('button', { name: /close/i }).length).toBe(1)
+  })
+
+  it('renders nothing when closed or keyless', () => {
+    const { container, rerender } = render(<AccessibleMediaDialog open={false} onClose={() => {}} youtubeKey="k" title="t" />)
+    expect(container).toBeEmptyDOMElement()
+    expect(document.querySelector('.ff-media-dialog')).toBeNull()
+    rerender(<AccessibleMediaDialog open onClose={() => {}} youtubeKey={null} title="t" />)
+    expect(document.querySelector('.ff-media-dialog')).toBeNull()
+  })
+})

--- a/src/features/movie/hooks/__tests__/useUserRating.test.js
+++ b/src/features/movie/hooks/__tests__/useUserRating.test.js
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+// ── Controllable supabase mock ────────────────────────────────────────────────
+// Reads (maybeSingle) resolve empty; writes (upsert/insert/delete) record the call
+// and resolve via a queue of deferred promises so tests can control settlement order.
+const writeCalls = []
+let deferreds = []
+function nextDeferred() {
+  let resolve, reject
+  const promise = new Promise((res) => { resolve = () => res({ error: null }); reject = () => res({ error: { message: 'fail' } }) })
+  const d = { promise, resolve, reject }
+  deferreds.push(d)
+  return d
+}
+function makeBuilder() {
+  const b = {}
+  for (const m of ['select', 'eq', 'not', 'order', 'limit']) b[m] = vi.fn(() => b)
+  b.maybeSingle = vi.fn(() => Promise.resolve({ data: null, error: null }))
+  for (const op of ['upsert', 'insert', 'delete']) {
+    b[op] = vi.fn((payload) => {
+      // delete().eq().eq() is awaited on the chain tail; upsert/insert are awaited
+      // directly. Record + return a thenable tied to the next deferred.
+      const d = nextDeferred()
+      const rec = { op, payload }
+      writeCalls.push(rec)
+      const thenable = {
+        eq: vi.fn(() => thenable),
+        then: (res, rej) => d.promise.then(res, rej),
+        catch: (fn) => d.promise.catch(fn),
+        __deferred: d,
+      }
+      // upsert/insert are awaited directly (no trailing .eq); delete chains .eq.
+      return op === 'delete' ? thenable : { then: (res, rej) => d.promise.then(res, rej) }
+    })
+  }
+  return b
+}
+vi.mock('@/shared/lib/supabase/client', () => ({
+  supabase: { from: vi.fn(() => makeBuilder()) },
+}))
+
+import { useUserRating } from '../useUserRating'
+
+beforeEach(() => { writeCalls.length = 0; deferreds = []; vi.useFakeTimers() })
+afterEach(() => { vi.useRealTimers(); vi.clearAllMocks() })
+
+const settleAll = async () => {
+  for (const d of deferreds) d.resolve()
+  await Promise.resolve(); await Promise.resolve(); await Promise.resolve()
+}
+
+describe('useUserRating — F5.4 serialization', () => {
+  it('26. rapid identical star clicks produce ONE effective write (debounce coalesces)', async () => {
+    const { result } = renderHook(() => useUserRating({ userId: 'u1', internalId: 7 }))
+    await act(async () => {}) // flush hydration
+    writeCalls.length = 0
+    act(() => { result.current.setStars(4); result.current.setStars(4); result.current.setStars(4) })
+    await act(async () => { vi.advanceTimersByTime(600) })
+    expect(writeCalls.filter(w => w.op === 'upsert').length).toBe(1)
+    expect(writeCalls.at(-1).payload.rating).toBe(8) // 4★ → canonical 8 (unchanged scale)
+  })
+
+  it('27/34. different values → latest-value-wins, payload byte-equivalent', async () => {
+    const { result } = renderHook(() => useUserRating({ userId: 'u1', internalId: 7 }))
+    await act(async () => {})
+    writeCalls.length = 0
+    act(() => { result.current.setStars(2); result.current.setStars(5) })
+    await act(async () => { vi.advanceTimersByTime(600) })
+    const writes = writeCalls.filter(w => w.op === 'upsert')
+    expect(writes.length).toBe(1)
+    expect(writes[0].payload).toMatchObject({ user_id: 'u1', movie_id: 7, rating: 10, review_text: null })
+    expect(writes[0].payload).toHaveProperty('rated_at')
+  })
+
+  it('28/29. one write in flight; a change mid-flight runs after, stale completion ignored', async () => {
+    const { result } = renderHook(() => useUserRating({ userId: 'u1', internalId: 7 }))
+    await act(async () => {})
+    writeCalls.length = 0
+    act(() => { result.current.setStars(3) })
+    await act(async () => { vi.advanceTimersByTime(600) })   // write #1 starts (deferred)
+    expect(writeCalls.length).toBe(1)
+    expect(result.current.saveStatus).toBe('saving')
+    // a new value while #1 is in flight
+    act(() => { result.current.setStars(5) })
+    await act(async () => { vi.advanceTimersByTime(600) })
+    // still only #1 has started (one in flight) — #2 is pending
+    expect(writeCalls.length).toBe(1)
+    // settle #1 → the drain runs the pending latest (#2)
+    await act(async () => { deferreds[0].resolve(); await Promise.resolve() })
+    expect(writeCalls.length).toBe(2)
+    expect(writeCalls[1].payload.rating).toBe(10) // latest value
+  })
+
+  it('30. latest successful write exposes saved status', async () => {
+    const { result } = renderHook(() => useUserRating({ userId: 'u1', internalId: 7 }))
+    await act(async () => {})
+    act(() => { result.current.setStars(4) })
+    await act(async () => { vi.advanceTimersByTime(600) })
+    await act(async () => { await settleAll() })
+    expect(result.current.saveStatus).toBe('saved')
+  })
+
+  it('31/32. failure exposes error + retains local values; retry succeeds', async () => {
+    const { result } = renderHook(() => useUserRating({ userId: 'u1', internalId: 7 }))
+    await act(async () => {})
+    act(() => { result.current.setStars(4) })
+    await act(async () => { vi.advanceTimersByTime(600) })
+    await act(async () => { deferreds[0].reject(); await Promise.resolve() })
+    expect(result.current.saveStatus).toBe('error')
+    expect(result.current.stars).toBe(4) // local value retained
+    // retry
+    act(() => { result.current.setStars(4) })
+    await act(async () => { vi.advanceTimersByTime(600) })
+    await act(async () => { await settleAll() })
+    expect(result.current.saveStatus).toBe('saved')
+  })
+
+  it('35. reaction uses the user_movie_feedback table with the unchanged payload', async () => {
+    const { result } = renderHook(() => useUserRating({ userId: 'u1', internalId: 7 }))
+    await act(async () => {})
+    writeCalls.length = 0
+    act(() => { result.current.setReaction('Loved it') })
+    await act(async () => { vi.advanceTimersByTime(600) })
+    const insert = writeCalls.find(w => w.op === 'insert')
+    expect(insert.payload).toMatchObject({
+      user_id: 'u1', movie_id: 7, sentiment: 'loved',
+      feedback_type: 'sentiment', placement: 'movie_detail_v2_your_take', watched_confirmed: true,
+    })
+  })
+
+  it('33. unmount clears pending timers without throwing (no state update after unmount)', async () => {
+    const { result, unmount } = renderHook(() => useUserRating({ userId: 'u1', internalId: 7 }))
+    await act(async () => {})
+    act(() => { result.current.setStars(4) }) // schedules a debounce
+    expect(() => unmount()).not.toThrow()
+    // advancing timers after unmount must not fire the (cleared) debounce again
+    writeCalls.length = 0
+    await act(async () => { vi.advanceTimersByTime(1000) })
+    expect(writeCalls.filter(w => w.op === 'upsert' || w.op === 'delete').length).toBeLessThanOrEqual(1)
+  })
+})

--- a/src/features/movie/hooks/useUserRating.js
+++ b/src/features/movie/hooks/useUserRating.js
@@ -47,6 +47,52 @@ export function useUserRating({ userId, internalId }) {
   const reactionDebounceRef  = useRef(null)
   const latestRef = useRef({ stars: 0, reviewText: '', reaction: '' })
 
+  // F5.4 write serialization. Each stream (rating, reaction) keeps ONE write in
+  // flight at a time; rapid changes coalesce to the latest pending job (latest-
+  // value-wins); a monotonic version guards against a stale completion overwriting
+  // the status of a newer write. mountedRef makes every setState unmount-safe.
+  const ratingWriteRef   = useRef({ inFlight: false, pending: null, version: 0 })
+  const reactionWriteRef = useRef({ inFlight: false, pending: null, version: 0 })
+  const savedClearTimerRef = useRef(null)
+  const mountedRef = useRef(true)
+  useEffect(() => () => { mountedRef.current = false }, [])
+
+  const safeSetStatus = useCallback((next) => {
+    if (mountedRef.current) setSaveStatus(next)
+  }, [])
+  const scheduleSavedClear = useCallback(() => {
+    if (savedClearTimerRef.current) clearTimeout(savedClearTimerRef.current)
+    savedClearTimerRef.current = setTimeout(
+      () => safeSetStatus((s) => (s === 'saved' ? 'idle' : s)),
+      1600,
+    )
+  }, [safeSetStatus])
+
+  // Serialized runner: one in-flight write per stream, latest pending wins, stale
+  // completions ignored. Only the latest settled write (no newer pending) drives the
+  // saved/error status.
+  const runSerial = useCallback(async (streamRef, job) => {
+    const st = streamRef.current
+    st.pending = job                 // latest-value-wins
+    if (st.inFlight) return           // the active drain loop will pick it up
+    while (st.pending) {
+      const next = st.pending
+      st.pending = null
+      st.inFlight = true
+      const myVersion = ++st.version
+      safeSetStatus('saving')
+      try {
+        await next()
+        if (st.version === myVersion && !st.pending) { safeSetStatus('saved'); scheduleSavedClear() }
+      } catch (err) {
+        console.warn('[useUserRating]', err)
+        if (st.version === myVersion && !st.pending) safeSetStatus('error')
+      } finally {
+        st.inFlight = false
+      }
+    }
+  }, [safeSetStatus, scheduleSavedClear])
+
   // Hydrate from DB on mount / when the (user, movie) pair changes.
   useEffect(() => {
     if (!userId || !internalId) {
@@ -102,112 +148,102 @@ export function useUserRating({ userId, internalId }) {
     return () => { abort = true }
   }, [userId, internalId])
 
-  const persistRating = useCallback(async (nextStars, nextReview) => {
+  // Pure DB writers — byte-identical payloads to before. They now THROW on a
+  // Supabase error so the serial runner can surface a real 'error' status (the prior
+  // code awaited without checking `error`, so write failures were never detected).
+  const writeRating = useCallback(async (nextStars, nextReview) => {
     if (!userId || !internalId) return
-    setSaveStatus('saving')
-    try {
-      // user_ratings.rating is the 1-10 canonical scale. Sending null when
-      // stars==0 lets users remove a rating by clicking the same star twice
-      // without losing the review text.
-      const rating = nextStars > 0 ? nextStars * 2 : null
-      const trimmed = (nextReview || '').trim() || null
-      if (rating == null && !trimmed) {
-        // Nothing to persist — delete the row so we don't leave a ghost
-        // record in user_ratings with both fields null.
-        await supabase
-          .from('user_ratings')
-          .delete()
-          .eq('user_id', userId)
-          .eq('movie_id', internalId)
-      } else {
-        await supabase
-          .from('user_ratings')
-          .upsert({
-            user_id: userId,
-            movie_id: internalId,
-            rating,
-            review_text: trimmed,
-            rated_at: new Date().toISOString(),
-          }, { onConflict: 'user_id,movie_id' })
-      }
-      setSaveStatus('saved')
-      // Auto-clear the "Saved ✓" pip after a short beat.
-      setTimeout(() => setSaveStatus((s) => (s === 'saved' ? 'idle' : s)), 1600)
-    } catch (err) {
-      console.warn('[useUserRating.persistRating]', err)
-      setSaveStatus('error')
+    // user_ratings.rating is the 1-10 canonical scale. Sending null when stars==0
+    // lets users remove a rating by clicking the same star twice without losing text.
+    const rating = nextStars > 0 ? nextStars * 2 : null
+    const trimmed = (nextReview || '').trim() || null
+    if (rating == null && !trimmed) {
+      // Nothing to persist — delete the row so we don't leave a ghost record.
+      const { error } = await supabase
+        .from('user_ratings')
+        .delete()
+        .eq('user_id', userId)
+        .eq('movie_id', internalId)
+      if (error) throw error
+    } else {
+      const { error } = await supabase
+        .from('user_ratings')
+        .upsert({
+          user_id: userId,
+          movie_id: internalId,
+          rating,
+          review_text: trimmed,
+          rated_at: new Date().toISOString(),
+        }, { onConflict: 'user_id,movie_id' })
+      if (error) throw error
     }
   }, [userId, internalId])
 
-  const persistReaction = useCallback(async (nextReaction) => {
+  const writeReaction = useCallback(async (nextReaction) => {
     if (!userId || !internalId) return
-    setSaveStatus('saving')
-    try {
-      const sentiment = nextReaction ? REACTION_TO_SENTIMENT[nextReaction] : 'neutral'
-      // Append-only — each chip click logs a new feedback row. Hydration
-      // reads the latest, so the most-recent value wins.
-      await supabase.from('user_movie_feedback').insert({
-        user_id: userId,
-        movie_id: internalId,
-        sentiment,
-        feedback_type: 'sentiment',
-        placement: 'movie_detail_v2_your_take',
-        watched_confirmed: true,
-      })
-      setSaveStatus('saved')
-      setTimeout(() => setSaveStatus((s) => (s === 'saved' ? 'idle' : s)), 1600)
-    } catch (err) {
-      console.warn('[useUserRating.persistReaction]', err)
-      setSaveStatus('error')
-    }
+    const sentiment = nextReaction ? REACTION_TO_SENTIMENT[nextReaction] : 'neutral'
+    // Append-only — each chip click logs a new feedback row. Hydration reads the
+    // latest, so the most-recent value wins.
+    const { error } = await supabase.from('user_movie_feedback').insert({
+      user_id: userId,
+      movie_id: internalId,
+      sentiment,
+      feedback_type: 'sentiment',
+      placement: 'movie_detail_v2_your_take',
+      watched_confirmed: true,
+    })
+    if (error) throw error
   }, [userId, internalId])
 
-  const scheduleRatingSave = useCallback((nextStars, nextReview) => {
+  const scheduleRatingSave = useCallback(() => {
     if (ratingDebounceRef.current) clearTimeout(ratingDebounceRef.current)
     ratingDebounceRef.current = setTimeout(() => {
-      persistRating(nextStars, nextReview)
+      // Read the LATEST values at fire time (latest-value-wins).
+      runSerial(ratingWriteRef, () => writeRating(latestRef.current.stars, latestRef.current.reviewText))
     }, DEBOUNCE_MS)
-  }, [persistRating])
+  }, [runSerial, writeRating])
 
-  const scheduleReactionSave = useCallback((nextReaction) => {
+  const scheduleReactionSave = useCallback(() => {
     if (reactionDebounceRef.current) clearTimeout(reactionDebounceRef.current)
     reactionDebounceRef.current = setTimeout(() => {
-      persistReaction(nextReaction)
+      runSerial(reactionWriteRef, () => writeReaction(latestRef.current.reaction))
     }, DEBOUNCE_MS)
-  }, [persistReaction])
+  }, [runSerial, writeReaction])
 
   const setStars = useCallback((next) => {
     setStarsState(next)
     latestRef.current.stars = next
-    scheduleRatingSave(next, latestRef.current.reviewText)
+    scheduleRatingSave()
   }, [scheduleRatingSave])
 
   const setReviewText = useCallback((next) => {
     setReviewTextState(next)
     latestRef.current.reviewText = next
-    scheduleRatingSave(latestRef.current.stars, next)
+    scheduleRatingSave()
   }, [scheduleRatingSave])
 
   const setReaction = useCallback((next) => {
     setReactionState(next)
     latestRef.current.reaction = next
-    scheduleReactionSave(next)
+    scheduleReactionSave()
   }, [scheduleReactionSave])
 
-  // Flush pending debounce on unmount so a quick rate-and-navigate doesn't
-  // lose the user's input.
+  // Flush a pending debounce on unmount (fire-and-forget) so a quick
+  // rate-and-navigate doesn't lose input — and clear every timer so no state update
+  // is scheduled after unmount. mountedRef already guards any in-flight status set.
   useEffect(() => {
     return () => {
+      if (savedClearTimerRef.current) clearTimeout(savedClearTimerRef.current)
       if (ratingDebounceRef.current) {
         clearTimeout(ratingDebounceRef.current)
-        persistRating(latestRef.current.stars, latestRef.current.reviewText)
+        writeRating(latestRef.current.stars, latestRef.current.reviewText).catch(() => {})
       }
       if (reactionDebounceRef.current) {
         clearTimeout(reactionDebounceRef.current)
-        persistReaction(latestRef.current.reaction)
+        writeReaction(latestRef.current.reaction).catch(() => {})
       }
     }
-  }, [persistRating, persistReaction])
+  }, [writeRating, writeReaction])
 
   return {
     stars, reviewText, reaction,

--- a/src/features/movie/sections-bottom.jsx
+++ b/src/features/movie/sections-bottom.jsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { useReducedMotion } from 'framer-motion'
 import { tmdbImg } from '@/shared/api/tmdb'
 import { FILM_PALETTE, PARASITE_TIMELINE_SAMPLE, PARASITE_DNA_DELTA_SAMPLE, HP, HP_GRAD, RADIUS } from './data'
 import { useMovieData } from './useMovieData'
@@ -47,6 +48,7 @@ function CastSection() {
 }
 
 function CastCard({ p }) {
+  const reduced = useReducedMotion();
   const [hover, setHover] = useState(false);
   const hasFlip = p.also && p.also.length > 0;
   const hasProfile = Boolean(p.profilePath);
@@ -61,7 +63,9 @@ function CastCard({ p }) {
       aria-label={`${p.name} as ${p.role}`}
       style={{ ...RESET_BTN, perspective:1000 }}
     >
-      <div style={{ aspectRatio:'2/3', borderRadius:RADIUS.sm, marginBottom:14, position:'relative', transformStyle:'preserve-3d', transition:'transform 0.6s cubic-bezier(0.2,0.8,0.2,1)', transform: flipped ? 'rotateY(180deg)' : 'rotateY(0deg)' }}>
+      {/* F5.4: the 3D flip transition is instant under reduced motion (the back face
+          still appears on hover/focus — just without the spin). */}
+      <div style={{ aspectRatio:'2/3', borderRadius:RADIUS.sm, marginBottom:14, position:'relative', transformStyle:'preserve-3d', transition: reduced ? 'none' : 'transform 0.6s cubic-bezier(0.2,0.8,0.2,1)', transform: flipped ? 'rotateY(180deg)' : 'rotateY(0deg)' }}>
         {/* Front */}
         <div style={{ position:'absolute', inset:0, borderRadius:RADIUS.sm, overflow:'hidden', background:`linear-gradient(155deg, ${p.tint}33, ${p.tint}08)`, border:`1px solid ${HP.border}`, backfaceVisibility:'hidden' }}>
           {hasProfile ? (
@@ -491,8 +495,8 @@ function DirectorShelf({ goToMovie }) {
 }
 
 // ── Your Take (locked → unlocked after watched) ──────────────────
-function YourTake({ isWatched, userId, internalId }) {
-  if (isWatched) return <YourTakeUnlocked userId={userId} internalId={internalId} />;
+function YourTake({ isWatched, userId, internalId, onSaved, onError }) {
+  if (isWatched) return <YourTakeUnlocked userId={userId} internalId={internalId} onSaved={onSaved} onError={onError} />;
 
   return (
     <section className="ff-movie-section" style={{ padding:'56px 88px', borderTop:`1px solid ${HP.border}` }}>
@@ -512,7 +516,7 @@ function YourTake({ isWatched, userId, internalId }) {
 
 const REACTION_TAGS = ['Loved it', 'Liked it', 'Mixed', "Didn't connect"];
 
-function YourTakeUnlocked({ userId, internalId }) {
+function YourTakeUnlocked({ userId, internalId, onSaved, onError }) {
   const { mv } = useMovieData();
   // DNADelta's projected motifs are still Parasite-specific until real
   // before/after deltas land. Gate to Parasite only so auto-generated
@@ -529,9 +533,21 @@ function YourTakeUnlocked({ userId, internalId }) {
   // status that flashes after a write.
   const hasPersistedData = hydrated && (stars > 0 || reviewText || reaction);
   const showIdleSavedHint = saveStatus === 'idle' && hasPersistedData;
+
+  // F5.4: surface the LATEST settled rating outcome through the page live region
+  // once — onSaved/onError fire on each saveStatus transition (not on every render).
+  const prevStatusRef = useRef(saveStatus);
+  useEffect(() => {
+    const prev = prevStatusRef.current;
+    prevStatusRef.current = saveStatus;
+    if (prev === saveStatus) return;
+    if (saveStatus === 'saved') onSaved?.();
+    else if (saveStatus === 'error') onError?.();
+  }, [saveStatus, onSaved, onError]);
+
   return (
     <section className="ff-movie-section" style={{ padding:'56px 88px', borderTop:`1px solid ${HP.border}`, animation:'mv-fade-in 0.6s ease both' }}>
-      <div className="ff-movie-your-take-card" style={{ padding:'32px 28px', borderRadius:RADIUS.sm, background:`linear-gradient(135deg, ${FILM_PALETTE.primary}11, rgba(167,139,250,0.04))`, border:`1px solid ${FILM_PALETTE.primary}33` }}>
+      <div className="ff-movie-your-take-card" aria-busy={saveStatus === 'saving' || undefined} style={{ padding:'32px 28px', borderRadius:RADIUS.sm, background:`linear-gradient(135deg, ${FILM_PALETTE.primary}11, rgba(167,139,250,0.04))`, border:`1px solid ${FILM_PALETTE.primary}33` }}>
         <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', gap:14, flexWrap:'wrap', marginBottom:14 }}>
           <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color: FILM_PALETTE.primary, display:'inline-flex', alignItems:'center', gap:10 }}>
             <span style={{ width:8, height:8, borderRadius:RADIUS.pill, background: FILM_PALETTE.primary, boxShadow:`0 0 12px ${FILM_PALETTE.primary}` }} />
@@ -615,7 +631,7 @@ function SaveIndicator({ status, showIdleSavedHint }) {
   const map = {
     saving:    { label: 'Saving…',                color: HP.textMuted },
     saved:     { label: 'Saved ✓',                color: HP.purple    },
-    error:     { label: 'Save failed — retry',    color: '#f87171'    },
+    error:     { label: 'Could not save. Try again.', color: '#f87171' },
     idleSaved: { label: 'Saved',                  color: HP.textMuted },
   };
   const key = status === 'idle' ? 'idleSaved' : status;

--- a/src/features/movie/sections-top.jsx
+++ b/src/features/movie/sections-top.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { useReducedMotion } from 'framer-motion'
 import Tooltip from '@/shared/ui/Tooltip'
 import { ActionButton, SecondaryActionButton } from '@/shared/components/ActionButton'
 import { FILM_PALETTE, HP, HP_GRAD, RADIUS } from './data'
@@ -10,10 +11,6 @@ const iconBtnStyle = { width:36, height:36, borderRadius:RADIUS.pill, background
 
 // Reset-button style for wrapping elements that need to be focusable buttons
 // without inheriting the browser's default button chrome.
-const RESET_BTN = {
-  background:'none', border:'none', padding:0, margin:0, font:'inherit',
-  color:'inherit', textAlign:'left', cursor:'pointer', display:'block', width:'100%',
-};
 
 // ── Scroll-progress hairline ──────────────────────────────────────
 function ScrollProgress() {
@@ -48,117 +45,32 @@ function FilmGrain() {
   );
 }
 
-// ── Trailer modal (with theatrical curtains) ─────────────────────
-// Plays whichever YouTube video the caller passed in `videoKey`. When the
-// hero CTA fires it omits `videoKey` and we fall back to mv.trailerYouTubeId
-// (the canonical main trailer). When a featurette tile fires it passes the
-// thumb's specific key + title so the modal honestly plays that clip.
-function TrailerModal({ open, onClose, videoKey: explicitKey, videoTitle: explicitTitle }) {
-  const { mv } = useMovieData();
-  const closeBtnRef = useRef(null);
-  const previouslyFocusedRef = useRef(null);
-
-  useEffect(() => {
-    if (!open) return;
-
-    previouslyFocusedRef.current = document.activeElement;
-    const prevOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-
-    const onKey = (e) => { if (e.key === 'Escape') onClose(); };
-    window.addEventListener('keydown', onKey);
-    const focusTimer = setTimeout(() => closeBtnRef.current?.focus(), 0);
-
-    return () => {
-      window.removeEventListener('keydown', onKey);
-      document.body.style.overflow = prevOverflow;
-      clearTimeout(focusTimer);
-      const prev = previouslyFocusedRef.current;
-      if (prev && typeof prev.focus === 'function') prev.focus();
-    };
-  }, [open, onClose]);
-
-  const youtubeKey = explicitKey || mv?.trailerYouTubeId;
-  if (!open || !youtubeKey) return null;
-  const captionTitle = explicitTitle
-    ? `${mv?.title || 'Film'} · ${explicitTitle}`
-    : `${mv?.title || 'Film'} · Official Trailer`;
-
-  return (
-    <div role="dialog" aria-modal="true" aria-labelledby="mv-trailer-caption" style={{
-      position:'fixed', inset:0, zIndex:300,
-      animation:'mv-fade-in 0.4s ease both',
-    }}>
-      <button
-        type="button"
-        onClick={onClose}
-        aria-label="Close trailer"
-        style={{
-          ...RESET_BTN,
-          position:'absolute', inset:0, width:'100%', height:'100%',
-          background:'rgba(0,0,0,0.92)', backdropFilter:'blur(20px)', cursor:'pointer',
-        }}
-      />
-
-      <div aria-hidden style={{ position:'absolute', top:0, bottom:0, left:0, width:'50%', background:`linear-gradient(90deg, ${FILM_PALETTE.glow} 0%, transparent 100%)`, opacity:0.6, animation:'mv-curtain-l 0.6s cubic-bezier(0.2,0.8,0.2,1) both', pointerEvents:'none' }} />
-      <div aria-hidden style={{ position:'absolute', top:0, bottom:0, right:0, width:'50%', background:`linear-gradient(-90deg, ${FILM_PALETTE.glow} 0%, transparent 100%)`, opacity:0.6, animation:'mv-curtain-r 0.6s cubic-bezier(0.2,0.8,0.2,1) both', pointerEvents:'none' }} />
-
-      <div style={{ position:'absolute', inset:0, display:'flex', alignItems:'center', justifyContent:'center', pointerEvents:'none' }}>
-        <button
-          ref={closeBtnRef}
-          onClick={onClose}
-          aria-label="Close trailer"
-          style={{
-            position:'absolute', top:24, right:24,
-            width:40, height:40, borderRadius:RADIUS.pill,
-            background:'rgba(255,255,255,0.08)', border:`1px solid ${HP.border}`, color: HP.text,
-            cursor:'pointer', display:'inline-flex', alignItems:'center', justifyContent:'center',
-            fontSize:18, lineHeight:1, zIndex:5, pointerEvents:'auto',
-          }}
-        >×</button>
-
-        <div style={{
-          position:'relative', width:'min(1120px, 90vw)', aspectRatio:'16/9',
-          borderRadius:RADIUS.md, overflow:'hidden', pointerEvents:'auto',
-          boxShadow:`0 40px 120px -20px rgba(0,0,0,0.9), 0 0 0 1px rgba(255,255,255,0.08), 0 0 80px ${FILM_PALETTE.primary}33`,
-          animation:'mv-zoom-in 0.5s cubic-bezier(0.2,0.8,0.2,1) both',
-        }}>
-          <iframe
-            key={youtubeKey}
-            src={`https://www.youtube.com/embed/${youtubeKey}?autoplay=1&rel=0&modestbranding=1&playsinline=1`}
-            title={captionTitle}
-            frameBorder="0"
-            allow="autoplay; encrypted-media; picture-in-picture"
-            allowFullScreen
-            style={{ position:'absolute', inset:0, width:'100%', height:'100%' }}
-          />
-        </div>
-
-        <div id="mv-trailer-caption" style={{ position:'absolute', bottom:32, left:'50%', transform:'translateX(-50%)', textAlign:'center', animation:'mv-fade-in 0.6s 0.2s ease both', pointerEvents:'none' }}>
-          <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color: HP.purple, marginBottom:6 }}>Now Playing</div>
-          <div style={{ fontFamily:'Outfit', fontSize:18, fontWeight:500, color: HP.text, letterSpacing:'-0.015em' }}>{captionTitle}</div>
-        </div>
-      </div>
-    </div>
-  );
-}
+// The trailer/featurette dialog now lives in ./components/AccessibleMediaDialog
+// (F5.4) — the inline TrailerModal was removed from here.
 
 // ── Hero ──────────────────────────────────────────────────────────
 function MovieHero({
   onPlayTrailer, onBack, onShare,
-  isInWatchlist, isWatched, onToggleWatchlist, onToggleWatched, loading, canAct,
+  isInWatchlist, isWatched, onToggleWatchlist, onToggleWatched, loading, canAct, celebrate,
 }) {
   const { mv, boundaryWarnings } = useMovieData();
+  const reduced = useReducedMotion();
   const [scrollY, setScrollY] = useState(0);
   const [tilt, setTilt] = useState({ x:0, y:0 });
 
+  // F5.4: backdrop parallax is JS-driven (inline transform) — the global CSS
+  // reduced-motion reset can't neutralize it, so skip the scroll tracking entirely
+  // under reduced motion.
   useEffect(() => {
+    if (reduced) return;
     const on = () => setScrollY(window.scrollY);
     window.addEventListener('scroll', on, { passive: true });
     return () => window.removeEventListener('scroll', on);
-  }, []);
+  }, [reduced]);
 
+  // F5.4: poster pointer-tilt is JS-driven — disabled under reduced motion.
   const onPosterMove = (e) => {
+    if (reduced) return;
     const r = e.currentTarget.getBoundingClientRect();
     const cx = (e.clientX - r.left) / r.width - 0.5;
     const cy = (e.clientY - r.top) / r.height - 0.5;
@@ -295,6 +207,7 @@ function MovieHero({
               onToggleWatched={onToggleWatched}
               loading={loading?.watched}
               canAct={canAct}
+              celebrate={celebrate}
             />
             <SaveButton
               isInWatchlist={isInWatchlist}
@@ -333,19 +246,10 @@ function MovieHero({
 }
 
 
-function MarkWatchedButton({ isWatched, onToggleWatched, loading, canAct }) {
-  const wasWatchedRef = useRef(isWatched);
-  const [confetti, setConfetti] = useState(false);
-
-  useEffect(() => {
-    if (isWatched && !wasWatchedRef.current) {
-      setConfetti(true);
-      const t = setTimeout(() => setConfetti(false), 1800);
-      return () => clearTimeout(t);
-    }
-    wasWatchedRef.current = isWatched;
-  }, [isWatched]);
-
+function MarkWatchedButton({ isWatched, onToggleWatched, loading, canAct, celebrate }) {
+  // F5.4: confetti is driven by `celebrate` from MovieDetail — fired ONLY on settled
+  // watched success AND only when motion is allowed (reduced-motion users never get
+  // it). The old optimistic isWatched-flip trigger is removed.
   const disabled = !canAct || loading;
 
   return (
@@ -355,14 +259,15 @@ function MarkWatchedButton({ isWatched, onToggleWatched, loading, canAct }) {
         active={isWatched}
         loading={loading}
         disabled={disabled}
+        aria-busy={Boolean(loading)}
         onClick={onToggleWatched}
         title={!canAct ? 'Sign in to track what you watch' : undefined}
         label={isWatched ? 'Watched' : 'Mark Watched'}
         className="ff-movie-hero-action-btn"
         style={{ position: 'relative', opacity: disabled && !isWatched ? 0.6 : 1 }}
-        icon={<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12"/></svg>}
+        icon={<svg aria-hidden="true" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12"/></svg>}
       />
-      {confetti && <Confetti />}
+      {celebrate && <Confetti />}
     </>
   );
 }
@@ -374,6 +279,7 @@ function SaveButton({ isInWatchlist, onToggleWatchlist, loading, canAct }) {
       active={isInWatchlist}
       loading={loading}
       disabled={disabled}
+      aria-busy={Boolean(loading)}
       onClick={onToggleWatchlist}
       title={!canAct ? 'Sign in to save films' : undefined}
       label={isInWatchlist ? 'Saved' : 'Save'}
@@ -410,6 +316,7 @@ function Confetti() {
 
 function StickyActionBar({ onPlayTrailer, onBack, onToggleWatchlist, isInWatchlist, loading, canAct }) {
   const { mv } = useMovieData();
+  const barRef = useRef(null);
   const [scrolled, setScrolled] = useState(false);
   useEffect(() => {
     const on = () => setScrolled(window.scrollY > 80);
@@ -418,20 +325,40 @@ function StickyActionBar({ onPlayTrailer, onBack, onToggleWatchlist, isInWatchli
     return () => window.removeEventListener('scroll', on);
   }, []);
 
+  // F5.4: when the bar is visually hidden it must not be tabbable. If focus is inside
+  // it as it hides, move focus out (least-disruptive safe fallback) so focus never
+  // remains in an inert subtree.
+  useEffect(() => {
+    if (scrolled) return;
+    const bar = barRef.current;
+    if (bar && bar.contains(document.activeElement)) {
+      document.activeElement.blur?.();
+    }
+  }, [scrolled]);
+
   const wlDisabled = !canAct || loading?.watchlist;
   const wlTitle = !canAct ? 'Sign in to save films' : undefined;
   const hasTrailer = Boolean(mv.trailerYouTubeId);
 
   return (
-    <div className="ff-movie-sticky-bar" style={{
-      position:'fixed', top:0, left:0, right:0, zIndex:100,
-      padding:'12px 56px',
-      background:'rgba(6,6,10,0.94)', backdropFilter:'blur(20px)',
-      borderBottom:`1px solid ${HP.border}`,
-      transform: scrolled ? 'translateY(0)' : 'translateY(-100%)',
-      transition:'transform 0.35s cubic-bezier(0.2,0.8,0.2,1)',
-      display:'flex', alignItems:'center', gap:20,
-    }}>
+    <div
+      ref={barRef}
+      className="ff-movie-sticky-bar"
+      // Hidden (un-scrolled) → aria-hidden + inert so its controls leave the
+      // accessibility tree and the tab order. Shown → fully interactive.
+      aria-hidden={!scrolled || undefined}
+      inert={!scrolled ? true : undefined}
+      style={{
+        position:'fixed', top:0, left:0, right:0, zIndex:100,
+        padding:'12px 56px',
+        background:'rgba(6,6,10,0.94)', backdropFilter:'blur(20px)',
+        borderBottom:`1px solid ${HP.border}`,
+        transform: scrolled ? 'translateY(0)' : 'translateY(-100%)',
+        transition:'transform 0.35s cubic-bezier(0.2,0.8,0.2,1)',
+        pointerEvents: scrolled ? 'auto' : 'none',
+        display:'flex', alignItems:'center', gap:20,
+      }}
+    >
       <button onClick={onBack} aria-label="Go back" style={{ width:32, height:32, borderRadius:RADIUS.pill, background:'rgba(255,255,255,0.06)', border:`1px solid ${HP.border}`, color: HP.textSoft, cursor:'pointer', display:'inline-flex', alignItems:'center', justifyContent:'center' }}>
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polyline points="15 18 9 12 15 6"/></svg>
       </button>
@@ -671,4 +598,4 @@ function MoodRadar({ axes, highlightMood, onHoverAxis }) {
 // consolidated PrimaryCaseCard, and the generated quotes moved to the honestly-
 // reframed ViewerNotes component — see PrimaryCaseCard.jsx / ViewerNotes.jsx.)
 
-export { ScrollProgress, FilmGrain, TrailerModal, MovieHero, StickyActionBar, WhyForYou, Synopsis, MoodRadar }
+export { ScrollProgress, FilmGrain, MovieHero, StickyActionBar, WhyForYou, Synopsis, MoodRadar }


### PR DESCRIPTION
**F5.4 — Harden Film File actions and accessibility.** Reliability + a11y wiring only. **Scoring, ranking, match bands, provenance, generated-content copy, providers, social data, section order, write payloads, event names, and routes are unchanged** (`useMovieData` / `PrimaryCaseCard` / `ViewerNotes` / derive modules / `useUserMovieStatus` / `matchScore` / `recommendations` / shared `ActionButton` untouched).

## Settled-success Save + Mark Watched
A Movie-local settlement model (mirrors Home F4.3) observes each shared `loading.{watched,watchlist}` true→false transition + the resulting state, **ref-guarded** so the first-render DB sync is never mistaken for a user op. **Mark Watched does NOT scroll, unlock, announce, or celebrate until the write settles `true`**; on failure/revert it stays put, announces failure, and remains retryable. **Save** announces success/removal/failure only on settlement; the button exposes `aria-pressed` + `aria-busy`. The shared hook + its byte-identical payloads are unchanged.

## Reduced-motion-safe watched handoff + confetti suppression
`useReducedMotion`: the scroll-to-Your-Take uses `behavior:'auto'` under reduced motion, **only after settled success**, never on hydration or failure. **Confetti renders ONLY on settled success AND only when motion is allowed** — driven from MovieDetail via a `celebrate` prop (the old optimistic `isWatched`-flip trigger is gone). Poster pointer-tilt + backdrop parallax (JS-driven) are disabled under reduced motion; cast-card flip is instant. The global CSS reset already neutralises every Movie CSS animation/transition + `scroll-behavior`, so **no `movie.css` change was needed**.

## Film File live region
One Film File-owned `role="status" aria-live="polite" aria-atomic="true"` (sr-only) region announces concise Save / Watched / rating / share outcomes — no raw backend text, no queue/score, no duplicate nested regions, fired only on settlement (not on rerender).

## Rating serialization / latest-value-wins (`useUserRating.js`)
Per-stream **one-in-flight + latest-value-wins + monotonic version** (stale completion ignored) + unmount-safe `setState` + cleared timers. Writers now **throw on a Supabase error** so a real failure surfaces as `'error'` (the prior code never detected write errors). Payloads (`user_ratings` upsert/delete + `user_movie_feedback` insert), the 1–5★→1–10 scale, sentiment keys, the 600 ms debounce, hydration, and the unmount flush are **byte-equivalent**. YourTake consumes saving/error, exposes `aria-busy`, keeps values editable, and announces the latest save once via the page live region.

## Accessible media-dialog extraction (`components/AccessibleMediaDialog.jsx`)
Replaces the inline TrailerModal: `role="dialog"` + `aria-modal` + `aria-labelledby`, initial focus on a **≥44×44** close, Escape + backdrop close, inside clicks don't close, **complete Tab/Shift+Tab focus trap**, **focus restoration to the exact opener** (hero / sticky / featurette), **body scroll lock** + cleanup on unmount AND media-key change, a **non-focusable backdrop (only ONE accessible Close)**, honest iframe title, no autoplay before open, no duplicate iframe after close, decorative curtains `aria-hidden`. YouTube URL params + caption wording + video-tracking-at-the-trigger preserved.

## Sticky-bar inert/tab-order + Share fallback + focus semantics
Hidden sticky bar → `aria-hidden` + `inert` + `pointer-events:none` (controls leave the tab order); shown → interactive; focus inside it as it hides is moved out (least-disruptive). **Share:** native `navigator.share` → `clipboard.writeText` of the canonical Film File URL → honest failure announce; analytics event/metadata unchanged + non-blocking; **no false success**. Decorative action icons `aria-hidden`; Save/Watched `aria-pressed`+`aria-busy`.

## Tests + validation
Film File **93 → 128** (full suite **1042 → 1077**). New: `TrailerDialog` (12), `useUserRating` serialization (7), `FilmFileWatchedFlow` settlement + live-region + share (11), reduced-motion + sticky (5). **All 93 F5.3 trust tests remain green.** `npm run lint` clean · `npx vitest run src/features/movie/` 128 (×3 deterministic) · `npm run test` 1077 · `npm run build` ✓.

**Browser verification: BLOCKED** — there is no intercepted `/movie` fixture until F5.8, so verification is component/hook tests only; **no live Film File route or write was triggered** (route entry can upsert the profile cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
