### PR TITLE
Harden Film File provider and error states

### DIFF
--- a/src/features/movie/MovieDetail.jsx
+++ b/src/features/movie/MovieDetail.jsx
@@ -29,6 +29,7 @@ import DecisionEvidence from './components/DecisionEvidence'
 import FilmFileDisclosure from './components/FilmFileDisclosure'
 import SocialContext from './components/SocialContext'
 import ExplorationTail from './components/ExplorationTail'
+import { classifyMovieRouteState } from './derive/movieRouteState'
 import PrimaryCaseCard from './PrimaryCaseCard'
 import {
   CastSection, VideosSection, ProvidersSection,
@@ -242,7 +243,11 @@ export default function MovieDetail() {
   }, [internalId, mv, movieUrl, movieTitle, announce])
 
   if (loading) return <PageSkeleton />
-  if (error || !mv) return <PageError error={error} onBack={handleBack} />
+  if (error || !mv) {
+    // F5.7: classify into safe, user-facing copy — never the raw error.
+    const routeState = classifyMovieRouteState({ routeId: id, hasMovie: Boolean(mv), error })
+    return <PageError routeState={routeState} onBack={handleBack} onHome={() => navigate('/home')} />
+  }
 
   // F5.5 — gate the collapsed Film Details disclosure. TimelineSection self-hides
   // when there's no release date / languages; DetailsSection always renders, so it
@@ -262,6 +267,9 @@ export default function MovieDetail() {
         minHeight: '100vh', background: '#06060a', color: '#FAFAFA',
         fontFamily: 'Inter, sans-serif', overflow: 'hidden', position: 'relative',
       }}>
+        {/* F5.7: first focusable element — lets keyboard users skip the cinematic
+            Hero controls and jump straight into the decision dossier. */}
+        <a href="#film-file-content" className="ff-movie-skip-link">Skip to Film File content</a>
         <ScrollProgress />
         <FilmGrain />
         <AccessibleMediaDialog
@@ -292,6 +300,10 @@ export default function MovieDetail() {
             celebrate={celebrate}
           />
 
+          {/* F5.7: the decision dossier (case → footer) is the route's <main>, and
+              the skip-link target. The Hero stays above it as the introductory
+              header. tabIndex=-1 lets the skip link move focus here. */}
+          <main id="film-file-content" tabIndex={-1}>
           {/* The case leads: one consolidated, tier-aware statement of why this
               film was surfaced (ff_take → adaptive "why this fits you" → honest
               standalone), before the Why-for-you signal cards expand it. */}
@@ -364,6 +376,7 @@ export default function MovieDetail() {
             </FilmFileDisclosure>
           )}
           <MovieFooter onBackToBriefing={() => navigate('/home')} />
+          </main>
         </div>
 
         <StickyActionBar
@@ -382,11 +395,15 @@ export default function MovieDetail() {
 function PageSkeleton() {
   const pulse = { background: 'rgba(255,255,255,0.04)' };
   return (
-    <div className="ff-movie" style={{
-      minHeight: '100vh', background: '#06060a', color: '#FAFAFA',
-      fontFamily: 'Inter, sans-serif', overflow: 'hidden',
-    }}>
-      <div style={{ maxWidth: 1440, margin: '0 auto' }}>
+    <div
+      className="ff-movie"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      style={{ minHeight: '100vh', background: '#06060a', color: '#FAFAFA', fontFamily: 'Inter, sans-serif', overflow: 'hidden' }}
+    >
+      <span className="sr-only">Loading Film File…</span>
+      <div aria-hidden="true" style={{ maxWidth: 1440, margin: '0 auto' }}>
         <div style={{ position:'relative', minHeight: 760, padding:'140px 88px 64px', display:'grid', gridTemplateColumns:'auto 1fr', gap:64, alignItems:'flex-end' }}>
           <div className="animate-pulse" style={{ ...pulse, width:300, aspectRatio:'2/3', borderRadius:8 }} />
           <div style={{ display:'flex', flexDirection:'column', gap:18 }}>
@@ -406,34 +423,44 @@ function PageSkeleton() {
   );
 }
 
-function PageError({ error, onBack }) {
+function PageError({ routeState, onBack, onHome }) {
+  // F5.7: copy comes ONLY from the safe route classifier — no raw error text,
+  // endpoints, or status messages reach the user.
+  const { eyebrow, title, message } = routeState;
   return (
     <div className="ff-movie" style={{
       minHeight: '100vh', background: '#06060a', color: '#FAFAFA',
       display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24,
       fontFamily: 'Inter, sans-serif',
     }}>
-      <div style={{ textAlign: 'center', maxWidth: 520 }}>
+      <div role="alert" style={{ textAlign: 'center', maxWidth: 520 }}>
         <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.28em', textTransform: 'uppercase', color: '#A78BFA', marginBottom: 18 }}>
-          404 · Film File Not Found
+          {eyebrow}
         </div>
-        <h1 style={{ fontFamily: 'Outfit, Inter, sans-serif', fontSize: 48, fontWeight: 500, color: '#FAFAFA', margin: '0 0 18px 0', letterSpacing: '-0.025em' }}>
-          Couldn’t find that movie.
+        <h1 style={{ fontFamily: 'Outfit, Inter, sans-serif', fontSize: 'clamp(30px, 6vw, 48px)', fontWeight: 500, color: '#FAFAFA', margin: '0 0 18px 0', letterSpacing: '-0.025em', textWrap: 'balance' }}>
+          {title}
         </h1>
         <p style={{ margin: '0 0 28px 0', color: 'rgba(250,250,250,0.6)', fontSize: 15, lineHeight: 1.6 }}>
-          {error || 'It may not exist or TMDB couldn’t reach it.'}
+          {message}
         </p>
-        <button
-          onClick={onBack}
-          style={{
-            padding: '12px 22px', borderRadius: 999,
-            background: 'linear-gradient(135deg, #9333ea 0%, #ec4899 100%)',
-            color: '#fff', border: 'none', cursor: 'pointer',
-            fontFamily: 'Outfit', fontSize: 14, fontWeight: 600,
-          }}
-        >
-          Go back
-        </button>
+        <div style={{ display: 'flex', gap: 12, justifyContent: 'center', flexWrap: 'wrap' }}>
+          <button
+            type="button"
+            onClick={onBack}
+            className="ff-movie-error-btn"
+            style={{ minHeight: 44, padding: '12px 22px', borderRadius: 999, background: 'linear-gradient(135deg, #9333ea 0%, #ec4899 100%)', color: '#fff', border: 'none', cursor: 'pointer', fontFamily: 'Outfit', fontSize: 14, fontWeight: 600 }}
+          >
+            Go back
+          </button>
+          <button
+            type="button"
+            onClick={onHome}
+            className="ff-movie-error-btn"
+            style={{ minHeight: 44, padding: '12px 22px', borderRadius: 999, background: 'transparent', color: 'rgba(250,250,250,0.85)', border: '1px solid rgba(250,250,250,0.2)', cursor: 'pointer', fontFamily: 'Outfit', fontSize: 14, fontWeight: 600 }}
+          >
+            Go to Home
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/features/movie/__tests__/FilmFileFinalA11y.test.jsx
+++ b/src/features/movie/__tests__/FilmFileFinalA11y.test.jsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { useState } from 'react'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+
+vi.mock('framer-motion', () => ({ useReducedMotion: () => false }))
+
+import { MovieHero, StickyActionBar } from '../sections-top'
+import { MovieDataProvider } from '../useMovieData'
+import FilmFileDisclosure from '../components/FilmFileDisclosure'
+
+const MV = { id: 1, title: 'Parasite', year: 2019, runtime: 132, director: 'Bong Joon-ho', genres: ['Drama'], language: 'KO', poster: '', backdrop: '', tmdbRating: 8.5, ffCritic: 91, ffAudience: 90, daypartFit: 'evening', trailerYouTubeId: 'abc' }
+const heroProps = { onPlayTrailer() {}, onBack() {}, onShare() {}, isInWatchlist: false, isWatched: false, onToggleWatchlist() {}, onToggleWatched() {}, loading: { watched: false, watchlist: false }, canAct: true, celebrate: false }
+const withData = (node) => render(<MovieDataProvider value={{ mv: MV, boundaryWarnings: [] }}>{node}</MovieDataProvider>)
+
+beforeEach(() => { cleanup(); document.body.innerHTML = ''; vi.stubGlobal('IntersectionObserver', class { observe() {} unobserve() {} disconnect() {} }) })
+afterEach(() => vi.unstubAllGlobals())
+
+describe('Final touch-target + icon semantics (F5.7)', () => {
+  it('64/66/67. hero Share is 44×44, type=button, with an aria-hidden icon', () => {
+    withData(<MovieHero {...heroProps} />)
+    const share = screen.getByRole('button', { name: 'Share this film' })
+    expect(share.style.width).toBe('44px')
+    expect(share.style.height).toBe('44px')
+    expect(share).toHaveAttribute('type', 'button')
+    expect(share.querySelector('svg')).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('65/66. hero Back is ≥44px, type=button', () => {
+    withData(<MovieHero {...heroProps} />)
+    const back = screen.getByRole('button', { name: 'Go back' })
+    expect(back.style.minHeight).toBe('44px')
+    expect(back).toHaveAttribute('type', 'button')
+  })
+
+  it('64. sticky Back icon control is 44×44 with type=button (when the bar is shown)', () => {
+    const { container } = render(<MovieDataProvider value={{ mv: MV }}><StickyActionBar onPlayTrailer={() => {}} onBack={() => {}} onToggleWatchlist={() => {}} isInWatchlist={false} loading={{}} canAct /></MovieDataProvider>)
+    // the bar is inert/aria-hidden until scrolled — show it so its controls are real
+    Object.defineProperty(window, 'scrollY', { value: 200, configurable: true })
+    fireEvent.scroll(window)
+    const back = container.querySelector('.ff-movie-sticky-bar button[aria-label="Go back"]')
+    expect(back.style.width).toBe('44px')
+    expect(back.style.height).toBe('44px')
+    expect(back).toHaveAttribute('type', 'button')
+    Object.defineProperty(window, 'scrollY', { value: 0, configurable: true })
+  })
+})
+
+function TwoDisclosures() {
+  const [n, setN] = useState(0)
+  return (
+    <div>
+      <button type="button" onClick={() => setN((x) => x + 1)}>bump {n}</button>
+      <FilmFileDisclosure heading="First disclosure"><p>one</p></FilmFileDisclosure>
+      <FilmFileDisclosure heading="Second disclosure"><p>two</p></FilmFileDisclosure>
+    </div>
+  )
+}
+
+describe('Disclosure independence + rerender persistence (F5.7)', () => {
+  it('68/69. opening one disclosure leaves the other closed and survives an unrelated rerender', () => {
+    const { container } = render(<TwoDisclosures />)
+    const [d1, d2] = container.querySelectorAll('details')
+    const s1 = d1.querySelector('summary')
+    // open the first
+    s1.click()
+    expect(d1.open).toBe(true)
+    expect(d2.open).toBe(false) // no accordion exclusivity
+    // an unrelated parent rerender must not collapse it
+    fireEvent.click(screen.getByText(/bump/))
+    expect(container.querySelectorAll('details')[0].open).toBe(true)
+  })
+})

--- a/src/features/movie/__tests__/FilmFileLandmarks.test.jsx
+++ b/src/features/movie/__tests__/FilmFileLandmarks.test.jsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+
+vi.mock('../sections-top', () => ({
+  ScrollProgress: () => null, FilmGrain: () => null,
+  MovieHero: () => <header data-sec="hero"><h1>Parasite</h1></header>,
+  StickyActionBar: () => <div data-sec="sticky"><button type="button">sticky</button></div>,
+  Synopsis: () => <div data-sec="synopsis" />,
+}))
+vi.mock('../sections-bottom', () => ({
+  CastSection: () => <div data-sec="cast" />, VideosSection: () => <div data-sec="videos" />,
+  ProvidersSection: () => <div data-sec="providers" />, TimelineSection: () => <div data-sec="timeline" />,
+  YourTake: () => <div data-sec="yourtake" />, DetailsSection: () => <div data-sec="details" />,
+  MovieFooter: () => <div data-sec="footer" />,
+}))
+vi.mock('../PrimaryCaseCard', () => ({ default: () => <div data-sec="case" /> }))
+vi.mock('../components/DecisionEvidence', () => ({ default: () => <div data-sec="evidence" /> }))
+vi.mock('../components/SocialContext', () => ({ default: () => <div data-sec="social" /> }))
+vi.mock('../components/ExplorationTail', () => ({ default: () => <div data-sec="explore" /> }))
+vi.mock('../components/AccessibleMediaDialog', () => ({ default: () => null }))
+vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn(), useParams: () => ({ id: '496243' }) }))
+vi.mock('@/shared/hooks/useAuthSession', () => ({ useAuthSession: () => ({ user: { id: 'u1' } }) }))
+vi.mock('@/shared/hooks/usePageMeta', () => ({ usePageMeta: () => {} }))
+vi.mock('@/shared/hooks/useUserMovieStatus', () => ({ useUserMovieStatus: () => ({ isInWatchlist: false, isWatched: false, loading: {}, toggleWatchlist: vi.fn(), toggleWatched: vi.fn(), internalId: 7 }) }))
+vi.mock('@/shared/services/interactions', () => ({ trackShare: vi.fn(), trackTrailerPlay: vi.fn() }))
+vi.mock('framer-motion', () => ({ useReducedMotion: () => false }))
+vi.mock('../hooks/useTasteFingerprint', () => ({ useTasteFingerprint: () => ({ fingerprint: null }) }))
+vi.mock('../hooks/useDirectorAffinity', () => ({ useDirectorAffinity: () => ({ count: 0 }) }))
+vi.mock('../hooks/useFriendsLoved', () => ({ useFriendsLoved: () => ({ friends: [] }) }))
+vi.mock('../hooks/useTasteTwin', () => ({ useTasteTwin: () => ({ twin: null }) }))
+
+let DATA = { mv: { id: 1, title: 'Parasite', releaseDate: '2019-05-30', runtime: 132 }, filmDbRow: null, moodAxes: null, overlay: null, similar: [], dirShelf: [], loading: false, error: null }
+vi.mock('../useMovieData', () => ({
+  useMovieDataFetch: () => DATA,
+  MovieDataProvider: ({ children }) => children,
+  useMovieData: () => ({ mv: DATA.mv }),
+}))
+
+import MovieDetail from '../MovieDetail'
+
+beforeEach(() => { cleanup(); document.body.innerHTML = ''; DATA = { ...DATA, loading: false, error: null } })
+afterEach(() => vi.clearAllMocks())
+
+describe('Film File — skip link + main landmark (F5.7)', () => {
+  it('48/49/50. the skip link is the first focusable element with the right label + target', () => {
+    const { container } = render(<MovieDetail />)
+    const focusables = container.querySelectorAll('a[href], button')
+    expect(focusables[0].tagName).toBe('A')
+    expect(focusables[0]).toHaveAttribute('href', '#film-file-content')
+    expect(focusables[0]).toHaveTextContent('Skip to Film File content')
+  })
+
+  it('51/52/53. the target is a single <main id> with tabIndex -1', () => {
+    const { container } = render(<MovieDetail />)
+    const mains = container.querySelectorAll('main')
+    expect(mains.length).toBe(1)
+    const main = container.querySelector('#film-file-content')
+    expect(main.tagName).toBe('MAIN')
+    expect(main).toHaveAttribute('tabindex', '-1')
+  })
+
+  it('54/55/56/57. Hero is before main; PrimaryCase begins main; Footer is inside main; sticky is outside', () => {
+    const { container } = render(<MovieDetail />)
+    const hero = container.querySelector('[data-sec="hero"]')
+    const main = container.querySelector('main')
+    expect(hero.compareDocumentPosition(main) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy() // hero before main
+    expect(main.contains(hero)).toBe(false)                                  // hero NOT in main
+    expect(main.querySelector('[data-sec="case"]')).toBeTruthy()             // case begins main
+    expect(main.querySelector('[data-sec="footer"]')).toBeTruthy()           // footer inside main
+    expect(main.contains(container.querySelector('[data-sec="sticky"]'))).toBe(false) // sticky outside
+  })
+
+  it('71. exactly one h1', () => {
+    const { container } = render(<MovieDetail />)
+    expect(container.querySelectorAll('h1').length).toBe(1)
+  })
+})
+
+describe('Film File — loading skeleton semantics (F5.7)', () => {
+  it('59/60/61/62/63. status + aria-busy + one sr-only message + decorative blocks, no progress', () => {
+    DATA = { ...DATA, loading: true }
+    const { container } = render(<MovieDetail />)
+    const status = container.querySelector('[role="status"]')
+    expect(status).toHaveAttribute('aria-busy', 'true')
+    expect(status).toHaveAttribute('aria-live', 'polite')
+    expect(screen.getByText('Loading Film File…')).toBeInTheDocument()
+    expect(container.querySelector('[aria-hidden="true"]')).toBeTruthy() // decorative blocks hidden
+    expect(container.textContent).not.toMatch(/\d+\s*%/)                  // no progress percentage
+  })
+})

--- a/src/features/movie/__tests__/MovieDataProviders.test.jsx
+++ b/src/features/movie/__tests__/MovieDataProviders.test.jsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+
+// ── TMDB/Supabase layer mocks ─────────────────────────────────────────────────
+let PROVIDER_MODE = 'found' // 'found' | 'empty' | 'fail'
+const fetchCalls = []
+const VALID_DETAILS = {
+  id: 496243, title: 'Parasite', original_title: 'Parasite', release_date: '2019-05-30',
+  runtime: 132, overview: 'A class war.', genres: [{ id: 18, name: 'Drama' }],
+  original_language: 'ko', spoken_languages: [], poster_path: '/p.jpg', backdrop_path: '/b.jpg',
+  tagline: '', vote_average: 8.5, budget: 0, revenue: 0,
+  credits: { cast: [], crew: [{ job: 'Director', name: 'Bong Joon-ho', id: 21684 }] },
+  videos: { results: [] }, recommendations: { results: [] }, similar: { results: [] },
+}
+const providerJson = () => PROVIDER_MODE === 'empty'
+  ? { results: {} }
+  : { results: { US: { link: 'https://justwatch.com/x', flatrate: [{ provider_id: 8, provider_name: 'Mock Stream', logo_path: '/l.png' }] } } }
+
+vi.mock('@/shared/api/tmdb', () => ({
+  getMovieDetails: vi.fn(async () => VALID_DETAILS),
+  fetchJson: vi.fn(async (url) => {
+    fetchCalls.push(url)
+    if (url.includes('/watch/providers')) {
+      if (PROVIDER_MODE === 'fail') throw new Error('boom')
+      return providerJson()
+    }
+    if (url.includes('/release_dates')) return { results: [] }
+    return {}
+  }),
+  backdropImg: (p) => p || '', tmdbImg: (p) => p || '',
+}))
+const sbChain = () => {
+  const c = {}
+  for (const m of ['select', 'eq', 'not', 'order', 'limit', 'in']) c[m] = vi.fn(() => c)
+  c.maybeSingle = vi.fn(async () => ({ data: null, error: null }))
+  c.then = (res) => Promise.resolve({ data: [], error: null }).then(res)
+  return c
+}
+vi.mock('@/shared/lib/supabase/client', () => ({ supabase: { from: vi.fn(() => sbChain()) } }))
+vi.mock('@/shared/hooks/useAuthSession', () => ({ useAuthSession: () => ({ user: null }) }))
+vi.mock('@/shared/services/recommendations', () => ({ computeUserProfile: vi.fn(async () => null), scoreMovieForUser: vi.fn(() => null) }))
+vi.mock('@/shared/services/matchScore', () => ({ computeMatchPercent: vi.fn(() => null) }))
+vi.mock('@/shared/services/movieFields', () => ({ MOVIE_ENGINE_COLS: '*' }))
+vi.mock('@/shared/services/boundaries', () => ({ activeMovieBoundaries: () => [], BOUNDARY_LABEL: {} }))
+vi.mock('@/shared/lib/format/date', () => ({ formatFullDate: () => '' }))
+
+import { useMovieDataFetch } from '../useMovieData'
+
+beforeEach(() => { PROVIDER_MODE = 'found'; fetchCalls.length = 0; vi.clearAllMocks() })
+afterEach(() => vi.clearAllMocks())
+
+const load = async (id = '496243') => {
+  const { result } = renderHook(() => useMovieDataFetch(id))
+  await waitFor(() => expect(result.current.loading).toBe(false))
+  return result
+}
+
+describe('useMovieData provider wiring (F5.7)', () => {
+  it('11/12. issues exactly ONE provider request, in the initial load', async () => {
+    await load()
+    expect(fetchCalls.filter((u) => u.includes('/watch/providers')).length).toBe(1)
+  })
+
+  it('13. a successful result with offers → status found', async () => {
+    PROVIDER_MODE = 'found'
+    const r = await load()
+    expect(r.current.providerStatus).toBe('found')
+    expect(r.current.mv).toBeTruthy()
+  })
+
+  it('14. a successful zero-result response → status empty (not error)', async () => {
+    PROVIDER_MODE = 'empty'
+    const r = await load()
+    expect(r.current.providerStatus).toBe('empty')
+  })
+
+  it('15/16. a provider failure → status error AND the Film File still loads', async () => {
+    PROVIDER_MODE = 'fail'
+    const r = await load()
+    expect(r.current.providerStatus).toBe('error')
+    expect(r.current.error).toBeNull()       // provider failure did NOT fail the route
+    expect(r.current.mv).toBeTruthy()        // the page still loaded
+  })
+
+  it('17. mapped provider arrays keep their shape', async () => {
+    PROVIDER_MODE = 'found'
+    const r = await load()
+    expect(Array.isArray(r.current.providers.flatrate)).toBe(true)
+    expect(r.current.providers.flatrate.length).toBe(1)
+    expect(r.current.providers.flatrate[0].name).toBe('Mock Stream')
+  })
+
+  it('18. provider status resets to loading for a new id', async () => {
+    PROVIDER_MODE = 'found'
+    const { result, rerender } = renderHook(({ id }) => useMovieDataFetch(id), { initialProps: { id: '1' } })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    rerender({ id: '2' })
+    expect(result.current.providerStatus).toBe('loading') // reset via INITIAL_STATE
+  })
+})

--- a/src/features/movie/__tests__/MovieRouteError.test.jsx
+++ b/src/features/movie/__tests__/MovieRouteError.test.jsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+
+let ROUTE_ID = '496243'
+let DATA = { mv: null, loading: false, error: { kind: 'not_found' } }
+const navigate = vi.fn()
+
+vi.mock('../useMovieData', () => ({
+  useMovieDataFetch: () => DATA,
+  MovieDataProvider: ({ children }) => children,
+  useMovieData: () => ({ mv: DATA.mv }),
+}))
+vi.mock('react-router-dom', () => ({ useNavigate: () => navigate, useParams: () => ({ id: ROUTE_ID }) }))
+vi.mock('@/shared/hooks/useAuthSession', () => ({ useAuthSession: () => ({ user: null }) }))
+vi.mock('@/shared/hooks/usePageMeta', () => ({ usePageMeta: () => {} }))
+vi.mock('@/shared/hooks/useUserMovieStatus', () => ({ useUserMovieStatus: () => ({ isInWatchlist: false, isWatched: false, loading: {}, toggleWatchlist: vi.fn(), toggleWatched: vi.fn(), internalId: null }) }))
+vi.mock('@/shared/services/interactions', () => ({ trackShare: vi.fn(), trackTrailerPlay: vi.fn() }))
+vi.mock('framer-motion', () => ({ useReducedMotion: () => false }))
+vi.mock('../hooks/useTasteFingerprint', () => ({ useTasteFingerprint: () => ({ fingerprint: null }) }))
+vi.mock('../hooks/useDirectorAffinity', () => ({ useDirectorAffinity: () => ({ count: 0 }) }))
+vi.mock('../hooks/useFriendsLoved', () => ({ useFriendsLoved: () => ({ friends: [] }) }))
+vi.mock('../hooks/useTasteTwin', () => ({ useTasteTwin: () => ({ twin: null }) }))
+
+import MovieDetail from '../MovieDetail'
+
+beforeEach(() => { cleanup(); document.body.innerHTML = ''; ROUTE_ID = '496243'; DATA = { mv: null, loading: false, error: { kind: 'not_found' } }; navigate.mockClear() })
+afterEach(() => vi.clearAllMocks())
+
+describe('Film File route errors — sanitized PageError (F5.7)', () => {
+  it('38. invalid id → "isn’t valid" copy', () => {
+    ROUTE_ID = 'abc'; DATA = { mv: null, loading: false, error: { kind: 'not_found' } }
+    render(<MovieDetail />)
+    expect(screen.getByText(/That movie link isn’t valid\./i)).toBeInTheDocument()
+  })
+
+  it('39. not-found (valid id) → 404 copy', () => {
+    render(<MovieDetail />)
+    expect(screen.getByText('404 · Film File Not Found')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 1, name: /Couldn’t find that movie\./i })).toBeInTheDocument()
+  })
+
+  it('40. load error → "We couldn’t open this Film File." copy', () => {
+    DATA = { mv: null, loading: false, error: { kind: 'load_error' } }
+    render(<MovieDetail />)
+    expect(screen.getByText(/We couldn’t open this Film File\./i)).toBeInTheDocument()
+  })
+
+  it('41/42/43. exactly one h1, alert semantics, and NO raw error text', () => {
+    DATA = { mv: null, loading: false, error: { kind: 'load_error', raw: 'PGRST relation movies does not exist' } }
+    const { container } = render(<MovieDetail />)
+    expect(container.querySelectorAll('h1').length).toBe(1)
+    expect(container.querySelector('[role="alert"]')).toBeTruthy()
+    expect(container.textContent).not.toMatch(/PGRST|relation|does not exist|TMDB|supabase|500/i)
+  })
+
+  it('44/45/46/47. Back + Go to Home (routes /home), 44px/type, no fake Retry', () => {
+    render(<MovieDetail />)
+    const back = screen.getByRole('button', { name: 'Go back' })
+    const home = screen.getByRole('button', { name: 'Go to Home' })
+    expect(back).toHaveAttribute('type', 'button')
+    expect(home).toHaveAttribute('type', 'button')
+    expect(back.style.minHeight).toBe('44px')
+    expect(home.style.minHeight).toBe('44px')
+    fireEvent.click(home)
+    expect(navigate).toHaveBeenCalledWith('/home')
+    expect(screen.queryByRole('button', { name: /retry|try again/i })).not.toBeInTheDocument()
+  })
+})

--- a/src/features/movie/__tests__/ProviderTruth.test.jsx
+++ b/src/features/movie/__tests__/ProviderTruth.test.jsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import { ProvidersSection } from '../sections-bottom'
+import { MovieDataProvider } from '../useMovieData'
+
+const P = (over = {}) => ({ flatrate: [], rent: [], buy: [], link: '', ...over })
+const withProviders = (providers, providerStatus) =>
+  render(<MovieDataProvider value={{ providers, providerStatus }}><ProvidersSection /></MovieDataProvider>)
+
+describe('ProvidersSection — honest provider states (F5.7)', () => {
+  it('20. loading shows "Checking availability…" as a status, not an alert', () => {
+    const { container } = withProviders(P(), 'loading')
+    expect(screen.getByText(/Checking availability…/i)).toBeInTheDocument()
+    expect(container.querySelector('[role="status"]')).toBeTruthy()
+    expect(container.querySelector('[role="alert"]')).toBeNull()
+  })
+
+  it('21/22/23. found renders providers + JustWatch + the United States attribution', () => {
+    const found = P({ flatrate: [{ name: 'Mock Stream', logoPath: '/l.png', logo: 'M', tint: '#fff' }], link: 'https://justwatch.com/x' })
+    withProviders(found, 'found')
+    expect(screen.getByText('Streaming', { exact: false })).toBeTruthy()
+    expect(screen.getByRole('link', { name: /Watch on Mock Stream/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /More options on JustWatch/i })).toBeInTheDocument()
+    expect(screen.getByText(/Availability for the United States via TMDB and JustWatch/i)).toBeInTheDocument()
+  })
+
+  it('24/25. empty renders "Availability not found" without claiming universal unavailability', () => {
+    const { container } = withProviders(P(), 'empty')
+    expect(screen.getByRole('heading', { level: 2, name: 'Availability not found' })).toBeInTheDocument()
+    expect(screen.getByText(/We couldn’t find streaming, rental, or purchase options for the United States\./i)).toBeInTheDocument()
+    expect(container.textContent).not.toMatch(/unavailable everywhere|not streaming anywhere|no one carries|not available\b/i)
+    expect(container.querySelector('[role="alert"]')).toBeNull()
+  })
+
+  it('26/27/28. error renders "Availability unavailable", no raw message, keeps a JustWatch option', () => {
+    const { container } = withProviders(P(), 'error')
+    expect(screen.getByRole('heading', { level: 2, name: 'Availability unavailable' })).toBeInTheDocument()
+    expect(screen.getByText(/Provider information couldn’t be reached right now\./i)).toBeInTheDocument()
+    expect(container.textContent).not.toMatch(/TMDB \d|500|PGRST|status_message|fetch|endpoint/i)
+    expect(screen.getByRole('link', { name: /Search on JustWatch/i })).toHaveAttribute('href', 'https://www.justwatch.com')
+    expect(container.querySelector('[role="alert"]')).toBeNull()
+  })
+
+  it('29/30. external link indicates a new tab; provider logo alt does not duplicate the link name', () => {
+    const found = P({ flatrate: [{ name: 'Mock Stream', logoPath: '/l.png', logo: 'M', tint: '#fff' }] })
+    const { container } = withProviders(found, 'found')
+    const watch = screen.getByRole('link', { name: /Watch on Mock Stream/i })
+    expect(watch).toHaveAttribute('target', '_blank')
+    expect(watch.getAttribute('rel')).toMatch(/noopener/)
+    const logo = container.querySelector('img')
+    expect(logo).toHaveAttribute('alt', '')
+  })
+
+  it('idle renders nothing; uses a labelled section with an h2', () => {
+    const { container } = withProviders(P(), 'idle')
+    expect(container).toBeEmptyDOMElement()
+    withProviders(P(), 'empty')
+    expect(screen.getByLabelText('Where to watch')).toBeInTheDocument()
+  })
+
+  it('falls back to data-derived found/empty when providerStatus is absent (back-compat)', () => {
+    const found = P({ flatrate: [{ name: 'X', logo: 'X', tint: '#fff' }] })
+    withProviders(found, undefined)
+    expect(screen.getByText('Streaming', { exact: false })).toBeTruthy()
+  })
+})

--- a/src/features/movie/derive/__tests__/movieRouteState.test.js
+++ b/src/features/movie/derive/__tests__/movieRouteState.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+
+import { classifyMovieRouteState } from '../movieRouteState'
+
+describe('classifyMovieRouteState — F5.7 safe route errors', () => {
+  it('31/32. malformed / zero / negative id → invalid', () => {
+    expect(classifyMovieRouteState({ routeId: 'abc', hasMovie: false, error: { kind: 'not_found' } }).kind).toBe('invalid')
+    expect(classifyMovieRouteState({ routeId: '0', hasMovie: false, error: null }).kind).toBe('invalid')
+    expect(classifyMovieRouteState({ routeId: '-5', hasMovie: false, error: null }).kind).toBe('invalid')
+    expect(classifyMovieRouteState({ routeId: '', hasMovie: false, error: null }).kind).toBe('invalid')
+    expect(classifyMovieRouteState({ routeId: null, hasMovie: false, error: null }).kind).toBe('invalid')
+    expect(classifyMovieRouteState({ routeId: '12.5', hasMovie: false, error: null }).kind).toBe('invalid')
+  })
+
+  it('33. a known not-found result (valid id) → not_found', () => {
+    expect(classifyMovieRouteState({ routeId: '496243', hasMovie: false, error: { kind: 'not_found' } }).kind).toBe('not_found')
+  })
+
+  it('34. network/unknown error (valid id) → load_error', () => {
+    expect(classifyMovieRouteState({ routeId: '496243', hasMovie: false, error: { kind: 'load_error' } }).kind).toBe('load_error')
+    expect(classifyMovieRouteState({ routeId: '496243', hasMovie: false, error: {} }).kind).toBe('load_error')
+  })
+
+  it('35. valid movie + no error → null', () => {
+    expect(classifyMovieRouteState({ routeId: '496243', hasMovie: true, error: null }).kind).toBeNull()
+  })
+
+  it('36/37. returned copy contains no raw error text; raw message never propagates', () => {
+    const r = classifyMovieRouteState({ routeId: '496243', hasMovie: false, error: { kind: 'load_error', raw: 'PGRST: relation movies does not exist' } })
+    const all = `${r.eyebrow} ${r.title} ${r.message}`
+    expect(all).not.toMatch(/PGRST|relation|movies does not exist|TMDB|supabase|500|status/i)
+  })
+
+  it('exposes safe copy per kind', () => {
+    expect(classifyMovieRouteState({ routeId: 'abc', hasMovie: false }).title).toMatch(/isn’t valid/)
+    expect(classifyMovieRouteState({ routeId: '1', hasMovie: false, error: { kind: 'not_found' } }).eyebrow).toMatch(/404 · Film File Not Found/)
+    expect(classifyMovieRouteState({ routeId: '1', hasMovie: false, error: { kind: 'load_error' } }).title).toMatch(/We couldn’t open this Film File/)
+  })
+})

--- a/src/features/movie/derive/__tests__/providerState.test.js
+++ b/src/features/movie/derive/__tests__/providerState.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+
+import { classifyMovieProviderState } from '../providerState'
+
+const P = (over = {}) => ({ flatrate: [], rent: [], buy: [], link: '', ...over })
+
+describe('classifyMovieProviderState — F5.7 provider truth', () => {
+  it('1. idle when no request has started (providers absent)', () => {
+    expect(classifyMovieProviderState({}).status).toBe('idle')
+    expect(classifyMovieProviderState({ providers: null }).status).toBe('idle')
+  })
+
+  it('2. loading while pending', () => {
+    expect(classifyMovieProviderState({ loading: true }).status).toBe('loading')
+  })
+
+  it('3/4/5. found when any flatrate / rent / buy offer exists', () => {
+    expect(classifyMovieProviderState({ providers: P({ flatrate: [{ id: 8 }] }) }).status).toBe('found')
+    expect(classifyMovieProviderState({ providers: P({ rent: [{ id: 2 }] }) }).status).toBe('found')
+    expect(classifyMovieProviderState({ providers: P({ buy: [{ id: 3 }] }) }).status).toBe('found')
+  })
+
+  it('6. empty for a successful zero-provider response', () => {
+    expect(classifyMovieProviderState({ providers: P() }).status).toBe('empty')
+    expect(classifyMovieProviderState({ providers: P() }).hasAny).toBe(false)
+  })
+
+  it('7. error wins over empty arrays', () => {
+    expect(classifyMovieProviderState({ failed: true, providers: P() }).status).toBe('error')
+    expect(classifyMovieProviderState({ failed: true, providers: P({ flatrate: [{ id: 8 }] }) }).status).toBe('error')
+  })
+
+  it('8. malformed provider shape is safe', () => {
+    expect(classifyMovieProviderState({ providers: { flatrate: 'nope' } }).status).toBe('empty')
+    expect(classifyMovieProviderState({ providers: {} }).status).toBe('empty')
+    expect(() => classifyMovieProviderState({ providers: { flatrate: null, rent: undefined } })).not.toThrow()
+  })
+
+  it('9. does not mutate the providers object', () => {
+    const providers = P({ flatrate: [{ id: 8 }] })
+    const snap = JSON.stringify(providers)
+    classifyMovieProviderState({ providers })
+    expect(JSON.stringify(providers)).toBe(snap)
+  })
+
+  it('10. a link-only result is empty, not found', () => {
+    expect(classifyMovieProviderState({ providers: P({ link: 'https://justwatch.com' }) }).status).toBe('empty')
+  })
+})

--- a/src/features/movie/derive/movieRouteState.js
+++ b/src/features/movie/derive/movieRouteState.js
@@ -1,0 +1,54 @@
+// src/features/movie/derive/movieRouteState.js
+// F5.7 — pure classifier for the Film File route-failure screen. It maps a normalized
+// internal signal to SAFE, user-facing copy — it never returns raw backend/TMDB/
+// Supabase error text, endpoints, status messages, or stack traces.
+//
+//   invalid    — the route id is malformed / non-positive / non-numeric
+//   not_found  — a known "movie does not exist" result (TMDB success:false / 404 / 34)
+//   load_error — a network/backend/unknown interruption
+//   null       — the film loaded fine
+//
+// `error` is the normalized { kind } shape stored by useMovieData (never a raw
+// string). The classifier may inspect a normalized kind but never displays it.
+
+const COPY = {
+  invalid: {
+    eyebrow: 'Film File',
+    title: 'That movie link isn’t valid.',
+    message: 'Check the link or return to the previous page.',
+  },
+  not_found: {
+    eyebrow: '404 · Film File Not Found',
+    title: 'Couldn’t find that movie.',
+    message: 'It may have been removed, or the movie identifier may be incorrect.',
+  },
+  load_error: {
+    eyebrow: 'Film File unavailable',
+    title: 'We couldn’t open this Film File.',
+    message: 'Something interrupted the request. Try again in a moment.',
+  },
+}
+
+function isValidId(routeId) {
+  if (typeof routeId === 'number') return Number.isInteger(routeId) && routeId > 0
+  if (typeof routeId === 'string') return /^\d+$/.test(routeId.trim()) && Number(routeId) > 0
+  return false
+}
+
+/**
+ * @param {object} args
+ * @param {string|number|null|undefined} args.routeId  the :id route param
+ * @param {boolean} args.hasMovie  whether a movie successfully loaded
+ * @param {{ kind?: 'not_found'|'load_error' }|null} [args.error]  normalized error
+ * @returns {{ kind: 'invalid'|'not_found'|'load_error'|null, eyebrow: string, title: string, message: string }}
+ */
+export function classifyMovieRouteState({ routeId, hasMovie, error = null }) {
+  if (hasMovie && !error) return { kind: null, eyebrow: '', title: '', message: '' }
+
+  let kind
+  if (!isValidId(routeId)) kind = 'invalid'
+  else if (error?.kind === 'not_found') kind = 'not_found'
+  else kind = 'load_error' // network / backend / unknown — never echo the raw error
+
+  return { kind, ...COPY[kind] }
+}

--- a/src/features/movie/derive/providerState.js
+++ b/src/features/movie/derive/providerState.js
@@ -1,0 +1,38 @@
+// src/features/movie/derive/providerState.js
+// F5.7 — pure classifier for the Film File's "Where to watch" truth state. The
+// provider request's success and failure are tracked separately in useMovieData so
+// that an EMPTY result and a FAILED request are no longer indistinguishable.
+//
+//   idle    — no request has started / providers intentionally absent
+//   loading — the request is still pending
+//   found   — the request succeeded and at least one offer exists
+//   empty   — the request succeeded but flatrate/rent/buy are all empty
+//   error   — the request explicitly failed
+//
+// Explicit failure wins over an empty result. Pure + null-safe + non-mutating; does
+// NOT sort or deduplicate.
+
+const asArray = (x) => (Array.isArray(x) ? x : [])
+
+/**
+ * @param {object} [args]
+ * @param {boolean} [args.loading]   request still pending
+ * @param {boolean} [args.failed]    request explicitly failed
+ * @param {object|null} [args.providers]  mapped providers ({ flatrate, rent, buy, link } or null)
+ * @returns {{ status: 'idle'|'loading'|'found'|'empty'|'error', hasAny: boolean }}
+ */
+export function classifyMovieProviderState({ loading = false, failed = false, providers = null } = {}) {
+  const hasAny =
+    asArray(providers?.flatrate).length +
+    asArray(providers?.rent).length +
+    asArray(providers?.buy).length > 0
+
+  let status
+  if (failed) status = 'error'            // explicit failure wins over empty
+  else if (loading) status = 'loading'    // request still pending
+  else if (hasAny) status = 'found'       // a real offer exists
+  else if (providers) status = 'empty'    // succeeded, but no offers (link-only counts as empty)
+  else status = 'idle'                    // no request / intentionally absent
+
+  return { status, hasAny }
+}

--- a/src/features/movie/movie.css
+++ b/src/features/movie/movie.css
@@ -413,3 +413,46 @@
     flex-wrap: wrap;
   }
 }
+
+/* ── F5.7 skip link + focus + error/provider hardening ──────────────
+   The skip link is the first focusable element: off-screen until focused, then
+   visible at the top-left above the scroll-progress bar. No transition (no motion
+   dependency). */
+.ff-movie-skip-link {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1000;
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 12px 20px;
+  background: #a78bfa;
+  color: #0a0510;
+  font-family: Outfit, Inter, sans-serif;
+  font-size: 14px;
+  font-weight: 700;
+  text-decoration: none;
+  border-radius: 0 0 8px 0;
+  transform: translateY(-120%);
+}
+.ff-movie-skip-link:focus,
+.ff-movie-skip-link:focus-visible {
+  transform: translateY(0);
+  outline: 3px solid #fff;
+  outline-offset: -3px;
+}
+/* Movie-local icon/error control focus rings. */
+.ff-movie-icon-btn:focus-visible {
+  outline: 2px solid #a78bfa;
+  outline-offset: 2px;
+}
+.ff-movie-error-btn:focus-visible {
+  outline: 2px solid #a78bfa;
+  outline-offset: 3px;
+}
+/* main landmark target must not steal an outline when focused programmatically by
+   the skip link (focus is moved, not visually highlighted). */
+#film-file-content:focus {
+  outline: none;
+}

--- a/src/features/movie/sections-bottom.jsx
+++ b/src/features/movie/sections-bottom.jsx
@@ -159,11 +159,69 @@ function VideoThumb({ v, onPlay }) {
 }
 
 // ── Providers ────────────────────────────────────────────────────
-function ProvidersSection() {
-  const { providers } = useMovieData();
-  const hasAny = providers.flatrate.length + providers.rent.length + providers.buy.length > 0;
-  if (!hasAny) return null;
+const PROVIDER_ATTRIBUTION = 'Availability for the United States via TMDB and JustWatch. Listings can change or lag behind provider updates.';
 
+// F5.7: an EYEBROW + a labelled <section> shared by every provider state.
+function ProviderSectionShell({ children }) {
+  return (
+    <section className="ff-movie-section ff-movie-providers" aria-label="Where to watch" style={{ padding:'64px 88px', borderTop:`1px solid ${HP.border}` }}>
+      <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color: HP.purple, marginBottom:14, display:'inline-flex', alignItems:'center', gap:10 }}>
+        <span style={{ height:1, width:22, background: HP.purple, opacity:0.6 }} />Where to watch
+      </div>
+      {children}
+    </section>
+  );
+}
+const sectionH2 = { fontFamily:'Outfit', fontSize:36, lineHeight:1.05, fontWeight:500, letterSpacing:'-0.03em', color: 'var(--ff-text, #FAFAFA)', margin:0 };
+const stateBody = { margin:'14px 0 0 0', fontSize:14, lineHeight:1.6, color:'rgba(250,250,250,0.7)', fontFamily:'Outfit, Inter, sans-serif', maxWidth:520, overflowWrap:'anywhere' };
+const attributionStyle = { margin:'18px 0 0 0', fontSize:11.5, lineHeight:1.5, color:'rgba(250,250,250,0.45)', fontFamily:'Outfit, Inter, sans-serif', maxWidth:560, overflowWrap:'anywhere' };
+
+function ProvidersSection() {
+  const { providers, providerStatus } = useMovieData();
+  const status = providerStatus
+    || (providers.flatrate.length + providers.rent.length + providers.buy.length > 0 ? 'found' : 'empty');
+
+  if (status === 'idle') return null;
+
+  if (status === 'loading') {
+    return (
+      <ProviderSectionShell>
+        <div role="status" aria-live="polite" style={{ marginTop:6, fontSize:14, color:'rgba(250,250,250,0.7)', fontFamily:'Outfit, Inter, sans-serif' }}>
+          Checking availability…
+        </div>
+      </ProviderSectionShell>
+    );
+  }
+
+  if (status === 'empty') {
+    return (
+      <ProviderSectionShell>
+        <h2 className="ff-movie-section-h2" style={{ ...sectionH2, color:'#FAFAFA' }}>Availability not found</h2>
+        <p style={stateBody}>We couldn’t find streaming, rental, or purchase options for the United States.</p>
+        <p style={attributionStyle}>{PROVIDER_ATTRIBUTION}</p>
+      </ProviderSectionShell>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <ProviderSectionShell>
+        <h2 className="ff-movie-section-h2" style={{ ...sectionH2, color:'#FAFAFA' }}>Availability unavailable</h2>
+        <p style={stateBody}>Provider information couldn’t be reached right now.</p>
+        <p style={stateBody}>You can check again later or search directly on JustWatch.</p>
+        <a
+          href="https://www.justwatch.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ marginTop:18, display:'inline-flex', alignItems:'center', gap:6, fontSize:11, color: HP.textSoft, fontFamily:'Outfit', letterSpacing:'0.06em', textTransform:'uppercase', textDecoration:'none' }}
+        >
+          Search on JustWatch <span aria-hidden="true">↗</span><span className="sr-only"> (opens in a new tab)</span>
+        </a>
+      </ProviderSectionShell>
+    );
+  }
+
+  // found
   const ProviderChip = ({ p }) => (
     <a
       href={providers.link || 'https://www.justwatch.com'}
@@ -182,7 +240,7 @@ function ProvidersSection() {
   );
 
   return (
-    <section className="ff-movie-section" style={{ padding:'64px 88px', borderTop:`1px solid ${HP.border}` }}>
+    <section className="ff-movie-section ff-movie-providers" aria-label="Where to watch" style={{ padding:'64px 88px', borderTop:`1px solid ${HP.border}` }}>
       <div className="ff-movie-providers-grid" style={{ display:'grid', gridTemplateColumns:'1fr 2fr', gap:64, alignItems:'flex-start' }}>
         <div>
           <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color: HP.purple, marginBottom:14, display:'inline-flex', alignItems:'center', gap:10 }}>
@@ -197,7 +255,7 @@ function ProvidersSection() {
             rel="noopener noreferrer"
             style={{ marginTop:18, display:'inline-flex', alignItems:'center', gap:6, fontSize:11, color: HP.textSoft, fontFamily:'Outfit', letterSpacing:'0.06em', textTransform:'uppercase', textDecoration:'none' }}
           >
-            More options on JustWatch <span style={{ fontSize:14, lineHeight:1 }}>›</span>
+            More options on JustWatch <span aria-hidden="true">›</span><span className="sr-only"> (opens in a new tab)</span>
           </a>
         </div>
         <div>
@@ -212,6 +270,7 @@ function ProvidersSection() {
               {providers.buy.map((p,i) => <ProviderChip key={`b${i}`} p={p} />)}
             </div>
           </>}
+          <p style={attributionStyle}>{PROVIDER_ATTRIBUTION}</p>
         </div>
       </div>
     </section>

--- a/src/features/movie/sections-top.jsx
+++ b/src/features/movie/sections-top.jsx
@@ -7,7 +7,8 @@ import { useMovieData } from './useMovieData'
 
 // FeelFlick — Movie page · Hero, scroll progress, trailer modal, why-for-you, synopsis, mood radar, take, critic quotes.
 
-const iconBtnStyle = { width:36, height:36, borderRadius:RADIUS.pill, background:'rgba(0,0,0,0.45)', backdropFilter:'blur(12px)', border:`1px solid rgba(255,255,255,0.08)`, color:'rgba(250,250,250,0.72)', cursor:'pointer', display:'inline-flex', alignItems:'center', justifyContent:'center' };
+// F5.7: ≥44×44 touch target (the visible icon stays small).
+const iconBtnStyle = { width:44, height:44, borderRadius:RADIUS.pill, background:'rgba(0,0,0,0.45)', backdropFilter:'blur(12px)', border:`1px solid rgba(255,255,255,0.08)`, color:'rgba(250,250,250,0.72)', cursor:'pointer', display:'inline-flex', alignItems:'center', justifyContent:'center' };
 
 // Reset-button style for wrapping elements that need to be focusable buttons
 // without inheriting the browser's default button chrome.
@@ -101,13 +102,13 @@ function MovieHero({
 
       {/* Top nav */}
       <div className="ff-movie-top-nav" style={{ position:'absolute', top:0, left:0, right:0, padding:'24px 56px', display:'flex', alignItems:'center', justifyContent:'space-between', zIndex:5 }}>
-        <button onClick={onBack} aria-label="Go back" style={{ display:'inline-flex', alignItems:'center', gap:8, padding:'8px 16px', borderRadius:RADIUS.pill, background:'rgba(0,0,0,0.45)', backdropFilter:'blur(12px)', border:`1px solid ${HP.border}`, color: HP.textSoft, fontFamily:'Outfit', fontSize:12, fontWeight:600, letterSpacing:'0.04em', cursor:'pointer' }}>
-          <span style={{ fontSize:14, lineHeight:1 }}>‹</span> Back
+        <button type="button" onClick={onBack} aria-label="Go back" className="ff-movie-icon-btn" style={{ display:'inline-flex', alignItems:'center', gap:8, minHeight:44, padding:'8px 16px', borderRadius:RADIUS.pill, background:'rgba(0,0,0,0.45)', backdropFilter:'blur(12px)', border:`1px solid ${HP.border}`, color: HP.textSoft, fontFamily:'Outfit', fontSize:12, fontWeight:600, letterSpacing:'0.04em', cursor:'pointer' }}>
+          <span aria-hidden="true" style={{ fontSize:14, lineHeight:1 }}>‹</span> Back
         </button>
         <div style={{ display:'flex', alignItems:'center', gap:14 }}>
           <Tooltip content="Share this film" side="bottom">
-            <button onClick={onShare} aria-label="Share this film" style={iconBtnStyle}>
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
+            <button type="button" onClick={onShare} aria-label="Share this film" className="ff-movie-icon-btn" style={iconBtnStyle}>
+              <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
             </button>
           </Tooltip>
         </div>
@@ -359,8 +360,8 @@ function StickyActionBar({ onPlayTrailer, onBack, onToggleWatchlist, isInWatchli
         display:'flex', alignItems:'center', gap:20,
       }}
     >
-      <button onClick={onBack} aria-label="Go back" style={{ width:32, height:32, borderRadius:RADIUS.pill, background:'rgba(255,255,255,0.06)', border:`1px solid ${HP.border}`, color: HP.textSoft, cursor:'pointer', display:'inline-flex', alignItems:'center', justifyContent:'center' }}>
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polyline points="15 18 9 12 15 6"/></svg>
+      <button type="button" onClick={onBack} aria-label="Go back" className="ff-movie-icon-btn" style={{ width:44, height:44, borderRadius:RADIUS.pill, background:'rgba(255,255,255,0.06)', border:`1px solid ${HP.border}`, color: HP.textSoft, cursor:'pointer', display:'inline-flex', alignItems:'center', justifyContent:'center' }}>
+        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polyline points="15 18 9 12 15 6"/></svg>
       </button>
       <div style={{ display:'flex', alignItems:'center', gap:14, flex:1 }}>
         {mv.poster && <img src={mv.poster} alt="" style={{ width:30, height:45, objectFit:'cover', borderRadius:3 }} />}

--- a/src/features/movie/useMovieData.jsx
+++ b/src/features/movie/useMovieData.jsx
@@ -16,6 +16,7 @@ import { activeMovieBoundaries, BOUNDARY_LABEL } from '@/shared/services/boundar
 import { formatFullDate } from '@/shared/lib/format/date'
 import { deriveMoodAxes } from './derive/moodRadar'
 import { classifyFilmFileContent } from './derive/sourceClassification'
+import { classifyMovieProviderState } from './derive/providerState'
 
 // Pull the full engine column set so the match % on this page matches
 // what /home shows for the same film. Single source of truth in
@@ -493,6 +494,8 @@ const INITIAL_STATE = {
   cast: [],
   videos: [],
   providers: EMPTY_PROVIDERS,
+  providerStatus: 'loading', // F5.7: 'idle'|'loading'|'found'|'empty'|'error'
+  providerRegion: 'US',
   similar: [],
   dirShelf: [],
   filmDbRow: null,     // internal movies row — mood_tags + llm_* used by Mood Radar / Why-for-you
@@ -519,7 +522,10 @@ export function useMovieDataFetch(id) {
         const [details, releaseDates, providers, filmDbResult, userSettingsResult] = await Promise.all([
           getMovieDetails(id),
           fetchJson(`/movie/${id}/release_dates`).catch(() => null),
-          fetchJson(`/movie/${id}/watch/providers`).catch(() => null),
+          // F5.7: keep the provider request in the same parallel batch, but settle it
+          // explicitly so an EMPTY result and a FAILED request can be told apart. No
+          // second request, no retry.
+          fetchJson(`/movie/${id}/watch/providers`).then(data => ({ ok: true, data })).catch(() => ({ ok: false, data: null })),
           supabase.from('movies').select(MOVIE_DB_COLS).eq('tmdb_id', id).maybeSingle(),
           // user's content-boundary toggles (anonymous viewers get [])
           user?.id
@@ -528,7 +534,8 @@ export function useMovieDataFetch(id) {
         ])
         if (abort) return
         if (!details || details?.success === false || details?.status_code) {
-          throw new Error(details?.status_message || 'Movie not found')
+          // Normalized internal signal — never store the raw TMDB status_message.
+          throw Object.assign(new Error('movie_not_found'), { kind: 'not_found' })
         }
 
         const usCert = releaseDates?.results?.find(r => r.iso_3166_1 === 'US')
@@ -538,7 +545,12 @@ export function useMovieDataFetch(id) {
         const cast = mapTmdbToCast(details)
         const videos = mapTmdbToVideos(details)
         const similar = mapTmdbToSimilar(details)
-        const prov = mapTmdbProviders(providers)
+        // F5.7: `providers` is now { ok, data }. On failure → EMPTY_PROVIDERS + an
+        // explicit 'error' status (never an 'empty'). The mapped array shape/order
+        // are unchanged. classifyMovieProviderState resolves found/empty/error.
+        const providerOk = providers?.ok !== false
+        const prov = mapTmdbProviders(providerOk ? providers?.data : null)
+        const providerStatus = classifyMovieProviderState({ loading: false, failed: !providerOk, providers: prov }).status
         const filmDbRow = filmDbResult?.data || null
         const moodAxes = deriveMoodAxes(filmDbRow)
 
@@ -625,6 +637,8 @@ export function useMovieDataFetch(id) {
           videos,
           similar: enrichedSimilar,
           providers: prov,
+          providerStatus,
+          providerRegion: 'US',
           dirShelf: [],
           filmDbRow,
           moodAxes,
@@ -675,7 +689,11 @@ export function useMovieDataFetch(id) {
         }
       } catch (e) {
         if (abort) return
-        setState(s => ({ ...s, loading: false, error: e?.message || 'Failed to load' }))
+        // F5.7: store ONLY a normalized internal kind — never a raw error string for
+        // rendering. Diagnostic detail stays in the console (no secrets).
+        console.warn('[useMovieData] load failed:', e?.kind || e?.message || e)
+        const kind = e?.kind === 'not_found' ? 'not_found' : 'load_error'
+        setState(s => ({ ...s, loading: false, error: { kind } }))
       }
     })()
 


### PR DESCRIPTION
**F5.7 — Harden Film File provider and error states** (final source-level trust, error, provider, navigation, a11y hardening before F5.8). **No recommendation logic, scoring, ranking, provenance, trust copy, social policy, action payloads, routes, schema, provider region-selection, or provider array ordering changed.** Section order + the decision dossier + all F5.3–F5.6 work are untouched (`PrimaryCaseCard` / `ViewerNotes` / `DecisionEvidence` / `FilmFileDisclosure` / `SocialContext` / `ExplorationTail` / `AccessibleMediaDialog` / all `derive/*` trust modules / rating+action hooks unchanged).

## Provider status model
Pure `classifyMovieProviderState` (`derive/providerState.js`) → `idle | loading | found | empty | error` (**explicit failure wins over empty**; link-only = empty; null-safe, non-mutating). `useMovieData` now **settles the provider request explicitly** — `fetchJson(...).then(ok:true).catch(ok:false)` — **in the same parallel batch** (no second request, no retry, abort intact) — so empty and failure are distinguishable. Exposes `providerStatus` + `providerRegion='US'`, uses `EMPTY_PROVIDERS` on failure, and **a provider failure never fails the Film File**.

**Confirmed unchanged:** the `/movie/:id/watch/providers` endpoint, `mapTmdbProviders`, the region logic, and the provider array shape/order.

## Found / empty / error copy + attribution
ProvidersSection (placement unchanged): **found** = current logos/groups + JustWatch + the quiet *"Availability for the United States via TMDB and JustWatch. Listings can change or lag behind provider updates."*; **empty** = `Availability not found` + *"We couldn't find streaming, rental, or purchase options for the United States."* (never "unavailable everywhere"); **error** = `Availability unavailable` + *"Provider information couldn't be reached right now."* + a direct **JustWatch** search link, **no raw error**; **loading** = a small `role=status` *"Checking availability…"*; **idle** = nothing. Labelled `<section>`, `h2` heading, external links state "(opens in a new tab)", logo `alt=""`.

## Route-error classification + sanitization
Pure `classifyMovieRouteState` (`derive/movieRouteState.js`) → **invalid / not_found / load_error** with **safe copy only** — never raw backend/TMDB/Supabase text, endpoints, or status messages. `useMovieData` normalizes the not-found throw + the catch to a `{ kind }` shape (no raw `e.message` stored for rendering; diagnostic stays in `console.warn`). **PageError** consumes the classifier: one `h1`, `role="alert"`, clamped title, **Back + "Go to Home" (→ /home)** buttons (≥44px, `type=button`, focus-visible), **no fake Retry**.

## Skip link + main landmark
A first-focusable `.ff-movie-skip-link` (off-screen until focused, ≥44px, above the scroll bar, no transition) targeting `#film-file-content`; the decision dossier (PrimaryCase → Footer) is wrapped in **one `<main id="film-file-content" tabIndex={-1}>`**; the Hero stays above as the introductory header; the sticky bar + dialog stay outside `main`.

## PageSkeleton semantics
`role=status` + `aria-live=polite` + `aria-busy=true` + sr-only *"Loading Film File…"*; pulse blocks `aria-hidden`; no progress %.

## Touch / focus / icon fixes
Hero Share **36→44×44**, hero Back **min-height 44**, sticky Back **32→44×44**; `type="button"` added; decorative SVGs `aria-hidden`; Movie-local `:focus-visible` rings. Disclosure independence + rerender persistence pinned; external links named.

## Tests + validation
Film File **176 → 217** (full **1125 → 1166**). New: `providerState` (8), `movieRouteState` (6), `ProviderTruth` UI (7), `MovieDataProviders` wiring (6), `MovieRouteError` (5), `FilmFileLandmarks` (5), `FilmFileFinalA11y` (4). **All F5.2–F5.6 tests green.** `npm run lint` clean · `npx vitest run src/features/movie/` 217 (×3 deterministic) · `npm run test` 1166 · `npm run build` ✓.

**Browser/axe/viewport verification deferred to F5.8** (no intercepted `/movie` fixture; route entry can upsert the profile cache) — pure/unit/component tests + static responsive reasoning only; **no live Film File route or write was triggered**, no Playwright snapshot changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
