### PR TITLE
Refocus Watchlist as calm saved intent

### DIFF
--- a/src/features/watchlist/Watchlist.jsx
+++ b/src/features/watchlist/Watchlist.jsx
@@ -1,7 +1,10 @@
 // src/features/watchlist/Watchlist.jsx
-// FeelFlick — Watchlist v2 ("The Queue").
-// F6.3: removals are settled + announced + focus-recovered; load errors are sanitized.
-// (No product/visual redesign — match %, stale, featured, grid/list, bulk all unchanged.)
+// FeelFlick — Watchlist: a calm record of saved intent ("Saved for later"). Films the
+// user chose to remember for another moment — NOT a recommendation feed. F6.4 removed
+// the match %, "Perfect for tonight", featured tier, pulse dashboard, "stale"/guilt
+// framing, the bulk cleanup, and the grid/list toggle. Home + Discover own nightly
+// selection; this surface just preserves and retrieves saved films. F6.3 removal
+// reliability (settled delete, live announcements, focus recovery, pending) is preserved.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
@@ -10,11 +13,11 @@ import MoodPill from '@/shared/components/MoodPill'
 import Eyebrow from '@/shared/ui/Eyebrow'
 import { HP, HP_GRAD } from './data'
 import { WatchlistDataProvider, useWatchlistData } from './useWatchlistData'
+import { sortItems } from './derive/watchlistDerive'
 import { useLibraryAnnouncement } from '@/features/library/useLibraryAnnouncement'
 import { scheduleFocus, findRemoveControl, findFallback, nextFocusId } from '@/features/library/focusAfterRemoval'
 import './watchlist.css'
 
-// === Reset-button style for elements wrapped as buttons ===
 const RESET_BTN = {
   background:'none', border:'none', padding:0, margin:0, font:'inherit',
   color:'inherit', textAlign:'left', cursor:'pointer', display:'block', width:'100%',
@@ -22,374 +25,144 @@ const RESET_BTN = {
 
 // ── Masthead ───────────────────────────────────────────────────
 function Masthead() {
-  const { stats } = useWatchlistData();
+  const { total } = useWatchlistData();
   return (
-    <section className="ff-wl-section ff-wl-section--masthead" style={{ padding:'72px 88px 36px', position:'relative' }}>
-      <div style={{ position:'absolute', inset:0, pointerEvents:'none', background:'radial-gradient(ellipse 60% 35% at 10% 0%, rgba(167,139,250,0.14), transparent 60%)' }} />
+    <section className="ff-wl-section ff-wl-section--masthead" style={{ padding:'72px 88px 28px', position:'relative' }}>
+      <div style={{ position:'absolute', inset:0, pointerEvents:'none', background:'radial-gradient(ellipse 60% 35% at 10% 0%, rgba(167,139,250,0.12), transparent 60%)' }} />
       <div style={{ position:'relative' }}>
         <div style={{ display:'flex', alignItems:'center', gap:14, marginBottom:24, flexWrap:'wrap' }}>
           <Eyebrow spacing="0.32em" size={10}>Watchlist</Eyebrow>
           <div style={{ height:1, width:38, background:HP.purple, opacity:0.5 }} />
-          <Eyebrow tone="meta" weight={500} size={10}>
-            {stats.watchlistTotal} film{stats.watchlistTotal === 1 ? '' : 's'} saved
-          </Eyebrow>
+          <Eyebrow tone="meta" weight={500} size={10}>{total} film{total === 1 ? '' : 's'} saved</Eyebrow>
         </div>
-        <h1 className="ff-wl-hero" style={{ fontFamily:'Outfit', fontSize:88, lineHeight:0.92, fontWeight:300, letterSpacing:'-0.05em', color:HP.text, margin:0, textWrap:'balance' }}>
-          The <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>queue.</em>
+        <h1 className="ff-wl-hero" style={{ fontFamily:'Outfit', fontSize:72, lineHeight:0.96, fontWeight:300, letterSpacing:'-0.045em', color:HP.text, margin:0, textWrap:'balance' }}>
+          Saved <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>for later.</em>
         </h1>
-        <p style={{ marginTop:18, fontFamily:'Outfit, Inter, sans-serif', fontSize:17, color:HP.textSoft, fontStyle:'italic', maxWidth:720, lineHeight:1.55 }}>
-          Filter, sort, and clean. Stale ones get flagged so you can decide what to cut.
+        <p style={{ marginTop:18, fontFamily:'Outfit, Inter, sans-serif', fontSize:17, color:HP.textSoft, maxWidth:640, lineHeight:1.55 }}>
+          Films you wanted to remember &mdash; ready whenever the moment feels right.
         </p>
       </div>
     </section>
   );
 }
 
-// ── Pulse strip (3 stats) ──────────────────────────────────────
-function PulseStrip() {
-  const { stats, hasFingerprint } = useWatchlistData();
-  const tonightStat = hasFingerprint
-    ? { label:'Perfect for tonight', value: stats.perfectForTonightCount, hex: HP.purple,   hint:'matches your current mood window' }
-    : { label:'Top match',           value: stats.topMatchPct ? `${stats.topMatchPct}%` : '—', hex: HP.purple, hint:'your queue’s highest match' };
-  const items = [
-    tonightStat,
-    { label:'Getting stale',       value: stats.gettingStaleCount,       hex: HP.amber,     hint:'saved over 60 days ago' },
-    { label:'Total queue',         value: stats.watchlistTotal,          hex: HP.textSoft,  hint:'films across all moods' },
-  ];
+// ── Retrieval controls: film-mood filter + saved-date sort (no ranking) ──
+function Controls({ filter, setFilter, sort, setSort }) {
+  const { availableMoods } = useWatchlistData();
   return (
-    <section className="ff-wl-section ff-wl-pulse" style={{ padding:'24px 88px 40px' }}>
-      <div className="ff-wl-pulse-grid" style={{ display:'grid', gridTemplateColumns:'repeat(3,1fr)', gap:24 }}>
-        {items.map(s => (
-          <div key={s.label} style={{ padding:'20px 22px', borderRadius:6, background:'rgba(255,255,255,0.025)', border:`1px solid ${HP.border}`, display:'grid', gridTemplateColumns:'auto 1fr', gap:18, alignItems:'center' }}>
-            <span style={{ fontFamily:'Outfit', fontSize:44, fontWeight:200, color:s.hex, letterSpacing:'-0.045em', lineHeight:1 }}>{s.value}</span>
-            <div>
-              <Eyebrow tone="meta" size={10}>{s.label}</Eyebrow>
-              <div style={{ marginTop:4, fontSize:12, color:HP.textSoft, fontFamily:'Outfit', fontStyle:'italic' }}>{s.hint}</div>
-            </div>
-          </div>
-        ))}
-      </div>
-    </section>
-  );
-}
-
-// ── Filter / sort bar ──────────────────────────────────────────
-function FilterBar({ filter, setFilter, sort, setSort, view, setView }) {
-  const { availableMoods, hasFingerprint, stats } = useWatchlistData();
-  const filters = [{ v:'all', l:'All' }];
-  if (hasFingerprint && stats.perfectForTonightCount > 0) {
-    filters.push({ v:'perfect', l:'Perfect tonight' });
-  }
-  for (const m of availableMoods.slice(0, 5)) {
-    filters.push({ v:`mood:${m.mood}`, l:m.mood });
-  }
-  if (stats.gettingStaleCount > 0) {
-    filters.push({ v:'stale', l:'Getting stale' });
-  }
-  return (
-    <section className="ff-wl-section ff-wl-filterbar" style={{ padding:'12px 88px 40px', display:'flex', alignItems:'center', justifyContent:'space-between', gap:24, flexWrap:'wrap' }}>
-      <div role="radiogroup" aria-label="Filter" style={{ display:'flex', gap:6, flexWrap:'wrap' }}>
-        {filters.map(f => {
+    <section className="ff-wl-section ff-wl-controls" style={{ padding:'4px 88px 36px', display:'flex', alignItems:'center', justifyContent:'space-between', gap:24, flexWrap:'wrap' }}>
+      <div role="group" aria-label="Filter by film mood" style={{ display:'flex', gap:6, flexWrap:'wrap' }}>
+        {[{ v:'all', l:'All' }, ...availableMoods.map(m => ({ v:`mood:${m.mood}`, l:m.mood }))].map(f => {
           const on = filter === f.v;
           return (
             <button
               key={f.v}
               type="button"
-              role="radio"
-              aria-checked={on}
+              aria-pressed={on}
               onClick={() => setFilter(f.v)}
+              className="ff-wl-filter-pill"
               style={{
-                padding:'8px 14px', borderRadius:999,
+                minHeight:44, padding:'8px 16px', borderRadius:999,
                 background: on ? `${HP.purple}22` : 'rgba(255,255,255,0.04)',
                 border:`1px solid ${on ? HP.purple+'66' : HP.border}`,
                 color: on ? HP.text : HP.textSoft,
-                fontFamily:'Outfit', fontSize:12, fontWeight:500, letterSpacing:'-0.005em', cursor:'pointer', transition:'all 0.2s ease',
+                fontFamily:'Outfit', fontSize:12, fontWeight:500, cursor:'pointer',
               }}
             >{f.l}</button>
           );
         })}
       </div>
-      <div style={{ display:'flex', alignItems:'center', gap:16 }}>
-        <label style={{ display:'inline-flex', alignItems:'center', gap:8, padding:'7px 12px', borderRadius:999, background:'rgba(255,255,255,0.04)', border:`1px solid ${HP.border}` }}>
-          <span style={{ fontSize:10, color:HP.textMuted, fontFamily:'Outfit', letterSpacing:'0.12em', textTransform:'uppercase' }}>Sort</span>
-          <select
-            value={sort}
-            onChange={e => setSort(e.target.value)}
-            aria-label="Sort queue"
-            style={{ background:'transparent', border:'none', color:HP.text, fontFamily:'Outfit', fontSize:12, fontWeight:600, cursor:'pointer', outline:'none' }}
-          >
-            <option value="match">Match %</option>
-            <option value="added">Recently added</option>
-            <option value="stale">Longest waiting</option>
-            <option value="runtime">Runtime</option>
-          </select>
-        </label>
-        <div role="radiogroup" aria-label="View" style={{ display:'inline-flex', padding:3, borderRadius:999, background:'rgba(255,255,255,0.04)', border:`1px solid ${HP.border}` }}>
-          {['grid','list'].map(v => {
-            const on = view === v;
-            return (
-              <button
-                key={v}
-                type="button"
-                role="radio"
-                aria-checked={on}
-                onClick={() => setView(v)}
-                style={{ padding:'6px 12px', borderRadius:999, background: on ? HP_GRAD : 'transparent', color: on ? '#fff' : HP.textMuted, border:'none', cursor:'pointer', fontFamily:'Outfit', fontSize:11, fontWeight:600, letterSpacing:'0.06em', textTransform:'uppercase' }}
-              >{v}</button>
-            );
-          })}
-        </div>
-      </div>
+      <label style={{ display:'inline-flex', alignItems:'center', gap:8, minHeight:44, padding:'7px 12px', borderRadius:999, background:'rgba(255,255,255,0.04)', border:`1px solid ${HP.border}` }}>
+        <span style={{ fontSize:10, color:HP.textMuted, fontFamily:'Outfit', letterSpacing:'0.12em', textTransform:'uppercase' }}>Sort</span>
+        <select
+          value={sort}
+          onChange={e => setSort(e.target.value)}
+          aria-label="Sort saved films"
+          style={{ background:'transparent', border:'none', color:HP.text, fontFamily:'Outfit', fontSize:12, fontWeight:600, cursor:'pointer', outline:'none' }}
+        >
+          <option value="recent">Recently saved</option>
+          <option value="oldest">Oldest saved</option>
+          <option value="runtime">Runtime</option>
+          <option value="title">Title</option>
+        </select>
+      </label>
     </section>
   );
 }
 
-// ── Remove control (shared pending/a11y wiring; visuals per view) ──
-function RemoveControl({ f, view, onRemove, style, children, removingLabel = 'Removing…' }) {
+// ── Saved-film card ────────────────────────────────────────────
+function SavedCard({ f, onRemove }) {
+  const navigate = useNavigate();
   const { isRemoving } = useWatchlistData();
+  const open = () => f.tmdbId && navigate(`/movie/${f.tmdbId}`);
   const busy = isRemoving(f.id);
   return (
-    <button
-      type="button"
-      data-library-action="remove"
-      data-library-item-id={f.id}
-      data-library-view={view}
-      disabled={busy}
-      aria-busy={busy || undefined}
-      aria-label={busy ? `Removing ${f.title}` : `Remove ${f.title} from watchlist`}
-      title="Remove"
-      onClick={(e) => onRemove(f, view, e.currentTarget)}
-      style={{ ...style, cursor: busy ? 'wait' : 'pointer', opacity: busy ? 0.6 : (style?.opacity ?? 1) }}
-    >
-      {busy ? removingLabel : children}
-    </button>
-  );
-}
-
-// ── Tonight tier — featured cards ──────────────────────────────
-function TonightTier({ picks, onRemove }) {
-  const { hasFingerprint } = useWatchlistData();
-  if (!picks.length) return null;
-  const kicker = hasFingerprint ? 'Perfect for tonight' : 'Top of your queue';
-  const sub = hasFingerprint
-    ? 'matched to your current mood window'
-    : 'ranked by match score — your taste profile builds as you rate';
-  return (
-    <section className="ff-wl-section ff-wl-tonight" style={{ padding:'8px 88px 48px' }}>
-      <div style={{ marginBottom:24, display:'flex', alignItems:'baseline', gap:14, flexWrap:'wrap' }}>
-        <Eyebrow rule size={10}>{kicker}</Eyebrow>
-        <span style={{ fontSize:12, color:HP.textMuted, fontFamily:'Outfit', fontStyle:'italic' }}>{sub}</span>
-      </div>
-      <div className="ff-wl-tonight-grid" style={{ display:'grid', gridTemplateColumns:`repeat(${Math.min(picks.length, 3)},1fr)`, gap:24 }}>
-        {picks.slice(0, 3).map((f, i) => <FeaturedCard key={f.id} f={f} idx={i} onRemove={onRemove} />)}
-      </div>
-    </section>
-  );
-}
-function FeaturedCard({ f, idx, onRemove }) {
-  const navigate = useNavigate();
-  const goToFilm = () => f.tmdbId && navigate(`/movie/${f.tmdbId}`);
-  return (
-    <article className="ff-wl-featured" style={{ display:'grid', gridTemplateColumns:'auto 1fr', gap:20 }}>
-      <button
-        type="button"
-        onClick={goToFilm}
-        aria-label={`Open ${f.title}`}
-        style={{ ...RESET_BTN, position:'relative', width:140, flex:'none' }}
-      >
-        {f.poster ? (
-          <img src={f.poster} alt={f.title} style={{ width:'100%', aspectRatio:'2/3', objectFit:'cover', borderRadius:6, boxShadow:`0 16px 36px -12px rgba(0,0,0,0.6), 0 0 32px ${f.hex}22` }} />
-        ) : (
-          <div style={{ width:'100%', aspectRatio:'2/3', borderRadius:6, background:`linear-gradient(155deg, ${f.hex}55, ${f.hex}11)`, display:'flex', alignItems:'center', justifyContent:'center', color:HP.text, fontFamily:'Outfit', fontSize:18, padding:14, textAlign:'center' }}>{f.title}</div>
-        )}
-        <div style={{ position:'absolute', top:10, left:10, padding:'4px 8px', borderRadius:3, background:'rgba(0,0,0,0.85)', backdropFilter:'blur(8px)', border:`1px solid ${HP.purple}55`, fontSize:9, fontWeight:700, color:HP.purple, fontFamily:'Outfit', letterSpacing:'0.08em' }}>{f.match}%</div>
+    <article className="ff-wl-card">
+      <button type="button" onClick={open} aria-label={`Open ${f.title}`} className="ff-wl-card__poster" style={{ ...RESET_BTN, position:'relative', borderRadius:6, overflow:'hidden' }}>
+        {f.poster
+          ? <img src={f.poster} alt="" style={{ width:'100%', aspectRatio:'2/3', objectFit:'cover', display:'block' }} />
+          : <div style={{ width:'100%', aspectRatio:'2/3', background:`linear-gradient(155deg, ${f.hex}55, ${f.hex}11)`, display:'flex', alignItems:'center', justifyContent:'center', color:HP.text, fontFamily:'Outfit', fontSize:14, padding:12, textAlign:'center' }}>{f.title}</div>}
       </button>
-      <div style={{ display:'flex', flexDirection:'column', justifyContent:'space-between' }}>
-        <div>
-          <div style={{ fontSize:9, fontWeight:700, letterSpacing:'0.22em', textTransform:'uppercase', color:HP.purple, marginBottom:8 }}>0{idx+1} · {f.mood}</div>
-          <button
-            type="button"
-            onClick={goToFilm}
-            aria-label={`Open ${f.title}`}
-            style={{ ...RESET_BTN, width:'auto' }}
-          >
-            <h3 style={{ fontFamily:'Outfit', fontSize:24, fontWeight:500, color:HP.text, letterSpacing:'-0.02em', margin:'0 0 6px 0' }}>{f.title}</h3>
-          </button>
-          <div style={{ fontSize:11, color:HP.textMuted, fontFamily:'Outfit', letterSpacing:'0.04em', marginBottom:14 }}>
-            {f.year}{f.runtime ? ` · ${f.runtime}m` : ''}{f.dir && f.dir !== '—' ? ` · ${f.dir}` : ''}
-          </div>
-          {f.why && (
-            <p style={{ margin:0, fontSize:12.5, lineHeight:1.55, color:HP.textSoft, fontFamily:'Outfit, Inter, sans-serif', fontStyle:'italic', textWrap:'pretty' }}>&ldquo;{f.why}&rdquo;</p>
-          )}
-        </div>
-        <div style={{ display:'flex', gap:8, marginTop:14 }}>
-          <button
-            type="button"
-            onClick={goToFilm}
-            style={{ padding:'8px 14px', borderRadius:6, background:HP_GRAD, border:'none', color:'#fff', fontFamily:'Outfit', fontSize:11, fontWeight:600, letterSpacing:'0.04em', cursor:'pointer' }}
-          >Open →</button>
-          <RemoveControl
-            f={f}
-            view="featured"
-            onRemove={onRemove}
-            style={{ padding:'8px 14px', borderRadius:6, background:'rgba(255,255,255,0.05)', border:`1px solid ${HP.border}`, color:HP.textMuted, fontFamily:'Outfit', fontSize:11, fontWeight:600, letterSpacing:'0.04em', minHeight:44 }}
-          >Remove</RemoveControl>
-        </div>
+      <button type="button" onClick={open} style={{ ...RESET_BTN, width:'auto', marginTop:12 }}>
+        <h3 style={{ fontFamily:'Outfit', fontSize:15, fontWeight:500, color:HP.text, letterSpacing:'-0.01em', margin:0, lineHeight:1.25 }}>{f.title}</h3>
+      </button>
+      <div style={{ marginTop:4, fontSize:11, color:HP.textMuted, fontFamily:'Outfit', letterSpacing:'0.03em' }}>
+        {f.year || '—'}{f.runtime ? ` · ${f.runtime}m` : ''}{f.dir && f.dir !== '—' ? ` · ${f.dir}` : ''}
+      </div>
+      <div style={{ marginTop:10, display:'flex', alignItems:'center', gap:10, flexWrap:'wrap' }}>
+        {f.mood && f.mood !== 'Mixed' && <MoodPill label={f.mood} color={f.hex} dot />}
+        <span style={{ fontSize:11, color:HP.textFaint, fontFamily:'Outfit', letterSpacing:'0.02em' }}>{f.savedLabel}</span>
+      </div>
+      <div style={{ marginTop:14, display:'flex', gap:8 }}>
+        <button type="button" onClick={open} style={{ flex:1, minHeight:44, padding:'8px 14px', borderRadius:6, background:'rgba(255,255,255,0.06)', border:`1px solid ${HP.border}`, color:HP.textSoft, fontFamily:'Outfit', fontSize:11, fontWeight:600, letterSpacing:'0.04em', cursor:'pointer' }}>Open</button>
+        <button
+          type="button"
+          data-library-action="remove"
+          data-library-item-id={f.id}
+          data-library-view="grid"
+          disabled={busy}
+          aria-busy={busy || undefined}
+          aria-label={busy ? `Removing ${f.title}` : `Remove ${f.title} from Watchlist`}
+          title="Remove from Watchlist"
+          onClick={(e) => onRemove(f, e.currentTarget)}
+          style={{ minHeight:44, padding:'8px 14px', borderRadius:6, background:'transparent', border:`1px solid ${HP.border}`, color:HP.textMuted, fontFamily:'Outfit', fontSize:11, fontWeight:600, letterSpacing:'0.04em', cursor: busy ? 'wait' : 'pointer', opacity: busy ? 0.6 : 1 }}
+        >{busy ? 'Removing…' : 'Remove'}</button>
       </div>
     </article>
   );
 }
 
-// ── Grid view ──────────────────────────────────────────────────
-function Grid({ items }) {
-  const navigate = useNavigate();
-  if (items.length === 0) return <EmptyState />;
-  return (
-    <section className="ff-wl-section ff-wl-grid-section" style={{ padding:'0 88px 56px' }}>
-      <Eyebrow rule size={10} style={{ marginBottom:20 }}>The full queue</Eyebrow>
-      <div className="ff-wl-grid" style={{ display:'grid', gridTemplateColumns:'repeat(5,1fr)', gap:22 }}>
-        {items.map(f => (
-          <button
-            key={f.id}
-            type="button"
-            onClick={() => f.tmdbId && navigate(`/movie/${f.tmdbId}`)}
-            aria-label={`Open ${f.title}`}
-            style={{ ...RESET_BTN, cursor:'pointer' }}
-          >
-            <div style={{ position:'relative', borderRadius:6, overflow:'hidden', marginBottom:12, boxShadow:'0 10px 24px -10px rgba(0,0,0,0.6)' }}>
-              {f.poster ? (
-                <img src={f.poster} alt={f.title} style={{ width:'100%', aspectRatio:'2/3', objectFit:'cover', display:'block' }} />
-              ) : (
-                <div style={{ width:'100%', aspectRatio:'2/3', background:`linear-gradient(155deg, ${f.hex}55, ${f.hex}11)`, display:'flex', alignItems:'center', justifyContent:'center', color:HP.text, fontFamily:'Outfit', fontSize:14, padding:12, textAlign:'center' }}>{f.title}</div>
-              )}
-              <div style={{ position:'absolute', top:8, left:8, padding:'3px 7px', borderRadius:3, background:'rgba(0,0,0,0.85)', backdropFilter:'blur(8px)', border:`1px solid ${f.hex}55`, fontSize:9, fontWeight:700, color:f.hex, fontFamily:'Outfit', letterSpacing:'0.06em' }}>{f.match}%</div>
-              {f.stale && <div style={{ position:'absolute', top:8, right:8, padding:'3px 7px', borderRadius:3, background:'rgba(0,0,0,0.85)', backdropFilter:'blur(8px)', border:`1px solid ${HP.amber}55`, fontSize:9, fontWeight:700, color:HP.amber, fontFamily:'Outfit', letterSpacing:'0.06em' }}>{f.addedDaysAgo}d</div>}
-              {f.perfect && <div style={{ position:'absolute', bottom:0, left:0, right:0, padding:'8px 10px', background:`linear-gradient(180deg, transparent, rgba(0,0,0,0.85))`, fontSize:9, fontWeight:700, color:HP.purple, fontFamily:'Outfit', letterSpacing:'0.1em', textTransform:'uppercase' }}>● Tonight</div>}
-            </div>
-            <div style={{ fontFamily:'Outfit', fontSize:14, fontWeight:500, color:HP.text, letterSpacing:'-0.01em', marginBottom:3 }}>{f.title}</div>
-            <div style={{ fontSize:11, color:HP.textMuted, fontFamily:'Outfit', letterSpacing:'0.04em' }}>{f.year || '—'} · {f.mood}</div>
-          </button>
-        ))}
-      </div>
-    </section>
-  );
-}
-
-// ── List view ──────────────────────────────────────────────────
-function List({ items, onRemove }) {
-  const navigate = useNavigate();
-  if (items.length === 0) return <EmptyState />;
-  return (
-    <section className="ff-wl-section ff-wl-list-section" style={{ padding:'0 88px 56px' }}>
-      <Eyebrow rule size={10} style={{ marginBottom:20 }}>The full queue</Eyebrow>
-      <div style={{ borderTop:`1px solid ${HP.border}` }}>
-        {items.map(f => (
-          <div key={f.id} className="ff-wl-list-row" style={{ display:'grid', gridTemplateColumns:'48px 1fr auto auto auto auto', gap:24, alignItems:'center', padding:'18px 0', borderBottom:`1px solid ${HP.border}` }}>
-            <button
-              type="button"
-              onClick={() => f.tmdbId && navigate(`/movie/${f.tmdbId}`)}
-              aria-label={`Open ${f.title}`}
-              style={{ ...RESET_BTN, width:48, height:72 }}
-            >
-              {f.poster
-                ? <img src={f.poster} alt="" style={{ width:'100%', height:'100%', objectFit:'cover', borderRadius:4 }} />
-                : <div style={{ width:'100%', height:'100%', borderRadius:4, background:`linear-gradient(155deg, ${f.hex}55, ${f.hex}11)` }} />
-              }
-            </button>
-            <div>
-              <div style={{ display:'flex', alignItems:'center', gap:10, flexWrap:'wrap' }}>
-                <button
-                  type="button"
-                  onClick={() => f.tmdbId && navigate(`/movie/${f.tmdbId}`)}
-                  style={{ ...RESET_BTN, width:'auto', fontFamily:'Outfit', fontSize:17, fontWeight:500, color:HP.text, letterSpacing:'-0.015em', cursor:'pointer' }}
-                >{f.title}</button>
-                {f.perfect && <span style={{ padding:'2px 7px', borderRadius:3, background:'rgba(167,139,250,0.16)', border:`1px solid ${HP.purple}44`, fontSize:8, fontWeight:700, color:HP.purple, fontFamily:'Outfit', letterSpacing:'0.12em', textTransform:'uppercase' }}>Tonight</span>}
-                {f.stale && <span style={{ padding:'2px 7px', borderRadius:3, background:'rgba(245,158,11,0.12)', border:`1px solid ${HP.amber}44`, fontSize:8, fontWeight:700, color:HP.amber, fontFamily:'Outfit', letterSpacing:'0.12em', textTransform:'uppercase' }}>Stale</span>}
-              </div>
-              <div style={{ fontSize:11, color:HP.textMuted, fontFamily:'Outfit', marginTop:3, letterSpacing:'0.04em' }}>
-                {f.year || '—'}{f.runtime ? ` · ${f.runtime}m` : ''}{f.dir && f.dir !== '—' ? ` · ${f.dir}` : ''} · added {f.addedDaysAgo}d ago
-              </div>
-            </div>
-            <MoodPill label={f.mood} color={f.hex} dot />
-            <div style={{ fontFamily:'Outfit', fontSize:18, fontWeight:300, color:HP.text, letterSpacing:'-0.03em' }}>{f.match}<span style={{ fontSize:10, color:HP.textMuted, marginLeft:1 }}>%</span></div>
-            <button
-              type="button"
-              onClick={() => f.tmdbId && navigate(`/movie/${f.tmdbId}`)}
-              style={{ padding:'7px 12px', borderRadius:6, background:'rgba(255,255,255,0.06)', border:`1px solid ${HP.border}`, color:HP.textSoft, fontFamily:'Outfit', fontSize:10, fontWeight:600, letterSpacing:'0.08em', textTransform:'uppercase', cursor:'pointer' }}
-            >Open</button>
-            <RemoveControl
-              f={f}
-              view="list"
-              onRemove={onRemove}
-              removingLabel={<span style={{ fontSize:10, fontFamily:'Outfit' }}>…</span>}
-              style={{ padding:'7px 10px', borderRadius:6, background:'transparent', border:'none', color:HP.textFaint, display:'inline-flex', alignItems:'center', justifyContent:'center', minWidth:44, minHeight:44 }}
-            >
-              <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-2 14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6M14 11v6"/></svg>
-            </RemoveControl>
-          </div>
-        ))}
-      </div>
-    </section>
-  );
-}
-
-// ── Empty state ────────────────────────────────────────────────
+// ── Empty states ───────────────────────────────────────────────
 function EmptyState() {
   const navigate = useNavigate();
   return (
-    <section className="ff-wl-section" style={{ padding:'72px 88px 96px', textAlign:'center' }}>
-      <Eyebrow size={10} style={{ marginBottom:18 }}>The queue is empty</Eyebrow>
-      <h2 style={{ fontFamily:'Outfit', fontSize:36, lineHeight:1, fontWeight:500, letterSpacing:'-0.03em', color:HP.text, margin:'0 0 14px 0' }}>Save a film to start.</h2>
-      <p style={{ margin:'0 auto 28px', maxWidth:480, fontSize:14, color:HP.textMuted, fontFamily:'Outfit, Inter, sans-serif', lineHeight:1.6 }}>
-        Tap Save on any film detail page and it lands here, re-sorted by mood + match every evening.
+    <section className="ff-wl-section" style={{ padding:'56px 88px 96px', textAlign:'center' }}>
+      <Eyebrow size={10} style={{ marginBottom:18 }}>Watchlist</Eyebrow>
+      <h2 style={{ fontFamily:'Outfit', fontSize:34, lineHeight:1.05, fontWeight:500, letterSpacing:'-0.03em', color:HP.text, margin:'0 0 14px 0' }}>Your Watchlist is open.</h2>
+      <p style={{ margin:'0 auto 28px', maxWidth:460, fontSize:14, color:HP.textMuted, fontFamily:'Outfit, Inter, sans-serif', lineHeight:1.6 }}>
+        Save a film when you want to remember it for another time.
       </p>
-      <button
-        type="button"
-        onClick={() => navigate('/home')}
-        style={{ padding:'12px 22px', borderRadius:999, background:HP_GRAD, border:'none', color:'#fff', fontFamily:'Outfit', fontSize:13, fontWeight:600, cursor:'pointer', boxShadow:'0 12px 28px -8px rgba(236,72,153,0.5)' }}
-      >Browse tonight&rsquo;s picks →</button>
-    </section>
-  );
-}
-
-// ── Cleanup nudge ──────────────────────────────────────────────
-function CleanupNudge({ count, onReview, onBulkRemove }) {
-  const { removingStale } = useWatchlistData();
-  if (count === 0) return null;
-  return (
-    <section className="ff-wl-section ff-wl-cleanup" style={{ padding:'48px 88px', borderTop:`1px solid ${HP.border}`, background:`linear-gradient(135deg, ${HP.amber}0a, transparent)` }}>
-      <div className="ff-wl-cleanup-grid" style={{ display:'grid', gridTemplateColumns:'auto 1fr auto', gap:32, alignItems:'center' }}>
-        <div style={{ width:48, height:48, borderRadius:999, background:`${HP.amber}1a`, border:`1px solid ${HP.amber}44`, display:'flex', alignItems:'center', justifyContent:'center' }}>
-          <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={HP.amber} strokeWidth="2" strokeLinecap="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>
-        </div>
-        <div>
-          <Eyebrow color={HP.amber} spacing="0.22em" size={10} style={{ marginBottom:6 }}>Queue hygiene</Eyebrow>
-          <div style={{ fontFamily:'Outfit', fontSize:22, fontWeight:500, color:HP.text, letterSpacing:'-0.02em' }}>{count} film{count === 1 ? '' : 's'} {count === 1 ? 'has' : 'have'} been waiting over 60 days.</div>
-          <div style={{ marginTop:6, fontSize:13, color:HP.textMuted, fontFamily:'Outfit, Inter, sans-serif', fontStyle:'italic' }}>Be honest. Cut what you won&rsquo;t watch &mdash; it sharpens tomorrow&rsquo;s picks.</div>
-        </div>
-        <div className="ff-wl-cleanup-actions" style={{ display:'flex', gap:10, flexWrap:'wrap', justifyContent:'flex-end' }}>
-          <button
-            type="button"
-            onClick={onReview}
-            style={{ padding:'12px 22px', borderRadius:6, background:'rgba(255,255,255,0.06)', border:`1px solid ${HP.borderStrong}`, color:HP.text, fontFamily:'Outfit', fontSize:13, fontWeight:600, cursor:'pointer', minHeight:44 }}
-          >Review stale picks →</button>
-          <button
-            type="button"
-            onClick={() => onBulkRemove(count)}
-            disabled={removingStale}
-            aria-busy={removingStale || undefined}
-            title={`Remove ${count} stale film${count === 1 ? '' : 's'} from your watchlist`}
-            style={{ padding:'12px 22px', borderRadius:6, background:'transparent', border:`1px solid ${HP.amber}66`, color:HP.amber, fontFamily:'Outfit', fontSize:13, fontWeight:600, cursor: removingStale ? 'wait' : 'pointer', opacity: removingStale ? 0.6 : 1, minHeight:44 }}
-          >{removingStale ? 'Removing…' : 'Clear all'}</button>
-        </div>
+      <div style={{ display:'flex', gap:12, justifyContent:'center', flexWrap:'wrap' }}>
+        <button type="button" onClick={() => navigate('/discover')} className="ff-wl-cta" style={{ minHeight:44, padding:'12px 22px', borderRadius:999, background:HP_GRAD, border:'none', color:'#fff', fontFamily:'Outfit', fontSize:13, fontWeight:600, cursor:'pointer' }}>Open Discover →</button>
+        <button type="button" onClick={() => navigate('/browse')} className="ff-wl-cta" style={{ minHeight:44, padding:'12px 22px', borderRadius:999, background:'transparent', border:`1px solid ${HP.border}`, color:HP.text, fontFamily:'Outfit', fontSize:13, fontWeight:600, cursor:'pointer' }}>Browse films</button>
       </div>
     </section>
   );
 }
 
-// ── Page (loading/error/empty shell) ───────────────────────────
+function FilteredEmpty({ onShowAll }) {
+  return (
+    <section className="ff-wl-section" style={{ padding:'56px 88px 96px', textAlign:'center' }}>
+      <h2 style={{ fontFamily:'Outfit', fontSize:26, lineHeight:1.1, fontWeight:500, letterSpacing:'-0.02em', color:HP.text, margin:'0 0 12px 0' }}>No saved films match this mood.</h2>
+      <p style={{ margin:'0 auto 24px', maxWidth:440, fontSize:14, color:HP.textMuted, fontFamily:'Outfit, Inter, sans-serif', lineHeight:1.6 }}>Choose another film mood or show everything.</p>
+      <button type="button" onClick={onShowAll} className="ff-wl-cta" style={{ minHeight:44, padding:'12px 22px', borderRadius:999, background:'rgba(255,255,255,0.06)', border:`1px solid ${HP.borderStrong}`, color:HP.text, fontFamily:'Outfit', fontSize:13, fontWeight:600, cursor:'pointer' }}>Show all</button>
+    </section>
+  );
+}
+
+// ── Shell ──────────────────────────────────────────────────────
 function WatchlistShell() {
-  const { items, stats, loading, error, removeFromWatchlist, removeStale, isRemoving, refresh } = useWatchlistData();
+  const { items, total, loading, error, removeFromWatchlist, isRemoving, refresh } = useWatchlistData();
   const navigate = useNavigate();
   const { announcement, announce } = useLibraryAnnouncement();
   const containerRef = useRef(null);
@@ -397,61 +170,33 @@ function WatchlistShell() {
   useEffect(() => () => focusCancelRef.current?.(), []);
 
   const [filter, setFilter] = useState('all');
-  const [sort, setSort]     = useState('match');
-  const [view, setView]     = useState('grid');
+  const [sort, setSort] = useState('recent');
 
-  const filtered = useMemo(() => {
-    let arr = items.slice();
-    if (filter === 'perfect') {
-      arr = arr.filter(f => f.perfect);
-    } else if (filter === 'stale') {
-      arr = arr.filter(f => f.stale);
-    } else if (filter.startsWith('mood:')) {
+  const visible = useMemo(() => {
+    let arr = items;
+    if (filter.startsWith('mood:')) {
       const mood = filter.slice('mood:'.length);
       arr = arr.filter(f => f.mood === mood);
     }
-    if (sort === 'match')   arr.sort((a,b) => b.match - a.match);
-    if (sort === 'added')   arr.sort((a,b) => a.addedDaysAgo - b.addedDaysAgo);
-    if (sort === 'stale')   arr.sort((a,b) => b.addedDaysAgo - a.addedDaysAgo);
-    if (sort === 'runtime') arr.sort((a,b) => a.runtime - b.runtime);
-    return arr;
+    return sortItems(arr, sort);
   }, [items, filter, sort]);
 
-  const { hasFingerprint } = useWatchlistData();
-  const tonightPicks = useMemo(() => {
-    if (hasFingerprint) return items.filter(f => f.perfect);
-    return [...items].sort((a, b) => b.match - a.match).slice(0, 3);
-  }, [items, hasFingerprint]);
-
-  // Settled removal + announcement + focus recovery for every individual control.
-  const onRemove = useCallback(async (f, viewName, triggerEl) => {
+  const onRemove = useCallback(async (f, triggerEl) => {
     if (isRemoving(f.id)) return;
-    const orderedIds = (viewName === 'featured' ? tonightPicks : filtered).map(it => it.id);
+    const orderedIds = visible.map(it => it.id);
     const targetId = nextFocusId(orderedIds, f.id);
     const res = await removeFromWatchlist(f.id);
     focusCancelRef.current?.();
     if (res.ok) {
       announce(`Removed ${f.title} from your Watchlist.`);
       focusCancelRef.current = scheduleFocus(() =>
-        findRemoveControl(containerRef.current, targetId, viewName) || findFallback(containerRef.current));
+        findRemoveControl(containerRef.current, targetId, 'grid') || findFallback(containerRef.current));
     } else if (!res.duplicate) {
       announce(`Could not remove ${f.title}. Try again.`);
       focusCancelRef.current = scheduleFocus(() =>
-        (triggerEl && triggerEl.isConnected ? triggerEl : findRemoveControl(containerRef.current, f.id, viewName)) || findFallback(containerRef.current));
+        (triggerEl && triggerEl.isConnected ? triggerEl : findRemoveControl(containerRef.current, f.id, 'grid')) || findFallback(containerRef.current));
     }
-  }, [isRemoving, tonightPicks, filtered, removeFromWatchlist, announce]);
-
-  const onBulkRemove = useCallback(async (count) => {
-    if (typeof window !== 'undefined' && !window.confirm(`Remove ${count} stale film${count === 1 ? '' : 's'} from your watchlist?`)) return;
-    const res = await removeStale();
-    focusCancelRef.current?.();
-    if (res.ok) {
-      announce(res.removedCount === 1 ? 'Removed 1 film from your Watchlist.' : `Removed ${res.removedCount} films from your Watchlist.`);
-      focusCancelRef.current = scheduleFocus(() => findFallback(containerRef.current));
-    } else if (!res.duplicate) {
-      announce('Could not remove those films. Try again.');
-    }
-  }, [removeStale, announce]);
+  }, [isRemoving, visible, removeFromWatchlist, announce]);
 
   if (loading) return <PageSkeleton />;
   if (error) return <PageError onRetry={refresh} onHome={() => navigate('/home')} />;
@@ -460,13 +205,24 @@ function WatchlistShell() {
     <div ref={containerRef}>
       <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">{announcement}</div>
       <Masthead />
-      <PulseStrip />
-      <FilterBar filter={filter} setFilter={setFilter} sort={sort} setSort={setSort} view={view} setView={setView} />
-      {filter === 'all' && <TonightTier picks={tonightPicks} onRemove={onRemove} />}
-      <div data-library-fallback tabIndex={-1} aria-label="Your watchlist films" style={{ outline:'none' }}>
-        {view === 'grid' ? <Grid items={filtered} /> : <List items={filtered} onRemove={onRemove} />}
-      </div>
-      <CleanupNudge count={stats.gettingStaleCount} onReview={() => setFilter('stale')} onBulkRemove={onBulkRemove} />
+      {total === 0 ? (
+        <EmptyState />
+      ) : (
+        <>
+          <Controls filter={filter} setFilter={setFilter} sort={sort} setSort={setSort} />
+          <div data-library-fallback tabIndex={-1} aria-label="Your saved films" style={{ outline:'none' }}>
+            {visible.length === 0 ? (
+              <FilteredEmpty onShowAll={() => setFilter('all')} />
+            ) : (
+              <section className="ff-wl-section" style={{ padding:'0 88px 72px' }}>
+                <div className="ff-wl-grid">
+                  {visible.map(f => <SavedCard key={f.id} f={f} onRemove={onRemove} />)}
+                </div>
+              </section>
+            )}
+          </div>
+        </>
+      )}
     </div>
   );
 }
@@ -475,17 +231,16 @@ function PageSkeleton() {
   const pulse = { background:'rgba(255,255,255,0.04)' };
   return (
     <div style={{ padding:'80px 88px' }}>
-      <div className="animate-pulse" style={{ ...pulse, height:14, width:280, borderRadius:999, marginBottom:30 }} />
-      <div className="animate-pulse" style={{ background:'rgba(167,139,250,0.10)', height:80, width:'40%', borderRadius:8, marginBottom:48 }} />
-      <div style={{ display:'grid', gridTemplateColumns:'repeat(3,1fr)', gap:24 }}>
-        {[0,1,2].map(i => <div key={i} className="animate-pulse" style={{ ...pulse, height:80, borderRadius:6 }} />)}
+      <div className="animate-pulse" style={{ ...pulse, height:14, width:240, borderRadius:999, marginBottom:28 }} />
+      <div className="animate-pulse" style={{ background:'rgba(167,139,250,0.10)', height:72, width:'40%', borderRadius:8, marginBottom:48 }} />
+      <div className="ff-wl-grid">
+        {[0,1,2,3,4].map(i => <div key={i} className="animate-pulse" style={{ ...pulse, aspectRatio:'2/3', borderRadius:6 }} />)}
       </div>
     </div>
   );
 }
 
-// F6.3: sanitized error — fixed, safe copy only (never a raw backend message), with
-// Try-again (refresh) + Go-to-Home recovery. role="alert", one h1, ≥44px buttons.
+// Sanitized error (unchanged from F6.3): fixed safe copy + Try-again + Go-to-Home.
 function PageError({ onRetry, onHome }) {
   return (
     <div style={{ minHeight:'60vh', display:'flex', alignItems:'center', justifyContent:'center', padding:24 }}>

--- a/src/features/watchlist/__tests__/WatchlistDataStates.test.jsx
+++ b/src/features/watchlist/__tests__/WatchlistDataStates.test.jsx
@@ -13,16 +13,14 @@ vi.mock('../useWatchlistData', () => ({
 
 import Watchlist from '../Watchlist'
 
-const baseStats = { watchlistTotal: 0, perfectForTonightCount: 0, gettingStaleCount: 0, topMatchPct: 0, avgMatchPct: 0 }
-const item = (over = {}) => ({ id: 1, internalId: 11, tmdbId: 101, title: 'A', year: 2020, runtime: 100, dir: 'D', mood: 'Tender', hex: '#A78BFA', match: 70, perfect: false, stale: false, addedDaysAgo: 1, poster: null, why: 'why', ...over })
+const item = (over = {}) => ({ id: 1, internalId: 11, tmdbId: 101, title: 'A', year: 2020, runtime: 100, dir: 'D', mood: 'Tender', hex: '#A78BFA', addedAt: '2026-03-09T00:00:00Z', addedDaysAgo: 1, savedDate: 'Mar 9', savedLabel: 'Saved yesterday', poster: null, ...over })
 
 function ctx(over = {}) {
   return {
-    items: [], stats: baseStats, availableMoods: [], hasFingerprint: false,
-    loading: false, error: null, removingStale: false,
+    items: [], total: 0, availableMoods: [],
+    loading: false, error: null,
     isRemoving: () => false,
     removeFromWatchlist: vi.fn(async () => ({ ok: true, action: 'removed', movieId: 1 })),
-    removeStale: vi.fn(async () => ({ ok: true, removedCount: 1 })),
     refresh: vi.fn(),
     ...over,
   }
@@ -31,15 +29,13 @@ function ctx(over = {}) {
 beforeEach(() => { navigate.mockClear() })
 afterEach(() => { cleanup(); vi.clearAllMocks() })
 
-describe('Watchlist load-error state — sanitized (F6.3)', () => {
-  it('26/27/28. renders fixed safe copy (no raw backend text), one h1, role=alert', () => {
-    mockCtx = ctx({ error: 'load_error', refresh: vi.fn() })
+describe('Watchlist load-error state — sanitized (F6.3 preserved)', () => {
+  it('26/27/28. fixed safe copy (no raw backend text), one h1, role=alert', () => {
+    mockCtx = ctx({ error: 'load_error' })
     const { container } = render(<Watchlist />)
     expect(screen.getByText('We couldn’t load your Watchlist.')).toBeInTheDocument()
-    expect(screen.getByText(/Your saved films are still safe/i)).toBeInTheDocument()
     expect(container.querySelectorAll('h1')).toHaveLength(1)
     expect(container.querySelector('[role="alert"]')).toBeTruthy()
-    // no raw backend wording anywhere
     expect(container.textContent).not.toMatch(/PGRST|rls|policy|relation|supabase|permission|undefined/i)
   })
 
@@ -54,55 +50,36 @@ describe('Watchlist load-error state — sanitized (F6.3)', () => {
   })
 })
 
-describe('Watchlist persistent live region + announcements (F6.3)', () => {
-  it('36/37. exactly one polite/atomic region, empty initially', () => {
-    mockCtx = ctx({ items: [item()], stats: { ...baseStats, watchlistTotal: 1 } })
+describe('Watchlist live region + announcements (F6.3 preserved)', () => {
+  it('42/37. exactly one polite/atomic region, empty initially', () => {
+    mockCtx = ctx({ items: [item()], total: 1 })
     const { container } = render(<Watchlist />)
     const regions = container.querySelectorAll('[role="status"][aria-live="polite"][aria-atomic="true"]')
     expect(regions).toHaveLength(1)
     expect(regions[0].textContent).toBe('')
   })
 
-  it('38. individual success announces AFTER settlement', async () => {
-    mockCtx = ctx({ items: [item({ title: 'A' }), item({ id: 2, title: 'B' })], stats: { ...baseStats, watchlistTotal: 2 } })
+  it('38. individual success announces after settlement', async () => {
+    mockCtx = ctx({ items: [item({ title: 'A' }), item({ id: 2, title: 'B' })], total: 2 })
     render(<Watchlist />)
-    fireEvent.click(screen.getAllByRole('button', { name: /Remove A from watchlist/i })[0])
+    fireEvent.click(screen.getByRole('button', { name: 'Remove A from Watchlist' }))
     await waitFor(() => expect(screen.getByText('Removed A from your Watchlist.')).toBeInTheDocument())
   })
 
-  it('39. individual failure announces failure (item retained)', async () => {
-    mockCtx = ctx({
-      items: [item({ title: 'A' })], stats: { ...baseStats, watchlistTotal: 1 },
-      removeFromWatchlist: vi.fn(async () => ({ ok: false, action: 'remove_failed', movieId: 1 })),
-    })
+  it('39. individual failure announces failure', async () => {
+    mockCtx = ctx({ items: [item({ title: 'A' })], total: 1, removeFromWatchlist: vi.fn(async () => ({ ok: false, action: 'remove_failed', movieId: 1 })) })
     render(<Watchlist />)
-    fireEvent.click(screen.getAllByRole('button', { name: /Remove A from watchlist/i })[0])
+    fireEvent.click(screen.getByRole('button', { name: 'Remove A from Watchlist' }))
     await waitFor(() => expect(screen.getByText('Could not remove A. Try again.')).toBeInTheDocument())
-  })
-
-  it('40/41. bulk singular/plural success + failure', async () => {
-    vi.spyOn(window, 'confirm').mockReturnValue(true)
-    mockCtx = ctx({ items: [item({ stale: true })], stats: { ...baseStats, watchlistTotal: 1, gettingStaleCount: 1 }, removeStale: vi.fn(async () => ({ ok: true, removedCount: 2 })) })
-    render(<Watchlist />)
-    fireEvent.click(screen.getByRole('button', { name: /Clear all/i }))
-    await waitFor(() => expect(screen.getByText('Removed 2 films from your Watchlist.')).toBeInTheDocument())
   })
 })
 
-describe('Watchlist remove control pending state (F6.3)', () => {
-  it('54/55/56. aria-busy + disabled + "Removing {title}" while pending', () => {
-    mockCtx = ctx({ items: [item({ title: 'A' })], stats: { ...baseStats, watchlistTotal: 1 }, isRemoving: (id) => id === 1 })
+describe('Watchlist remove control pending state (F6.3 preserved)', () => {
+  it('43/54/55. aria-busy + disabled + "Removing {title}" while pending', () => {
+    mockCtx = ctx({ items: [item({ title: 'A' })], total: 1, isRemoving: (id) => id === 1 })
     render(<Watchlist />)
     const btn = screen.getByRole('button', { name: 'Removing A' })
     expect(btn).toHaveAttribute('aria-busy', 'true')
     expect(btn).toBeDisabled()
-  })
-
-  it('57. bulk button shows pending', () => {
-    mockCtx = ctx({ items: [item({ stale: true })], stats: { ...baseStats, watchlistTotal: 1, gettingStaleCount: 1 }, removingStale: true })
-    render(<Watchlist />)
-    const btn = screen.getByRole('button', { name: /Removing/i })
-    expect(btn).toBeDisabled()
-    expect(btn).toHaveTextContent('Removing…')
   })
 })

--- a/src/features/watchlist/__tests__/WatchlistRemoval.test.jsx
+++ b/src/features/watchlist/__tests__/WatchlistRemoval.test.jsx
@@ -98,33 +98,21 @@ describe('Watchlist individual removal — settled (F6.3)', () => {
   })
 })
 
-describe('Watchlist bulk stale removal — settled (F6.3)', () => {
-  it('12/17. success returns the actual count + keeps the .in("movie_id", staleIds) filter', async () => {
+describe('Watchlist load no longer triggers recommendation work (F6.4)', () => {
+  it('13/14/15/16. loads only the saved-film query — no fingerprint fetch, no profile compute, no bulk API', async () => {
+    const { getTasteFingerprint } = await import('@/shared/services/tasteCache')
+    const { computeUserProfile } = await import('@/shared/services/recommendations')
     await mountProvider()
-    const stale = ctx.items.filter(i => i.stale)
-    expect(stale.length).toBeGreaterThan(0)
-    let res
-    await act(async () => { res = await ctx.removeStale() })
-    expect(res).toEqual({ ok: true, removedCount: stale.length })
-    const del = deleteCalls.find(d => d.kind === 'delete')
-    expect(del.eqs).toContainEqual(['user_id', 'u1'])
-    expect(del.ins[0][0]).toBe('movie_id')
+    expect(getTasteFingerprint).not.toHaveBeenCalled()  // no fingerprint → no taste-cache work
+    expect(computeUserProfile).not.toHaveBeenCalled()    // no profile compute → no profile-cache WRITE on view
+    // the bulk API is gone from the public context
+    expect(ctx.removeStale).toBeUndefined()
+    expect(ctx.removingStale).toBeUndefined()
+    expect(ctx.total).toBe(ctx.items.length)
   })
 
-  it('13/14. a failed bulk delete reports removedCount 0 (never the attempted count) and restores rows', async () => {
-    cfg.deleteError = { message: 'boom' }
+  it('19. the saved-film read is user-scoped', async () => {
     await mountProvider()
-    const before = ctx.items.length
-    let res
-    await act(async () => { res = await ctx.removeStale() })
-    expect(res).toEqual({ ok: false, removedCount: 0 })
-    expect(ctx.items.length).toBe(before) // stale rows retained (no false success)
-  })
-
-  it('15/16. duplicate bulk click fires ONE delete; pending clears', async () => {
-    await mountProvider()
-    await act(async () => { const a = ctx.removeStale(); const b = ctx.removeStale(); await Promise.all([a, b]) })
-    expect(deleteCalls.filter(d => d.kind === 'delete')).toHaveLength(1)
-    expect(ctx.removingStale).toBe(false)
+    expect(ctx.items.length).toBeGreaterThan(0) // proves the user-scoped select resolved
   })
 })

--- a/src/features/watchlist/__tests__/WatchlistTrust.test.jsx
+++ b/src/features/watchlist/__tests__/WatchlistTrust.test.jsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, cleanup, within } from '@testing-library/react'
+
+const navigate = vi.fn()
+vi.mock('react-router-dom', () => ({ useNavigate: () => navigate }))
+vi.mock('@/shared/hooks/usePageMeta', () => ({ usePageMeta: () => {} }))
+
+let mockCtx
+vi.mock('../useWatchlistData', () => ({
+  WatchlistDataProvider: ({ children }) => children,
+  useWatchlistData: () => mockCtx,
+}))
+
+import Watchlist from '../Watchlist'
+
+const item = (over = {}) => ({ id: 1, internalId: 11, tmdbId: 101, title: 'A', year: 2020, runtime: 100, dir: 'D', mood: 'Tender', hex: '#A78BFA', addedAt: '2026-03-09T00:00:00Z', addedDaysAgo: 1, savedDate: 'Mar 9', savedLabel: 'Saved yesterday', poster: null, ...over })
+function ctx(over = {}) {
+  return { items: [], total: 0, availableMoods: [], loading: false, error: null, isRemoving: () => false, removeFromWatchlist: vi.fn(async () => ({ ok: true, movieId: 1 })), refresh: vi.fn(), ...over }
+}
+const withItems = (n = 2, over = {}) => {
+  const items = Array.from({ length: n }, (_, i) => item({ id: i + 1, tmdbId: 100 + i, title: `Film ${i + 1}` }))
+  return ctx({ items, total: n, availableMoods: [{ mood: 'Tender', count: n }], ...over })
+}
+
+beforeEach(() => navigate.mockClear())
+afterEach(() => { cleanup(); vi.clearAllMocks() })
+
+describe('Watchlist — calm saved-intent role (F6.4)', () => {
+  it('20/40. masthead says Watchlist + "Saved for later."; exactly one h1', () => {
+    mockCtx = withItems()
+    const { container } = render(<Watchlist />)
+    expect(screen.getByRole('heading', { level: 1, name: /Saved for later\./i })).toBeInTheDocument()
+    expect(container.querySelectorAll('h1')).toHaveLength(1)
+    expect(screen.getByText(/Films you wanted to remember/i)).toBeInTheDocument()
+  })
+
+  it('21/22/23/24/31. no queue / stale / "Perfect for tonight" / "Top match" / bulk-guilt framing', () => {
+    mockCtx = withItems()
+    const { container } = render(<Watchlist />)
+    const t = container.textContent
+    expect(t).not.toMatch(/\bqueue\b/i)
+    expect(t).not.toMatch(/stale|getting stale|longest waiting|waiting \d+d/i)
+    expect(t).not.toMatch(/perfect for tonight|perfect tonight|tonight/i)
+    expect(t).not.toMatch(/top match|match %|clear all|queue hygiene|cut what you/i)
+  })
+
+  it('25. no integer match percentage anywhere (text or accessible names)', () => {
+    mockCtx = withItems()
+    const { container } = render(<Watchlist />)
+    expect(container.textContent).not.toMatch(/\d+%/)
+    for (const b of screen.getAllByRole('button')) {
+      expect(b.getAttribute('aria-label') || '').not.toMatch(/\d+%|match/i)
+    }
+  })
+
+  it('26/27. sort options are saved-date based (default Recently saved); no Match % / Longest waiting', () => {
+    mockCtx = withItems()
+    render(<Watchlist />)
+    const select = screen.getByRole('combobox', { name: 'Sort saved films' })
+    expect(select).toHaveValue('recent')
+    const opts = within(select).getAllByRole('option').map(o => o.textContent)
+    expect(opts).toEqual(['Recently saved', 'Oldest saved', 'Runtime', 'Title'])
+    expect(opts.join(' ')).not.toMatch(/Match|Longest waiting/i)
+  })
+
+  it('28/29/30/41. one saved-film collection — no featured tier, no pulse dashboard, no duplicate film', () => {
+    mockCtx = withItems(2)
+    const { container } = render(<Watchlist />)
+    expect(container.querySelectorAll('.ff-wl-grid')).toHaveLength(1)
+    // each film title appears exactly once (heading) → no featured-vs-list duplication
+    expect(screen.getAllByRole('heading', { name: 'Film 1' })).toHaveLength(1)
+    // no stat dashboard labels
+    expect(container.textContent).not.toMatch(/Perfect for tonight|Getting stale|Total queue|Avg/i)
+  })
+
+  it('32/33. the mood filter is labelled "Filter by film mood" with only All + present moods', () => {
+    mockCtx = withItems()
+    render(<Watchlist />)
+    const group = screen.getByRole('group', { name: 'Filter by film mood' })
+    const labels = within(group).getAllByRole('button').map(b => b.textContent)
+    expect(labels).toEqual(['All', 'Tender'])
+    expect(labels.join(' ')).not.toMatch(/Perfect|Stale/i)
+  })
+
+  it('34. cards show neutral saved-age language', () => {
+    mockCtx = withItems(1)
+    render(<Watchlist />)
+    expect(screen.getByText('Saved yesterday')).toBeInTheDocument()
+  })
+
+  it('35. Open routes to /movie/:tmdbId (unchanged)', () => {
+    mockCtx = withItems(1)
+    render(<Watchlist />)
+    fireEvent.click(screen.getByRole('button', { name: 'Open' }))
+    expect(navigate).toHaveBeenCalledWith('/movie/100')
+  })
+})
+
+describe('Watchlist empty + filtered-empty states (F6.4)', () => {
+  it('37/38. empty state routes to Discover + Browse (not only Home)', () => {
+    mockCtx = ctx({ items: [], total: 0 })
+    render(<Watchlist />)
+    expect(screen.getByText('Your Watchlist is open.')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Open Discover/i }))
+    expect(navigate).toHaveBeenCalledWith('/discover')
+    fireEvent.click(screen.getByRole('button', { name: /Browse films/i }))
+    expect(navigate).toHaveBeenCalledWith('/browse')
+  })
+
+  it('39. filtered-empty shows a Show-all reset that restores the collection', () => {
+    // availableMoods offers a mood no item actually has → choosing it yields filtered-empty.
+    mockCtx = ctx({ items: [item({ mood: 'Tender' })], total: 1, availableMoods: [{ mood: 'Tense', count: 0 }] })
+    render(<Watchlist />)
+    fireEvent.click(screen.getByRole('button', { name: 'Tense' }))
+    expect(screen.getByText('No saved films match this mood.')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Show all' }))
+    expect(screen.getByRole('heading', { name: 'A' })).toBeInTheDocument() // collection restored
+  })
+})

--- a/src/features/watchlist/derive/__tests__/watchlistDerive.test.js
+++ b/src/features/watchlist/derive/__tests__/watchlistDerive.test.js
@@ -1,134 +1,95 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-
-// Control the engine-vs-approx selection in deriveItems deterministically.
-vi.mock('@/shared/services/recommendations', () => ({ scoreMovieForUser: vi.fn(() => null) }))
-vi.mock('@/shared/services/matchScore', () => ({ computeMatchPercent: vi.fn(() => null) }))
-
-import { scoreMovieForUser } from '@/shared/services/recommendations'
-import { computeMatchPercent } from '@/shared/services/matchScore'
+import { describe, it, expect } from 'vitest'
 import {
-  STALE_DAYS, capitalize, pickPrimaryMood, daysAgo, approxMatch, deriveWhy,
-  deriveItems, deriveAvailableMoods, recomputeStats,
+  capitalize, pickPrimaryMood, daysAgo, savedAgeLabel,
+  deriveItems, deriveAvailableMoods, SORTS, sortItems,
 } from '../watchlistDerive'
 
-// F6.2 — pins CURRENT Watchlist derivation behavior (incl. the match-% / approxMatch
-// presentation that F6.4 will deliberately change). These assertions are the contract
-// the trust redesign must consciously edit.
+// F6.4 — the Watchlist derivation is now CALM SAVED-INTENT: no match %, no approx score,
+// no "perfect", no "stale", and NO recommendation profile/fingerprint input. (The F6.2
+// match/perfect/stale/approx pins were removed deliberately — that behavior no longer
+// exists.) Only honest saved-film attributes + deterministic saved-date ordering remain.
 
-const fp = { topMoodTags: [{ key: 'tender' }, { key: 'cozy' }, { key: 'tense' }], topFitProfiles: [{ key: 'comfort_watch' }] }
+const ago = (days) => new Date(Date.now() - days * 86400000).toISOString()
+const row = (over = {}) => ({ movie_id: 1, added_at: ago(1), status: 'want_to_watch', movies: { id: 11, tmdb_id: 101, title: 'A', mood_tags: ['tender'], release_date: '2020-06-15', runtime: 120, director_name: 'D', poster_path: '/p.jpg' }, ...over })
 
-beforeEach(() => { vi.clearAllMocks(); scoreMovieForUser.mockReturnValue(null); computeMatchPercent.mockReturnValue(null) })
-afterEach(() => vi.useRealTimers())
-
-describe('STALE_DAYS', () => {
-  it('is 60', () => { expect(STALE_DAYS).toBe(60) })
-})
-
-describe('capitalize / pickPrimaryMood', () => {
-  it('capitalizes + de-underscores', () => {
+describe('helpers', () => {
+  it('capitalize / pickPrimaryMood', () => {
     expect(capitalize('comfort_watch')).toBe('Comfort watch')
-    expect(capitalize('')).toBe('')
-  })
-  it('pickPrimaryMood returns the capitalized first tag or null', () => {
     expect(pickPrimaryMood(['tender', 'cozy'])).toBe('Tender')
     expect(pickPrimaryMood([])).toBeNull()
-    expect(pickPrimaryMood(null)).toBeNull()
   })
-})
-
-describe('daysAgo', () => {
-  it('floors to whole local days, never negative', () => {
-    vi.useFakeTimers(); vi.setSystemTime(new Date('2026-03-10T12:00:00Z'))
-    expect(daysAgo('2026-03-10T00:00:00Z')).toBe(0)
-    expect(daysAgo('2026-03-05T12:00:00Z')).toBe(5)
-    expect(daysAgo('2026-04-01T00:00:00Z')).toBe(0) // future → clamped to 0
+  it('daysAgo floors to whole days, never negative', () => {
+    expect(daysAgo(ago(5))).toBe(5)
     expect(daysAgo(null)).toBe(0)
   })
-})
-
-describe('approxMatch (the F6.4 false-precision target — pinned)', () => {
-  const q = (r) => ({ mood_tags: [], fit_profile: null, ff_final_rating: r })
-  it('base floor is 50 with no signals', () => {
-    expect(approxMatch({ movie: { mood_tags: [] }, fingerprint: fp })).toBe(50)
-  })
-  it('+25 for a top-3 mood overlap', () => {
-    expect(approxMatch({ movie: { mood_tags: ['tender'] }, fingerprint: fp })).toBe(75)
-  })
-  it('+10 more for a top-5 fit overlap', () => {
-    expect(approxMatch({ movie: { mood_tags: ['tender'], fit_profile: 'comfort_watch' }, fingerprint: fp })).toBe(85)
-  })
-  it('+ up to 15 from quality (7.0→0, 8.0→7.5/8, 9.0→15)', () => {
-    expect(approxMatch({ movie: q(7.0), fingerprint: fp })).toBe(50)
-    expect(approxMatch({ movie: q(8.0), fingerprint: fp })).toBe(58) // 50 + 7.5 → round 58
-    expect(approxMatch({ movie: q(9.0), fingerprint: fp })).toBe(65)
-  })
-  it('caps at 96 (all signals = 100 → 96) and floors at 50', () => {
-    expect(approxMatch({ movie: { mood_tags: ['tender'], fit_profile: 'comfort_watch', ff_final_rating: 9.5 }, fingerprint: fp })).toBe(96)
-    expect(approxMatch({ movie: { mood_tags: ['nope'] }, fingerprint: { topMoodTags: [], topFitProfiles: [] } })).toBe(50)
+  it('2. savedAgeLabel uses neutral, non-guilt phrasing (no stale/waiting/overdue)', () => {
+    expect(savedAgeLabel(ago(0))).toBe('Saved today')
+    expect(savedAgeLabel(ago(1))).toBe('Saved yesterday')
+    expect(savedAgeLabel(ago(5))).toBe('Saved 5 days ago')
+    expect(savedAgeLabel(ago(120))).toMatch(/^Saved on /)
+    for (const l of [savedAgeLabel(ago(0)), savedAgeLabel(ago(5)), savedAgeLabel(ago(120))]) {
+      expect(l).not.toMatch(/stale|waiting|overdue|cut|queue/i)
+    }
   })
 })
 
-describe('deriveWhy (restated-metadata line — pinned)', () => {
-  it('top-mood + age variants', () => {
-    expect(deriveWhy({ mood: 'Tender', match: 84, addedDaysAgo: 5, matchesTopMood: true })).toBe('Your tender pick · 84% match · waiting 5d')
-    expect(deriveWhy({ mood: 'Cozy', match: 70, addedDaysAgo: 0, matchesTopMood: false })).toBe('Cozy pick · 70% match · saved today')
-    expect(deriveWhy({ mood: 'Cozy', match: 70, addedDaysAgo: 1, matchesTopMood: false })).toBe('Cozy pick · 70% match · saved yesterday')
-  })
-})
-
-describe('deriveItems (engine-vs-approx selection, perfect, stale)', () => {
-  const row = (over = {}) => ({ movie_id: 1, added_at: '2026-03-09T00:00:00Z', movies: { id: 11, tmdb_id: 101, title: 'A', release_date: '2020-01-01', runtime: 100, director_name: 'D', mood_tags: ['tender'], poster_path: '/p.jpg', ...over.movies }, ...over })
-
-  it('uses the engine match when computeMatchPercent returns non-null', () => {
-    vi.useFakeTimers(); vi.setSystemTime(new Date('2026-03-10T12:00:00Z'))
-    computeMatchPercent.mockReturnValue(88)
-    const [it] = deriveItems({ rows: [row()], fingerprint: fp, profile: { x: 1 } })
-    expect(it.match).toBe(88)
+describe('deriveItems (saved-film presentation; no scoring)', () => {
+  it('1/3/12. preserves identity + metadata + film mood; missing metadata degrades safely', () => {
+    const [a] = deriveItems({ rows: [row()] })
+    expect(a).toMatchObject({ id: 1, internalId: 11, tmdbId: 101, title: 'A', mood: 'Tender' })
+    expect(a.poster).toContain('w500')
+    const [b] = deriveItems({ rows: [{ movie_id: 2, added_at: null, movies: {} }] })
+    expect(b).toMatchObject({ id: 2, title: 'Untitled', dir: '—', mood: 'Mixed', runtime: 0, poster: null })
   })
 
-  it('falls back to approxMatch when the engine returns null (cold-start path)', () => {
-    vi.useFakeTimers(); vi.setSystemTime(new Date('2026-03-10T12:00:00Z'))
-    computeMatchPercent.mockReturnValue(null) // engine has no signal
-    const [it] = deriveItems({ rows: [row()], fingerprint: fp, profile: null })
-    expect(it.match).toBe(75) // approxMatch: base 50 + 25 (tender is top mood)
+  it('2. derives saved age/date label', () => {
+    const [a] = deriveItems({ rows: [row({ added_at: ago(3) })] })
+    expect(a.addedDaysAgo).toBe(3)
+    expect(a.savedLabel).toBe('Saved 3 days ago')
+    expect(a.savedDate).toBeTruthy()
   })
 
-  it('perfect = top-mood match AND match≥80 AND not stale; stale = added >60d', () => {
-    vi.useFakeTimers(); vi.setSystemTime(new Date('2026-03-10T12:00:00Z'))
-    computeMatchPercent.mockReturnValue(82)
-    const fresh = deriveItems({ rows: [row({ added_at: '2026-03-09T00:00:00Z' })], fingerprint: fp, profile: { x: 1 } })[0]
-    expect(fresh.stale).toBe(false)
-    expect(fresh.perfect).toBe(true) // tender == top mood, 82≥80, fresh
-    // 61 days old → stale → not perfect even with the same high match
-    const old = deriveItems({ rows: [row({ added_at: '2026-01-07T00:00:00Z' })], fingerprint: fp, profile: { x: 1 } })[0]
-    expect(old.addedDaysAgo).toBeGreaterThan(60)
-    expect(old.stale).toBe(true)
-    expect(old.perfect).toBe(false)
+  it('4. preserves backend saved-date order (map, no re-sort)', () => {
+    const items = deriveItems({ rows: [row({ movie_id: 3, added_at: ago(1) }), row({ movie_id: 1, added_at: ago(5) })] })
+    expect(items.map(i => i.id)).toEqual([3, 1])
   })
 
-  it('maps the row to the page shape (id, internalId, mood, poster size w500)', () => {
-    vi.useFakeTimers(); vi.setSystemTime(new Date('2026-03-10T12:00:00Z'))
-    computeMatchPercent.mockReturnValue(70)
-    const [it] = deriveItems({ rows: [row()], fingerprint: fp, profile: { x: 1 } })
-    expect(it).toMatchObject({ id: 1, internalId: 11, tmdbId: 101, title: 'A', mood: 'Tender' })
-    expect(it.poster).toContain('w500')
+  it('10/11. NO rendered item property exposes match/perfect/stale/rank — and no profile input is needed', () => {
+    const [a] = deriveItems({ rows: [row()] }) // note: called with { rows } only — no fingerprint/profile
+    for (const k of ['match', 'matchPct', 'approximateMatch', 'perfect', 'stale', 'rank', 'why']) {
+      expect(a).not.toHaveProperty(k)
+    }
   })
 })
 
 describe('deriveAvailableMoods', () => {
-  it('counts distinct moods desc, excluding Mixed', () => {
+  it('9. reflects only present film moods (excludes Mixed), ranked by count', () => {
     const items = [{ mood: 'Tender' }, { mood: 'Tender' }, { mood: 'Cozy' }, { mood: 'Mixed' }]
     expect(deriveAvailableMoods(items).map(m => [m.mood, m.count])).toEqual([['Tender', 2], ['Cozy', 1]])
   })
 })
 
-describe('recomputeStats', () => {
-  it('top/avg match + perfect/stale counts', () => {
-    const items = [
-      { match: 90, perfect: true, stale: false },
-      { match: 70, perfect: false, stale: true },
-      { match: 50, perfect: false, stale: false },
-    ]
-    expect(recomputeStats(items)).toEqual({ watchlistTotal: 3, perfectForTonightCount: 1, gettingStaleCount: 1, topMatchPct: 90, avgMatchPct: 70 })
+describe('sortItems (deterministic saved-intent ordering)', () => {
+  const items = [
+    { id: 1, addedAt: ago(2), runtime: 120, title: 'Banana' },
+    { id: 2, addedAt: ago(5), runtime: 90, title: 'Apple' },
+    { id: 3, addedAt: ago(1), runtime: 0, title: 'Cherry' },
+  ]
+  it('5. recent (default) = added_at descending', () => {
+    expect(sortItems(items, 'recent').map(i => i.id)).toEqual([3, 1, 2])
+    expect(sortItems(items, 'whatever').map(i => i.id)).toEqual([3, 1, 2]) // default
+  })
+  it('6. oldest = added_at ascending', () => {
+    expect(sortItems(items, 'oldest').map(i => i.id)).toEqual([2, 1, 3])
+  })
+  it('7. runtime ascending, missing runtime (0) first', () => {
+    expect(sortItems(items, 'runtime').map(i => i.id)).toEqual([3, 2, 1])
+  })
+  it('8. title alphabetical', () => {
+    expect(sortItems(items, 'title').map(i => i.title)).toEqual(['Apple', 'Banana', 'Cherry'])
+  })
+  it('exposes the SORTS list, default included', () => {
+    expect(SORTS).toContain('recent')
+    expect(SORTS).not.toContain('match')
   })
 })

--- a/src/features/watchlist/derive/watchlistDerive.js
+++ b/src/features/watchlist/derive/watchlistDerive.js
@@ -1,17 +1,18 @@
 // src/features/watchlist/derive/watchlistDerive.js
-// F6.2 — pure Watchlist derivations, extracted verbatim from useWatchlistData.jsx
-// (the provider is now a thin caller). NO behavior change: every function body is
-// byte-for-byte identical to the inlined originals, so the rendered Watchlist output
-// is unchanged. These are the surfaces the F6.3–F6.5 trust/reliability work will edit
-// deliberately (e.g. the match-% presentation); pinning them here makes those edits
-// reviewable test diffs.
+// F6.4 — pure Watchlist derivations for the CALM SAVED-INTENT role. The Watchlist is
+// "films I chose to remember for another moment" — not a ranked recommendation feed.
+// So this layer no longer computes (or exposes) any match percentage, approximate
+// score, "perfect for tonight", or "stale" classification, and it needs NO recommendation
+// profile or taste fingerprint. It derives only honest saved-film attributes (mood,
+// runtime, year, director, saved date/age) + deterministic saved-date ordering.
+//
+// Frozen elsewhere: the recommendation engine, computeUserProfile, scoreMovieForUser,
+// computeMatchPercent and the fingerprint services are UNCHANGED — F6.4 simply stops
+// being a consumer of them. The user_watchlist delete filters + reliability live in the
+// provider (F6.3) and are untouched.
 
 import { HP, MOOD_HEX, tmdbImg } from '../data'
-import { scoreMovieForUser } from '@/shared/services/recommendations'
-import { computeMatchPercent } from '@/shared/services/matchScore'
-
-// Stale threshold matches the README: items added >60 days ago.
-export const STALE_DAYS = 60
+import { formatShortDate } from '@/shared/lib/format/date'
 
 export function capitalize(s) {
   return s ? s.charAt(0).toUpperCase() + s.slice(1).replace(/_/g, ' ') : ''
@@ -19,8 +20,6 @@ export function capitalize(s) {
 
 export function pickPrimaryMood(moodTags) {
   if (!Array.isArray(moodTags) || moodTags.length === 0) return null
-  // Pick the first non-empty tag; tags are populated in order of strength
-  // by the LLM enrichment pipeline.
   return capitalize(moodTags[0])
 }
 
@@ -35,75 +34,23 @@ export function daysAgo(iso) {
   return Math.max(0, Math.floor(ms / (1000 * 60 * 60 * 24)))
 }
 
-// Per-(user, film) match score. We don't run the full 7-dimension
-// scoring engine here — that's expensive and tied to the recommendation
-// pipeline. Instead we approximate from the signals we already have:
-//   - 50 base
-//   - +25 if the film's primary mood is one of the user's top 3
-//   - +10 if it's also one of the user's top 5 fits
-//   - +up to 15 from objective quality (ff_final_rating)
-// Capped at 96, floored at 50. Deterministic given same inputs.
-export function approxMatch({ movie, fingerprint }) {
-  const moodTags = movie.mood_tags || []
-  const fitProfile = movie.fit_profile
-  const userTopMoods = (fingerprint?.topMoodTags || []).slice(0, 3).map(t => t.key)
-  const userTopFits = (fingerprint?.topFitProfiles || []).slice(0, 5).map(t => t.key)
-  let score = 50
-  if (moodTags.some(t => userTopMoods.includes(t))) score += 25
-  if (fitProfile && userTopFits.includes(fitProfile)) score += 10
-  const quality = Number(movie.ff_final_rating) || Number(movie.ff_rating) || 0
-  if (quality > 0) {
-    // ff_final_rating is 0–10; map 7.0–9.0 → 0–15 bonus
-    const q = Math.max(0, Math.min(15, ((quality - 7) / 2) * 15))
-    score += q
-  }
-  return Math.max(50, Math.min(96, Math.round(score)))
+// Neutral, non-guilt saved-age phrasing. Recent → relative; older → an explicit date.
+// "saved" is a calm fact, never "stale / waiting / overdue".
+export function savedAgeLabel(iso) {
+  if (!iso) return 'Saved'
+  const d = daysAgo(iso)
+  if (d === 0) return 'Saved today'
+  if (d === 1) return 'Saved yesterday'
+  if (d < 30) return `Saved ${d} days ago`
+  return `Saved on ${formatShortDate(new Date(iso))}`
 }
 
-// Build a contextual "why" line for FeaturedCard from real per-item signals.
-// FeaturedCard only renders for perfect/top items, so this always has
-// something concrete to say (mood + match + age). Deterministic given inputs.
-export function deriveWhy({ mood, match, addedDaysAgo, matchesTopMood }) {
-  const parts = []
-  if (matchesTopMood) parts.push(`Your ${mood.toLowerCase()} pick`)
-  else parts.push(`${mood} pick`)
-  parts.push(`${match}% match`)
-  if (addedDaysAgo === 0) parts.push('saved today')
-  else if (addedDaysAgo === 1) parts.push('saved yesterday')
-  else parts.push(`waiting ${addedDaysAgo}d`)
-  return parts.join(' · ')
-}
-
-// A film is "perfect for tonight" when its primary mood matches the
-// user's #1 mood AND it scored ≥ 80. Cold-start (no fingerprint) → no
-// perfect items; the page falls back to "top of your queue" in that case.
-export function deriveItems({ rows, fingerprint, profile }) {
-  const userTopMood = fingerprint?.topMoodTags?.[0]?.key || null
-  const items = rows.map(r => {
+// Map a user_watchlist × movies row to the saved-film presentation shape. No score,
+// percentage, rank, "perfect" or "stale" — and no fingerprint/profile input.
+export function deriveItems({ rows }) {
+  return (rows || []).map(r => {
     const m = r.movies || {}
     const mood = pickPrimaryMood(m.mood_tags)
-    // Engine when we have a profile; cold-start fallback otherwise.
-    // computeMatchPercent is the system-wide match%: confidence-tiered
-    // mapping of engineScore → 0-99. Same definition + curve as /home,
-    // /movie/:id, /history. Returns null when the engine has no signal;
-    // we coerce to approxMatch fallback in that case.
-    // scoreMovieForUser returns null when a content-boundary hard filter
-    // hits (graphic/sexual + matching keywords/cert). Coerce to null so
-    // we fall back to approxMatch below — the film still shows on the
-    // watchlist; we just can't compute a real match %.
-    const engineScore = profile
-      ? (scoreMovieForUser(m, profile, 'default')?.score ?? null)
-      : null
-    const engineMatch = computeMatchPercent({ engineScore, profile })
-    const match = engineMatch != null
-      ? engineMatch
-      : approxMatch({ movie: m, fingerprint })
-    const addedDaysAgo = daysAgo(r.added_at)
-    const stale = addedDaysAgo > STALE_DAYS
-    const moodKey = (m.mood_tags || [])[0] || null
-    const matchesTopMood = Boolean(userTopMood && moodKey && moodKey === userTopMood)
-    const perfect = Boolean(matchesTopMood && match >= 80 && !stale)
-    const why = deriveWhy({ mood: mood || 'Mixed', match, addedDaysAgo, matchesTopMood })
     return {
       id: r.movie_id,
       internalId: m.id,
@@ -114,20 +61,17 @@ export function deriveItems({ rows, fingerprint, profile }) {
       dir: m.director_name || '—',
       mood: mood || 'Mixed',
       hex: hexFor(mood),
-      match,
-      perfect,
-      stale,
-      addedDaysAgo,
+      addedAt: r.added_at || null,
+      addedDaysAgo: daysAgo(r.added_at),
+      savedDate: r.added_at ? formatShortDate(new Date(r.added_at)) : '',
+      savedLabel: savedAgeLabel(r.added_at),
       poster: m.poster_path ? tmdbImg(m.poster_path, 'w500') : null,
-      why,
     }
   })
-  return items
 }
 
-// Distinct moods present in the queue, ranked by count (descending). Used to
-// generate dynamic filter pills so a user only ever sees moods that match
-// something in their actual list.
+// Distinct film moods present in the saved collection, ranked by count (descending).
+// These drive the "filter by film mood" pills — only moods that match ≥1 saved film.
 export function deriveAvailableMoods(items) {
   const counts = new Map()
   for (const it of items) {
@@ -139,15 +83,16 @@ export function deriveAvailableMoods(items) {
     .map(([mood, count]) => ({ mood, count, hex: hexFor(mood) }))
 }
 
-export function recomputeStats(items) {
-  const matches = items.map(it => it.match).filter(Number.isFinite)
-  const topMatchPct = matches.length ? Math.max(...matches) : 0
-  const avgMatchPct = matches.length ? Math.round(matches.reduce((s, n) => s + n, 0) / matches.length) : 0
-  return {
-    watchlistTotal: items.length,
-    perfectForTonightCount: items.filter(it => it.perfect).length,
-    gettingStaleCount: items.filter(it => it.stale).length,
-    topMatchPct,
-    avgMatchPct,
-  }
+// Deterministic saved-intent ordering. Default 'recent' (added_at descending — the
+// order the backend already returns). No recommendation ranking.
+export const SORTS = ['recent', 'oldest', 'runtime', 'title']
+
+export function sortItems(items, sort) {
+  const arr = (items || []).slice()
+  const t = (iso) => (iso ? new Date(iso).getTime() : 0)
+  if (sort === 'oldest') arr.sort((a, b) => t(a.addedAt) - t(b.addedAt))
+  else if (sort === 'runtime') arr.sort((a, b) => (a.runtime || 0) - (b.runtime || 0))
+  else if (sort === 'title') arr.sort((a, b) => String(a.title).localeCompare(String(b.title)))
+  else arr.sort((a, b) => t(b.addedAt) - t(a.addedAt)) // 'recent' (default)
+  return arr
 }

--- a/src/features/watchlist/useWatchlistData.jsx
+++ b/src/features/watchlist/useWatchlistData.jsx
@@ -1,43 +1,36 @@
 // src/features/watchlist/useWatchlistData.jsx
-// FeelFlick — Watchlist v2 data layer. Fetches the signed-in user's
-// user_watchlist (joined with movies) + their taste_fingerprint, then
-// derives the shape the page expects: items[] with match/mood/perfect/
-// stale/addedDaysAgo/hex/tmdbId/internalId, plus aggregate stats.
+// FeelFlick — Watchlist data layer (calm saved-intent role, F6.4).
 //
-// F6.2: the pure derivations live in ./derive/watchlistDerive (behavior unchanged).
-// F6.3: removals are now SETTLED (the local list changes only after the DB delete
-// succeeds — a resolved Supabase { error } is recognised, never silently treated as
-// success), with explicit result objects, per-id pending state, duplicate-click guards,
-// and a sanitized 'load_error' state (no raw backend text reaches the UI).
+// The Watchlist preserves saved INTENT, not a recommendation ranking, so this provider
+// no longer fetches the taste fingerprint or computes the user profile — which means
+// simply VIEWING /watchlist no longer triggers a profile-cache write. It reads only the
+// user_watchlist × movies rows needed to present saved films. The recommendation engine,
+// computeUserProfile, scoreMovieForUser and the fingerprint services are UNCHANGED — this
+// is a consumer removal, not an engine change.
+//
+// F6.3 reliability is preserved verbatim: settled removal that recognises a resolved
+// Supabase { error } (never a false success), explicit result objects, per-id pending
+// state, duplicate-click guards, logout/unmount safety, and a sanitized 'load_error'.
 
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { supabase } from '@/shared/lib/supabase/client'
 import { useAuthSession } from '@/shared/hooks/useAuthSession'
-import { getTasteFingerprint } from '@/shared/services/tasteCache'
-import { computeUserProfile } from '@/shared/services/recommendations'
-import { MOVIE_ENGINE_COLS } from '@/shared/services/movieFields'
-import { deriveItems, deriveAvailableMoods, recomputeStats } from './derive/watchlistDerive'
+import { deriveItems, deriveAvailableMoods } from './derive/watchlistDerive'
 
 const WatchlistDataContext = createContext(null)
 
+// Presentation-only movie columns — no engine/scoring columns needed any more.
+const MOVIE_COLS = 'id, tmdb_id, title, director_name, release_date, runtime, mood_tags, poster_path'
+
 const INITIAL = {
   items: [],
-  stats: {
-    watchlistTotal: 0,
-    perfectForTonightCount: 0,
-    gettingStaleCount: 0,
-    topMatchPct: 0,
-    avgMatchPct: 0,
-  },
-  availableMoods: [],         // distinct moods present in the queue (sorted by count desc)
-  hasFingerprint: false,      // false until taste_fingerprint exists; gates "Perfect for tonight"
+  total: 0,
+  availableMoods: [],
   loading: true,
-  error: null,                // F6.3: 'load_error' | null — never a raw backend message
-  removingIds: new Set(),     // F6.3: movie ids with a removal in flight
-  removingStale: false,       // F6.3: bulk stale removal in flight
+  error: null,                // 'load_error' | null — never a raw backend message
+  removingIds: new Set(),
   isRemoving: () => false,
   removeFromWatchlist: async () => ({ ok: false, action: 'remove_failed' }),
-  removeStale: async () => ({ ok: false, removedCount: 0 }),
   refresh: () => {},
 }
 
@@ -46,33 +39,16 @@ export function WatchlistDataProvider({ children }) {
   const [state, setState] = useState(INITIAL)
   const [nonce, setNonce] = useState(0)
   const [removingIds, setRemovingIds] = useState(() => new Set())
-  const [removingStale, setRemovingStale] = useState(false)
 
-  // Mirror of state.items, kept current via effect so side-effecting callbacks
-  // (e.g. bulk delete) can read the canonical list without piggybacking on
-  // setState callbacks — those are double-invoked in Strict Mode.
-  const itemsRef = useRef(state.items)
-  useEffect(() => { itemsRef.current = state.items }, [state.items])
-
-  // Synchronous in-flight guards (dedupe rapid clicks) + a mounted/user guard so a
-  // stale async completion never updates an unmounted provider or a new user's state.
   const inFlightRef = useRef(new Set())
-  const staleInFlightRef = useRef(false)
   const mountedRef = useRef(true)
   const userIdRef = useRef(user?.id)
   useEffect(() => { mountedRef.current = true; return () => { mountedRef.current = false } }, [])
   useEffect(() => { userIdRef.current = user?.id }, [user?.id])
-  // Reset pending state on user change (logout / switch).
-  useEffect(() => {
-    inFlightRef.current = new Set()
-    staleInFlightRef.current = false
-    setRemovingIds(new Set())
-    setRemovingStale(false)
-  }, [user?.id])
+  useEffect(() => { inFlightRef.current = new Set(); setRemovingIds(new Set()) }, [user?.id])
 
   const refresh = useCallback(() => setNonce(n => n + 1), [])
   const isRemoving = useCallback((movieId) => removingIds.has(movieId), [removingIds])
-  // Only touch state if still mounted AND the action's user is still the active user.
   const alive = useCallback((uid) => mountedRef.current && userIdRef.current === uid, [])
 
   const removeFromWatchlist = useCallback(async (movieId) => {
@@ -85,7 +61,8 @@ export function WatchlistDataProvider({ children }) {
     let result = fail
     try {
       // SETTLED: recognise a resolved PostgREST { error } (it does NOT throw) — only
-      // remove from the local list once the DB delete has actually succeeded.
+      // remove from the local list once the DB delete has actually succeeded. Delete
+      // filter (user_id + movie_id) is unchanged.
       const { error } = await supabase
         .from('user_watchlist')
         .delete()
@@ -93,12 +70,12 @@ export function WatchlistDataProvider({ children }) {
         .eq('movie_id', movieId)
       if (error) {
         console.warn('[removeFromWatchlist]', error)
-        refresh() // re-sync canonical; item was never removed locally → no false success
+        refresh()
       } else {
         if (alive(uid)) {
           setState(prev => {
             const items = prev.items.filter(it => it.id !== movieId)
-            return { ...prev, items, stats: recomputeStats(items), availableMoods: deriveAvailableMoods(items) }
+            return { ...prev, items, total: items.length, availableMoods: deriveAvailableMoods(items) }
           })
         }
         result = { ok: true, action: 'removed', movieId }
@@ -113,45 +90,6 @@ export function WatchlistDataProvider({ children }) {
     return result
   }, [user, refresh, alive])
 
-  // Bulk-delete every stale item in one DB round-trip. Returns the count ACTUALLY
-  // removed (0 on failure — never the attempted count).
-  const removeStale = useCallback(async () => {
-    if (!user?.id) return { ok: false, removedCount: 0 }
-    const uid = user.id
-    if (staleInFlightRef.current) return { ok: false, removedCount: 0, duplicate: true }
-    const staleIds = (itemsRef.current || []).filter(it => it.stale).map(it => it.id)
-    if (staleIds.length === 0) return { ok: true, removedCount: 0 }
-    staleInFlightRef.current = true
-    if (alive(uid)) setRemovingStale(true)
-    let result = { ok: false, removedCount: 0 }
-    try {
-      const { error } = await supabase
-        .from('user_watchlist')
-        .delete()
-        .eq('user_id', uid)
-        .in('movie_id', staleIds)
-      if (error) {
-        console.warn('[removeStale]', error)
-        refresh() // restore canonical stale rows
-      } else {
-        if (alive(uid)) {
-          setState(prev => {
-            const items = prev.items.filter(it => !it.stale)
-            return { ...prev, items, stats: recomputeStats(items), availableMoods: deriveAvailableMoods(items) }
-          })
-        }
-        result = { ok: true, removedCount: staleIds.length }
-      }
-    } catch (e) {
-      console.warn('[removeStale]', e)
-      refresh()
-    } finally {
-      staleInFlightRef.current = false
-      if (alive(uid)) setRemovingStale(false)
-    }
-    return result
-  }, [user, refresh, alive])
-
   useEffect(() => {
     if (!user?.id) {
       setState({ ...INITIAL, loading: false })
@@ -162,37 +100,26 @@ export function WatchlistDataProvider({ children }) {
 
     ;(async () => {
       try {
-        const [watchRes, fingerprint, profile] = await Promise.all([
-          supabase
-            .from('user_watchlist')
-            .select(`
-              movie_id,
-              added_at,
-              status,
-              movies!inner (${MOVIE_ENGINE_COLS})
-            `)
-            .eq('user_id', user.id)
-            .order('added_at', { ascending: false }),
-          getTasteFingerprint(user.id).catch(() => null),
-          computeUserProfile(user.id).catch(() => null),
-        ])
+        // Only the saved-film rows — no fingerprint, no profile compute, no cache write.
+        const watchRes = await supabase
+          .from('user_watchlist')
+          .select(`movie_id, added_at, status, movies!inner (${MOVIE_COLS})`)
+          .eq('user_id', user.id)
+          .order('added_at', { ascending: false })
         if (abort) return
         if (watchRes.error) throw watchRes.error
 
-        const items = deriveItems({ rows: watchRes.data || [], fingerprint, profile })
-        const availableMoods = deriveAvailableMoods(items)
+        const items = deriveItems({ rows: watchRes.data || [] })
         setState(s => ({
           ...s,
           items,
-          stats: recomputeStats(items),
-          availableMoods,
-          hasFingerprint: Boolean(fingerprint?.topMoodTags?.length),
+          total: items.length,
+          availableMoods: deriveAvailableMoods(items),
           loading: false,
           error: null,
         }))
       } catch (e) {
         if (abort) return
-        // F6.3: keep raw diagnostics in console only; expose a safe classification.
         console.error('[useWatchlistData]', e)
         setState(s => ({ ...s, loading: false, error: 'load_error' }))
       }
@@ -204,12 +131,10 @@ export function WatchlistDataProvider({ children }) {
   const value = useMemo(() => ({
     ...state,
     removingIds,
-    removingStale,
     isRemoving,
     removeFromWatchlist,
-    removeStale,
     refresh,
-  }), [state, removingIds, removingStale, isRemoving, removeFromWatchlist, removeStale, refresh])
+  }), [state, removingIds, isRemoving, removeFromWatchlist, refresh])
 
   return <WatchlistDataContext.Provider value={value}>{children}</WatchlistDataContext.Provider>
 }

--- a/src/features/watchlist/watchlist.css
+++ b/src/features/watchlist/watchlist.css
@@ -1,4 +1,4 @@
-/* watchlist.css */
+/* watchlist.css — F6.4 calm saved-intent layout */
 @import url('https://fonts.googleapis.com/css2?family=Outfit:wght@200;300;400;500;600;700&family=Inter:wght@400;500;600&display=swap');
 .ff-watchlist-v2 { font-family:'Inter', system-ui, sans-serif; -webkit-font-smoothing:antialiased; }
 .ff-watchlist-v2 em { font-style: italic; }
@@ -7,94 +7,40 @@
 .ff-watchlist-v2 select { font-family: inherit; }
 .ff-watchlist-v2 ::selection { background: rgba(167,139,250,0.4); color:#fff; }
 
-/* === Responsive overrides ==================================================
-   Every section uses inline `padding: ...88px` and fixed grid templates. The
-   overrides reach in by class hook and collapse layouts at narrow widths.
-   `!important` is required because the source styles are inline. */
+/* One responsive saved-film grid (no fixed 5-col assumption; auto-fills, never wraps a
+   card's controls awkwardly). The card is a simple vertical stack. */
+.ff-wl-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+  gap: 24px;
+}
+.ff-wl-card { display: flex; flex-direction: column; min-width: 0; }
+.ff-wl-card__poster { box-shadow: 0 10px 24px -10px rgba(0,0,0,0.6); }
 
-/* Tablet (≤ 1100px): trim padding; grid drops from 5 → 4 cols. */
+/* Visible focus rings on the interactive controls (programmatic-focus fallback excepted). */
+.ff-wl-filter-pill:focus-visible,
+.ff-wl-cta:focus-visible,
+.ff-wl-card button:focus-visible {
+  outline: 2px solid #a78bfa;
+  outline-offset: 2px;
+}
+
+/* === Responsive (inline section paddings reached by class hook) ============== */
 @media (max-width: 1100px) {
   .ff-wl-section {
     padding-left: clamp(28px, 5vw, 60px) !important;
     padding-right: clamp(28px, 5vw, 60px) !important;
   }
-  .ff-wl-grid {
-    grid-template-columns: repeat(4, 1fr) !important;
-  }
-  .ff-wl-tonight-grid {
-    grid-template-columns: repeat(2, 1fr) !important;
-  }
 }
-
-/* Smaller tablet (≤ 880px): 3-col poster grid. */
-@media (max-width: 880px) {
-  .ff-wl-grid {
-    grid-template-columns: repeat(3, 1fr) !important;
-    gap: 16px !important;
-  }
-  .ff-wl-pulse-grid {
-    grid-template-columns: repeat(3, 1fr) !important;
-    gap: 12px !important;
-  }
-  .ff-wl-cleanup-grid {
-    grid-template-columns: 1fr !important;
-    gap: 16px !important;
-    text-align: left;
-  }
-}
-
-/* Phone (≤ 720px). */
 @media (max-width: 720px) {
   .ff-wl-section {
     padding-left: clamp(16px, 4vw, 24px) !important;
     padding-right: clamp(16px, 4vw, 24px) !important;
   }
-  .ff-wl-section--masthead {
-    padding-top: 56px !important;
-    padding-bottom: 24px !important;
-  }
-  .ff-wl-hero {
-    font-size: clamp(44px, 13vw, 72px) !important;
-    line-height: 1 !important;
-  }
-  /* PulseStrip: 3-card row → vertical stack so 44px numbers + 2-line labels read. */
-  .ff-wl-pulse-grid {
-    grid-template-columns: 1fr !important;
-    gap: 10px !important;
-  }
-  /* Grid view: 2-col posters (3 was still too tight at 390px once gap + padding eaten). */
-  .ff-wl-grid {
-    grid-template-columns: repeat(2, 1fr) !important;
-    gap: 14px !important;
-  }
-  /* TonightTier: single column featured cards. */
-  .ff-wl-tonight-grid {
-    grid-template-columns: 1fr !important;
-  }
-  /* FeaturedCard inner: stack poster above the meta + actions. */
-  .ff-wl-featured {
-    grid-template-columns: 1fr !important;
-    gap: 14px !important;
-  }
-  /* List view rows: drop the mood pill + match-% columns from the grid,
-     surface them inline under the title to keep rows readable. */
-  .ff-wl-list-row {
-    grid-template-columns: 48px 1fr auto !important;
-    gap: 12px !important;
-  }
-  .ff-wl-list-row > div:nth-child(3),  /* mood pill */
-  .ff-wl-list-row > div:nth-child(4)   /* match % big number */ {
-    display: none !important;
-  }
-  /* Cleanup nudge actions stack on mobile so both buttons stay tappable. */
-  .ff-wl-cleanup-actions {
-    flex-direction: column !important;
-    align-items: stretch !important;
-    width: 100%;
-  }
-  .ff-wl-cleanup-actions button {
-    width: 100% !important;
-  }
+  .ff-wl-section--masthead { padding-top: 56px !important; padding-bottom: 20px !important; }
+  .ff-wl-hero { font-size: clamp(40px, 12vw, 72px) !important; line-height: 1 !important; }
+  /* 2 poster columns on phones — comfortable once gap + padding are eaten. */
+  .ff-wl-grid { grid-template-columns: repeat(2, 1fr); gap: 14px; }
 }
 
 /* F6.3 — sanitized error recovery buttons + the data-library-fallback focus target


### PR DESCRIPTION
**F6.4 — Refocus Watchlist as calm saved intent.** Redesign `/watchlist` as a calm record of *saved intent* — "films I chose to remember for another moment" — not a ranked recommendation feed. The underlying saved films, F6.3 removal reliability, routes, and `user_watchlist` delete filters are preserved; the recommendation engine, `computeUserProfile`, `scoreMovieForUser`, `computeMatchPercent` and the fingerprint services are **unchanged** (consumer removal, not an engine change). **History/Diary is untouched.**

## Role shift: recommendation queue → saved-intent library
Masthead is now eyebrow **"Watchlist"** + h1 **"Saved for later."** + *"Films you wanted to remember — ready whenever the moment feels right."* + one quiet **"{n} films saved"** count.

## Removed precise + approximate percentages
No per-film integer match anywhere — featured/grid/list badges, pulse Top-match/avg, the "Match %" sort, the `%` in `deriveWhy`, and any %-bearing aria-label/title are all gone. No score/ring/meter/grade. `approxMatch` + the engine-vs-approx selection are removed from the derivation entirely.

## Removed false "tonight" inference
No "Perfect for tonight", no "Perfect tonight" filter, no "matches your current mood window". Home + Discover own nightly selection.

## Removed featured / pulse / stale / guilt / bulk
The top-three featured tier, the 3-card pulse dashboard, the "Getting stale"/60-day labels, *"Be honest. Cut what you won't watch"*, and the bulk "Clear all" section are removed. **Grid/list decision: removed the toggle** — one responsive auto-fill grid is canonical (fewer duplicate action paths, calmer, lower a11y burden). **Bulk decision: removed the section AND the now-unused `removeStale`/`removingStale` provider state** (no other consumer; F6.3 bulk tests updated deliberately) — the reliable **individual** settled removal is unchanged.

## Saved-date default ordering
Default **"Recently saved"** (`added_at` desc); options Recently saved / Oldest saved / Runtime / Title (deterministic `sortItems`). No ranking by recommendation score.

## Retained mood retrieval (relabelled)
**"Filter by film mood"** (`role=group`), All + only the moods actually present in the saved collection — no "Perfect"/"Stale" choices, no implication it's the user's current mood.

## Simplified data/provider path — no profile-cache write on view
The provider now reads **only `user_watchlist × movies`** (presentation columns), with **no `getTasteFingerprint` and no `computeUserProfile`** — so simply **viewing `/watchlist` no longer triggers a profile-cache write**. Public context is `{ items, total, availableMoods, loading, error, removingIds, isRemoving, removeFromWatchlist, refresh }` (dropped `stats`/`hasFingerprint`/`removeStale`/`removingStale`).

## F6.3 reliability preserved
Settled removal with resolved-`{error}` inspection, duplicate-click guard, per-id pending (`aria-busy` + `disabled` + "Removing {title}"), the one persistent polite/atomic live region, sanitized `'load_error'` (Try-again + Go-to-Home), and focus-after-removal. Saved-age language is neutral ("Saved {n} days ago" / "Saved on {date}"). Empty state → **Open Discover (/discover) + Browse films (/browse)**; filtered-empty → "Show all". Open still routes to `/movie/:tmdbId`.

## Confirmations
Engine, shared services, `user_watchlist` writes/filters, routes, schema, and History remain unchanged; only `src/features/watchlist/**` changed. **No live route opened** (the profile-cache write path is gone); **no live write**. (The existing `watchlist.e2e.js` exercises the Film File Save toggle + the `user_watchlist` write — it never visits `/watchlist`, so it's unaffected; there are no `/watchlist` visual baselines.)

## Tests + validation
The F6.2 match/perfect/stale/approx/`deriveWhy`/`recomputeStats` derivation pins were **replaced** by saved-intent pins (metadata, saved-age, mood, backend order, recent/oldest/runtime/title sort, available moods, no-match/perfect/stale exposure, no profile input, missing-metadata safety). Provider tests assert no fingerprint fetch / no profile compute / no bulk API + user-scoped read. New **WatchlistTrust** covers the masthead, no-queue/stale/tonight/match framing, default sort, one collection, no featured/pulse/bulk, mood-filter label, saved-age language, Open route, empty/filtered-empty, one h1, no duplicate film. **All History F6.2/F6.3 tests unchanged + green.** `npm run lint` clean · targeted **66 ×3** · full **1228 → 1232** · `npm run build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
