### PR TITLE
Harden User Library removals and error states

### DIFF
--- a/src/features/history/History.jsx
+++ b/src/features/history/History.jsx
@@ -1,9 +1,11 @@
 // src/features/history/History.jsx
-// FeelFlick — Diary v2. Mount at /history-v2.
-// All sections (heatmap, timeline, mood share, stats, entries) are derived
-// live from user_history × movies × user_ratings — see ./useHistoryData.jsx.
+// FeelFlick — Diary v2. All sections derived live from
+// user_history × movies × user_ratings — see ./useHistoryData.jsx.
+// F6.3: removal is settled + announced + focus-recovered; load errors are sanitized.
+// (No stat/semantics/removal-meaning redesign — those are F6.5. Confirm copy + the
+// rating/review retention are unchanged.)
 
-import { useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { usePageMeta } from '@/shared/hooks/usePageMeta'
 import MoodPill from '@/shared/components/MoodPill'
@@ -11,6 +13,8 @@ import Eyebrow from '@/shared/ui/Eyebrow'
 import PageContainer from '@/shared/ui/PageContainer'
 import { HP, HP_GRAD } from './data'
 import { HistoryDataProvider, useHistoryData } from './useHistoryData'
+import { useLibraryAnnouncement } from '@/features/library/useLibraryAnnouncement'
+import { scheduleFocus, findRemoveControl, findFallback, nextFocusId } from '@/features/library/focusAfterRemoval'
 import './history.css'
 
 // === Reset-button style for elements wrapped as buttons ===
@@ -58,18 +62,7 @@ function PulseStrip() {
   );
 }
 
-// Streak heatmap, "Films per month", and "Mood share" used to live here.
-// They were trend/signature visuals, not diary content — moved out so this
-// page stays a chronological record. The DNA page (/profile) is the home
-// for taste patterns; deriveTrajectory + the mood radar there already cover
-// monthly volume + mood share. The streak heatmap is a follow-up port to
-// /profile (TODO).
-
 function FilterBar({ filter, setFilter, sort, setSort, query, setQuery }) {
-  // "Favorites" was redundant with "Loved (5★)" — both filtered on the same
-  // ≥9 rating bucket. Dropped until there's a real per-row favorite toggle
-  // separate from the rating scale. The ♥ heart in DiaryGroup is dropped
-  // for the same reason.
   const filters = [
     { v:'all', l:'All' },
     { v:'5',   l:'Loved (5★)' },
@@ -130,32 +123,24 @@ function Stars({ n }) {
   return (
     <span style={{ display:'inline-flex', gap:2 }} aria-label={`${n} of 5 stars`}>
       {[1,2,3,4,5].map(i => (
-        <svg key={i} width="11" height="11" viewBox="0 0 24 24" fill={i<=n?HP.amber:'transparent'} stroke={i<=n?HP.amber:HP.textFaint} strokeWidth="1.6"><path d="M12 2l3 7 7 1-5 5 1 7-6-3-6 3 1-7-5-5 7-1z"/></svg>
+        <svg key={i} aria-hidden="true" width="11" height="11" viewBox="0 0 24 24" fill={i<=n?HP.amber:'transparent'} stroke={i<=n?HP.amber:HP.textFaint} strokeWidth="1.6"><path d="M12 2l3 7 7 1-5 5 1 7-6-3-6 3 1-7-5-5 7-1z"/></svg>
       ))}
     </span>
   );
 }
 
-function DiaryGroup({ month, entries }) {
+function DiaryGroup({ month, entries, onRemove }) {
   const navigate = useNavigate();
-  const { removeEntry } = useHistoryData();
+  const { isRemoving } = useHistoryData();
   const open = (e) => e.tmdbId && navigate(`/movie/${e.tmdbId}`);
-  async function handleRemove(e) {
-    if (typeof window !== 'undefined' && !window.confirm(`Remove "${e.title}" from your diary?`)) return;
-    await removeEntry(e.id);
-  }
 
-  // Bucket entries within this month by day. Surfaces bingeing patterns
-  // (a Sat with 10 logs reads as one chunk rather than 10 repeated "24"
-  // numerals) and gives mobile rows a date they previously lacked (the
-  // per-row day numeral was hidden at narrow widths).
   const byDay = useMemo(() => {
     const map = new Map();
     entries.forEach(e => {
       if (!map.has(e.day)) map.set(e.day, []);
       map.get(e.day).push(e);
     });
-    return [...map.entries()];  // already in newest-first order from entries
+    return [...map.entries()];
   }, [entries]);
 
   return (
@@ -169,7 +154,6 @@ function DiaryGroup({ month, entries }) {
       </div>
       <div style={{ borderTop:`1px solid ${HP.border}` }}>
         {byDay.map(([day, dayEntries]) => {
-          // Weekday lives in e.context as "<dayPart> · <Weekday>"
           const weekday = dayEntries[0]?.context?.split(' · ')[1] || '';
           const dayDate = dayEntries[0]?.date || '';
           const dayHours = Math.round(dayEntries.reduce((s, e) => s + (e.runtime || 0), 0) / 60);
@@ -187,51 +171,59 @@ function DiaryGroup({ month, entries }) {
                   · {dayEntries.length} film{dayEntries.length === 1 ? '' : 's'}{dayHours > 0 ? ` · ${dayHours}h` : ''}
                 </span>
               </div>
-              {dayEntries.map(e => (
-                <div key={e.id} className="ff-hist-row" style={{ display:'grid', gridTemplateColumns:'64px 1fr auto auto', gap:24, alignItems:'flex-start', padding:'20px 0', borderBottom:`1px solid ${HP.border}` }}>
-                  <button
-                    type="button"
-                    onClick={() => open(e)}
-                    aria-label={`Open ${e.title}`}
-                    style={{ ...RESET_BTN, width:64, height:96 }}
-                  >
-                    {e.poster
-                      ? <img src={e.poster} alt="" style={{ width:'100%', height:'100%', objectFit:'cover', borderRadius:4 }} />
-                      : <div style={{ width:'100%', height:'100%', borderRadius:4, background:`linear-gradient(155deg, ${e.moodHex}55, ${e.moodHex}11)` }} />
-                    }
-                  </button>
-                  <div style={{ minWidth:0 }}>
-                    <div style={{ display:'flex', alignItems:'center', gap:10, flexWrap:'wrap' }}>
-                      <button
-                        type="button"
-                        onClick={() => open(e)}
-                        style={{ ...RESET_BTN, fontFamily:'Outfit', fontSize:20, fontWeight:500, color:HP.text, letterSpacing:'-0.02em', cursor:'pointer' }}
-                      >{e.title}</button>
-                      {e.year && <span style={{ fontSize:11, color:HP.textMuted, fontFamily:'Outfit', letterSpacing:'0.04em' }}>{e.year}{e.dir && e.dir !== '—' ? ` · ${e.dir}` : ''}</span>}
+              {dayEntries.map(e => {
+                const busy = isRemoving(e.id);
+                return (
+                  <div key={e.id} className="ff-hist-row" style={{ display:'grid', gridTemplateColumns:'64px 1fr auto auto', gap:24, alignItems:'flex-start', padding:'20px 0', borderBottom:`1px solid ${HP.border}` }}>
+                    <button
+                      type="button"
+                      onClick={() => open(e)}
+                      aria-label={`Open ${e.title}`}
+                      style={{ ...RESET_BTN, width:64, height:96 }}
+                    >
+                      {e.poster
+                        ? <img src={e.poster} alt="" style={{ width:'100%', height:'100%', objectFit:'cover', borderRadius:4 }} />
+                        : <div style={{ width:'100%', height:'100%', borderRadius:4, background:`linear-gradient(155deg, ${e.moodHex}55, ${e.moodHex}11)` }} />
+                      }
+                    </button>
+                    <div style={{ minWidth:0 }}>
+                      <div style={{ display:'flex', alignItems:'center', gap:10, flexWrap:'wrap' }}>
+                        <button
+                          type="button"
+                          onClick={() => open(e)}
+                          style={{ ...RESET_BTN, fontFamily:'Outfit', fontSize:20, fontWeight:500, color:HP.text, letterSpacing:'-0.02em', cursor:'pointer' }}
+                        >{e.title}</button>
+                        {e.year && <span style={{ fontSize:11, color:HP.textMuted, fontFamily:'Outfit', letterSpacing:'0.04em' }}>{e.year}{e.dir && e.dir !== '—' ? ` · ${e.dir}` : ''}</span>}
+                      </div>
+                      <div style={{ marginTop:8, display:'flex', alignItems:'center', gap:12, flexWrap:'wrap' }}>
+                        <Stars n={e.rating} />
+                        {e.mood && e.mood !== 'Mixed' && <MoodPill label={e.mood} color={e.moodHex} dot />}
+                      </div>
+                      {e.note && (
+                        <p style={{ margin:'14px 0 0 0', fontSize:14, lineHeight:1.55, color:HP.textSoft, fontFamily:'Outfit, Inter, sans-serif', fontStyle:'italic', borderLeft:`2px solid ${e.moodHex}55`, paddingLeft:14, textWrap:'pretty' }}>
+                          &ldquo;{e.note}&rdquo;
+                        </p>
+                      )}
                     </div>
-                    <div style={{ marginTop:8, display:'flex', alignItems:'center', gap:12, flexWrap:'wrap' }}>
-                      <Stars n={e.rating} />
-                      {e.mood && e.mood !== 'Mixed' && <MoodPill label={e.mood} color={e.moodHex} dot />}
-                    </div>
-                    {e.note && (
-                      <p style={{ margin:'14px 0 0 0', fontSize:14, lineHeight:1.55, color:HP.textSoft, fontFamily:'Outfit, Inter, sans-serif', fontStyle:'italic', borderLeft:`2px solid ${e.moodHex}55`, paddingLeft:14, textWrap:'pretty' }}>
-                        &ldquo;{e.note}&rdquo;
-                      </p>
-                    )}
+                    <span className="ff-hist-row__runtime" style={{ fontSize:11, color:HP.textFaint, fontFamily:'Outfit', letterSpacing:'0.06em', textTransform:'uppercase', paddingTop:8 }}>{e.runtime ? `${e.runtime}m` : ''}</span>
+                    <button
+                      type="button"
+                      data-library-action="remove"
+                      data-library-item-id={e.id}
+                      data-library-view="diary"
+                      onClick={(ev) => onRemove(e, ev.currentTarget)}
+                      disabled={busy}
+                      aria-busy={busy || undefined}
+                      aria-label={busy ? `Removing ${e.title}` : `Remove ${e.title} from diary`}
+                      title="Remove from diary"
+                      className="ff-hist-row__remove"
+                      style={{ minWidth:44, minHeight:44, display:'inline-flex', alignItems:'center', justifyContent:'center', borderRadius:6, background:'transparent', border:'none', color:HP.textFaint, cursor: busy ? 'wait' : 'pointer', opacity: busy ? 0.5 : 1 }}
+                    >
+                      <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-2 14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6M14 11v6"/></svg>
+                    </button>
                   </div>
-                  <span className="ff-hist-row__runtime" style={{ fontSize:11, color:HP.textFaint, fontFamily:'Outfit', letterSpacing:'0.06em', textTransform:'uppercase', paddingTop:8 }}>{e.runtime ? `${e.runtime}m` : ''}</span>
-                  <button
-                    type="button"
-                    onClick={() => handleRemove(e)}
-                    aria-label={`Remove ${e.title} from diary`}
-                    title="Remove from diary"
-                    className="ff-hist-row__remove"
-                    style={{ minWidth:44, minHeight:44, display:'inline-flex', alignItems:'center', justifyContent:'center', borderRadius:6, background:'transparent', border:'none', color:HP.textFaint, cursor:'pointer' }}
-                  >
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-2 14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6M14 11v6"/></svg>
-                  </button>
-                </div>
-              ))}
+                );
+              })}
             </div>
           );
         })}
@@ -271,20 +263,32 @@ function PageSkeleton() {
   );
 }
 
-function PageError({ error }) {
+// F6.3: sanitized error — fixed, safe copy only (never a raw backend message), with
+// Try-again (refresh) + Go-to-Home recovery. role="alert", one h1, ≥44px buttons.
+function PageError({ onRetry, onHome }) {
   return (
     <div style={{ minHeight:'60vh', display:'flex', alignItems:'center', justifyContent:'center', padding:24 }}>
-      <div style={{ textAlign:'center', maxWidth:520 }}>
-        <Eyebrow size={10} style={{ marginBottom:18 }}>Diary · error</Eyebrow>
-        <h1 style={{ fontFamily:'Outfit, Inter, sans-serif', fontSize:36, fontWeight:500, color:HP.text, margin:'0 0 18px 0', letterSpacing:'-0.025em' }}>Couldn&rsquo;t load your diary.</h1>
-        <p style={{ margin:0, color:'rgba(250,250,250,0.6)', fontSize:14, lineHeight:1.6 }}>{error}</p>
+      <div role="alert" style={{ textAlign:'center', maxWidth:520 }}>
+        <Eyebrow size={10} style={{ marginBottom:18 }}>Diary</Eyebrow>
+        <h1 style={{ fontFamily:'Outfit, Inter, sans-serif', fontSize:36, fontWeight:500, color:HP.text, margin:'0 0 14px 0', letterSpacing:'-0.025em' }}>We couldn&rsquo;t load your Diary.</h1>
+        <p style={{ margin:'0 0 28px 0', color:'rgba(250,250,250,0.6)', fontSize:14, lineHeight:1.6 }}>Your watched films and notes are still safe. Try again in a moment.</p>
+        <div style={{ display:'flex', gap:12, justifyContent:'center', flexWrap:'wrap' }}>
+          <button type="button" onClick={onRetry} className="ff-hist-error-btn" style={{ minHeight:44, padding:'12px 22px', borderRadius:999, background:HP_GRAD, color:'#fff', border:'none', cursor:'pointer', fontFamily:'Outfit', fontSize:14, fontWeight:600 }}>Try again</button>
+          <button type="button" onClick={onHome} className="ff-hist-error-btn" style={{ minHeight:44, padding:'12px 22px', borderRadius:999, background:'transparent', color:'rgba(250,250,250,0.85)', border:`1px solid ${HP.border}`, cursor:'pointer', fontFamily:'Outfit', fontSize:14, fontWeight:600 }}>Go to Home</button>
+        </div>
       </div>
     </div>
   );
 }
 
 function HistoryShell() {
-  const { entries, stats, loading, error } = useHistoryData();
+  const { entries, stats, loading, error, removeEntry, isRemoving, refresh } = useHistoryData();
+  const navigate = useNavigate();
+  const { announcement, announce } = useLibraryAnnouncement();
+  const containerRef = useRef(null);
+  const focusCancelRef = useRef(null);
+  useEffect(() => () => focusCancelRef.current?.(), []);
+
   const [filter, setFilter] = useState('all');
   const [sort, setSort] = useState('recent');
   const [query, setQuery] = useState('');
@@ -303,7 +307,6 @@ function HistoryShell() {
     }
     if (sort === 'rating')  arr.sort((a,b) => b.rating - a.rating);
     if (sort === 'runtime') arr.sort((a,b) => a.runtime - b.runtime);
-    // 'recent' = source order (already sorted newest-first by the hook)
     return arr;
   }, [entries, filter, sort, query]);
 
@@ -316,12 +319,33 @@ function HistoryShell() {
     return [...g.entries()];
   }, [filtered]);
 
+  // Settled removal + announcement + focus recovery. Confirm copy + rating/review
+  // retention are unchanged (F6.5 owns those semantics).
+  const onRemove = useCallback(async (e, triggerEl) => {
+    if (isRemoving(e.id)) return;
+    if (typeof window !== 'undefined' && !window.confirm(`Remove "${e.title}" from your diary?`)) return;
+    const orderedIds = filtered.map(x => x.id);
+    const targetId = nextFocusId(orderedIds, e.id);
+    const res = await removeEntry(e.id);
+    focusCancelRef.current?.();
+    if (res.ok) {
+      announce(`Removed ${e.title} from your Diary.`);
+      focusCancelRef.current = scheduleFocus(() =>
+        findRemoveControl(containerRef.current, targetId, 'diary') || findFallback(containerRef.current));
+    } else if (!res.duplicate) {
+      announce(`Could not remove ${e.title} from your Diary. Try again.`);
+      focusCancelRef.current = scheduleFocus(() =>
+        (triggerEl && triggerEl.isConnected ? triggerEl : findRemoveControl(containerRef.current, e.id, 'diary')) || findFallback(containerRef.current));
+    }
+  }, [isRemoving, filtered, removeEntry, announce]);
+
   if (loading) return <PageSkeleton />;
-  if (error) return <PageError error={error} />;
+  if (error) return <PageError onRetry={refresh} onHome={() => navigate('/home')} />;
 
   if (stats.totalLogged === 0) {
     return (
       <>
+        <h1 className="sr-only">Your diary</h1>
         <Masthead />
         <PulseStrip />
         <EmptyState />
@@ -330,21 +354,25 @@ function HistoryShell() {
   }
 
   return (
-    <>
+    <div ref={containerRef}>
+      <h1 className="sr-only">Your diary</h1>
+      <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">{announcement}</div>
       <Masthead />
       <PulseStrip />
       <FilterBar filter={filter} setFilter={setFilter} sort={sort} setSort={setSort} query={query} setQuery={setQuery} />
-      {grouped.length === 0 && (
-        <section className="ff-hist-section" style={{ padding:'72px 88px', textAlign:'center', borderTop:`1px solid ${HP.border}` }}>
-          <div style={{ fontFamily:'Outfit', fontSize:24, color:HP.textMuted, fontStyle:'italic' }}>
-            {query.trim()
-              ? <>0 of {entries.length} match &ldquo;{query.trim()}&rdquo;</>
-              : <>0 of {entries.length} match this filter</>}
-          </div>
-        </section>
-      )}
-      {grouped.map(([month, ents]) => <DiaryGroup key={month} month={month} entries={ents} />)}
-    </>
+      <div data-library-fallback tabIndex={-1} aria-label="Your diary entries" style={{ outline:'none' }}>
+        {grouped.length === 0 && (
+          <section className="ff-hist-section" style={{ padding:'72px 88px', textAlign:'center', borderTop:`1px solid ${HP.border}` }}>
+            <div style={{ fontFamily:'Outfit', fontSize:24, color:HP.textMuted, fontStyle:'italic' }}>
+              {query.trim()
+                ? <>0 of {entries.length} match &ldquo;{query.trim()}&rdquo;</>
+                : <>0 of {entries.length} match this filter</>}
+            </div>
+          </section>
+        )}
+        {grouped.map(([month, ents]) => <DiaryGroup key={month} month={month} entries={ents} onRemove={onRemove} />)}
+      </div>
+    </div>
   );
 }
 
@@ -355,7 +383,6 @@ export default function History() {
       <div className="ff-history-v2" style={{ minHeight:'100vh', background:HP.bgDeep, color:HP.text, fontFamily:'Inter, sans-serif' }}>
         {/* F12B: shared PageContainer (size="wide" = 1440, byte-identical to the old inline cap) + a11y landmark. */}
         <PageContainer size="wide" padding="none">
-          <h1 className="sr-only">Your diary</h1>
           <HistoryShell />
         </PageContainer>
       </div>

--- a/src/features/history/__tests__/HistoryDataStates.test.jsx
+++ b/src/features/history/__tests__/HistoryDataStates.test.jsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+
+const navigate = vi.fn()
+vi.mock('react-router-dom', () => ({ useNavigate: () => navigate }))
+vi.mock('@/shared/hooks/usePageMeta', () => ({ usePageMeta: () => {} }))
+
+let mockCtx
+vi.mock('../useHistoryData', () => ({
+  HistoryDataProvider: ({ children }) => children,
+  useHistoryData: () => mockCtx,
+}))
+
+import History from '../History'
+
+const baseStats = { totalLogged: 0, totalHours: 0, avgRating: 0, thisMonthCount: 0, streakDays: 0 }
+const entry = (over = {}) => ({ id: 'e1', movieId: 1, tmdbId: 101, title: 'A', year: 2020, runtime: 100, dir: 'D', date: 'Mar 9', month: 'Mar 2026', day: 9, rating: 5, mood: 'Tender', moodHex: '#A78BFA', context: 'Evening · Monday', note: null, poster: null, fav: true, ...over })
+
+function ctx(over = {}) {
+  return {
+    entries: [], stats: baseStats, loading: false, error: null,
+    isRemoving: () => false,
+    removeEntry: vi.fn(async () => ({ ok: true, action: 'removed', entryId: 'e1', movieId: 1 })),
+    refresh: vi.fn(),
+    ...over,
+  }
+}
+
+beforeEach(() => { navigate.mockClear() })
+afterEach(() => { cleanup(); vi.clearAllMocks() })
+
+describe('Diary load-error state — sanitized (F6.3)', () => {
+  it('31/32/33. fixed safe copy (no raw backend text), one h1, role=alert', () => {
+    mockCtx = ctx({ error: 'load_error' })
+    const { container } = render(<History />)
+    expect(screen.getByText('We couldn’t load your Diary.')).toBeInTheDocument()
+    expect(screen.getByText(/Your watched films and notes are still safe/i)).toBeInTheDocument()
+    expect(container.querySelectorAll('h1')).toHaveLength(1)
+    expect(container.querySelector('[role="alert"]')).toBeTruthy()
+    expect(container.textContent).not.toMatch(/PGRST|rls|policy|relation|supabase|permission|undefined/i)
+  })
+
+  it('34/35. Try again calls refresh; Go to Home routes to /home', () => {
+    const refresh = vi.fn()
+    mockCtx = ctx({ error: 'load_error', refresh })
+    render(<History />)
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+    expect(refresh).toHaveBeenCalledTimes(1)
+    fireEvent.click(screen.getByRole('button', { name: 'Go to Home' }))
+    expect(navigate).toHaveBeenCalledWith('/home')
+  })
+})
+
+describe('Diary live region + announcements (F6.3)', () => {
+  it('42. exactly one polite/atomic region', () => {
+    mockCtx = ctx({ entries: [entry()], stats: { ...baseStats, totalLogged: 1 } })
+    const { container } = render(<History />)
+    expect(container.querySelectorAll('[role="status"][aria-live="polite"][aria-atomic="true"]')).toHaveLength(1)
+  })
+
+  it('43. success announces after settlement', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    mockCtx = ctx({ entries: [entry({ title: 'A' })], stats: { ...baseStats, totalLogged: 1 } })
+    render(<History />)
+    fireEvent.click(screen.getByRole('button', { name: 'Remove A from diary' }))
+    await waitFor(() => expect(screen.getByText('Removed A from your Diary.')).toBeInTheDocument())
+  })
+
+  it('44. failure announces failure (entry retained)', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    mockCtx = ctx({
+      entries: [entry({ title: 'A' })], stats: { ...baseStats, totalLogged: 1 },
+      removeEntry: vi.fn(async () => ({ ok: false, action: 'remove_failed', entryId: 'e1', movieId: 1 })),
+    })
+    render(<History />)
+    fireEvent.click(screen.getByRole('button', { name: 'Remove A from diary' }))
+    await waitFor(() => expect(screen.getByText('Could not remove A from your Diary. Try again.')).toBeInTheDocument())
+  })
+
+  it('confirm cancel does not call removeEntry', () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const removeEntry = vi.fn(async () => ({ ok: true }))
+    mockCtx = ctx({ entries: [entry({ title: 'A' })], stats: { ...baseStats, totalLogged: 1 }, removeEntry })
+    render(<History />)
+    fireEvent.click(screen.getByRole('button', { name: 'Remove A from diary' }))
+    expect(removeEntry).not.toHaveBeenCalled()
+  })
+})
+
+describe('Diary remove control pending state (F6.3)', () => {
+  it('aria-busy + disabled + "Removing {title}" while pending', () => {
+    mockCtx = ctx({ entries: [entry({ title: 'A' })], stats: { ...baseStats, totalLogged: 1 }, isRemoving: (id) => id === 'e1' })
+    render(<History />)
+    const btn = screen.getByRole('button', { name: 'Removing A' })
+    expect(btn).toHaveAttribute('aria-busy', 'true')
+    expect(btn).toBeDisabled()
+  })
+})

--- a/src/features/history/__tests__/HistoryRemoval.test.jsx
+++ b/src/features/history/__tests__/HistoryRemoval.test.jsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, waitFor, act } from '@testing-library/react'
+
+const cfg = { history: [], ratings: [], deleteError: null }
+const deleteCalls = []
+vi.mock('@/shared/lib/supabase/client', () => ({
+  supabase: {
+    from: (table) => {
+      const op = { table, kind: 'select', eqs: [] }
+      const chain = {
+        select: vi.fn(() => chain),
+        delete: vi.fn(() => { op.kind = 'delete'; return chain }),
+        eq: vi.fn((c, v) => { op.eqs.push([c, v]); return chain }),
+        order: vi.fn(() => chain),
+        then: (res, rej) => {
+          if (op.kind === 'delete') { deleteCalls.push(op); return Promise.resolve({ error: cfg.deleteError }).then(res, rej) }
+          const data = table === 'user_history' ? cfg.history : table === 'user_ratings' ? cfg.ratings : []
+          return Promise.resolve({ data, error: null }).then(res, rej)
+        },
+      }
+      return chain
+    },
+  },
+}))
+vi.mock('@/shared/hooks/useAuthSession', () => { const u = { id: 'u1' }; return { useAuthSession: () => ({ user: u }) } })
+
+import { HistoryDataProvider, useHistoryData } from '../useHistoryData'
+
+const hist = () => [
+  { movie_id: 1, watched_at: '2026-03-09T20:00:00', movies: { id: 11, tmdb_id: 101, title: 'A', director_name: 'D', release_date: '2020-06-15', runtime: 100, mood_tags: ['tender'], poster_path: '/p.jpg' } },
+  { movie_id: 2, watched_at: '2026-03-08T20:00:00', movies: { id: 12, tmdb_id: 102, title: 'B', director_name: 'E', release_date: '2019-06-15', runtime: 90, mood_tags: ['cozy'], poster_path: '/q.jpg' } },
+]
+
+let ctx
+function Probe() { ctx = useHistoryData(); return null }
+async function mountProvider() {
+  render(<HistoryDataProvider><Probe /></HistoryDataProvider>)
+  await waitFor(() => expect(ctx.loading).toBe(false))
+}
+const entryIdOf = (movieId) => ctx.entries.find(e => e.movieId === movieId)?.id
+
+beforeEach(() => { cfg.history = hist(); cfg.ratings = [{ movie_id: 1, rating: 8, review_text: 'note' }]; cfg.deleteError = null; deleteCalls.length = 0 })
+afterEach(() => vi.clearAllMocks())
+
+describe('Diary removal — settled (F6.3)', () => {
+  it('18/23/24. success returns { ok, action, entryId, movieId }; delete keys off user_id+movie_id on user_history ONLY', async () => {
+    await mountProvider()
+    const id = entryIdOf(1)
+    let res
+    await act(async () => { res = await ctx.removeEntry(id) })
+    expect(res).toMatchObject({ ok: true, action: 'removed', movieId: 1 })
+    expect(res.entryId).toBe(id)
+    const del = deleteCalls.find(d => d.kind === 'delete')
+    expect(del.table).toBe('user_history')
+    expect(del.eqs).toEqual([['user_id', 'u1'], ['movie_id', 1]])
+    // ratings/feedback tables never deleted
+    expect(deleteCalls.some(d => d.table === 'user_ratings' || d.table === 'user_movie_feedback')).toBe(false)
+  })
+
+  it('19/20. a RESOLVED { error } returns failure and retains the entry', async () => {
+    cfg.deleteError = { code: 'PGRST', message: 'rls policy detail' }
+    await mountProvider()
+    const id = entryIdOf(1)
+    let res
+    await act(async () => { res = await ctx.removeEntry(id) })
+    expect(res.ok).toBe(false)
+    expect(res.action).toBe('remove_failed')
+    expect(ctx.entries.some(e => e.movieId === 1)).toBe(true) // retained — no false success
+  })
+
+  it('21/22. duplicate click fires ONE delete; pending clears', async () => {
+    await mountProvider()
+    const id = entryIdOf(1)
+    let r1, r2
+    await act(async () => { const p1 = ctx.removeEntry(id); const p2 = ctx.removeEntry(id); [r1, r2] = await Promise.all([p1, p2]) })
+    expect(deleteCalls.filter(d => d.kind === 'delete')).toHaveLength(1)
+    expect([r1, r2].some(r => r.duplicate)).toBe(true)
+    expect(ctx.removingEntryIds.has(id)).toBe(false)
+    expect(ctx.isRemoving(id)).toBe(false)
+  })
+
+  it('25. context exposes no load error after a removal failure', async () => {
+    cfg.deleteError = { message: 'secret backend detail' }
+    await mountProvider()
+    await act(async () => { await ctx.removeEntry(entryIdOf(1)) })
+    expect(ctx.error).toBeNull()
+  })
+})

--- a/src/features/history/history.css
+++ b/src/features/history/history.css
@@ -80,3 +80,12 @@
     font-size: 36px !important;
   }
 }
+
+/* F6.3 — sanitized error recovery buttons + the data-library-fallback focus target. */
+.ff-hist-error-btn:focus-visible {
+  outline: 2px solid #a78bfa;
+  outline-offset: 3px;
+}
+[data-library-fallback]:focus {
+  outline: none;
+}

--- a/src/features/history/useHistoryData.jsx
+++ b/src/features/history/useHistoryData.jsx
@@ -3,11 +3,13 @@
 // user_history (joined with movies) + user_ratings, then derives:
 //   - entries[]: diary rows grouped by month → day in the UI
 //   - stats: totalLogged, totalHours, avgRating, thisMonthCount, streakDays
-// Trend/signature visuals (heatmap, monthly timeline, mood share) live on
-// /profile (DNA) — they're patterns, not diary content.
 //
-// F6.2: the pure derivations now live in ./derive/historyDerive (behavior
-// unchanged); this provider is a thin caller over them.
+// F6.2: the pure derivations live in ./derive/historyDerive (behavior unchanged).
+// F6.3: removeEntry is now SETTLED (the row leaves the list only after the DB delete
+// succeeds — a resolved Supabase { error } is recognised, never silently treated as
+// success), with explicit result objects, per-entry pending state, a duplicate guard,
+// and a sanitized 'load_error' state. The (user_id, movie_id) delete filter and the
+// rating/review-retention behavior are FROZEN here — F6.5 owns those semantics.
 
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { supabase } from '@/shared/lib/supabase/client'
@@ -20,58 +22,75 @@ const INITIAL = {
   entries: [],
   stats: { totalLogged: 0, totalHours: 0, avgRating: 0, thisMonthCount: 0, streakDays: 0 },
   loading: true,
-  error: null,
-  removeEntry: async () => {},
+  error: null,                  // F6.3: 'load_error' | null — never a raw backend message
+  removingEntryIds: new Set(),  // F6.3: entry ids with a removal in flight
+  isRemoving: () => false,
+  removeEntry: async () => ({ ok: false, action: 'remove_failed' }),
   refresh: () => {},
 }
-
-// === Provider ============================================================
 
 export function HistoryDataProvider({ children }) {
   const { user } = useAuthSession()
   const [state, setState] = useState(INITIAL)
   const [nonce, setNonce] = useState(0)
-  // Mirror of state.entries kept current so side-effecting callbacks (delete)
-  // can read the canonical list without piggybacking on setState callbacks —
-  // those get double-invoked in Strict Mode and the 2nd run sees already-
-  // filtered state, zeroing out the work. Same pattern as /watchlist.
+  const [removingEntryIds, setRemovingEntryIds] = useState(() => new Set())
+
+  // Mirror of state.entries kept current so the delete callback can read the
+  // canonical list without piggybacking on setState callbacks (Strict-Mode safe).
   const entriesRef = useRef(state.entries)
   useEffect(() => { entriesRef.current = state.entries }, [state.entries])
 
+  const inFlightRef = useRef(new Set())
+  const mountedRef = useRef(true)
+  const userIdRef = useRef(user?.id)
+  useEffect(() => { mountedRef.current = true; return () => { mountedRef.current = false } }, [])
+  useEffect(() => { userIdRef.current = user?.id }, [user?.id])
+  useEffect(() => { inFlightRef.current = new Set(); setRemovingEntryIds(new Set()) }, [user?.id])
+
   const refresh = useCallback(() => setNonce(n => n + 1), [])
+  const isRemoving = useCallback((entryId) => removingEntryIds.has(entryId), [removingEntryIds])
+  const alive = useCallback((uid) => mountedRef.current && userIdRef.current === uid, [])
 
   const removeEntry = useCallback(async (entryId) => {
-    if (!user?.id || !entryId) return
-    const current = entriesRef.current || []
-    const target = current.find(e => e.id === entryId)
-    if (!target) return
-    // Optimistic: drop from the visible entries list immediately so the row
-    // disappears under the user's cursor. The aggregates (heatmap / timeline
-    // / mood share / stats) will catch up after the post-delete refresh —
-    // re-deriving them from already-derived entries is lossy (we'd lose the
-    // raw watched_at timestamp, mood_tags etc.), so it's cleaner to just
-    // re-fetch the canonical rows.
-    setState(prev => ({
-      ...prev,
-      entries: prev.entries.filter(e => e.id !== entryId),
-    }))
+    if (!user?.id || !entryId) return { ok: false, action: 'remove_failed', entryId, movieId: null }
+    const uid = user.id
+    const target = (entriesRef.current || []).find(e => e.id === entryId)
+    if (!target) return { ok: false, action: 'remove_failed', entryId, movieId: null }
+    const movieId = target.movieId
+    const fail = { ok: false, action: 'remove_failed', entryId, movieId }
+    if (inFlightRef.current.has(entryId)) return { ...fail, duplicate: true }
+    inFlightRef.current.add(entryId)
+    if (alive(uid)) setRemovingEntryIds(prev => { const n = new Set(prev); n.add(entryId); return n })
+    let result = fail
     try {
-      // The row's surfaced id is either user_history.id (uuid) or our fallback
-      // composite `${movie_id}-${watched_at}`. The delete keys off
-      // (user_id, movie_id): the app dedupes by (user, movie) so there's
-      // only ever one row to remove.
-      await supabase
+      // FROZEN (F6.5 owns the semantics): delete keys off (user_id, movie_id); the app
+      // dedupes by (user, movie) so there is only ever one row. Ratings/feedback are
+      // intentionally NOT touched here. SETTLED: recognise a resolved { error }.
+      const { error } = await supabase
         .from('user_history')
         .delete()
-        .eq('user_id', user.id)
-        .eq('movie_id', target.movieId)
+        .eq('user_id', uid)
+        .eq('movie_id', movieId)
+      if (error) {
+        console.warn('[removeEntry]', error)
+        refresh() // re-sync canonical; the entry was never removed locally
+      } else {
+        if (alive(uid)) {
+          setState(prev => ({ ...prev, entries: prev.entries.filter(e => e.id !== entryId) }))
+        }
+        // Re-fetch to keep the aggregate stats in sync with the now-shorter list.
+        refresh()
+        result = { ok: true, action: 'removed', entryId, movieId }
+      }
     } catch (e) {
       console.warn('[removeEntry]', e)
+      refresh()
+    } finally {
+      inFlightRef.current.delete(entryId)
+      if (alive(uid)) setRemovingEntryIds(prev => { const n = new Set(prev); n.delete(entryId); return n })
     }
-    // Refresh re-fetches and re-derives all aggregates — cheap on the small
-    // user_history table and avoids drift between visible entries and stats.
-    refresh()
-  }, [user, refresh])
+    return result
+  }, [user, refresh, alive])
 
   useEffect(() => {
     if (!user?.id) {
@@ -107,18 +126,25 @@ export function HistoryDataProvider({ children }) {
         const entries = deriveEntries(history, ratings)
         const stats = deriveStats({ history, ratings })
 
-        setState({ entries, stats, loading: false, error: null, removeEntry, refresh })
+        setState(s => ({ ...s, entries, stats, loading: false, error: null }))
       } catch (e) {
         if (abort) return
         console.error('[useHistoryData]', e)
-        setState(s => ({ ...s, loading: false, error: e?.message || 'Failed to load' }))
+        setState(s => ({ ...s, loading: false, error: 'load_error' }))
       }
     })()
 
     return () => { abort = true }
-  }, [user, nonce, removeEntry, refresh])
+  }, [user, nonce])
 
-  const value = useMemo(() => state, [state])
+  const value = useMemo(() => ({
+    ...state,
+    removingEntryIds,
+    isRemoving,
+    removeEntry,
+    refresh,
+  }), [state, removingEntryIds, isRemoving, removeEntry, refresh])
+
   return <HistoryDataContext.Provider value={value}>{children}</HistoryDataContext.Provider>
 }
 

--- a/src/features/library/__tests__/focusAfterRemoval.test.js
+++ b/src/features/library/__tests__/focusAfterRemoval.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest'
+import { nextFocusId, findRemoveControl, findFallback, scheduleFocus } from '../focusAfterRemoval'
+
+describe('nextFocusId (pure)', () => {
+  it('46. prefers the NEXT equivalent id', () => {
+    expect(nextFocusId([1, 2, 3], 2)).toBe(3)
+  })
+  it('47. last-item removal falls back to the PREVIOUS id, then null (→ caller uses fallback)', () => {
+    expect(nextFocusId([1, 2, 3], 3)).toBe(2)
+    expect(nextFocusId([5], 5)).toBeNull() // only item → no sibling
+  })
+  it('returns null for an unknown id / bad input', () => {
+    expect(nextFocusId([1, 2], 9)).toBeNull()
+    expect(nextFocusId(null, 1)).toBeNull()
+  })
+})
+
+describe('findRemoveControl / findFallback', () => {
+  function mount(html) { const d = document.createElement('div'); d.innerHTML = html; return d }
+  it('resolves a remove control by stable id + view (never by title)', () => {
+    const c = mount(`
+      <button data-library-action="remove" data-library-item-id="7" data-library-view="list">a</button>
+      <button data-library-action="remove" data-library-item-id="8" data-library-view="list">b</button>`)
+    expect(findRemoveControl(c, 8, 'list')?.textContent).toBe('b')
+    expect(findRemoveControl(c, 99, 'list')).toBeNull()
+  })
+  it('findFallback returns the data-library-fallback element', () => {
+    const c = mount(`<div data-library-fallback tabindex="-1">fb</div>`)
+    expect(findFallback(c)?.textContent).toBe('fb')
+  })
+})
+
+describe('scheduleFocus', () => {
+  const syncRaf = (cb) => cb() // run both rAF layers synchronously
+  it('focuses the resolved element', () => {
+    const el = { focus: vi.fn() }
+    scheduleFocus(() => el, { raf: syncRaf })
+    expect(el.focus).toHaveBeenCalledTimes(1)
+  })
+  it('52. the cancel fn prevents focus (cleanup on unmount)', () => {
+    let fire
+    const deferRaf = (cb) => { fire = fire ? (() => { const p = fire; return () => { p(); cb() } })() : cb }
+    const el = { focus: vi.fn() }
+    // two-layer rAF: capture both callbacks, then fire after cancelling
+    const layers = []
+    const raf = (cb) => layers.push(cb)
+    const cancel = scheduleFocus(() => el, { raf })
+    cancel()
+    layers.forEach(fn => fn()) // first layer schedules second
+    layers.forEach(fn => fn())
+    expect(el.focus).not.toHaveBeenCalled()
+    void deferRaf; void fire
+  })
+  it('53. never focuses document.body or a null target', () => {
+    const bodyFocus = vi.spyOn(document.body, 'focus')
+    scheduleFocus(() => document.body, { raf: syncRaf })
+    scheduleFocus(() => null, { raf: syncRaf })
+    expect(bodyFocus).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/library/focusAfterRemoval.js
+++ b/src/features/library/focusAfterRemoval.js
@@ -1,0 +1,52 @@
+// src/features/library/focusAfterRemoval.js
+// F6.3 — deterministic, testable focus recovery after a Library item is removed.
+// The pure part (nextFocusId) decides WHICH equivalent control should receive focus;
+// the impure part (scheduleFocus) moves focus after the DOM settles and is cancellable
+// on unmount. Targets are resolved by stable data attributes keyed on movie/entry ids
+// (never by film title), so multiple card representations of the same movie are
+// unambiguous and titles never leak into selectors. <body> is never a focus target.
+
+// Pure: the id to focus after `removedId` is removed from `orderedIds`.
+// Prefer the NEXT equivalent item; otherwise the PREVIOUS; otherwise null (the caller
+// then falls back to a stable section heading / results container).
+export function nextFocusId(orderedIds, removedId) {
+  if (!Array.isArray(orderedIds)) return null
+  const i = orderedIds.indexOf(removedId)
+  if (i === -1) return null
+  if (i + 1 < orderedIds.length) return orderedIds[i + 1]
+  if (i - 1 >= 0) return orderedIds[i - 1]
+  return null
+}
+
+// Escape a value for safe use inside an attribute selector.
+function attrEscape(v) {
+  return String(v).replace(/["\\\]]/g, '\\$&')
+}
+
+// Resolve a Library remove control within `container` by its stable id (+ optional
+// view), matching the data attributes the pages stamp on each Remove button.
+export function findRemoveControl(container, itemId, view) {
+  if (!container || itemId == null) return null
+  let sel = `[data-library-action="remove"][data-library-item-id="${attrEscape(itemId)}"]`
+  if (view) sel += `[data-library-view="${attrEscape(view)}"]`
+  return container.querySelector(sel)
+}
+
+export function findFallback(container) {
+  return container ? container.querySelector('[data-library-fallback]') : null
+}
+
+// Schedule focus after the DOM settles (double rAF). `getEl` is invoked at fire time
+// so it sees the post-removal DOM. Never focuses <body> or a null/non-focusable node.
+// Returns a cancel fn — call it on unmount or before scheduling another focus.
+export function scheduleFocus(getEl, { raf } = {}) {
+  const schedule = raf || ((cb) => requestAnimationFrame(cb))
+  let cancelled = false
+  schedule(() => schedule(() => {
+    if (cancelled) return
+    const el = typeof getEl === 'function' ? getEl() : getEl
+    const body = typeof document !== 'undefined' ? document.body : null
+    if (el && el !== body && typeof el.focus === 'function') el.focus()
+  }))
+  return () => { cancelled = true }
+}

--- a/src/features/library/useLibraryAnnouncement.js
+++ b/src/features/library/useLibraryAnnouncement.js
@@ -1,0 +1,14 @@
+// src/features/library/useLibraryAnnouncement.js
+// F6.3 — one persistent, polite, atomic live region per Library page. The page
+// renders a single visually-hidden <div role="status" aria-live="polite"
+// aria-atomic="true">{announcement}</div>; `announce(msg)` sets it. Unrelated
+// re-renders never change the string (so they never re-announce). No raw errors,
+// no counts/match-score noise — callers pass only the settled outcome sentence.
+
+import { useCallback, useState } from 'react'
+
+export function useLibraryAnnouncement() {
+  const [announcement, setAnnouncement] = useState('')
+  const announce = useCallback((msg) => setAnnouncement(msg || ''), [])
+  return { announcement, announce }
+}

--- a/src/features/watchlist/Watchlist.jsx
+++ b/src/features/watchlist/Watchlist.jsx
@@ -1,17 +1,17 @@
 // src/features/watchlist/Watchlist.jsx
-// FeelFlick — Watchlist v2 ("The Queue"). Mount at /watchlist-v2.
-// PR 1: drop the internal nav (AppShell already provides the global TopNav),
-//        wire every card/button to a real action (navigate, remove).
-// PR 2: ITEMS + USER now derived live from user_watchlist × movies + the
-//        user's taste_fingerprint — see ./useWatchlistData.jsx.
+// FeelFlick — Watchlist v2 ("The Queue").
+// F6.3: removals are settled + announced + focus-recovered; load errors are sanitized.
+// (No product/visual redesign — match %, stale, featured, grid/list, bulk all unchanged.)
 
-import { useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { usePageMeta } from '@/shared/hooks/usePageMeta'
 import MoodPill from '@/shared/components/MoodPill'
 import Eyebrow from '@/shared/ui/Eyebrow'
 import { HP, HP_GRAD } from './data'
 import { WatchlistDataProvider, useWatchlistData } from './useWatchlistData'
+import { useLibraryAnnouncement } from '@/features/library/useLibraryAnnouncement'
+import { scheduleFocus, findRemoveControl, findFallback, nextFocusId } from '@/features/library/focusAfterRemoval'
 import './watchlist.css'
 
 // === Reset-button style for elements wrapped as buttons ===
@@ -46,8 +46,6 @@ function Masthead() {
 }
 
 // ── Pulse strip (3 stats) ──────────────────────────────────────
-// Cold-start (no fingerprint) → swap "Perfect for tonight" for "Top match %"
-// so the first stat is always meaningful. The other two are universal.
 function PulseStrip() {
   const { stats, hasFingerprint } = useWatchlistData();
   const tonightStat = hasFingerprint
@@ -76,10 +74,6 @@ function PulseStrip() {
 }
 
 // ── Filter / sort bar ──────────────────────────────────────────
-// Filter pills are dynamic: "All" + ("Perfect tonight" when fingerprint
-// exists) + top-5 actual moods from the user's queue + ("Getting stale"
-// when there is at least one stale item). Each pill always points to ≥1
-// item so we never render dead controls.
 function FilterBar({ filter, setFilter, sort, setSort, view, setView }) {
   const { availableMoods, hasFingerprint, stats } = useWatchlistData();
   const filters = [{ v:'all', l:'All' }];
@@ -150,8 +144,30 @@ function FilterBar({ filter, setFilter, sort, setSort, view, setView }) {
   );
 }
 
+// ── Remove control (shared pending/a11y wiring; visuals per view) ──
+function RemoveControl({ f, view, onRemove, style, children, removingLabel = 'Removing…' }) {
+  const { isRemoving } = useWatchlistData();
+  const busy = isRemoving(f.id);
+  return (
+    <button
+      type="button"
+      data-library-action="remove"
+      data-library-item-id={f.id}
+      data-library-view={view}
+      disabled={busy}
+      aria-busy={busy || undefined}
+      aria-label={busy ? `Removing ${f.title}` : `Remove ${f.title} from watchlist`}
+      title="Remove"
+      onClick={(e) => onRemove(f, view, e.currentTarget)}
+      style={{ ...style, cursor: busy ? 'wait' : 'pointer', opacity: busy ? 0.6 : (style?.opacity ?? 1) }}
+    >
+      {busy ? removingLabel : children}
+    </button>
+  );
+}
+
 // ── Tonight tier — featured cards ──────────────────────────────
-function TonightTier({ picks }) {
+function TonightTier({ picks, onRemove }) {
   const { hasFingerprint } = useWatchlistData();
   if (!picks.length) return null;
   const kicker = hasFingerprint ? 'Perfect for tonight' : 'Top of your queue';
@@ -165,14 +181,13 @@ function TonightTier({ picks }) {
         <span style={{ fontSize:12, color:HP.textMuted, fontFamily:'Outfit', fontStyle:'italic' }}>{sub}</span>
       </div>
       <div className="ff-wl-tonight-grid" style={{ display:'grid', gridTemplateColumns:`repeat(${Math.min(picks.length, 3)},1fr)`, gap:24 }}>
-        {picks.slice(0, 3).map((f, i) => <FeaturedCard key={f.id} f={f} idx={i} />)}
+        {picks.slice(0, 3).map((f, i) => <FeaturedCard key={f.id} f={f} idx={i} onRemove={onRemove} />)}
       </div>
     </section>
   );
 }
-function FeaturedCard({ f, idx }) {
+function FeaturedCard({ f, idx, onRemove }) {
   const navigate = useNavigate();
-  const { removeFromWatchlist } = useWatchlistData();
   const goToFilm = () => f.tmdbId && navigate(`/movie/${f.tmdbId}`);
   return (
     <article className="ff-wl-featured" style={{ display:'grid', gridTemplateColumns:'auto 1fr', gap:20 }}>
@@ -213,11 +228,12 @@ function FeaturedCard({ f, idx }) {
             onClick={goToFilm}
             style={{ padding:'8px 14px', borderRadius:6, background:HP_GRAD, border:'none', color:'#fff', fontFamily:'Outfit', fontSize:11, fontWeight:600, letterSpacing:'0.04em', cursor:'pointer' }}
           >Open →</button>
-          <button
-            type="button"
-            onClick={() => removeFromWatchlist(f.id)}
-            style={{ padding:'8px 14px', borderRadius:6, background:'rgba(255,255,255,0.05)', border:`1px solid ${HP.border}`, color:HP.textMuted, fontFamily:'Outfit', fontSize:11, fontWeight:600, letterSpacing:'0.04em', cursor:'pointer' }}
-          >Remove</button>
+          <RemoveControl
+            f={f}
+            view="featured"
+            onRemove={onRemove}
+            style={{ padding:'8px 14px', borderRadius:6, background:'rgba(255,255,255,0.05)', border:`1px solid ${HP.border}`, color:HP.textMuted, fontFamily:'Outfit', fontSize:11, fontWeight:600, letterSpacing:'0.04em', minHeight:44 }}
+          >Remove</RemoveControl>
         </div>
       </div>
     </article>
@@ -260,9 +276,8 @@ function Grid({ items }) {
 }
 
 // ── List view ──────────────────────────────────────────────────
-function List({ items }) {
+function List({ items, onRemove }) {
   const navigate = useNavigate();
-  const { removeFromWatchlist } = useWatchlistData();
   if (items.length === 0) return <EmptyState />;
   return (
     <section className="ff-wl-section ff-wl-list-section" style={{ padding:'0 88px 56px' }}>
@@ -302,15 +317,15 @@ function List({ items }) {
               onClick={() => f.tmdbId && navigate(`/movie/${f.tmdbId}`)}
               style={{ padding:'7px 12px', borderRadius:6, background:'rgba(255,255,255,0.06)', border:`1px solid ${HP.border}`, color:HP.textSoft, fontFamily:'Outfit', fontSize:10, fontWeight:600, letterSpacing:'0.08em', textTransform:'uppercase', cursor:'pointer' }}
             >Open</button>
-            <button
-              type="button"
-              onClick={() => removeFromWatchlist(f.id)}
-              aria-label={`Remove ${f.title} from watchlist`}
-              title="Remove"
-              style={{ padding:'7px 10px', borderRadius:6, background:'transparent', border:'none', color:HP.textFaint, cursor:'pointer' }}
+            <RemoveControl
+              f={f}
+              view="list"
+              onRemove={onRemove}
+              removingLabel={<span style={{ fontSize:10, fontFamily:'Outfit' }}>…</span>}
+              style={{ padding:'7px 10px', borderRadius:6, background:'transparent', border:'none', color:HP.textFaint, display:'inline-flex', alignItems:'center', justifyContent:'center', minWidth:44, minHeight:44 }}
             >
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-2 14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6M14 11v6"/></svg>
-            </button>
+              <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-2 14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6M14 11v6"/></svg>
+            </RemoveControl>
           </div>
         ))}
       </div>
@@ -338,24 +353,14 @@ function EmptyState() {
 }
 
 // ── Cleanup nudge ──────────────────────────────────────────────
-// Action lives here (not in the footer): the user is being asked to act on
-// stale items in the same breath that we surface the count.
-function CleanupNudge({ count, onReview }) {
-  const { removeStale } = useWatchlistData();
-  const [busy, setBusy] = useState(false);
+function CleanupNudge({ count, onReview, onBulkRemove }) {
+  const { removingStale } = useWatchlistData();
   if (count === 0) return null;
-  async function clearStale() {
-    if (busy) return;
-    if (typeof window !== 'undefined' && !window.confirm(`Remove ${count} stale film${count === 1 ? '' : 's'} from your watchlist?`)) return;
-    setBusy(true);
-    try { await removeStale(); }
-    finally { setBusy(false); }
-  }
   return (
     <section className="ff-wl-section ff-wl-cleanup" style={{ padding:'48px 88px', borderTop:`1px solid ${HP.border}`, background:`linear-gradient(135deg, ${HP.amber}0a, transparent)` }}>
       <div className="ff-wl-cleanup-grid" style={{ display:'grid', gridTemplateColumns:'auto 1fr auto', gap:32, alignItems:'center' }}>
         <div style={{ width:48, height:48, borderRadius:999, background:`${HP.amber}1a`, border:`1px solid ${HP.amber}44`, display:'flex', alignItems:'center', justifyContent:'center' }}>
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={HP.amber} strokeWidth="2" strokeLinecap="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>
+          <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={HP.amber} strokeWidth="2" strokeLinecap="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>
         </div>
         <div>
           <Eyebrow color={HP.amber} spacing="0.22em" size={10} style={{ marginBottom:6 }}>Queue hygiene</Eyebrow>
@@ -366,15 +371,16 @@ function CleanupNudge({ count, onReview }) {
           <button
             type="button"
             onClick={onReview}
-            style={{ padding:'12px 22px', borderRadius:6, background:'rgba(255,255,255,0.06)', border:`1px solid ${HP.borderStrong}`, color:HP.text, fontFamily:'Outfit', fontSize:13, fontWeight:600, cursor:'pointer' }}
+            style={{ padding:'12px 22px', borderRadius:6, background:'rgba(255,255,255,0.06)', border:`1px solid ${HP.borderStrong}`, color:HP.text, fontFamily:'Outfit', fontSize:13, fontWeight:600, cursor:'pointer', minHeight:44 }}
           >Review stale picks →</button>
           <button
             type="button"
-            onClick={clearStale}
-            disabled={busy}
+            onClick={() => onBulkRemove(count)}
+            disabled={removingStale}
+            aria-busy={removingStale || undefined}
             title={`Remove ${count} stale film${count === 1 ? '' : 's'} from your watchlist`}
-            style={{ padding:'12px 22px', borderRadius:6, background:'transparent', border:`1px solid ${HP.amber}66`, color:HP.amber, fontFamily:'Outfit', fontSize:13, fontWeight:600, cursor: busy ? 'wait' : 'pointer', opacity: busy ? 0.6 : 1 }}
-          >{busy ? 'Clearing…' : 'Clear all'}</button>
+            style={{ padding:'12px 22px', borderRadius:6, background:'transparent', border:`1px solid ${HP.amber}66`, color:HP.amber, fontFamily:'Outfit', fontSize:13, fontWeight:600, cursor: removingStale ? 'wait' : 'pointer', opacity: removingStale ? 0.6 : 1, minHeight:44 }}
+          >{removingStale ? 'Removing…' : 'Clear all'}</button>
         </div>
       </div>
     </section>
@@ -383,7 +389,13 @@ function CleanupNudge({ count, onReview }) {
 
 // ── Page (loading/error/empty shell) ───────────────────────────
 function WatchlistShell() {
-  const { items, stats, loading, error } = useWatchlistData();
+  const { items, stats, loading, error, removeFromWatchlist, removeStale, isRemoving, refresh } = useWatchlistData();
+  const navigate = useNavigate();
+  const { announcement, announce } = useLibraryAnnouncement();
+  const containerRef = useRef(null);
+  const focusCancelRef = useRef(null);
+  useEffect(() => () => focusCancelRef.current?.(), []);
+
   const [filter, setFilter] = useState('all');
   const [sort, setSort]     = useState('match');
   const [view, setView]     = useState('grid');
@@ -405,26 +417,57 @@ function WatchlistShell() {
     return arr;
   }, [items, filter, sort]);
 
-  // TonightTier picks: with fingerprint use real "perfect" matches; cold-start
-  // falls back to top 3 by match% so the tier always says something honest.
   const { hasFingerprint } = useWatchlistData();
   const tonightPicks = useMemo(() => {
     if (hasFingerprint) return items.filter(f => f.perfect);
     return [...items].sort((a, b) => b.match - a.match).slice(0, 3);
   }, [items, hasFingerprint]);
 
+  // Settled removal + announcement + focus recovery for every individual control.
+  const onRemove = useCallback(async (f, viewName, triggerEl) => {
+    if (isRemoving(f.id)) return;
+    const orderedIds = (viewName === 'featured' ? tonightPicks : filtered).map(it => it.id);
+    const targetId = nextFocusId(orderedIds, f.id);
+    const res = await removeFromWatchlist(f.id);
+    focusCancelRef.current?.();
+    if (res.ok) {
+      announce(`Removed ${f.title} from your Watchlist.`);
+      focusCancelRef.current = scheduleFocus(() =>
+        findRemoveControl(containerRef.current, targetId, viewName) || findFallback(containerRef.current));
+    } else if (!res.duplicate) {
+      announce(`Could not remove ${f.title}. Try again.`);
+      focusCancelRef.current = scheduleFocus(() =>
+        (triggerEl && triggerEl.isConnected ? triggerEl : findRemoveControl(containerRef.current, f.id, viewName)) || findFallback(containerRef.current));
+    }
+  }, [isRemoving, tonightPicks, filtered, removeFromWatchlist, announce]);
+
+  const onBulkRemove = useCallback(async (count) => {
+    if (typeof window !== 'undefined' && !window.confirm(`Remove ${count} stale film${count === 1 ? '' : 's'} from your watchlist?`)) return;
+    const res = await removeStale();
+    focusCancelRef.current?.();
+    if (res.ok) {
+      announce(res.removedCount === 1 ? 'Removed 1 film from your Watchlist.' : `Removed ${res.removedCount} films from your Watchlist.`);
+      focusCancelRef.current = scheduleFocus(() => findFallback(containerRef.current));
+    } else if (!res.duplicate) {
+      announce('Could not remove those films. Try again.');
+    }
+  }, [removeStale, announce]);
+
   if (loading) return <PageSkeleton />;
-  if (error) return <PageError error={error} />;
+  if (error) return <PageError onRetry={refresh} onHome={() => navigate('/home')} />;
 
   return (
-    <>
+    <div ref={containerRef}>
+      <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">{announcement}</div>
       <Masthead />
       <PulseStrip />
       <FilterBar filter={filter} setFilter={setFilter} sort={sort} setSort={setSort} view={view} setView={setView} />
-      {filter === 'all' && <TonightTier picks={tonightPicks} />}
-      {view === 'grid' ? <Grid items={filtered} /> : <List items={filtered} />}
-      <CleanupNudge count={stats.gettingStaleCount} onReview={() => setFilter('stale')} />
-    </>
+      {filter === 'all' && <TonightTier picks={tonightPicks} onRemove={onRemove} />}
+      <div data-library-fallback tabIndex={-1} aria-label="Your watchlist films" style={{ outline:'none' }}>
+        {view === 'grid' ? <Grid items={filtered} /> : <List items={filtered} onRemove={onRemove} />}
+      </div>
+      <CleanupNudge count={stats.gettingStaleCount} onReview={() => setFilter('stale')} onBulkRemove={onBulkRemove} />
+    </div>
   );
 }
 
@@ -441,13 +484,19 @@ function PageSkeleton() {
   );
 }
 
-function PageError({ error }) {
+// F6.3: sanitized error — fixed, safe copy only (never a raw backend message), with
+// Try-again (refresh) + Go-to-Home recovery. role="alert", one h1, ≥44px buttons.
+function PageError({ onRetry, onHome }) {
   return (
     <div style={{ minHeight:'60vh', display:'flex', alignItems:'center', justifyContent:'center', padding:24 }}>
-      <div style={{ textAlign:'center', maxWidth:520 }}>
-        <Eyebrow size={10} style={{ marginBottom:18 }}>Queue · error</Eyebrow>
-        <h1 style={{ fontFamily:'Outfit, Inter, sans-serif', fontSize:36, fontWeight:500, color:HP.text, margin:'0 0 18px 0', letterSpacing:'-0.025em' }}>Couldn&rsquo;t load your queue.</h1>
-        <p style={{ margin:0, color:'rgba(250,250,250,0.6)', fontSize:14, lineHeight:1.6 }}>{error}</p>
+      <div role="alert" style={{ textAlign:'center', maxWidth:520 }}>
+        <Eyebrow size={10} style={{ marginBottom:18 }}>Watchlist</Eyebrow>
+        <h1 style={{ fontFamily:'Outfit, Inter, sans-serif', fontSize:36, fontWeight:500, color:HP.text, margin:'0 0 14px 0', letterSpacing:'-0.025em' }}>We couldn&rsquo;t load your Watchlist.</h1>
+        <p style={{ margin:'0 0 28px 0', color:'rgba(250,250,250,0.6)', fontSize:14, lineHeight:1.6 }}>Your saved films are still safe. Try again in a moment.</p>
+        <div style={{ display:'flex', gap:12, justifyContent:'center', flexWrap:'wrap' }}>
+          <button type="button" onClick={onRetry} className="ff-wl-error-btn" style={{ minHeight:44, padding:'12px 22px', borderRadius:999, background:HP_GRAD, color:'#fff', border:'none', cursor:'pointer', fontFamily:'Outfit', fontSize:14, fontWeight:600 }}>Try again</button>
+          <button type="button" onClick={onHome} className="ff-wl-error-btn" style={{ minHeight:44, padding:'12px 22px', borderRadius:999, background:'transparent', color:'rgba(250,250,250,0.85)', border:`1px solid ${HP.border}`, cursor:'pointer', fontFamily:'Outfit', fontSize:14, fontWeight:600 }}>Go to Home</button>
+        </div>
       </div>
     </div>
   );

--- a/src/features/watchlist/__tests__/WatchlistDataStates.test.jsx
+++ b/src/features/watchlist/__tests__/WatchlistDataStates.test.jsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+
+const navigate = vi.fn()
+vi.mock('react-router-dom', () => ({ useNavigate: () => navigate }))
+vi.mock('@/shared/hooks/usePageMeta', () => ({ usePageMeta: () => {} }))
+
+let mockCtx
+vi.mock('../useWatchlistData', () => ({
+  WatchlistDataProvider: ({ children }) => children,
+  useWatchlistData: () => mockCtx,
+}))
+
+import Watchlist from '../Watchlist'
+
+const baseStats = { watchlistTotal: 0, perfectForTonightCount: 0, gettingStaleCount: 0, topMatchPct: 0, avgMatchPct: 0 }
+const item = (over = {}) => ({ id: 1, internalId: 11, tmdbId: 101, title: 'A', year: 2020, runtime: 100, dir: 'D', mood: 'Tender', hex: '#A78BFA', match: 70, perfect: false, stale: false, addedDaysAgo: 1, poster: null, why: 'why', ...over })
+
+function ctx(over = {}) {
+  return {
+    items: [], stats: baseStats, availableMoods: [], hasFingerprint: false,
+    loading: false, error: null, removingStale: false,
+    isRemoving: () => false,
+    removeFromWatchlist: vi.fn(async () => ({ ok: true, action: 'removed', movieId: 1 })),
+    removeStale: vi.fn(async () => ({ ok: true, removedCount: 1 })),
+    refresh: vi.fn(),
+    ...over,
+  }
+}
+
+beforeEach(() => { navigate.mockClear() })
+afterEach(() => { cleanup(); vi.clearAllMocks() })
+
+describe('Watchlist load-error state — sanitized (F6.3)', () => {
+  it('26/27/28. renders fixed safe copy (no raw backend text), one h1, role=alert', () => {
+    mockCtx = ctx({ error: 'load_error', refresh: vi.fn() })
+    const { container } = render(<Watchlist />)
+    expect(screen.getByText('We couldn’t load your Watchlist.')).toBeInTheDocument()
+    expect(screen.getByText(/Your saved films are still safe/i)).toBeInTheDocument()
+    expect(container.querySelectorAll('h1')).toHaveLength(1)
+    expect(container.querySelector('[role="alert"]')).toBeTruthy()
+    // no raw backend wording anywhere
+    expect(container.textContent).not.toMatch(/PGRST|rls|policy|relation|supabase|permission|undefined/i)
+  })
+
+  it('29/30. Try again calls refresh; Go to Home routes to /home', () => {
+    const refresh = vi.fn()
+    mockCtx = ctx({ error: 'load_error', refresh })
+    render(<Watchlist />)
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+    expect(refresh).toHaveBeenCalledTimes(1)
+    fireEvent.click(screen.getByRole('button', { name: 'Go to Home' }))
+    expect(navigate).toHaveBeenCalledWith('/home')
+  })
+})
+
+describe('Watchlist persistent live region + announcements (F6.3)', () => {
+  it('36/37. exactly one polite/atomic region, empty initially', () => {
+    mockCtx = ctx({ items: [item()], stats: { ...baseStats, watchlistTotal: 1 } })
+    const { container } = render(<Watchlist />)
+    const regions = container.querySelectorAll('[role="status"][aria-live="polite"][aria-atomic="true"]')
+    expect(regions).toHaveLength(1)
+    expect(regions[0].textContent).toBe('')
+  })
+
+  it('38. individual success announces AFTER settlement', async () => {
+    mockCtx = ctx({ items: [item({ title: 'A' }), item({ id: 2, title: 'B' })], stats: { ...baseStats, watchlistTotal: 2 } })
+    render(<Watchlist />)
+    fireEvent.click(screen.getAllByRole('button', { name: /Remove A from watchlist/i })[0])
+    await waitFor(() => expect(screen.getByText('Removed A from your Watchlist.')).toBeInTheDocument())
+  })
+
+  it('39. individual failure announces failure (item retained)', async () => {
+    mockCtx = ctx({
+      items: [item({ title: 'A' })], stats: { ...baseStats, watchlistTotal: 1 },
+      removeFromWatchlist: vi.fn(async () => ({ ok: false, action: 'remove_failed', movieId: 1 })),
+    })
+    render(<Watchlist />)
+    fireEvent.click(screen.getAllByRole('button', { name: /Remove A from watchlist/i })[0])
+    await waitFor(() => expect(screen.getByText('Could not remove A. Try again.')).toBeInTheDocument())
+  })
+
+  it('40/41. bulk singular/plural success + failure', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    mockCtx = ctx({ items: [item({ stale: true })], stats: { ...baseStats, watchlistTotal: 1, gettingStaleCount: 1 }, removeStale: vi.fn(async () => ({ ok: true, removedCount: 2 })) })
+    render(<Watchlist />)
+    fireEvent.click(screen.getByRole('button', { name: /Clear all/i }))
+    await waitFor(() => expect(screen.getByText('Removed 2 films from your Watchlist.')).toBeInTheDocument())
+  })
+})
+
+describe('Watchlist remove control pending state (F6.3)', () => {
+  it('54/55/56. aria-busy + disabled + "Removing {title}" while pending', () => {
+    mockCtx = ctx({ items: [item({ title: 'A' })], stats: { ...baseStats, watchlistTotal: 1 }, isRemoving: (id) => id === 1 })
+    render(<Watchlist />)
+    const btn = screen.getByRole('button', { name: 'Removing A' })
+    expect(btn).toHaveAttribute('aria-busy', 'true')
+    expect(btn).toBeDisabled()
+  })
+
+  it('57. bulk button shows pending', () => {
+    mockCtx = ctx({ items: [item({ stale: true })], stats: { ...baseStats, watchlistTotal: 1, gettingStaleCount: 1 }, removingStale: true })
+    render(<Watchlist />)
+    const btn = screen.getByRole('button', { name: /Removing/i })
+    expect(btn).toBeDisabled()
+    expect(btn).toHaveTextContent('Removing…')
+  })
+})

--- a/src/features/watchlist/__tests__/WatchlistRemoval.test.jsx
+++ b/src/features/watchlist/__tests__/WatchlistRemoval.test.jsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, waitFor, act } from '@testing-library/react'
+
+// ── controllable Supabase mock (records delete filters; resolves { error }) ──
+const cfg = { rows: [], deleteError: null, selectError: null }
+const deleteCalls = []
+vi.mock('@/shared/lib/supabase/client', () => ({
+  supabase: {
+    from: () => {
+      const op = { kind: 'select', eqs: [], ins: [] }
+      const chain = {
+        select: vi.fn(() => chain),
+        delete: vi.fn(() => { op.kind = 'delete'; return chain }),
+        eq: vi.fn((c, v) => { op.eqs.push([c, v]); return chain }),
+        in: vi.fn((c, v) => { op.ins.push([c, v]); return chain }),
+        order: vi.fn(() => chain),
+        then: (res, rej) => {
+          if (op.kind === 'delete') { deleteCalls.push(op); return Promise.resolve({ error: cfg.deleteError }).then(res, rej) }
+          return Promise.resolve({ data: cfg.rows, error: cfg.selectError }).then(res, rej)
+        },
+      }
+      return chain
+    },
+  },
+}))
+vi.mock('@/shared/hooks/useAuthSession', () => { const u = { id: 'u1' }; return { useAuthSession: () => ({ user: u }) } })
+vi.mock('@/shared/services/tasteCache', () => ({ getTasteFingerprint: vi.fn(async () => null) }))
+vi.mock('@/shared/services/recommendations', () => ({ computeUserProfile: vi.fn(async () => null), scoreMovieForUser: vi.fn(() => null) }))
+vi.mock('@/shared/services/matchScore', () => ({ computeMatchPercent: vi.fn(() => null) }))
+vi.mock('@/shared/services/movieFields', () => ({ MOVIE_ENGINE_COLS: '*' }))
+
+import { WatchlistDataProvider, useWatchlistData } from '../useWatchlistData'
+
+const ago = (days) => new Date(Date.now() - days * 86400000).toISOString()
+const rows = () => [
+  { movie_id: 1, added_at: ago(1), status: 'want_to_watch', movies: { id: 11, tmdb_id: 101, title: 'A', mood_tags: ['tender'], release_date: '2020-06-15', runtime: 100, director_name: 'D', poster_path: '/p.jpg', ff_final_rating: 8, fit_profile: null } },
+  { movie_id: 2, added_at: ago(90), status: 'want_to_watch', movies: { id: 12, tmdb_id: 102, title: 'B', mood_tags: ['cozy'], release_date: '2019-06-15', runtime: 90, director_name: 'E', poster_path: '/q.jpg', ff_final_rating: 7, fit_profile: null } }, // >60d → stale
+]
+
+let ctx
+function Probe() { ctx = useWatchlistData(); return null }
+async function mountProvider() {
+  render(<WatchlistDataProvider><Probe /></WatchlistDataProvider>)
+  await waitFor(() => expect(ctx.loading).toBe(false))
+}
+
+beforeEach(() => {
+  cfg.rows = rows(); cfg.deleteError = null; cfg.selectError = null; deleteCalls.length = 0
+})
+afterEach(() => { vi.clearAllMocks() })
+
+describe('Watchlist individual removal — settled (F6.3)', () => {
+  it('1/2/3/10. success inspects { error: null }, returns { ok:true }, removes once, filters = user_id + movie_id', async () => {
+    await mountProvider()
+    expect(ctx.items).toHaveLength(2)
+    let res
+    await act(async () => { res = await ctx.removeFromWatchlist(1) })
+    expect(res).toMatchObject({ ok: true, action: 'removed', movieId: 1 })
+    expect(ctx.items.map(i => i.id)).toEqual([2]) // removed exactly once
+    const del = deleteCalls.find(d => d.kind === 'delete')
+    expect(del.eqs).toEqual([['user_id', 'u1'], ['movie_id', 1]])
+  })
+
+  it('4/5. a RESOLVED { error } returns failure and does NOT permanently remove the item', async () => {
+    cfg.deleteError = { code: 'PGRST', message: 'rls' }
+    await mountProvider()
+    let res
+    await act(async () => { res = await ctx.removeFromWatchlist(1) })
+    expect(res.ok).toBe(false)
+    expect(res.action).toBe('remove_failed')
+    expect(ctx.items.map(i => i.id)).toContain(1) // item retained — no false success
+  })
+
+  it('7/8/9. duplicate click while pending fires ONE delete; pending clears on success', async () => {
+    await mountProvider()
+    let r1, r2
+    await act(async () => { const p1 = ctx.removeFromWatchlist(1); const p2 = ctx.removeFromWatchlist(1); [r1, r2] = await Promise.all([p1, p2]) })
+    expect(deleteCalls.filter(d => d.kind === 'delete')).toHaveLength(1) // deduped
+    expect(r1.ok || r2.ok).toBe(true)
+    expect([r1, r2].some(r => r.duplicate)).toBe(true)
+    expect(ctx.removingIds.has(1)).toBe(false) // pending cleared
+    expect(ctx.isRemoving(1)).toBe(false)
+  })
+
+  it('9. pending clears on failure', async () => {
+    cfg.deleteError = { message: 'boom' }
+    await mountProvider()
+    await act(async () => { await ctx.removeFromWatchlist(1) })
+    expect(ctx.removingIds.has(1)).toBe(false)
+  })
+
+  it('11. the public context never exposes a raw Error object', async () => {
+    cfg.deleteError = { message: 'secret table policy detail' }
+    await mountProvider()
+    await act(async () => { await ctx.removeFromWatchlist(1) })
+    expect(JSON.stringify(Object.keys(ctx))).not.toContain('error: [object')
+    expect(ctx.error).toBeNull() // a removal failure is not a load error
+  })
+})
+
+describe('Watchlist bulk stale removal — settled (F6.3)', () => {
+  it('12/17. success returns the actual count + keeps the .in("movie_id", staleIds) filter', async () => {
+    await mountProvider()
+    const stale = ctx.items.filter(i => i.stale)
+    expect(stale.length).toBeGreaterThan(0)
+    let res
+    await act(async () => { res = await ctx.removeStale() })
+    expect(res).toEqual({ ok: true, removedCount: stale.length })
+    const del = deleteCalls.find(d => d.kind === 'delete')
+    expect(del.eqs).toContainEqual(['user_id', 'u1'])
+    expect(del.ins[0][0]).toBe('movie_id')
+  })
+
+  it('13/14. a failed bulk delete reports removedCount 0 (never the attempted count) and restores rows', async () => {
+    cfg.deleteError = { message: 'boom' }
+    await mountProvider()
+    const before = ctx.items.length
+    let res
+    await act(async () => { res = await ctx.removeStale() })
+    expect(res).toEqual({ ok: false, removedCount: 0 })
+    expect(ctx.items.length).toBe(before) // stale rows retained (no false success)
+  })
+
+  it('15/16. duplicate bulk click fires ONE delete; pending clears', async () => {
+    await mountProvider()
+    await act(async () => { const a = ctx.removeStale(); const b = ctx.removeStale(); await Promise.all([a, b]) })
+    expect(deleteCalls.filter(d => d.kind === 'delete')).toHaveLength(1)
+    expect(ctx.removingStale).toBe(false)
+  })
+})

--- a/src/features/watchlist/useWatchlistData.jsx
+++ b/src/features/watchlist/useWatchlistData.jsx
@@ -4,8 +4,11 @@
 // derives the shape the page expects: items[] with match/mood/perfect/
 // stale/addedDaysAgo/hex/tmdbId/internalId, plus aggregate stats.
 //
-// F6.2: the pure derivations now live in ./derive/watchlistDerive (behavior
-// unchanged); this provider is a thin caller over them.
+// F6.2: the pure derivations live in ./derive/watchlistDerive (behavior unchanged).
+// F6.3: removals are now SETTLED (the local list changes only after the DB delete
+// succeeds — a resolved Supabase { error } is recognised, never silently treated as
+// success), with explicit result objects, per-id pending state, duplicate-click guards,
+// and a sanitized 'load_error' state (no raw backend text reaches the UI).
 
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { supabase } from '@/shared/lib/supabase/client'
@@ -29,9 +32,12 @@ const INITIAL = {
   availableMoods: [],         // distinct moods present in the queue (sorted by count desc)
   hasFingerprint: false,      // false until taste_fingerprint exists; gates "Perfect for tonight"
   loading: true,
-  error: null,
-  removeFromWatchlist: async () => {},
-  removeStale: async () => {},
+  error: null,                // F6.3: 'load_error' | null — never a raw backend message
+  removingIds: new Set(),     // F6.3: movie ids with a removal in flight
+  removingStale: false,       // F6.3: bulk stale removal in flight
+  isRemoving: () => false,
+  removeFromWatchlist: async () => ({ ok: false, action: 'remove_failed' }),
+  removeStale: async () => ({ ok: false, removedCount: 0 }),
   refresh: () => {},
 }
 
@@ -39,72 +45,112 @@ export function WatchlistDataProvider({ children }) {
   const { user } = useAuthSession()
   const [state, setState] = useState(INITIAL)
   const [nonce, setNonce] = useState(0)
+  const [removingIds, setRemovingIds] = useState(() => new Set())
+  const [removingStale, setRemovingStale] = useState(false)
+
   // Mirror of state.items, kept current via effect so side-effecting callbacks
   // (e.g. bulk delete) can read the canonical list without piggybacking on
   // setState callbacks — those are double-invoked in Strict Mode.
   const itemsRef = useRef(state.items)
   useEffect(() => { itemsRef.current = state.items }, [state.items])
 
+  // Synchronous in-flight guards (dedupe rapid clicks) + a mounted/user guard so a
+  // stale async completion never updates an unmounted provider or a new user's state.
+  const inFlightRef = useRef(new Set())
+  const staleInFlightRef = useRef(false)
+  const mountedRef = useRef(true)
+  const userIdRef = useRef(user?.id)
+  useEffect(() => { mountedRef.current = true; return () => { mountedRef.current = false } }, [])
+  useEffect(() => { userIdRef.current = user?.id }, [user?.id])
+  // Reset pending state on user change (logout / switch).
+  useEffect(() => {
+    inFlightRef.current = new Set()
+    staleInFlightRef.current = false
+    setRemovingIds(new Set())
+    setRemovingStale(false)
+  }, [user?.id])
+
   const refresh = useCallback(() => setNonce(n => n + 1), [])
+  const isRemoving = useCallback((movieId) => removingIds.has(movieId), [removingIds])
+  // Only touch state if still mounted AND the action's user is still the active user.
+  const alive = useCallback((uid) => mountedRef.current && userIdRef.current === uid, [])
 
   const removeFromWatchlist = useCallback(async (movieId) => {
-    if (!user?.id || !movieId) return
-    // Optimistic: drop locally first; refresh re-syncs.
-    setState(prev => {
-      const items = prev.items.filter(it => it.id !== movieId)
-      return {
-        ...prev,
-        items,
-        stats: recomputeStats(items),
-        availableMoods: deriveAvailableMoods(items),
-      }
-    })
+    const fail = { ok: false, action: 'remove_failed', movieId }
+    if (!user?.id || !movieId) return fail
+    const uid = user.id
+    if (inFlightRef.current.has(movieId)) return { ...fail, duplicate: true }
+    inFlightRef.current.add(movieId)
+    if (alive(uid)) setRemovingIds(prev => { const n = new Set(prev); n.add(movieId); return n })
+    let result = fail
     try {
-      await supabase
+      // SETTLED: recognise a resolved PostgREST { error } (it does NOT throw) — only
+      // remove from the local list once the DB delete has actually succeeded.
+      const { error } = await supabase
         .from('user_watchlist')
         .delete()
-        .eq('user_id', user.id)
+        .eq('user_id', uid)
         .eq('movie_id', movieId)
+      if (error) {
+        console.warn('[removeFromWatchlist]', error)
+        refresh() // re-sync canonical; item was never removed locally → no false success
+      } else {
+        if (alive(uid)) {
+          setState(prev => {
+            const items = prev.items.filter(it => it.id !== movieId)
+            return { ...prev, items, stats: recomputeStats(items), availableMoods: deriveAvailableMoods(items) }
+          })
+        }
+        result = { ok: true, action: 'removed', movieId }
+      }
     } catch (e) {
       console.warn('[removeFromWatchlist]', e)
-      // Re-fetch to fix optimistic mismatch on error.
       refresh()
+    } finally {
+      inFlightRef.current.delete(movieId)
+      if (alive(uid)) setRemovingIds(prev => { const n = new Set(prev); n.delete(movieId); return n })
     }
-  }, [user, refresh])
+    return result
+  }, [user, refresh, alive])
 
-  // Bulk-delete every stale item in one DB round-trip. Used by the footer
-  // "Clear all stale" button. Returns the count actually removed.
-  // WHY itemsRef: React 18 Strict Mode double-invokes setState callbacks
-  // during dev — the 2nd invocation sees the 1st invocation's result as
-  // `prev`, so any side effect computed from `prev.items` runs against an
-  // already-filtered list and reports zero work. We snapshot the latest
-  // items via a ref written on every state set, then read it before the
-  // (still optimistic) setState that mutates UI.
+  // Bulk-delete every stale item in one DB round-trip. Returns the count ACTUALLY
+  // removed (0 on failure — never the attempted count).
   const removeStale = useCallback(async () => {
-    if (!user?.id) return 0
+    if (!user?.id) return { ok: false, removedCount: 0 }
+    const uid = user.id
+    if (staleInFlightRef.current) return { ok: false, removedCount: 0, duplicate: true }
     const staleIds = (itemsRef.current || []).filter(it => it.stale).map(it => it.id)
-    if (staleIds.length === 0) return 0
-    // Optimistic UI: drop stale rows from local state.
-    setState(prev => {
-      const items = prev.items.filter(it => !it.stale)
-      return {
-        ...prev,
-        items,
-        stats: recomputeStats(items),
-        availableMoods: deriveAvailableMoods(items),
+    if (staleIds.length === 0) return { ok: true, removedCount: 0 }
+    staleInFlightRef.current = true
+    if (alive(uid)) setRemovingStale(true)
+    let result = { ok: false, removedCount: 0 }
+    try {
+      const { error } = await supabase
+        .from('user_watchlist')
+        .delete()
+        .eq('user_id', uid)
+        .in('movie_id', staleIds)
+      if (error) {
+        console.warn('[removeStale]', error)
+        refresh() // restore canonical stale rows
+      } else {
+        if (alive(uid)) {
+          setState(prev => {
+            const items = prev.items.filter(it => !it.stale)
+            return { ...prev, items, stats: recomputeStats(items), availableMoods: deriveAvailableMoods(items) }
+          })
+        }
+        result = { ok: true, removedCount: staleIds.length }
       }
-    })
-    const { error } = await supabase
-      .from('user_watchlist')
-      .delete()
-      .eq('user_id', user.id)
-      .in('movie_id', staleIds)
-    if (error) {
-      console.warn('[removeStale]', error)
+    } catch (e) {
+      console.warn('[removeStale]', e)
       refresh()
+    } finally {
+      staleInFlightRef.current = false
+      if (alive(uid)) setRemovingStale(false)
     }
-    return staleIds.length
-  }, [user, refresh])
+    return result
+  }, [user, refresh, alive])
 
   useEffect(() => {
     if (!user?.id) {
@@ -135,28 +181,36 @@ export function WatchlistDataProvider({ children }) {
 
         const items = deriveItems({ rows: watchRes.data || [], fingerprint, profile })
         const availableMoods = deriveAvailableMoods(items)
-        setState({
+        setState(s => ({
+          ...s,
           items,
           stats: recomputeStats(items),
           availableMoods,
           hasFingerprint: Boolean(fingerprint?.topMoodTags?.length),
           loading: false,
           error: null,
-          removeFromWatchlist,
-          removeStale,
-          refresh,
-        })
+        }))
       } catch (e) {
         if (abort) return
+        // F6.3: keep raw diagnostics in console only; expose a safe classification.
         console.error('[useWatchlistData]', e)
-        setState(s => ({ ...s, loading: false, error: e?.message || 'Failed to load' }))
+        setState(s => ({ ...s, loading: false, error: 'load_error' }))
       }
     })()
 
     return () => { abort = true }
-  }, [user, nonce, removeFromWatchlist, removeStale, refresh])
+  }, [user, nonce])
 
-  const value = useMemo(() => state, [state])
+  const value = useMemo(() => ({
+    ...state,
+    removingIds,
+    removingStale,
+    isRemoving,
+    removeFromWatchlist,
+    removeStale,
+    refresh,
+  }), [state, removingIds, removingStale, isRemoving, removeFromWatchlist, removeStale, refresh])
+
   return <WatchlistDataContext.Provider value={value}>{children}</WatchlistDataContext.Provider>
 }
 

--- a/src/features/watchlist/watchlist.css
+++ b/src/features/watchlist/watchlist.css
@@ -96,3 +96,13 @@
     width: 100% !important;
   }
 }
+
+/* F6.3 — sanitized error recovery buttons + the data-library-fallback focus target
+   should not paint a visible ring (focus is moved programmatically, not highlighted). */
+.ff-wl-error-btn:focus-visible {
+  outline: 2px solid #a78bfa;
+  outline-offset: 3px;
+}
+[data-library-fallback]:focus {
+  outline: none;
+}


### PR DESCRIPTION
**F6.3 — Harden User Library removals and error states.** Reliability + error-sanitization + accessibility for Watchlist + Diary removals. **No product/visual redesign**: match %, approx scoring, default sort, "Perfect for tonight", featured cards, stale framing, bulk-cleanup copy, History avg-rating scope, streak, mood/note semantics, the diary rating-retention behavior, routes, the engine, the F6.2 derive modules, and schema/RLS are all **unchanged** (those are F6.4–F6.6).

## Watchlist individual settlement fix (P1)
`removeFromWatchlist` now **inspects the resolved Supabase `{ error }`** — PostgREST does *not* throw on a DB/RLS failure, so the previous try/catch silently treated failures as success. It now removes the item locally **only after** the delete succeeds, returns an explicit `{ ok, action, movieId }`, dedupes rapid clicks (in-flight guard), and exposes per-id pending state (`removingIds`/`isRemoving`). Delete filter (`user_id` + `movie_id`) unchanged.

## Bulk stale result hardening
`removeStale` returns the **actual** successful count (`0` on failure — never the attempted count), guards duplicate bulk clicks, restores canonical rows on failure, clears pending in `finally`. `.in('movie_id', staleIds)` unchanged.

## Diary removal settlement (P1)
`removeEntry` inspects the resolved `{ error }`, returns `{ ok, action, entryId, movieId }`, dedupes, exposes pending (`removingEntryIds`), and retains the entry on failure. The `(user_id, movie_id)` filter and **rating/review retention are frozen** (F6.5).

## Sanitized load errors + retry/Home recovery (P1)
Both providers expose `error: 'load_error' | null` (raw diagnostics stay in `console.error` only). Both pages render fixed safe copy — *"We couldn't load your Watchlist/Diary. … still safe. Try again in a moment."* — with `role="alert"`, **one h1**, and **Try-again (→ refresh) + Go-to-Home (→ /home)** ≥44px focus-ring `type=button` buttons. **No raw backend text reaches the DOM / title / aria-label / tooltip** anywhere.

## Live announcements
One persistent visually-hidden `role="status" aria-live="polite" aria-atomic` region per page (`useLibraryAnnouncement`); individual / bulk / diary success + failure are announced **only after settlement**; unrelated re-renders never repeat.

## Focus-after-removal
A reusable, testable helper (`focusAfterRemoval.js`): the pure `nextFocusId` picks **next → prev → fallback**; `scheduleFocus` moves focus after a double-rAF and is **cancelled on unmount**; **never focuses `<body>`**; targets resolve by stable `data-library-*` id attributes (**never by film title**). Success → next equivalent Remove control (or the `data-library-fallback` results region); failure → the retryable control; bulk success → the results heading.

## Pending / duplicate-click protection
Every Remove control + the bulk button expose `aria-busy` + `disabled` + "Removing {title}" / "Removing…" while in flight; decorative SVGs `aria-hidden`. The in-flight guards make duplicate clicks fire exactly one delete.

## Discover `watched_at` investigation (read-only, NOT fixed here — Option 3)
The "Already watched" insert omits `watched_at` (`useDiscoverResultActions.js:115`); `watched_at` is nullable (the stats RPC filters `IS NOT NULL`); there is **no generated types file and no `user_history` DDL/DEFAULT in committed migrations**, so a live `DEFAULT now()` **cannot be verified from the repo** — retained as an explicit unresolved lifecycle risk for F6.5 (no default inferred from nullable behavior; **no test write performed**). Discover unchanged.

## Tests (+35 → full **1228**)
`focusAfterRemoval` (pure next/prev/fallback + scheduler cancel + never-body); Watchlist provider (settled `{error}` recognition, dup-guard, pending clear, filters, bulk actual-count/0-on-fail, no raw error in context); Watchlist page (sanitized error, retry/home, persistent region, settled announce, pending UI); History provider (settled, retains on failure, `user_history`-only delete, dup, pending); History page (sanitized error, announce, pending, confirm-cancel). **The 27 F6.2 derivation tests are unchanged + green.**

## Confirmations
F6.2 derivations + all trust/stat semantics + routes + engine + schema unchanged; only the 6 allowed files + the `library/` helpers + tests changed. **No live route opened** (the Watchlist profile-cache write was never triggered); **no live write**.

`npm run lint` clean · targeted **62 ×3** · full **1228** · `npm run build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
