### PR TITLE
Simplify Film File social and exploration tail

### DIFF
--- a/docs/movie/social-content-policy-f56.md
+++ b/docs/movie/social-content-policy-f56.md
@@ -1,0 +1,37 @@
+# Film File social-content & privacy policy (F5.6)
+
+**Status:** current · implementation-specific · **not legal advice or final privacy approval.**
+**Scope:** the `/movie/:id` Film File social-proof surfaces — `Friends Loved` and `Taste Twin` — as rendered by `SocialContext` (`src/features/movie/components/SocialContext.jsx`). This records the rule applied in F5.6; it does not change any query, hook, similarity calculation, or stored data.
+
+## Friends Loved — identified presentation is permitted
+
+- **Data source:** `useFriendsLoved` reads the current user's `user_follows` (who *they* follow), then those followed users' `user_ratings` for this film (`rating ≥ 8`), including `user_ratings.review_text`.
+- **Truth:** the rating and the review text are **real `user_ratings` content** authored by real users. Friends without a note still contribute honestly to the rating summary; no fabricated fallback note is ever shown.
+- **Why identity is allowed:** the relationship is an **explicit follow** initiated by the current user. Showing a followed user's name, avatar, rating, and note is consistent with that intentional, user-initiated relationship.
+- **Empty behaviour:** self-hides when there are no qualifying followed-user ratings.
+- **Presentation (F5.6):** a compact "{n} {person/people} you follow loved this" summary + an avatar stack + real notes rendered inline inside the single collapsed disclosure (the old nested *See their notes / Hide notes* toggle was removed — the outer disclosure is the one toggle). Avatar images use `alt=""` because the name is adjacent.
+
+## Taste Twin — anonymised presentation
+
+- **Data source:** `useTasteTwin` selects, from `user_similarity` (profile-level overall similarity), the highest-similarity user who has rated *this* film, and returns their real `user_ratings.rating` + `user_ratings.review_text` + `rated_at`, plus `name`, `avatar_url`, and a UUID-derived avatar colour.
+- **Truth that is kept verbatim:** the **rating, the review text, the watched/rated date, and the exact `overall_similarity` value** are real and unchanged. The similarity number is **overall profile similarity, not film-specific agreement** — it is labelled `"{n}% overall taste similarity"`.
+- **Identity is hidden on the Film File.** The current schema and hooks contain **no explicit public-profile, public-review, or taste-twin-visibility/consent field**. A taste twin is a *stranger* surfaced by an algorithm (unlike a follow, which the user chose). Therefore the Film File:
+  - does **not** display the twin's name,
+  - does **not** display the twin's avatar URL,
+  - does **not** display identity-derived initials,
+  - does **not** use the UUID-derived identity colour,
+  - includes **no accessible label/alt text containing their name**.
+  - uses the neutral label **"A taste twin"** + a generic, identity-free, `aria-hidden` glyph.
+- **The review is real.** When a note exists it is shown verbatim and framed as a real user note (quotation styling is appropriate because it *is* real user-authored text). It is **never** labelled "generated." When no note exists, the honest rating-only fallback ("No note yet — just the rating.") is preserved.
+- **Re-identification is a future, explicit decision.** Surfacing the twin's identity here requires a deliberate product/privacy decision **and an enforceable eligibility field/policy** (e.g. an opt-in public-review / public-taste-twin flag), checked by the hook or schema.
+
+## "New to you" deferral (exploration tail)
+
+The old Director Shelf showed a `NEW TO YOU` badge whenever the user had **no rating row** for a film. "No rating" is **not** a genuine seen/unseen signal (a user may have watched a film without rating it), so the badge could mislead. F5.6 **drops `NEW TO YOU`** and keeps only the real `{n}★ YOU` rating badge. Re-introducing a seen/unseen badge requires a genuinely **history-backed** field; deferred.
+
+## General rules applied
+
+- **Cross-user-readable RLS is NOT treated as consent.** That `user_ratings` is intentionally cross-user-readable enables the feature; it does not authorise exposing a stranger's *identity* in this context.
+- **Generated text must never be presented as real user content**, and **real user text must never be labelled generated.** (Friends/Twin notes are real; the FeelFlick impressions in Decision Evidence are clearly labelled generated — see F5.3.)
+- **Sparse social data self-hides.** No social placeholder, no fabricated review, no "no reviews yet" filler — both `SocialContext` and the friends/twin sub-blocks self-hide when empty.
+- **Presentation-only anonymisation.** The hooks' returned identity data is not altered or overwritten; the Film File simply does not render it.

--- a/src/features/movie/MovieDetail.jsx
+++ b/src/features/movie/MovieDetail.jsx
@@ -27,11 +27,12 @@ import {
 import AccessibleMediaDialog from './components/AccessibleMediaDialog'
 import DecisionEvidence from './components/DecisionEvidence'
 import FilmFileDisclosure from './components/FilmFileDisclosure'
+import SocialContext from './components/SocialContext'
+import ExplorationTail from './components/ExplorationTail'
 import PrimaryCaseCard from './PrimaryCaseCard'
 import {
-  CastSection, VideosSection, ProvidersSection, PairsWith,
-  FriendsLoved, TasteTwinReview, TimelineSection, DirectorShelf,
-  YourTake, DetailsSection, MovieFooter,
+  CastSection, VideosSection, ProvidersSection,
+  TimelineSection, YourTake, DetailsSection, MovieFooter,
 } from './sections-bottom'
 import { MovieDataProvider, useMovieDataFetch } from './useMovieData'
 import './movie.css'
@@ -333,12 +334,21 @@ export default function MovieDetail() {
 
           <VideosSection onPlayVideo={handlePlayVideo} />
 
-          <FriendsLoved friends={friends} />
-          <TasteTwinReview twin={twin} />
-
-          <PairsWith goToMovie={goToMovie} />
+          {/* Cast is factual film information — it leads the lower tail, before the
+              optional social + exploration disclosures. */}
           <CastSection />
-          <DirectorShelf goToMovie={goToMovie} />
+
+          {/* F5.6: one restrained social-proof disclosure (Friends + anonymised
+              Taste Twin) + one restrained exploration disclosure (similar + director),
+              replacing the four old full-page tail sections. Both self-hide empty. */}
+          <SocialContext friends={friends} twin={twin} />
+          <ExplorationTail
+            similar={data.similar}
+            directorFilms={data.dirShelf}
+            directorName={mv.director}
+            directorId={mv.directorId}
+            onOpenMovie={goToMovie}
+          />
 
           {/* Collapsed reference: release history + production facts, behind one
               disclosure. Renders only when there is something to show. */}

--- a/src/features/movie/__tests__/FilmFileHierarchy.test.jsx
+++ b/src/features/movie/__tests__/FilmFileHierarchy.test.jsx
@@ -12,14 +12,15 @@ vi.mock('../sections-top', () => ({
 }))
 vi.mock('../sections-bottom', () => ({
   CastSection: () => <div data-sec="cast" />, VideosSection: () => <div data-sec="videos" />,
-  ProvidersSection: () => <div data-sec="providers" />, PairsWith: () => <div data-sec="pairs" />,
-  FriendsLoved: () => <div data-sec="friends" />, TasteTwinReview: () => <div data-sec="twin" />,
-  TimelineSection: () => <div data-sec="timeline" />, DirectorShelf: () => <div data-sec="director" />,
+  ProvidersSection: () => <div data-sec="providers" />,
+  TimelineSection: () => <div data-sec="timeline" />,
   YourTake: () => <div data-sec="yourtake" />, DetailsSection: () => <div data-sec="details" />,
   MovieFooter: () => <div data-sec="footer" />,
 }))
 vi.mock('../PrimaryCaseCard', () => ({ default: () => <div data-sec="case" /> }))
 vi.mock('../components/DecisionEvidence', () => ({ default: () => <div data-sec="evidence" /> }))
+vi.mock('../components/SocialContext', () => ({ default: () => <div data-sec="social" /> }))
+vi.mock('../components/ExplorationTail', () => ({ default: () => <div data-sec="explore" /> }))
 vi.mock('../components/AccessibleMediaDialog', () => ({ default: () => null }))
 vi.mock('@/shared/hooks/useAuthSession', () => ({ useAuthSession: () => ({ user: { id: 'u1' } }) }))
 vi.mock('@/shared/hooks/usePageMeta', () => ({ usePageMeta: () => {} }))
@@ -48,21 +49,32 @@ afterEach(() => vi.clearAllMocks())
 const order = () => Array.from(document.querySelectorAll('[data-sec]')).map((n) => n.dataset.sec)
 
 describe('Film File hierarchy — decision dossier (F5.5)', () => {
-  it('1-8/13. composes the sections in the decision-first order', () => {
+  it('1-8/13. composes the sections in the decision-first order (F5.6 tail)', () => {
     render(<MovieDetail />)
     const o = order().filter((s) => s !== 'sticky')
     expect(o).toEqual([
       'hero', 'case', 'synopsis', 'providers', 'yourtake', 'evidence',
-      'videos', 'friends', 'twin', 'pairs', 'cast', 'director', 'timeline', 'details', 'footer',
+      'videos', 'cast', 'social', 'explore', 'timeline', 'details', 'footer',
     ])
-    // key adjacencies
+    // decision-zone adjacencies (unchanged)
     expect(o.indexOf('case')).toBeLessThan(o.indexOf('synopsis'))
     expect(o.indexOf('synopsis')).toBeLessThan(o.indexOf('providers'))
     expect(o.indexOf('providers')).toBeLessThan(o.indexOf('yourtake'))
     expect(o.indexOf('yourtake')).toBeLessThan(o.indexOf('evidence'))
-    expect(o.indexOf('evidence')).toBeLessThan(o.indexOf('videos'))
-    expect(o.indexOf('director')).toBeLessThan(o.indexOf('timeline'))
     expect(o.at(-1)).toBe('footer')
+  })
+
+  it('41-49. F5.6 tail: Videos → Cast → Social → Exploration → Film Details; old sections gone', () => {
+    render(<MovieDetail />)
+    const o = order()
+    expect(o.indexOf('videos')).toBeLessThan(o.indexOf('cast'))      // Cast moved before social
+    expect(o.indexOf('cast')).toBeLessThan(o.indexOf('social'))
+    expect(o.indexOf('social')).toBeLessThan(o.indexOf('explore'))
+    expect(o.indexOf('explore')).toBeLessThan(o.indexOf('timeline')) // Film Details after exploration
+    // the four old full-page tail sections are no longer independently rendered
+    for (const dead of ['friends', 'twin', 'pairs', 'director']) {
+      expect(document.querySelector(`[data-sec="${dead}"]`)).toBeNull()
+    }
   })
 
   it('9/10/11/12. exactly one Synopsis, Providers, Your Take, and one page h1', () => {

--- a/src/features/movie/components/ExplorationTail.jsx
+++ b/src/features/movie/components/ExplorationTail.jsx
@@ -1,0 +1,108 @@
+// src/features/movie/components/ExplorationTail.jsx
+// F5.6 — consolidates the two exploration shelves (Pairs With + Director Shelf) into
+// ONE restrained, collapsed-by-default disclosure. Browse stays the primary
+// exploration surface; this is a quiet "a few nearby films" tail.
+//
+// Removed vs the old PairsWith: the seeded reshuffle / "Show me more" / circular
+// cycling / per-card entry animation. We render a DETERMINISTIC bounded set in the
+// source array's existing order — no randomise / seed / re-rank / mutate / sort.
+// No match percentages, no recommendation-confidence labels. The underlying similar
+// + director arrays + their ordering are unchanged (presentation only).
+
+import FilmFileDisclosure from './FilmFileDisclosure'
+import { HP, RADIUS } from '../data'
+
+const MAX = 4
+
+function PosterButton({ title, year, dir, why, yourRating, poster, tmdbId, onOpenMovie }) {
+  return (
+    <button
+      type="button"
+      onClick={() => onOpenMovie?.(tmdbId)}
+      aria-label={`Open ${title}${year ? ` (${year})` : ''}`}
+      className="ff-movie-explore-card"
+    >
+      <div style={{ position: 'relative', borderRadius: RADIUS.sm, overflow: 'hidden', marginBottom: 12, boxShadow: '0 12px 28px -10px rgba(0,0,0,0.5)' }}>
+        {/* poster is decorative — the title is adjacent + the button is named */}
+        <img src={poster} alt="" style={{ width: '100%', aspectRatio: '2/3', objectFit: 'cover', display: 'block' }} onError={(e) => { e.currentTarget.style.display = 'none' }} />
+        {Number.isFinite(yourRating) && yourRating > 0 && (
+          <div aria-label={`Your rating: ${yourRating} out of 5`} style={{ position: 'absolute', top: 8, right: 8, padding: '3px 7px', borderRadius: 3, background: 'rgba(0,0,0,0.85)', border: `1px solid ${HP.amber}55`, fontSize: 9, fontWeight: 700, color: HP.amber, fontFamily: 'Outfit', letterSpacing: '0.06em' }}>{yourRating}★ YOU</div>
+        )}
+      </div>
+      <div style={{ fontFamily: 'Outfit', fontSize: 15, fontWeight: 500, color: HP.text, letterSpacing: '-0.015em' }}>{title}</div>
+      <div style={{ fontSize: 11, color: HP.textMuted, fontFamily: 'Outfit', letterSpacing: '0.04em', marginTop: 3 }}>
+        {year}{dir ? ` · ${dir}` : ''}
+      </div>
+      {why && (
+        <span style={{ display: 'block', marginTop: 8, fontSize: 12, lineHeight: 1.5, color: HP.textSoft, fontFamily: 'Outfit, Inter, sans-serif', fontStyle: 'italic' }}>{why}</span>
+      )}
+    </button>
+  )
+}
+
+function Subsection({ kicker, children }) {
+  return (
+    <div style={{ marginBottom: 8 }}>
+      <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.22em', textTransform: 'uppercase', color: HP.purple, margin: '0 0 16px 0' }}>{kicker}</div>
+      <div className="ff-movie-explore-grid">{children}</div>
+    </div>
+  )
+}
+
+/**
+ * @param {object} props
+ * @param {Array} [props.similar]         similar-film entries (existing order)
+ * @param {Array} [props.directorFilms]   director-shelf entries (existing order)
+ * @param {string} [props.directorName]
+ * @param {string|number|null} [props.directorId]
+ * @param {function} props.onOpenMovie
+ */
+export default function ExplorationTail({ similar = [], directorFilms = [], directorName, directorId, onOpenMovie }) {
+  const sims = Array.isArray(similar) ? similar.slice(0, MAX) : []
+  const dirs = Array.isArray(directorFilms) ? directorFilms.slice(0, MAX) : []
+  if (sims.length === 0 && dirs.length === 0) return null
+
+  const directorHeading = directorName && directorName !== '—'
+    ? `More from ${directorName}`
+    : 'More from the director'
+
+  return (
+    <FilmFileDisclosure
+      className="ff-movie-exploration-tail"
+      heading="Explore from here"
+      copy="A few nearby films—similar in spirit or from the same director."
+      defaultOpen={false}
+    >
+      {sims.length > 0 && (
+        <Subsection kicker="Similar in spirit">
+          {sims.map((s) => (
+            <PosterButton key={s.key ?? s.tmdbId} title={s.title} year={s.year} dir={s.dir} why={s.why} poster={s.poster} tmdbId={s.tmdbId} onOpenMovie={onOpenMovie} />
+          ))}
+        </Subsection>
+      )}
+
+      {dirs.length > 0 && (
+        <Subsection kicker={directorHeading}>
+          {dirs.map((f) => (
+            <PosterButton key={f.tmdbId} title={f.title} year={f.year} poster={f.poster} yourRating={f.yourRating} tmdbId={f.tmdbId} onOpenMovie={onOpenMovie} />
+          ))}
+        </Subsection>
+      )}
+
+      {/* F5.6: the "NEW TO YOU" badge was dropped — its source (no rating row) is not
+          a genuine watch-history signal, so it could mislead. Deferred until a
+          history-backed seen/unseen field exists (documented in the policy doc). */}
+
+      {directorId && (
+        <a
+          href={`https://www.themoviedb.org/person/${directorId}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ display: 'inline-flex', marginTop: 8, padding: '9px 16px', borderRadius: RADIUS.pill, background: 'transparent', border: `1px solid ${HP.border}`, color: HP.textSoft, fontFamily: 'Outfit', fontSize: 11, fontWeight: 600, letterSpacing: '0.08em', textTransform: 'uppercase', textDecoration: 'none' }}
+        >
+          Full filmography <span aria-hidden="true"> ↗</span><span className="sr-only"> (opens in a new tab)</span>
+        </a>
+      )}
+    </FilmFileDisclosure>
+  )
+}

--- a/src/features/movie/components/SocialContext.jsx
+++ b/src/features/movie/components/SocialContext.jsx
@@ -1,0 +1,132 @@
+// src/features/movie/components/SocialContext.jsx
+// F5.6 — consolidates social proof (Friends Loved + Taste Twin) into ONE restrained,
+// collapsed-by-default disclosure so the Film File supports the decision dossier
+// without becoming a social feed.
+//
+// PRIVACY (see docs/movie/social-content-policy-f56.md):
+//  • Friends remain IDENTIFIED — the current user explicitly follows them, so names,
+//    avatars, real ratings, and real review text may show.
+//  • Taste Twin is ANONYMISED on the Film File: the rating, review text, watched
+//    date, and exact overall-similarity value are REAL and kept verbatim, but the
+//    twin's name / avatar / identity-derived initials & colour are hidden. There is
+//    no explicit public-profile / taste-twin-consent field in the schema or hooks,
+//    and cross-user-readable RLS is NOT treated as consent. Re-identification needs
+//    an explicit, enforceable consent model. This is presentation-only — the hook's
+//    returned identity data is not altered or overwritten.
+
+import FilmFileDisclosure from './FilmFileDisclosure'
+import { HP, RADIUS } from '../data'
+
+const starText = (rating10) => `${(rating10 / 2).toFixed(1)} out of 5 stars`
+
+function FriendsSummary({ friends }) {
+  const avg = friends.reduce((s, f) => s + (f.rating || 0), 0) / friends.length
+  const avgDisplay = (avg / 2).toFixed(1)
+  const summaryNames = friends.slice(0, 3).map((f) => f.name).join(', ')
+  const noted = friends.filter((f) => f.reviewText)
+  return (
+    <div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 24, flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex' }}>
+          {friends.slice(0, 5).map((f, i) => (
+            <div key={f.id} style={{ width: 36, height: 36, borderRadius: RADIUS.pill, background: f.avatarBg, display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: 'Outfit', fontWeight: 700, color: '#0A0510', fontSize: 14, border: '2px solid #06060a', marginLeft: i > 0 ? -10 : 0, overflow: 'hidden' }}>
+              {f.avatarUrl
+                ? <img src={f.avatarUrl} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+                : (f.name || '?').charAt(0).toUpperCase()}
+            </div>
+          ))}
+        </div>
+        <div>
+          <div style={{ fontFamily: 'Outfit', fontSize: 16, fontWeight: 500, color: HP.text, letterSpacing: '-0.01em' }}>
+            {friends.length} {friends.length === 1 ? 'person' : 'people'} you follow loved this
+          </div>
+          <div style={{ fontSize: 12, color: HP.textMuted, fontFamily: 'Outfit', marginTop: 2 }}>
+            {summaryNames} · avg <span style={{ color: HP.amber, fontWeight: 600 }}>{avgDisplay}★</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Real friend notes, flattened (no nested disclosure — the outer one is the
+          single toggle). Friends without notes still count toward the summary. */}
+      {noted.length > 0 && (
+        <div style={{ marginTop: 20, display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 14 }}>
+          {noted.map((f) => (
+            <div key={f.id} style={{ padding: '14px 16px', borderRadius: RADIUS.sm, background: 'rgba(255,255,255,0.03)', border: `1px solid ${HP.border}` }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8 }}>
+                <div style={{ width: 28, height: 28, borderRadius: RADIUS.pill, background: f.avatarBg, display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: 'Outfit', fontWeight: 700, color: '#0A0510', fontSize: 12, overflow: 'hidden' }}>
+                  {f.avatarUrl ? <img src={f.avatarUrl} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} /> : (f.name || '?').charAt(0).toUpperCase()}
+                </div>
+                <div style={{ fontFamily: 'Outfit', fontSize: 13, fontWeight: 600, color: HP.text }}>{f.name}</div>
+                <div style={{ marginLeft: 'auto', fontSize: 11, color: HP.amber, fontFamily: 'Outfit', fontWeight: 700 }} aria-label={starText(f.rating)}>{(f.rating / 2).toFixed(1)}★</div>
+              </div>
+              <div style={{ fontSize: 12, color: HP.textMuted, fontFamily: 'Outfit, Inter, sans-serif', fontStyle: 'italic' }}>
+                {f.reviewText}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function TwinSpotlight({ twin }) {
+  // rating + review text + watched date + similarity are REAL user-authored data and
+  // are kept verbatim. Identity (name / avatar / initials / UUID-colour) is hidden —
+  // there is no consent field for surfacing it here.
+  const starsFilled = Math.round(twin.rating / 2)
+  return (
+    <div className="ff-movie-twin-anon" style={{ display: 'flex', gap: 18, alignItems: 'flex-start' }}>
+      {/* generic, identity-free glyph */}
+      <div aria-hidden="true" style={{ flexShrink: 0, width: 44, height: 44, borderRadius: RADIUS.pill, background: 'rgba(167,139,250,0.12)', border: `1px solid ${HP.purple}33`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={HP.purple} strokeWidth="1.6"><circle cx="12" cy="8" r="4" /><path d="M4 21v-1a8 8 0 0 1 16 0v1" /></svg>
+      </div>
+      <div style={{ minWidth: 0 }}>
+        <div style={{ fontFamily: 'Outfit', fontSize: 14, fontWeight: 600, color: HP.text }}>A taste twin rated this film</div>
+        <div style={{ fontSize: 11.5, color: HP.textMuted, fontFamily: 'Outfit', marginTop: 2 }}>
+          {twin.matchPct}% overall taste similarity · rated {twin.watchedDate}
+        </div>
+        <div style={{ marginTop: 10, display: 'inline-flex', gap: 3 }} aria-label={starText(twin.rating)}>
+          {[1, 2, 3, 4, 5].map((i) => (
+            <svg key={i} aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill={i <= starsFilled ? HP.amber : 'transparent'} stroke={i <= starsFilled ? HP.amber : HP.textFaint} strokeWidth="2"><path d="M12 2l3 7 7 1-5 5 1 7-6-3-6 3 1-7-5-5 7-1z" /></svg>
+          ))}
+        </div>
+        {twin.note
+          ? (
+            <p style={{ margin: '12px 0 0 0', fontFamily: 'Outfit, Inter, sans-serif', fontSize: 16, lineHeight: 1.5, color: HP.text, fontStyle: 'italic', letterSpacing: '-0.012em', textWrap: 'pretty' }}>
+              “{twin.note}”
+            </p>
+            )
+          : (
+            <p style={{ margin: '12px 0 0 0', fontFamily: 'Outfit, Inter, sans-serif', fontSize: 14, lineHeight: 1.5, color: HP.textSoft, fontStyle: 'italic' }}>
+              No note yet — just the rating.
+            </p>
+            )}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * @param {object} props
+ * @param {Array} [props.friends]  identified followed-user entries (or [])
+ * @param {object|null} [props.twin]  the anonymised taste-twin entry (or null)
+ */
+export default function SocialContext({ friends = [], twin = null }) {
+  const hasFriends = Array.isArray(friends) && friends.length > 0
+  const hasTwin = Boolean(twin)
+  if (!hasFriends && !hasTwin) return null
+
+  return (
+    <FilmFileDisclosure
+      className="ff-movie-social-context"
+      heading="What others thought"
+      copy="Real ratings and notes from people connected to your taste."
+      defaultOpen={false}
+    >
+      {hasFriends && <FriendsSummary friends={friends} />}
+      {hasFriends && hasTwin && <div style={{ height: 1, background: HP.border, margin: '28px 0' }} aria-hidden="true" />}
+      {hasTwin && <TwinSpotlight twin={twin} />}
+    </FilmFileDisclosure>
+  )
+}

--- a/src/features/movie/components/__tests__/ExplorationTail.test.jsx
+++ b/src/features/movie/components/__tests__/ExplorationTail.test.jsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import ExplorationTail from '../ExplorationTail'
+
+const SIMILAR = Array.from({ length: 6 }, (_, i) => ({
+  key: `s${i}`, tmdbId: 100 + i, title: `Sim ${i}`, year: 2010 + i, poster: `p${i}.jpg`,
+  dir: `Dir ${i}`, why: `Shares mood ${i}`, match: 80 - i,
+}))
+const DIRECTOR = Array.from({ length: 6 }, (_, i) => ({
+  tmdbId: 200 + i, title: `Dir film ${i}`, year: 2000 + i, poster: `d${i}.jpg`, yourRating: i === 0 ? 4 : null,
+}))
+
+describe('ExplorationTail — restrained exploration disclosure (F5.6)', () => {
+  it('24/25/26. self-hides when both empty; otherwise collapsed under "Explore from here"', () => {
+    const { container } = render(<ExplorationTail similar={[]} directorFilms={[]} onOpenMovie={() => {}} />)
+    expect(container).toBeEmptyDOMElement()
+    const { container: c2 } = render(<ExplorationTail similar={SIMILAR} directorFilms={[]} onOpenMovie={() => {}} />)
+    expect(c2.querySelector('details').open).toBe(false)
+    expect(screen.getByText('Explore from here')).toBeInTheDocument()
+    expect(screen.getByText(/A few nearby films—similar in spirit or from the same director/i)).toBeInTheDocument()
+  })
+
+  it('27. similar-only renders only the "Similar in spirit" subsection', () => {
+    render(<ExplorationTail similar={SIMILAR} directorFilms={[]} onOpenMovie={() => {}} />)
+    expect(screen.getByText('Similar in spirit')).toBeInTheDocument()
+    expect(screen.queryByText(/More from/i)).not.toBeInTheDocument()
+  })
+
+  it('28. director-only renders only the "More from …" subsection', () => {
+    render(<ExplorationTail similar={[]} directorFilms={DIRECTOR} directorName="Bong Joon-ho" onOpenMovie={() => {}} />)
+    expect(screen.getByText('More from Bong Joon-ho')).toBeInTheDocument()
+    expect(screen.queryByText('Similar in spirit')).not.toBeInTheDocument()
+  })
+
+  it('29. both subsections render when both arrays have data', () => {
+    render(<ExplorationTail similar={SIMILAR} directorFilms={DIRECTOR} directorName="Bong Joon-ho" onOpenMovie={() => {}} />)
+    expect(screen.getByText('Similar in spirit')).toBeInTheDocument()
+    expect(screen.getByText('More from Bong Joon-ho')).toBeInTheDocument()
+  })
+
+  it('30/31/32. caps each subsection at 4, in source order', () => {
+    render(<ExplorationTail similar={SIMILAR} directorFilms={DIRECTOR} onOpenMovie={() => {}} />)
+    const simButtons = screen.getAllByRole('button', { name: /^Open Sim/ })
+    expect(simButtons.length).toBe(4)
+    expect(simButtons.map((b) => b.getAttribute('aria-label'))).toEqual([
+      'Open Sim 0 (2010)', 'Open Sim 1 (2011)', 'Open Sim 2 (2012)', 'Open Sim 3 (2013)',
+    ])
+    expect(screen.getAllByRole('button', { name: /^Open Dir film/ }).length).toBe(4)
+  })
+
+  it('33/34. has NO reshuffle / pagination / load-more control', () => {
+    render(<ExplorationTail similar={SIMILAR} directorFilms={DIRECTOR} onOpenMovie={() => {}} />)
+    expect(screen.queryByText(/show me more|load more|reshuffle/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /next|previous|more|shuffle/i })).not.toBeInTheDocument()
+  })
+
+  it('35/36. no user-match %, but the honest similar "why" text remains', () => {
+    const { container } = render(<ExplorationTail similar={SIMILAR} directorFilms={[]} onOpenMovie={() => {}} />)
+    expect(container.textContent).not.toMatch(/\d+\s*%/)
+    expect(screen.getByText('Shares mood 0')).toBeInTheDocument()
+  })
+
+  it('37. real director "your rating" badge remains (NEW-TO-YOU dropped)', () => {
+    const { container } = render(<ExplorationTail similar={[]} directorFilms={DIRECTOR} onOpenMovie={() => {}} />)
+    expect(container.textContent).toContain('4★ YOU')
+    expect(container.textContent).not.toMatch(/NEW TO YOU/)
+  })
+
+  it('38. the open-movie callback receives the unchanged TMDB id', () => {
+    const onOpenMovie = vi.fn()
+    render(<ExplorationTail similar={SIMILAR} directorFilms={[]} onOpenMovie={onOpenMovie} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Open Sim 0 (2010)' }))
+    expect(onOpenMovie).toHaveBeenCalledWith(100)
+  })
+
+  it('39/40. full-filmography link opens TMDB in a new tab with safe rel', () => {
+    render(<ExplorationTail similar={[]} directorFilms={DIRECTOR} directorId={42} onOpenMovie={() => {}} />)
+    const link = screen.getByRole('link', { name: /Full filmography/i })
+    expect(link).toHaveAttribute('href', 'https://www.themoviedb.org/person/42')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link.getAttribute('rel')).toMatch(/noopener/)
+    expect(link.textContent).toMatch(/opens in a new tab/i)
+  })
+
+  it('does not mutate the source arrays', () => {
+    const sim = [...SIMILAR]
+    const dir = [...DIRECTOR]
+    render(<ExplorationTail similar={sim} directorFilms={dir} onOpenMovie={() => {}} />)
+    expect(sim).toEqual(SIMILAR)
+    expect(dir).toEqual(DIRECTOR)
+    expect(sim.length).toBe(6)
+  })
+})

--- a/src/features/movie/components/__tests__/SocialContext.test.jsx
+++ b/src/features/movie/components/__tests__/SocialContext.test.jsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import SocialContext from '../SocialContext'
+
+const FRIENDS = [
+  { id: 'a', name: 'Alex', avatarBg: '#A78BFA', avatarUrl: null, rating: 9, reviewText: 'Stunning.' },
+  { id: 'b', name: 'Sam', avatarBg: '#34D399', avatarUrl: null, rating: 8, reviewText: '' },
+  { id: 'c', name: 'Rey', avatarBg: '#F472B6', avatarUrl: null, rating: 10, reviewText: 'Best of the year.' },
+]
+const TWIN = { id: 't', name: 'Jordan Lee', avatarBg: '#112233', avatarUrl: 'http://x/a.jpg', matchPct: 84, rating: 9, note: 'It lingers.', watchedDate: 'Mar 2024' }
+
+describe('SocialContext — one restrained social disclosure (F5.6)', () => {
+  it('1. self-hides when friends empty and twin absent', () => {
+    const { container } = render(<SocialContext friends={[]} twin={null} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('2/3/4/5/6. renders (friends or twin), collapsed, with honest heading + copy', () => {
+    const { container } = render(<SocialContext friends={FRIENDS} twin={null} />)
+    expect(container.querySelector('details').open).toBe(false)
+    expect(screen.getByText('What others thought')).toBeInTheDocument()
+    expect(screen.getByText(/Real ratings and notes from people connected to your taste/i)).toBeInTheDocument()
+    // twin-only also renders
+    const { container: c2 } = render(<SocialContext friends={[]} twin={TWIN} />)
+    expect(c2.querySelector('details')).toBeTruthy()
+  })
+
+  it('7. has NO nested friend-notes disclosure (no See/Hide notes toggle)', () => {
+    render(<SocialContext friends={FRIENDS} twin={null} />)
+    expect(screen.queryByRole('button', { name: /see their notes|hide notes/i })).not.toBeInTheDocument()
+  })
+
+  it('8/9/10/11. friend order + names + ratings + real review text remain', () => {
+    render(<SocialContext friends={FRIENDS} twin={null} />)
+    expect(screen.getByText('3 people you follow loved this')).toBeInTheDocument()
+    expect(screen.getByText(/Alex, Sam, Rey/)).toBeInTheDocument()           // order preserved
+    expect(screen.getByText('Stunning.')).toBeInTheDocument()                // real note
+    expect(screen.getByText('Best of the year.')).toBeInTheDocument()        // real note
+    // ratings present (avg + per-note)
+    expect(screen.getByText(/avg/)).toBeInTheDocument()
+  })
+
+  it('12. friends without notes do not create empty note cards', () => {
+    const { container } = render(<SocialContext friends={FRIENDS} twin={null} />)
+    // 2 of 3 friends have notes → exactly 2 note cards
+    const noteCards = Array.from(container.querySelectorAll('div')).filter((d) => /Stunning\.|Best of the year\./.test(d.textContent) && d.querySelector('div'))
+    expect(screen.getByText('Stunning.')).toBeInTheDocument()
+    expect(container.textContent).not.toMatch(/Sam[^]*?undefined/) // Sam (no note) doesn't render an empty note
+    void noteCards
+  })
+
+  it('singular wording for one friend', () => {
+    render(<SocialContext friends={[FRIENDS[0]]} twin={null} />)
+    expect(screen.getByText('1 person you follow loved this')).toBeInTheDocument()
+  })
+})

--- a/src/features/movie/components/__tests__/TasteTwinPrivacy.test.jsx
+++ b/src/features/movie/components/__tests__/TasteTwinPrivacy.test.jsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import SocialContext from '../SocialContext'
+
+// F5.6 — the Taste Twin is anonymised on the Film File: rating / review text /
+// watched date / exact overall-similarity are REAL and kept; identity is hidden.
+const TWIN = { id: 'uuid-123', name: 'Jordan Lee', avatarBg: '#1a2b3c', avatarUrl: 'http://cdn/jordan.jpg', matchPct: 84, rating: 9, note: 'It lingers long after.', watchedDate: 'Mar 2024' }
+
+describe('Taste Twin privacy (F5.6)', () => {
+  it('13/14/15/16. hides the real name, avatar URL, identity initials, and any name in the a11y tree', () => {
+    const { container } = render(<SocialContext friends={[]} twin={TWIN} />)
+    expect(screen.queryByText('Jordan Lee')).not.toBeInTheDocument()
+    expect(screen.queryByText('Jordan')).not.toBeInTheDocument()
+    expect(container.querySelector('img[src*="jordan.jpg"]')).toBeNull()
+    expect(container.querySelector('img')).toBeNull()                 // no avatar image at all
+    expect(container.textContent).not.toMatch(/Jordan|\bJL\b/)
+    // no aria-label/alt leaks the name
+    expect(container.querySelector('[aria-label*="Jordan"]')).toBeNull()
+    expect(container.innerHTML).not.toContain('jordan.jpg')
+  })
+
+  it('17. uses the neutral "A taste twin" label', () => {
+    render(<SocialContext friends={[]} twin={TWIN} />)
+    expect(screen.getByText(/A taste twin rated this film/i)).toBeInTheDocument()
+  })
+
+  it('18/19/20/21. keeps the real review verbatim, the rating, the exact similarity, and the overall-similarity wording', () => {
+    const { container } = render(<SocialContext friends={[]} twin={TWIN} />)
+    expect(container.textContent).toContain('It lingers long after.')          // verbatim review
+    expect(screen.getByLabelText('4.5 out of 5 stars')).toBeInTheDocument()     // rating 9 → 4.5★
+    expect(container.textContent).toMatch(/84% overall taste similarity/)       // exact value + wording
+  })
+
+  it('22. never implies film-specific agreement', () => {
+    const { container } = render(<SocialContext friends={[]} twin={TWIN} />)
+    expect(container.textContent).not.toMatch(/film match|agreement on this film|84%\s*match\b/i)
+  })
+
+  it('23. rating-only fallback stays honest when there is no note', () => {
+    render(<SocialContext friends={[]} twin={{ ...TWIN, note: null }} />)
+    expect(screen.getByText(/No note yet — just the rating\./i)).toBeInTheDocument()
+  })
+
+  it('does not label the real review as generated', () => {
+    const { container } = render(<SocialContext friends={[]} twin={TWIN} />)
+    expect(container.textContent).not.toMatch(/generated|FeelFlick impression/i)
+  })
+})

--- a/src/features/movie/movie.css
+++ b/src/features/movie/movie.css
@@ -369,3 +369,47 @@
   .ff-disclosure__summary { padding: 22px 24px; }
   .ff-disclosure__heading { font-size: 20px; }
 }
+
+/* ── F5.6 social + exploration tail ────────────────────────────────
+   SocialContext + ExplorationTail render inside FilmFileDisclosure, so their
+   bodies need the page gutter + a bottom rhythm. */
+.ff-movie-social-context .ff-disclosure__content,
+.ff-movie-exploration-tail .ff-disclosure__content {
+  padding: 4px 88px 36px;
+}
+.ff-movie-explore-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+}
+/* Movie-local button reset for exploration poster cards + a visible focus ring. */
+.ff-movie-explore-card {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  display: block;
+  width: 100%;
+  border-radius: 8px;
+}
+.ff-movie-explore-card:focus-visible {
+  outline: 2px solid #a78bfa;
+  outline-offset: 4px;
+}
+@media (max-width: 720px) {
+  .ff-movie-social-context .ff-disclosure__content,
+  .ff-movie-exploration-tail .ff-disclosure__content {
+    padding: 4px 24px 28px;
+  }
+  .ff-movie-explore-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 14px;
+  }
+  .ff-movie-twin-anon {
+    flex-wrap: wrap;
+  }
+}


### PR DESCRIPTION
**F5.6 — Simplify the Film File social and exploration tail** into two restrained disclosures. Presentation / IA + Taste-Twin anonymisation only. **No scoring, ranking, candidate data, social queries, similarity calculation, review text, provider behavior, payloads, event names, routes, or schema changed.** The decision zone (Hero → Case → Synopsis → Providers → YourTake → DecisionEvidence) + F5.3 trust framing + F5.4 action reliability + F5.5 disclosures are untouched (`useMovieData` / `useFriendsLoved` / `useTasteTwin` / `PrimaryCaseCard` / `ViewerNotes` / `DecisionEvidence` / `FilmFileDisclosure` / `AccessibleMediaDialog` / `sections-top` / `useUserRating` / `sections-bottom` all unchanged).

## Final lower-tail hierarchy
`Videos → CastSection → SocialContext → ExplorationTail → Film Details → Footer` — Cast (factual info) moves before the optional social + exploration tail.

## Social-proof consolidation (`SocialContext.jsx`)
One **collapsed** `What others thought` disclosure — *"Real ratings and notes from people connected to your taste."* **Self-hides when both Friends and Taste Twin are empty.**

**Friends Loved — preserved & identified:** the user explicitly follows them, so names, avatars, real ratings, real review text, order, and max set remain, with the `"{n} {person/people} you follow loved this"` summary + average. The old **nested *See their notes / Hide notes* toggle is removed** (the outer disclosure is the single toggle); friend notes render inline; friends without notes contribute to the summary but make no empty card; avatar images use `alt=""`.

## Taste Twin anonymisation rationale
**The twin's rating, review text, watched date, and exact `overall_similarity` value/label are REAL and kept verbatim.** Identity is hidden on the Film File — **no name, avatar URL, identity-derived initials, or UUID-derived colour, and no name in the a11y tree** — replaced by a neutral **`A taste twin`** label + a generic `aria-hidden` glyph. The real review is **never** labelled generated; the honest rating-only fallback is preserved. **No public-profile / taste-twin-consent field exists in the schema or hooks, and cross-user-readable RLS is not treated as consent** — re-identification needs an explicit, enforceable consent model. **Anonymisation is presentation-only; the hook's returned data is not altered.** *(Confirmed: twin rating / review / similarity remain real and unchanged.)*

## Social policy document
`docs/movie/social-content-policy-f56.md` records the Friends-identified-vs-Twin-anonymised rule, the *cross-user RLS ≠ consent* principle, the real-vs-generated rules, sparse-data self-hide, and the NEW-TO-YOU deferral.

## Exploration consolidation + reshuffle removal (`ExplorationTail.jsx`)
One **collapsed** `Explore from here` disclosure — *"A few nearby films—similar in spirit or from the same director."* **Self-hides when both arrays empty.**
- **Similar in spirit:** `similar.slice(0, 4)` in **source order**, the honest "why" line, **no match %**.
- **More from the director:** `dirShelf.slice(0, 4)` in **source order**, the real `{n}★ YOU` rating kept; **`NEW TO YOU` dropped** (its "no rating row" source isn't a genuine seen/unseen signal — deferred + documented); TMDB **Full filmography** link (new tab + sr-only "opens in a new tab").
- **Reshuffle removed:** seed state / "Show me more" / circular cycling / per-card entry animation gone; no pagination / arrows / load-more; the source arrays are not mutated / sorted / re-ranked.

The old `FriendsLoved` / `TasteTwinReview` / `PairsWith` / `DirectorShelf` are **retained as `sections-bottom` exports** (consumed by `FilmFileTrustFraming.test`) but **no longer rendered**.

## Accessibility outcomes
Native `<details>/<summary>` disclosures (no custom ARIA); the generic twin label is announced; no real identity in alt/aria-label; exploration cards stay real `<button>`s named `Open <title> (<year>)` with focus-visible rings + decorative poster `alt=""`; the external director link indicates a new tab; collapsed content stays keyboard-accessible.

## Tests + validation
Film File **152 → 176** (full **1101 → 1125**). New: `SocialContext` (6), `TasteTwinPrivacy` (6), `ExplorationTail` (12); `FilmFileHierarchy` updated to the F5.6 tail order + assertions that FriendsLoved/TasteTwinReview/PairsWith/DirectorShelf are no longer independently rendered. **All prior F5.2–F5.5 tests remain green.** `npm run lint` clean · `npx vitest run src/features/movie/` 176 (×3 deterministic) · `npm run test` 1125 · `npm run build` ✓.

**Browser verification deferred to F5.8** (no intercepted `/movie` fixture; route entry can upsert the profile cache) — DOM/component tests + static responsive reasoning only; **no live Film File route or write was triggered**, no Playwright snapshot changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
