### PR TITLE
Extract User Library derivations + pin current behavior (safety net)

### DIFF
--- a/src/features/history/derive/__tests__/historyDerive.test.js
+++ b/src/features/history/derive/__tests__/historyDerive.test.js
@@ -1,0 +1,113 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+
+import {
+  WEEKDAY_NAMES, capitalize, dayKey, dayPart, moodHexFor,
+  deriveEntries, deriveStats,
+} from '../historyDerive'
+
+// F6.2 — pins CURRENT History/Diary derivation behavior. The `avgRating` scope
+// (averaged over ALL user_ratings, not just diary films) is pinned ON PURPOSE so the
+// F6.5 scope fix is a deliberate, reviewable test change. Same for the film-mood pill.
+
+afterEach(() => vi.useRealTimers())
+
+const hRow = (over = {}) => ({
+  movie_id: 1, watched_at: '2026-03-09T20:30:00',
+  movies: { id: 11, tmdb_id: 101, title: 'A', director_name: 'D', release_date: '2020-01-01', runtime: 120, mood_tags: ['tender'], poster_path: '/p.jpg', ...over.movies },
+  ...over,
+})
+
+describe('helpers', () => {
+  it('capitalize / dayPart / dayKey (local) / moodHexFor', () => {
+    expect(capitalize('feel_good')).toBe('Feel good')
+    expect(dayPart(8)).toBe('Morning'); expect(dayPart(13)).toBe('Afternoon')
+    expect(dayPart(19)).toBe('Evening'); expect(dayPart(2)).toBe('Late')
+    expect(dayKey(new Date(2026, 2, 9))).toBe('2026-03-09') // local Y-M-D
+    expect(typeof moodHexFor('Tender')).toBe('string')
+    expect(WEEKDAY_NAMES).toHaveLength(7)
+  })
+})
+
+describe('deriveEntries', () => {
+  it('filters out null watched_at, sorts newest-first', () => {
+    const rows = [
+      hRow({ movie_id: 1, watched_at: '2026-03-01T10:00:00' }),
+      hRow({ movie_id: 2, watched_at: null }),
+      hRow({ movie_id: 3, watched_at: '2026-03-05T10:00:00' }),
+    ]
+    const out = deriveEntries(rows, [])
+    expect(out.map(e => e.movieId)).toEqual([3, 1]) // movie 2 (null watched_at) dropped
+  })
+
+  it('maps rating 1-10 → 1-5 stars, mood = FILM mood_tags[0], note = review_text', () => {
+    const rows = [hRow()]
+    const ratings = [{ movie_id: 1, rating: 9, review_text: 'Stayed with me.' }]
+    const [e] = deriveEntries(rows, ratings)
+    expect(e.rating).toBe(5)          // round(9/2) = 5
+    expect(e.mood).toBe('Tender')     // the FILM's generated mood tag (pinned — F6.5 clarifies)
+    expect(e.note).toBe('Stayed with me.')
+    expect(e.fav).toBe(true)          // raw rating ≥ 9
+    expect(e.rewatch).toBe(false)
+    expect(e.poster).toContain('w342')
+    expect(e.context).toMatch(/Evening · (Sunday|Monday)/) // 20:30 local
+  })
+
+  it('fav fires at raw 9 and 10, not at 8; no rating → 0 stars', () => {
+    const mk = (rt) => deriveEntries([hRow()], rt == null ? [] : [{ movie_id: 1, rating: rt }])[0]
+    expect(mk(8).fav).toBe(false)
+    expect(mk(9).fav).toBe(true)
+    expect(mk(10).fav).toBe(true)
+    expect(mk(null).rating).toBe(0)
+  })
+
+  it('id falls back to `${movie_id}-${watched_at}` when no row id', () => {
+    const [e] = deriveEntries([hRow({ id: undefined, movie_id: 7, watched_at: '2026-03-09T20:30:00' })], [])
+    expect(e.id).toBe('7-2026-03-09T20:30:00')
+  })
+})
+
+describe('deriveStats', () => {
+  it('totalLogged = rows; totalHours = summed runtime/60 rounded', () => {
+    const history = [hRow({ movies: { runtime: 120 } }), hRow({ movie_id: 2, movies: { runtime: 90 } })]
+    const s = deriveStats({ history, ratings: [] })
+    expect(s.totalLogged).toBe(2)
+    expect(s.totalHours).toBe(4) // (120+90)/60 = 3.5 → round 4
+  })
+
+  it('PINNED (F6.5 target): avgRating averages ALL user_ratings, even films NOT in history', () => {
+    const history = [hRow({ movie_id: 1 })] // only movie 1 is in the diary
+    const ratings = [
+      { movie_id: 1, rating: 8 },   // in history
+      { movie_id: 999, rating: 4 }, // NOT in history — but still counted today
+    ]
+    const s = deriveStats({ history, ratings })
+    // ((8 + 4) / 2) / 2 = 3.0  → includes movie 999 which is not a diary entry.
+    expect(s.avgRating).toBe(3)
+  })
+
+  it('avgRating is 0 with no ratings', () => {
+    expect(deriveStats({ history: [hRow()], ratings: [] }).avgRating).toBe(0)
+  })
+
+  it('streak counts consecutive local days back from today (today-or-yesterday alive)', () => {
+    vi.useFakeTimers(); vi.setSystemTime(new Date(2026, 2, 10, 12, 0, 0)) // Mar 10 local
+    const day = (d) => `2026-03-${String(d).padStart(2, '0')}T18:00:00`
+    const history = [hRow({ watched_at: day(10) }), hRow({ movie_id: 2, watched_at: day(9) }), hRow({ movie_id: 3, watched_at: day(8) })]
+    expect(deriveStats({ history, ratings: [] }).streakDays).toBe(3) // 10,9,8 consecutive
+  })
+
+  it('streak breaks on a gap and is 0 when neither today nor yesterday has a watch', () => {
+    vi.useFakeTimers(); vi.setSystemTime(new Date(2026, 2, 10, 12, 0, 0))
+    const day = (d) => `2026-03-${String(d).padStart(2, '0')}T18:00:00`
+    // today (10) + a gap at 9 then 8 → streak is just today
+    expect(deriveStats({ history: [hRow({ watched_at: day(10) }), hRow({ movie_id: 2, watched_at: day(8) })], ratings: [] }).streakDays).toBe(1)
+    // last watch was Mar 5 → neither today nor yesterday alive → 0
+    expect(deriveStats({ history: [hRow({ watched_at: day(5) })], ratings: [] }).streakDays).toBe(0)
+  })
+
+  it('thisMonthCount counts only rows in the current local month', () => {
+    vi.useFakeTimers(); vi.setSystemTime(new Date(2026, 2, 10, 12, 0, 0)) // March
+    const history = [hRow({ watched_at: '2026-03-02T10:00:00' }), hRow({ movie_id: 2, watched_at: '2026-02-27T10:00:00' })]
+    expect(deriveStats({ history, ratings: [] }).thisMonthCount).toBe(1)
+  })
+})

--- a/src/features/history/derive/historyDerive.js
+++ b/src/features/history/derive/historyDerive.js
@@ -1,0 +1,120 @@
+// src/features/history/derive/historyDerive.js
+// F6.2 — pure History/Diary derivations, extracted verbatim from useHistoryData.jsx
+// (the provider is now a thin caller). NO behavior change: every function body is
+// byte-for-byte identical to the inlined originals, so the rendered Diary output is
+// unchanged. The current `avgRating` scope (averaged over ALL user_ratings, not just
+// diary films) is preserved AS-IS and pinned by tests on purpose — the F6.5 scope fix
+// will then show up as a deliberate, reviewable test change.
+
+import { formatShortDate, formatShortMonthYear } from '@/shared/lib/format/date'
+import { HP, MOOD_HEX, tmdbImg } from '../data'
+
+export const WEEKDAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+
+export function capitalize(s) {
+  return s ? s.charAt(0).toUpperCase() + s.slice(1).replace(/_/g, ' ') : ''
+}
+
+export function dayKey(date) {
+  // YYYY-MM-DD in local time — matches how a user thinks about "a day".
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+export function dayPart(hour) {
+  if (hour >= 5 && hour < 12) return 'Morning'
+  if (hour >= 12 && hour < 17) return 'Afternoon'
+  if (hour >= 17 && hour < 21) return 'Evening'
+  return 'Late'
+}
+
+export function moodHexFor(name) {
+  if (!name) return HP.purple
+  return MOOD_HEX[name] || MOOD_HEX[capitalize(name)] || HP.purple
+}
+
+// === Derivers ============================================================
+
+export function deriveEntries(history, ratings) {
+  const ratingByMovieId = new Map(ratings.map(r => [r.movie_id, r]))
+  return history
+    .filter(h => h.watched_at)
+    .sort((a, b) => new Date(b.watched_at) - new Date(a.watched_at))
+    .map(h => {
+      const m = h.movies || {}
+      const r = ratingByMovieId.get(h.movie_id) || {}
+      const d = new Date(h.watched_at)
+      const moodTag = (m.mood_tags || [])[0]
+      const mood = capitalize(moodTag) || 'Mixed'
+      return {
+        id: h.id || `${h.movie_id}-${h.watched_at}`,
+        movieId: h.movie_id,
+        tmdbId: m.tmdb_id,
+        title: m.title || 'Untitled',
+        year: m.release_date ? new Date(m.release_date).getFullYear() : '',
+        runtime: m.runtime || 0,
+        dir: m.director_name || '—',
+        date: formatShortDate(d),
+        month: formatShortMonthYear(d),
+        day: d.getDate(),
+        // user_ratings.rating is on the 1-10 scale; map to 1-5 for star display.
+        rating: r.rating ? Math.round(r.rating / 2) : 0,
+        mood,
+        moodHex: moodHexFor(mood),
+        context: `${dayPart(d.getHours())} · ${WEEKDAY_NAMES[d.getDay()]}`,
+        note: r.review_text || null,
+        poster: m.poster_path ? tmdbImg(m.poster_path, 'w342') : null,
+        // Rewatches aren't currently tracked in user_history (the app
+        // dedupes by (user, movie)). Leaving rewatch=false until that
+        // changes. ♥ fav fires for any 5★-display rating (raw 9 or 10 on
+        // the 1-10 scale) — matches what the star row shows. Previously
+        // gated on rating===10, which left favorites permanently dead for
+        // users who rate at 9.
+        rewatch: false,
+        fav: typeof r.rating === 'number' && r.rating >= 9,
+      }
+    })
+}
+
+export function deriveStats({ history, ratings }) {
+  const totalLogged = history.length
+  const totalHours = Math.round(history.reduce((s, h) => s + (h.movies?.runtime || 0), 0) / 60)
+  const rated = ratings.filter(r => r.rating != null)
+  const avgRating = rated.length > 0
+    ? Math.round((rated.reduce((s, r) => s + r.rating, 0) / rated.length / 2) * 10) / 10
+    : 0
+  const now = new Date()
+  const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1)
+  const thisMonthCount = history.filter(h => h.watched_at && new Date(h.watched_at) >= startOfMonth).length
+
+  // Streak: consecutive days back from today (or yesterday if today has no
+  // entries yet) with at least one watched entry.
+  const days = new Set()
+  for (const h of history) {
+    if (!h.watched_at) continue
+    days.add(dayKey(new Date(h.watched_at)))
+  }
+  let streakDays = 0
+  if (days.size > 0) {
+    const today = new Date()
+    const todayK = dayKey(today)
+    const yesterdayK = (() => { const d = new Date(); d.setDate(d.getDate() - 1); return dayKey(d) })()
+    const alive = days.has(todayK) || days.has(yesterdayK)
+    if (alive) {
+      const cursor = new Date(today)
+      // If today is empty but yesterday has a watch, start counting from yesterday.
+      if (!days.has(todayK)) cursor.setDate(cursor.getDate() - 1)
+      for (let i = 0; i < 365; i++) {
+        if (days.has(dayKey(cursor))) {
+          streakDays += 1
+          cursor.setDate(cursor.getDate() - 1)
+        } else {
+          break
+        }
+      }
+    }
+  }
+  return { totalLogged, totalHours, avgRating, thisMonthCount, streakDays }
+}

--- a/src/features/history/useHistoryData.jsx
+++ b/src/features/history/useHistoryData.jsx
@@ -5,16 +5,16 @@
 //   - stats: totalLogged, totalHours, avgRating, thisMonthCount, streakDays
 // Trend/signature visuals (heatmap, monthly timeline, mood share) live on
 // /profile (DNA) — they're patterns, not diary content.
+//
+// F6.2: the pure derivations now live in ./derive/historyDerive (behavior
+// unchanged); this provider is a thin caller over them.
 
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { supabase } from '@/shared/lib/supabase/client'
 import { useAuthSession } from '@/shared/hooks/useAuthSession'
-import { formatShortDate, formatShortMonthYear } from '@/shared/lib/format/date'
-import { HP, MOOD_HEX, tmdbImg } from './data'
+import { deriveEntries, deriveStats } from './derive/historyDerive'
 
 const HistoryDataContext = createContext(null)
-
-const WEEKDAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
 
 const INITIAL = {
   entries: [],
@@ -23,114 +23,6 @@ const INITIAL = {
   error: null,
   removeEntry: async () => {},
   refresh: () => {},
-}
-
-function capitalize(s) {
-  return s ? s.charAt(0).toUpperCase() + s.slice(1).replace(/_/g, ' ') : ''
-}
-
-function dayKey(date) {
-  // YYYY-MM-DD in local time — matches how a user thinks about "a day".
-  const y = date.getFullYear()
-  const m = String(date.getMonth() + 1).padStart(2, '0')
-  const d = String(date.getDate()).padStart(2, '0')
-  return `${y}-${m}-${d}`
-}
-
-function dayPart(hour) {
-  if (hour >= 5 && hour < 12) return 'Morning'
-  if (hour >= 12 && hour < 17) return 'Afternoon'
-  if (hour >= 17 && hour < 21) return 'Evening'
-  return 'Late'
-}
-
-function moodHexFor(name) {
-  if (!name) return HP.purple
-  return MOOD_HEX[name] || MOOD_HEX[capitalize(name)] || HP.purple
-}
-
-// === Derivers ============================================================
-
-function deriveEntries(history, ratings) {
-  const ratingByMovieId = new Map(ratings.map(r => [r.movie_id, r]))
-  return history
-    .filter(h => h.watched_at)
-    .sort((a, b) => new Date(b.watched_at) - new Date(a.watched_at))
-    .map(h => {
-      const m = h.movies || {}
-      const r = ratingByMovieId.get(h.movie_id) || {}
-      const d = new Date(h.watched_at)
-      const moodTag = (m.mood_tags || [])[0]
-      const mood = capitalize(moodTag) || 'Mixed'
-      return {
-        id: h.id || `${h.movie_id}-${h.watched_at}`,
-        movieId: h.movie_id,
-        tmdbId: m.tmdb_id,
-        title: m.title || 'Untitled',
-        year: m.release_date ? new Date(m.release_date).getFullYear() : '',
-        runtime: m.runtime || 0,
-        dir: m.director_name || '—',
-        date: formatShortDate(d),
-        month: formatShortMonthYear(d),
-        day: d.getDate(),
-        // user_ratings.rating is on the 1-10 scale; map to 1-5 for star display.
-        rating: r.rating ? Math.round(r.rating / 2) : 0,
-        mood,
-        moodHex: moodHexFor(mood),
-        context: `${dayPart(d.getHours())} · ${WEEKDAY_NAMES[d.getDay()]}`,
-        note: r.review_text || null,
-        poster: m.poster_path ? tmdbImg(m.poster_path, 'w342') : null,
-        // Rewatches aren't currently tracked in user_history (the app
-        // dedupes by (user, movie)). Leaving rewatch=false until that
-        // changes. ♥ fav fires for any 5★-display rating (raw 9 or 10 on
-        // the 1-10 scale) — matches what the star row shows. Previously
-        // gated on rating===10, which left favorites permanently dead for
-        // users who rate at 9.
-        rewatch: false,
-        fav: typeof r.rating === 'number' && r.rating >= 9,
-      }
-    })
-}
-
-function deriveStats({ history, ratings }) {
-  const totalLogged = history.length
-  const totalHours = Math.round(history.reduce((s, h) => s + (h.movies?.runtime || 0), 0) / 60)
-  const rated = ratings.filter(r => r.rating != null)
-  const avgRating = rated.length > 0
-    ? Math.round((rated.reduce((s, r) => s + r.rating, 0) / rated.length / 2) * 10) / 10
-    : 0
-  const now = new Date()
-  const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1)
-  const thisMonthCount = history.filter(h => h.watched_at && new Date(h.watched_at) >= startOfMonth).length
-
-  // Streak: consecutive days back from today (or yesterday if today has no
-  // entries yet) with at least one watched entry.
-  const days = new Set()
-  for (const h of history) {
-    if (!h.watched_at) continue
-    days.add(dayKey(new Date(h.watched_at)))
-  }
-  let streakDays = 0
-  if (days.size > 0) {
-    const today = new Date()
-    const todayK = dayKey(today)
-    const yesterdayK = (() => { const d = new Date(); d.setDate(d.getDate() - 1); return dayKey(d) })()
-    const alive = days.has(todayK) || days.has(yesterdayK)
-    if (alive) {
-      const cursor = new Date(today)
-      // If today is empty but yesterday has a watch, start counting from yesterday.
-      if (!days.has(todayK)) cursor.setDate(cursor.getDate() - 1)
-      for (let i = 0; i < 365; i++) {
-        if (days.has(dayKey(cursor))) {
-          streakDays += 1
-          cursor.setDate(cursor.getDate() - 1)
-        } else {
-          break
-        }
-      }
-    }
-  }
-  return { totalLogged, totalHours, avgRating, thisMonthCount, streakDays }
 }
 
 // === Provider ============================================================

--- a/src/features/watchlist/derive/__tests__/watchlistDerive.test.js
+++ b/src/features/watchlist/derive/__tests__/watchlistDerive.test.js
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// Control the engine-vs-approx selection in deriveItems deterministically.
+vi.mock('@/shared/services/recommendations', () => ({ scoreMovieForUser: vi.fn(() => null) }))
+vi.mock('@/shared/services/matchScore', () => ({ computeMatchPercent: vi.fn(() => null) }))
+
+import { scoreMovieForUser } from '@/shared/services/recommendations'
+import { computeMatchPercent } from '@/shared/services/matchScore'
+import {
+  STALE_DAYS, capitalize, pickPrimaryMood, daysAgo, approxMatch, deriveWhy,
+  deriveItems, deriveAvailableMoods, recomputeStats,
+} from '../watchlistDerive'
+
+// F6.2 — pins CURRENT Watchlist derivation behavior (incl. the match-% / approxMatch
+// presentation that F6.4 will deliberately change). These assertions are the contract
+// the trust redesign must consciously edit.
+
+const fp = { topMoodTags: [{ key: 'tender' }, { key: 'cozy' }, { key: 'tense' }], topFitProfiles: [{ key: 'comfort_watch' }] }
+
+beforeEach(() => { vi.clearAllMocks(); scoreMovieForUser.mockReturnValue(null); computeMatchPercent.mockReturnValue(null) })
+afterEach(() => vi.useRealTimers())
+
+describe('STALE_DAYS', () => {
+  it('is 60', () => { expect(STALE_DAYS).toBe(60) })
+})
+
+describe('capitalize / pickPrimaryMood', () => {
+  it('capitalizes + de-underscores', () => {
+    expect(capitalize('comfort_watch')).toBe('Comfort watch')
+    expect(capitalize('')).toBe('')
+  })
+  it('pickPrimaryMood returns the capitalized first tag or null', () => {
+    expect(pickPrimaryMood(['tender', 'cozy'])).toBe('Tender')
+    expect(pickPrimaryMood([])).toBeNull()
+    expect(pickPrimaryMood(null)).toBeNull()
+  })
+})
+
+describe('daysAgo', () => {
+  it('floors to whole local days, never negative', () => {
+    vi.useFakeTimers(); vi.setSystemTime(new Date('2026-03-10T12:00:00Z'))
+    expect(daysAgo('2026-03-10T00:00:00Z')).toBe(0)
+    expect(daysAgo('2026-03-05T12:00:00Z')).toBe(5)
+    expect(daysAgo('2026-04-01T00:00:00Z')).toBe(0) // future → clamped to 0
+    expect(daysAgo(null)).toBe(0)
+  })
+})
+
+describe('approxMatch (the F6.4 false-precision target — pinned)', () => {
+  const q = (r) => ({ mood_tags: [], fit_profile: null, ff_final_rating: r })
+  it('base floor is 50 with no signals', () => {
+    expect(approxMatch({ movie: { mood_tags: [] }, fingerprint: fp })).toBe(50)
+  })
+  it('+25 for a top-3 mood overlap', () => {
+    expect(approxMatch({ movie: { mood_tags: ['tender'] }, fingerprint: fp })).toBe(75)
+  })
+  it('+10 more for a top-5 fit overlap', () => {
+    expect(approxMatch({ movie: { mood_tags: ['tender'], fit_profile: 'comfort_watch' }, fingerprint: fp })).toBe(85)
+  })
+  it('+ up to 15 from quality (7.0→0, 8.0→7.5/8, 9.0→15)', () => {
+    expect(approxMatch({ movie: q(7.0), fingerprint: fp })).toBe(50)
+    expect(approxMatch({ movie: q(8.0), fingerprint: fp })).toBe(58) // 50 + 7.5 → round 58
+    expect(approxMatch({ movie: q(9.0), fingerprint: fp })).toBe(65)
+  })
+  it('caps at 96 (all signals = 100 → 96) and floors at 50', () => {
+    expect(approxMatch({ movie: { mood_tags: ['tender'], fit_profile: 'comfort_watch', ff_final_rating: 9.5 }, fingerprint: fp })).toBe(96)
+    expect(approxMatch({ movie: { mood_tags: ['nope'] }, fingerprint: { topMoodTags: [], topFitProfiles: [] } })).toBe(50)
+  })
+})
+
+describe('deriveWhy (restated-metadata line — pinned)', () => {
+  it('top-mood + age variants', () => {
+    expect(deriveWhy({ mood: 'Tender', match: 84, addedDaysAgo: 5, matchesTopMood: true })).toBe('Your tender pick · 84% match · waiting 5d')
+    expect(deriveWhy({ mood: 'Cozy', match: 70, addedDaysAgo: 0, matchesTopMood: false })).toBe('Cozy pick · 70% match · saved today')
+    expect(deriveWhy({ mood: 'Cozy', match: 70, addedDaysAgo: 1, matchesTopMood: false })).toBe('Cozy pick · 70% match · saved yesterday')
+  })
+})
+
+describe('deriveItems (engine-vs-approx selection, perfect, stale)', () => {
+  const row = (over = {}) => ({ movie_id: 1, added_at: '2026-03-09T00:00:00Z', movies: { id: 11, tmdb_id: 101, title: 'A', release_date: '2020-01-01', runtime: 100, director_name: 'D', mood_tags: ['tender'], poster_path: '/p.jpg', ...over.movies }, ...over })
+
+  it('uses the engine match when computeMatchPercent returns non-null', () => {
+    vi.useFakeTimers(); vi.setSystemTime(new Date('2026-03-10T12:00:00Z'))
+    computeMatchPercent.mockReturnValue(88)
+    const [it] = deriveItems({ rows: [row()], fingerprint: fp, profile: { x: 1 } })
+    expect(it.match).toBe(88)
+  })
+
+  it('falls back to approxMatch when the engine returns null (cold-start path)', () => {
+    vi.useFakeTimers(); vi.setSystemTime(new Date('2026-03-10T12:00:00Z'))
+    computeMatchPercent.mockReturnValue(null) // engine has no signal
+    const [it] = deriveItems({ rows: [row()], fingerprint: fp, profile: null })
+    expect(it.match).toBe(75) // approxMatch: base 50 + 25 (tender is top mood)
+  })
+
+  it('perfect = top-mood match AND match≥80 AND not stale; stale = added >60d', () => {
+    vi.useFakeTimers(); vi.setSystemTime(new Date('2026-03-10T12:00:00Z'))
+    computeMatchPercent.mockReturnValue(82)
+    const fresh = deriveItems({ rows: [row({ added_at: '2026-03-09T00:00:00Z' })], fingerprint: fp, profile: { x: 1 } })[0]
+    expect(fresh.stale).toBe(false)
+    expect(fresh.perfect).toBe(true) // tender == top mood, 82≥80, fresh
+    // 61 days old → stale → not perfect even with the same high match
+    const old = deriveItems({ rows: [row({ added_at: '2026-01-07T00:00:00Z' })], fingerprint: fp, profile: { x: 1 } })[0]
+    expect(old.addedDaysAgo).toBeGreaterThan(60)
+    expect(old.stale).toBe(true)
+    expect(old.perfect).toBe(false)
+  })
+
+  it('maps the row to the page shape (id, internalId, mood, poster size w500)', () => {
+    vi.useFakeTimers(); vi.setSystemTime(new Date('2026-03-10T12:00:00Z'))
+    computeMatchPercent.mockReturnValue(70)
+    const [it] = deriveItems({ rows: [row()], fingerprint: fp, profile: { x: 1 } })
+    expect(it).toMatchObject({ id: 1, internalId: 11, tmdbId: 101, title: 'A', mood: 'Tender' })
+    expect(it.poster).toContain('w500')
+  })
+})
+
+describe('deriveAvailableMoods', () => {
+  it('counts distinct moods desc, excluding Mixed', () => {
+    const items = [{ mood: 'Tender' }, { mood: 'Tender' }, { mood: 'Cozy' }, { mood: 'Mixed' }]
+    expect(deriveAvailableMoods(items).map(m => [m.mood, m.count])).toEqual([['Tender', 2], ['Cozy', 1]])
+  })
+})
+
+describe('recomputeStats', () => {
+  it('top/avg match + perfect/stale counts', () => {
+    const items = [
+      { match: 90, perfect: true, stale: false },
+      { match: 70, perfect: false, stale: true },
+      { match: 50, perfect: false, stale: false },
+    ]
+    expect(recomputeStats(items)).toEqual({ watchlistTotal: 3, perfectForTonightCount: 1, gettingStaleCount: 1, topMatchPct: 90, avgMatchPct: 70 })
+  })
+})

--- a/src/features/watchlist/derive/watchlistDerive.js
+++ b/src/features/watchlist/derive/watchlistDerive.js
@@ -1,0 +1,153 @@
+// src/features/watchlist/derive/watchlistDerive.js
+// F6.2 — pure Watchlist derivations, extracted verbatim from useWatchlistData.jsx
+// (the provider is now a thin caller). NO behavior change: every function body is
+// byte-for-byte identical to the inlined originals, so the rendered Watchlist output
+// is unchanged. These are the surfaces the F6.3–F6.5 trust/reliability work will edit
+// deliberately (e.g. the match-% presentation); pinning them here makes those edits
+// reviewable test diffs.
+
+import { HP, MOOD_HEX, tmdbImg } from '../data'
+import { scoreMovieForUser } from '@/shared/services/recommendations'
+import { computeMatchPercent } from '@/shared/services/matchScore'
+
+// Stale threshold matches the README: items added >60 days ago.
+export const STALE_DAYS = 60
+
+export function capitalize(s) {
+  return s ? s.charAt(0).toUpperCase() + s.slice(1).replace(/_/g, ' ') : ''
+}
+
+export function pickPrimaryMood(moodTags) {
+  if (!Array.isArray(moodTags) || moodTags.length === 0) return null
+  // Pick the first non-empty tag; tags are populated in order of strength
+  // by the LLM enrichment pipeline.
+  return capitalize(moodTags[0])
+}
+
+export function hexFor(mood) {
+  if (!mood) return HP.textSoft
+  return MOOD_HEX[mood] || MOOD_HEX[mood.toLowerCase()] || HP.purple
+}
+
+export function daysAgo(iso) {
+  if (!iso) return 0
+  const ms = Date.now() - new Date(iso).getTime()
+  return Math.max(0, Math.floor(ms / (1000 * 60 * 60 * 24)))
+}
+
+// Per-(user, film) match score. We don't run the full 7-dimension
+// scoring engine here — that's expensive and tied to the recommendation
+// pipeline. Instead we approximate from the signals we already have:
+//   - 50 base
+//   - +25 if the film's primary mood is one of the user's top 3
+//   - +10 if it's also one of the user's top 5 fits
+//   - +up to 15 from objective quality (ff_final_rating)
+// Capped at 96, floored at 50. Deterministic given same inputs.
+export function approxMatch({ movie, fingerprint }) {
+  const moodTags = movie.mood_tags || []
+  const fitProfile = movie.fit_profile
+  const userTopMoods = (fingerprint?.topMoodTags || []).slice(0, 3).map(t => t.key)
+  const userTopFits = (fingerprint?.topFitProfiles || []).slice(0, 5).map(t => t.key)
+  let score = 50
+  if (moodTags.some(t => userTopMoods.includes(t))) score += 25
+  if (fitProfile && userTopFits.includes(fitProfile)) score += 10
+  const quality = Number(movie.ff_final_rating) || Number(movie.ff_rating) || 0
+  if (quality > 0) {
+    // ff_final_rating is 0–10; map 7.0–9.0 → 0–15 bonus
+    const q = Math.max(0, Math.min(15, ((quality - 7) / 2) * 15))
+    score += q
+  }
+  return Math.max(50, Math.min(96, Math.round(score)))
+}
+
+// Build a contextual "why" line for FeaturedCard from real per-item signals.
+// FeaturedCard only renders for perfect/top items, so this always has
+// something concrete to say (mood + match + age). Deterministic given inputs.
+export function deriveWhy({ mood, match, addedDaysAgo, matchesTopMood }) {
+  const parts = []
+  if (matchesTopMood) parts.push(`Your ${mood.toLowerCase()} pick`)
+  else parts.push(`${mood} pick`)
+  parts.push(`${match}% match`)
+  if (addedDaysAgo === 0) parts.push('saved today')
+  else if (addedDaysAgo === 1) parts.push('saved yesterday')
+  else parts.push(`waiting ${addedDaysAgo}d`)
+  return parts.join(' · ')
+}
+
+// A film is "perfect for tonight" when its primary mood matches the
+// user's #1 mood AND it scored ≥ 80. Cold-start (no fingerprint) → no
+// perfect items; the page falls back to "top of your queue" in that case.
+export function deriveItems({ rows, fingerprint, profile }) {
+  const userTopMood = fingerprint?.topMoodTags?.[0]?.key || null
+  const items = rows.map(r => {
+    const m = r.movies || {}
+    const mood = pickPrimaryMood(m.mood_tags)
+    // Engine when we have a profile; cold-start fallback otherwise.
+    // computeMatchPercent is the system-wide match%: confidence-tiered
+    // mapping of engineScore → 0-99. Same definition + curve as /home,
+    // /movie/:id, /history. Returns null when the engine has no signal;
+    // we coerce to approxMatch fallback in that case.
+    // scoreMovieForUser returns null when a content-boundary hard filter
+    // hits (graphic/sexual + matching keywords/cert). Coerce to null so
+    // we fall back to approxMatch below — the film still shows on the
+    // watchlist; we just can't compute a real match %.
+    const engineScore = profile
+      ? (scoreMovieForUser(m, profile, 'default')?.score ?? null)
+      : null
+    const engineMatch = computeMatchPercent({ engineScore, profile })
+    const match = engineMatch != null
+      ? engineMatch
+      : approxMatch({ movie: m, fingerprint })
+    const addedDaysAgo = daysAgo(r.added_at)
+    const stale = addedDaysAgo > STALE_DAYS
+    const moodKey = (m.mood_tags || [])[0] || null
+    const matchesTopMood = Boolean(userTopMood && moodKey && moodKey === userTopMood)
+    const perfect = Boolean(matchesTopMood && match >= 80 && !stale)
+    const why = deriveWhy({ mood: mood || 'Mixed', match, addedDaysAgo, matchesTopMood })
+    return {
+      id: r.movie_id,
+      internalId: m.id,
+      tmdbId: m.tmdb_id,
+      title: m.title || 'Untitled',
+      year: m.release_date ? new Date(m.release_date).getFullYear() : '',
+      runtime: m.runtime || 0,
+      dir: m.director_name || '—',
+      mood: mood || 'Mixed',
+      hex: hexFor(mood),
+      match,
+      perfect,
+      stale,
+      addedDaysAgo,
+      poster: m.poster_path ? tmdbImg(m.poster_path, 'w500') : null,
+      why,
+    }
+  })
+  return items
+}
+
+// Distinct moods present in the queue, ranked by count (descending). Used to
+// generate dynamic filter pills so a user only ever sees moods that match
+// something in their actual list.
+export function deriveAvailableMoods(items) {
+  const counts = new Map()
+  for (const it of items) {
+    if (!it.mood || it.mood === 'Mixed') continue
+    counts.set(it.mood, (counts.get(it.mood) || 0) + 1)
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([mood, count]) => ({ mood, count, hex: hexFor(mood) }))
+}
+
+export function recomputeStats(items) {
+  const matches = items.map(it => it.match).filter(Number.isFinite)
+  const topMatchPct = matches.length ? Math.max(...matches) : 0
+  const avgMatchPct = matches.length ? Math.round(matches.reduce((s, n) => s + n, 0) / matches.length) : 0
+  return {
+    watchlistTotal: items.length,
+    perfectForTonightCount: items.filter(it => it.perfect).length,
+    gettingStaleCount: items.filter(it => it.stale).length,
+    topMatchPct,
+    avgMatchPct,
+  }
+}

--- a/src/features/watchlist/useWatchlistData.jsx
+++ b/src/features/watchlist/useWatchlistData.jsx
@@ -3,20 +3,19 @@
 // user_watchlist (joined with movies) + their taste_fingerprint, then
 // derives the shape the page expects: items[] with match/mood/perfect/
 // stale/addedDaysAgo/hex/tmdbId/internalId, plus aggregate stats.
+//
+// F6.2: the pure derivations now live in ./derive/watchlistDerive (behavior
+// unchanged); this provider is a thin caller over them.
 
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { supabase } from '@/shared/lib/supabase/client'
 import { useAuthSession } from '@/shared/hooks/useAuthSession'
 import { getTasteFingerprint } from '@/shared/services/tasteCache'
-import { computeUserProfile, scoreMovieForUser } from '@/shared/services/recommendations'
-import { computeMatchPercent } from '@/shared/services/matchScore'
+import { computeUserProfile } from '@/shared/services/recommendations'
 import { MOVIE_ENGINE_COLS } from '@/shared/services/movieFields'
-import { HP, MOOD_HEX, tmdbImg } from './data'
+import { deriveItems, deriveAvailableMoods, recomputeStats } from './derive/watchlistDerive'
 
 const WatchlistDataContext = createContext(null)
-
-// Stale threshold matches the README: items added >60 days ago.
-const STALE_DAYS = 60
 
 const INITIAL = {
   items: [],
@@ -34,132 +33,6 @@ const INITIAL = {
   removeFromWatchlist: async () => {},
   removeStale: async () => {},
   refresh: () => {},
-}
-
-function capitalize(s) {
-  return s ? s.charAt(0).toUpperCase() + s.slice(1).replace(/_/g, ' ') : ''
-}
-
-function pickPrimaryMood(moodTags) {
-  if (!Array.isArray(moodTags) || moodTags.length === 0) return null
-  // Pick the first non-empty tag; tags are populated in order of strength
-  // by the LLM enrichment pipeline.
-  return capitalize(moodTags[0])
-}
-
-function hexFor(mood) {
-  if (!mood) return HP.textSoft
-  return MOOD_HEX[mood] || MOOD_HEX[mood.toLowerCase()] || HP.purple
-}
-
-function daysAgo(iso) {
-  if (!iso) return 0
-  const ms = Date.now() - new Date(iso).getTime()
-  return Math.max(0, Math.floor(ms / (1000 * 60 * 60 * 24)))
-}
-
-// Per-(user, film) match score. We don't run the full 7-dimension
-// scoring engine here — that's expensive and tied to the recommendation
-// pipeline. Instead we approximate from the signals we already have:
-//   - 50 base
-//   - +25 if the film's primary mood is one of the user's top 3
-//   - +10 if it's also one of the user's top 5 fits
-//   - +up to 15 from objective quality (ff_final_rating)
-// Capped at 96, floored at 50. Deterministic given same inputs.
-function approxMatch({ movie, fingerprint }) {
-  const moodTags = movie.mood_tags || []
-  const fitProfile = movie.fit_profile
-  const userTopMoods = (fingerprint?.topMoodTags || []).slice(0, 3).map(t => t.key)
-  const userTopFits = (fingerprint?.topFitProfiles || []).slice(0, 5).map(t => t.key)
-  let score = 50
-  if (moodTags.some(t => userTopMoods.includes(t))) score += 25
-  if (fitProfile && userTopFits.includes(fitProfile)) score += 10
-  const quality = Number(movie.ff_final_rating) || Number(movie.ff_rating) || 0
-  if (quality > 0) {
-    // ff_final_rating is 0–10; map 7.0–9.0 → 0–15 bonus
-    const q = Math.max(0, Math.min(15, ((quality - 7) / 2) * 15))
-    score += q
-  }
-  return Math.max(50, Math.min(96, Math.round(score)))
-}
-
-// Build a contextual "why" line for FeaturedCard from real per-item signals.
-// FeaturedCard only renders for perfect/top items, so this always has
-// something concrete to say (mood + match + age). Deterministic given inputs.
-function deriveWhy({ mood, match, addedDaysAgo, matchesTopMood }) {
-  const parts = []
-  if (matchesTopMood) parts.push(`Your ${mood.toLowerCase()} pick`)
-  else parts.push(`${mood} pick`)
-  parts.push(`${match}% match`)
-  if (addedDaysAgo === 0) parts.push('saved today')
-  else if (addedDaysAgo === 1) parts.push('saved yesterday')
-  else parts.push(`waiting ${addedDaysAgo}d`)
-  return parts.join(' · ')
-}
-
-// A film is "perfect for tonight" when its primary mood matches the
-// user's #1 mood AND it scored ≥ 80. Cold-start (no fingerprint) → no
-// perfect items; the page falls back to "top of your queue" in that case.
-function deriveItems({ rows, fingerprint, profile }) {
-  const userTopMood = fingerprint?.topMoodTags?.[0]?.key || null
-  const items = rows.map(r => {
-    const m = r.movies || {}
-    const mood = pickPrimaryMood(m.mood_tags)
-    // Engine when we have a profile; cold-start fallback otherwise.
-    // computeMatchPercent is the system-wide match%: confidence-tiered
-    // mapping of engineScore → 0-99. Same definition + curve as /home,
-    // /movie/:id, /history. Returns null when the engine has no signal;
-    // we coerce to approxMatch fallback in that case.
-    // scoreMovieForUser returns null when a content-boundary hard filter
-    // hits (graphic/sexual + matching keywords/cert). Coerce to null so
-    // we fall back to approxMatch below — the film still shows on the
-    // watchlist; we just can't compute a real match %.
-    const engineScore = profile
-      ? (scoreMovieForUser(m, profile, 'default')?.score ?? null)
-      : null
-    const engineMatch = computeMatchPercent({ engineScore, profile })
-    const match = engineMatch != null
-      ? engineMatch
-      : approxMatch({ movie: m, fingerprint })
-    const addedDaysAgo = daysAgo(r.added_at)
-    const stale = addedDaysAgo > STALE_DAYS
-    const moodKey = (m.mood_tags || [])[0] || null
-    const matchesTopMood = Boolean(userTopMood && moodKey && moodKey === userTopMood)
-    const perfect = Boolean(matchesTopMood && match >= 80 && !stale)
-    const why = deriveWhy({ mood: mood || 'Mixed', match, addedDaysAgo, matchesTopMood })
-    return {
-      id: r.movie_id,
-      internalId: m.id,
-      tmdbId: m.tmdb_id,
-      title: m.title || 'Untitled',
-      year: m.release_date ? new Date(m.release_date).getFullYear() : '',
-      runtime: m.runtime || 0,
-      dir: m.director_name || '—',
-      mood: mood || 'Mixed',
-      hex: hexFor(mood),
-      match,
-      perfect,
-      stale,
-      addedDaysAgo,
-      poster: m.poster_path ? tmdbImg(m.poster_path, 'w500') : null,
-      why,
-    }
-  })
-  return items
-}
-
-// Distinct moods present in the queue, ranked by count (descending). Used to
-// generate dynamic filter pills so a user only ever sees moods that match
-// something in their actual list.
-function deriveAvailableMoods(items) {
-  const counts = new Map()
-  for (const it of items) {
-    if (!it.mood || it.mood === 'Mixed') continue
-    counts.set(it.mood, (counts.get(it.mood) || 0) + 1)
-  }
-  return [...counts.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .map(([mood, count]) => ({ mood, count, hex: hexFor(mood) }))
 }
 
 export function WatchlistDataProvider({ children }) {
@@ -285,19 +158,6 @@ export function WatchlistDataProvider({ children }) {
 
   const value = useMemo(() => state, [state])
   return <WatchlistDataContext.Provider value={value}>{children}</WatchlistDataContext.Provider>
-}
-
-function recomputeStats(items) {
-  const matches = items.map(it => it.match).filter(Number.isFinite)
-  const topMatchPct = matches.length ? Math.max(...matches) : 0
-  const avgMatchPct = matches.length ? Math.round(matches.reduce((s, n) => s + n, 0) / matches.length) : 0
-  return {
-    watchlistTotal: items.length,
-    perfectForTonightCount: items.filter(it => it.perfect).length,
-    gettingStaleCount: items.filter(it => it.stale).length,
-    topMatchPct,
-    avgMatchPct,
-  }
 }
 
 export function useWatchlistData() {


### PR DESCRIPTION
**F6.2 — User Library derivation extraction + test safety net.** Refactor + test-only. The pure Watchlist + History derivations are extracted **byte-for-byte** into tested pure modules; the providers become thin callers. **No visible change, no behavior change, no engine/schema/route/copy change**; no live route opened, no live write performed. This pins current behavior so the F6.3–F6.5 trust/reliability/data-truth edits land as deliberate, reviewable test diffs.

## What moved
- `src/features/watchlist/derive/watchlistDerive.js` — `STALE_DAYS`, `capitalize`, `pickPrimaryMood`, `hexFor`, `daysAgo`, `approxMatch`, `deriveWhy`, `deriveItems`, `deriveAvailableMoods`, `recomputeStats`.
- `src/features/history/derive/historyDerive.js` — `WEEKDAY_NAMES`, `capitalize`, `dayKey`, `dayPart`, `moodHexFor`, `deriveEntries`, `deriveStats`.

`useWatchlistData.jsx` / `useHistoryData.jsx` now import these (**net −257/+9** across the two providers); the provider bodies (fetch + optimistic remove + refresh) are unchanged. Function bodies are identical to the inlined originals.

## Tests added (27, pinning CURRENT behavior)
- **watchlistDerive.test.js** — `approxMatch` bounds (50–96) + the +25/+10/+≤15 contributions + the **engine-vs-approx selection** (the F6.4 false-precision target, pinned), `perfect`/`stale` thresholds (60-day boundary), `deriveWhy` strings, `recomputeStats`, mood pills.
- **historyDerive.test.js** — `deriveEntries` ordering + `watched_at` filter + 1-10→1-5 star mapping + fav-at-≥9 + film-mood pill + id fallback; `deriveStats` `totalLogged`/`totalHours`, streak (today/yesterday-alive, gap, local-day), `thisMonthCount`, and — **pinned on purpose** (the F6.5 scope target) — `avgRating` averaged over **all** `user_ratings`, including a film *not* in history.

## Recorded for F6.3/F6.5 (investigated, NOT fixed here — per the phase boundary)
Discover's "Already watched" inserts `user_history` **without `watched_at`** (`useDiscoverResultActions.js:116` — `{user_id, movie_id, source:'discover_marked'}`), unlike the Film File/Home paths. `user_history.watched_at` is nullable (the stats RPC filters `IS NOT NULL`); the base-table DDL/default isn't in committed migrations. Since `deriveEntries` filters on `watched_at` while `totalLogged` counts all rows, **absent a DB `DEFAULT now()` a Discover-marked film would be hidden from the Diary and desync the count** — verify the live-schema default before fixing.

## Validation
`npm run lint` clean · `npx vitest run` (derive) 27 ×3 deterministic · `npm run test` **1193** (1166 prior unchanged + 27 new) · `npm run build` ✓. Pages + provider output render identically. Only the 2 providers + 2 derive dirs changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
