### PR TITLE
Correct Diary data truth and reflection integrity

### DIFF
--- a/src/features/discover/__tests__/DiscoverResult.test.jsx
+++ b/src/features/discover/__tests__/DiscoverResult.test.jsx
@@ -212,11 +212,18 @@ describe('StagePick — actions', () => {
     expect(h.inserts).toContainEqual({ table: 'user_watchlist', row: { user_id: 'u1', movie_id: 1 } })
     expect(updateImpression).toHaveBeenCalledWith('u1', 1, 'saved')
   })
-  it('Already watched writes user_history (source discover_marked) + the watched impression', async () => {
+  it('48-52. Already watched writes user_history with explicit watched_at (ISO) + unchanged ids/source/impression', async () => {
     render(<StagePick {...baseProps()} />)
     fireEvent.click(screen.getByRole('button', { name: 'Already watched' }))
     await screen.findByText('Watched')
-    expect(h.inserts).toContainEqual({ table: 'user_history', row: { user_id: 'u1', movie_id: 1, source: 'discover_marked' } })
+    const histInsert = h.inserts.find(i => i.table === 'user_history')
+    expect(histInsert).toBeTruthy()
+    // 50/51: ids + source unchanged
+    expect(histInsert.row).toMatchObject({ user_id: 'u1', movie_id: 1, source: 'discover_marked' })
+    // 48/49: watched_at is now written explicitly and is a valid ISO timestamp
+    expect(typeof histInsert.row.watched_at).toBe('string')
+    expect(new Date(histInsert.row.watched_at).toISOString()).toBe(histInsert.row.watched_at)
+    // 52: impression payload unchanged
     expect(updateImpression).toHaveBeenCalledWith('u1', 1, 'watched')
   })
   it('Not tonight flags the skipped impression + logs a dismiss interaction with Stage-2 metadata', () => {

--- a/src/features/discover/hooks/useDiscoverResultActions.js
+++ b/src/features/discover/hooks/useDiscoverResultActions.js
@@ -110,10 +110,14 @@ export function useDiscoverResultActions({ top, user, selected, intention, energ
     const filmId = top.id;
     setWatchedState('saving');
     try {
-      // 23505 (unique violation) = already in history; treat as success
+      // 23505 (unique violation) = already in history; treat as success.
+      // F6.5: write watched_at explicitly (the base table has no proven default and
+      // the Diary filters out rows without it) so Discover-marked films appear in the
+      // Diary like every other watched-entry path. Payload-completeness only — every
+      // other field, source, and the success/failure behavior are unchanged.
       const { error } = await supabase
         .from('user_history')
-        .insert({ user_id: user.id, movie_id: filmId, source: 'discover_marked' });
+        .insert({ user_id: user.id, movie_id: filmId, source: 'discover_marked', watched_at: new Date().toISOString() });
       if (error && error.code !== '23505') throw error;
     } catch (e) {
       console.error('[Discover.markWatched]', e);

--- a/src/features/history/History.jsx
+++ b/src/features/history/History.jsx
@@ -13,6 +13,8 @@ import Eyebrow from '@/shared/ui/Eyebrow'
 import PageContainer from '@/shared/ui/PageContainer'
 import { HP, HP_GRAD } from './data'
 import { HistoryDataProvider, useHistoryData } from './useHistoryData'
+import { matchesQuery } from './derive/historyDerive'
+import RemoveDiaryEntryDialog from './components/RemoveDiaryEntryDialog'
 import { useLibraryAnnouncement } from '@/features/library/useLibraryAnnouncement'
 import { scheduleFocus, findRemoveControl, findFallback, nextFocusId } from '@/features/library/focusAfterRemoval'
 import './history.css'
@@ -32,7 +34,7 @@ function Masthead() {
         <Eyebrow spacing="0.32em" size={10}>Diary</Eyebrow>
         <div style={{ height:1, width:38, background:HP.purple, opacity:0.5 }} />
         <Eyebrow tone="meta" weight={500} size={10}>
-          {stats.totalLogged} film{stats.totalLogged === 1 ? '' : 's'} · {stats.totalHours} hours · {stats.streakDays}-day streak
+          {stats.totalLogged} film{stats.totalLogged === 1 ? '' : 's'} · {stats.totalHours} hours
         </Eyebrow>
       </div>
     </section>
@@ -41,11 +43,13 @@ function Masthead() {
 
 function PulseStrip() {
   const { stats } = useHistoryData();
+  // F6.5: restrained, Diary-scoped facts only — no streak / gamification. The average
+  // is now computed over rated films that are actually in the Diary.
   const items = [
     { label:'Logged',        value: stats.totalLogged,         hint:'films across your diary' },
     { label:'Hours watched', value: `${stats.totalHours}h`,     hint:'total runtime logged' },
-    { label:'Avg rating',    value: stats.avgRating ? stats.avgRating.toFixed(1) : '—', hint:'on a 5-star scale' },
-    { label:'Streak',        value: `${stats.streakDays}d`,     hint:'consecutive days with a log' },
+    { label:'Avg rating',    value: stats.avgRating ? stats.avgRating.toFixed(1) : '—', hint:'your rated diary films, on a 5-star scale' },
+    { label:'This month',    value: stats.thisMonthCount,       hint:'films logged this month' },
   ];
   return (
     <section className="ff-hist-section ff-hist-pulse" style={{ padding:'24px 88px 40px' }}>
@@ -63,9 +67,11 @@ function PulseStrip() {
 }
 
 function FilterBar({ filter, setFilter, sort, setSort, query, setQuery }) {
+  // "Loved" is derived from the rating (raw 9–10), not an independent favourite flag —
+  // the label says so honestly.
   const filters = [
-    { v:'all', l:'All' },
-    { v:'5',   l:'Loved (5★)' },
+    { v:'all',   l:'All' },
+    { v:'loved', l:'Loved · 9–10' },
   ];
   return (
     <section className="ff-hist-section ff-hist-filterbar" style={{ padding:'40px 88px 20px', borderTop:`1px solid ${HP.border}`, display:'flex', alignItems:'center', justifyContent:'space-between', gap:24, flexWrap:'wrap' }}>
@@ -197,12 +203,20 @@ function DiaryGroup({ month, entries, onRemove }) {
                       </div>
                       <div style={{ marginTop:8, display:'flex', alignItems:'center', gap:12, flexWrap:'wrap' }}>
                         <Stars n={e.rating} />
-                        {e.mood && e.mood !== 'Mixed' && <MoodPill label={e.mood} color={e.moodHex} dot />}
+                        {/* F6.5: the pill shows the FILM's mood/tone — its accessible name says
+                            so explicitly, so it is never mistaken for the user's viewing mood. */}
+                        {e.filmMood && e.filmMood !== 'Mixed' && (
+                          <MoodPill label={e.filmMood} color={e.moodHex} dot role="img" aria-label={`Film mood: ${e.filmMood}`} />
+                        )}
                       </div>
-                      {e.note && (
-                        <p style={{ margin:'14px 0 0 0', fontSize:14, lineHeight:1.55, color:HP.textSoft, fontFamily:'Outfit, Inter, sans-serif', fontStyle:'italic', borderLeft:`2px solid ${e.moodHex}55`, paddingLeft:14, textWrap:'pretty' }}>
-                          &ldquo;{e.note}&rdquo;
-                        </p>
+                      {e.review && (
+                        <div style={{ marginTop:14 }}>
+                          {/* review_text is a film-level review, not a note written on this watch date. */}
+                          <div style={{ fontSize:9, fontWeight:700, letterSpacing:'0.14em', textTransform:'uppercase', color:HP.textFaint, fontFamily:'Outfit', marginBottom:6 }}>Your review</div>
+                          <p style={{ margin:0, fontSize:14, lineHeight:1.55, color:HP.textSoft, fontFamily:'Outfit, Inter, sans-serif', fontStyle:'italic', borderLeft:`2px solid ${e.moodHex}55`, paddingLeft:14, textWrap:'pretty' }}>
+                            &ldquo;{e.review}&rdquo;
+                          </p>
+                        </div>
                       )}
                     </div>
                     <span className="ff-hist-row__runtime" style={{ fontSize:11, color:HP.textFaint, fontFamily:'Outfit', letterSpacing:'0.06em', textTransform:'uppercase', paddingTop:8 }}>{e.runtime ? `${e.runtime}m` : ''}</span>
@@ -292,19 +306,15 @@ function HistoryShell() {
   const [filter, setFilter] = useState('all');
   const [sort, setSort] = useState('recent');
   const [query, setQuery] = useState('');
+  // Pending removal awaiting confirmation: { entry, triggerEl }.
+  const [pendingRemoval, setPendingRemoval] = useState(null);
 
   const filtered = useMemo(() => {
     let arr = entries.slice();
-    if (filter === '5')   arr = arr.filter(e => e.rating === 5);
-    if (filter === 'fav') arr = arr.filter(e => e.fav);
-    if (query.trim()) {
-      const q = query.toLowerCase();
-      arr = arr.filter(e =>
-        e.title.toLowerCase().includes(q)
-        || (e.note && e.note.toLowerCase().includes(q))
-        || (e.dir && e.dir.toLowerCase().includes(q))
-      );
-    }
+    // "Loved" = raw rating 9–10 (e.fav), derived from the rating — not a separate flag.
+    if (filter === 'loved') arr = arr.filter(e => e.fav);
+    // Search matches the user's own content (title / director / review) — NOT film mood.
+    arr = arr.filter(e => matchesQuery(e, query));
     if (sort === 'rating')  arr.sort((a,b) => b.rating - a.rating);
     if (sort === 'runtime') arr.sort((a,b) => a.runtime - b.runtime);
     return arr;
@@ -319,14 +329,30 @@ function HistoryShell() {
     return [...g.entries()];
   }, [filtered]);
 
-  // Settled removal + announcement + focus recovery. Confirm copy + rating/review
-  // retention are unchanged (F6.5 owns those semantics).
-  const onRemove = useCallback(async (e, triggerEl) => {
+  // F6.5: removal goes through an honest, accessible confirmation dialog. The Remove
+  // control opens it; "Remove from Diary" performs the settled delete; "Keep entry" /
+  // Escape cancels and returns focus to the trigger. The settled-removal reliability,
+  // live announcements, and focus-next behavior (F6.3) are preserved.
+  const requestRemove = useCallback((e, triggerEl) => {
     if (isRemoving(e.id)) return;
-    if (typeof window !== 'undefined' && !window.confirm(`Remove "${e.title}" from your diary?`)) return;
+    setPendingRemoval({ entry: e, triggerEl });
+  }, [isRemoving]);
+
+  const cancelRemove = useCallback(() => {
+    const trigger = pendingRemoval?.triggerEl;
+    setPendingRemoval(null);
+    focusCancelRef.current?.();
+    focusCancelRef.current = scheduleFocus(() => (trigger && trigger.isConnected ? trigger : null));
+  }, [pendingRemoval]);
+
+  const confirmRemove = useCallback(async () => {
+    const p = pendingRemoval;
+    if (!p) return;
+    setPendingRemoval(null); // close immediately → a second confirm can't fire
+    const e = p.entry;
     const orderedIds = filtered.map(x => x.id);
     const targetId = nextFocusId(orderedIds, e.id);
-    const res = await removeEntry(e.id);
+    const res = await removeEntry(e.id); // deletes only user_history (settled); ratings/feedback untouched
     focusCancelRef.current?.();
     if (res.ok) {
       announce(`Removed ${e.title} from your Diary.`);
@@ -335,9 +361,9 @@ function HistoryShell() {
     } else if (!res.duplicate) {
       announce(`Could not remove ${e.title} from your Diary. Try again.`);
       focusCancelRef.current = scheduleFocus(() =>
-        (triggerEl && triggerEl.isConnected ? triggerEl : findRemoveControl(containerRef.current, e.id, 'diary')) || findFallback(containerRef.current));
+        (p.triggerEl && p.triggerEl.isConnected ? p.triggerEl : findRemoveControl(containerRef.current, e.id, 'diary')) || findFallback(containerRef.current));
     }
-  }, [isRemoving, filtered, removeEntry, announce]);
+  }, [pendingRemoval, filtered, removeEntry, announce]);
 
   if (loading) return <PageSkeleton />;
   if (error) return <PageError onRetry={refresh} onHome={() => navigate('/home')} />;
@@ -370,8 +396,15 @@ function HistoryShell() {
             </div>
           </section>
         )}
-        {grouped.map(([month, ents]) => <DiaryGroup key={month} month={month} entries={ents} onRemove={onRemove} />)}
+        {grouped.map(([month, ents]) => <DiaryGroup key={month} month={month} entries={ents} onRemove={requestRemove} />)}
       </div>
+      {pendingRemoval && (
+        <RemoveDiaryEntryDialog
+          title={pendingRemoval.entry.title}
+          onConfirm={confirmRemove}
+          onCancel={cancelRemove}
+        />
+      )}
     </div>
   );
 }

--- a/src/features/history/__tests__/DiaryTrust.test.jsx
+++ b/src/features/history/__tests__/DiaryTrust.test.jsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+
+const navigate = vi.fn()
+vi.mock('react-router-dom', () => ({ useNavigate: () => navigate }))
+vi.mock('@/shared/hooks/usePageMeta', () => ({ usePageMeta: () => {} }))
+
+let mockCtx
+vi.mock('../useHistoryData', () => ({
+  HistoryDataProvider: ({ children }) => children,
+  useHistoryData: () => mockCtx,
+}))
+
+import History from '../History'
+
+const stats = (over = {}) => ({ totalLogged: 2, totalHours: 4, avgRating: 4.5, thisMonthCount: 1, ...over })
+const entry = (over = {}) => ({ id: 'e1', movieId: 1, tmdbId: 101, title: 'Past Lives', year: 2023, runtime: 106, dir: 'Celine Song', date: 'Mar 9', month: 'Mar 2026', day: 9, rating: 5, filmMood: 'Tender', mood: 'Tender', moodHex: '#A78BFA', context: 'Evening · Monday', review: 'Quiet and aching.', note: 'Quiet and aching.', poster: null, fav: true, ...over })
+
+function ctx(over = {}) {
+  return { entries: [entry()], stats: stats(), loading: false, error: null, isRemoving: () => false, removeEntry: vi.fn(async () => ({ ok: true })), refresh: vi.fn(), ...over }
+}
+
+beforeEach(() => navigate.mockClear())
+afterEach(() => { cleanup(); vi.clearAllMocks() })
+
+describe('Diary — data-truth + reflection labelling (F6.5)', () => {
+  it('16/26. keeps the Diary identity and exactly one h1', () => {
+    mockCtx = ctx()
+    const { container } = render(<History />)
+    expect(screen.getAllByText('Diary').length).toBeGreaterThan(0)
+    expect(container.querySelectorAll('h1')).toHaveLength(1)
+  })
+
+  it('17. no streak text / icon / card anywhere', () => {
+    mockCtx = ctx()
+    const { container } = render(<History />)
+    expect(container.textContent).not.toMatch(/streak|day streak|consecutive days|🔥/i)
+  })
+
+  it('18. shows a Diary-scoped average rating (and labels it as rated diary films)', () => {
+    mockCtx = ctx({ stats: stats({ avgRating: 4.5 }) })
+    render(<History />)
+    expect(screen.getByText('4.5')).toBeInTheDocument()
+    expect(screen.getByText(/rated diary films/i)).toBeInTheDocument()
+  })
+
+  it('19. the Loved filter is labelled by its rating basis (9–10), not a separate flag', () => {
+    mockCtx = ctx()
+    render(<History />)
+    expect(screen.getByRole('radio', { name: 'Loved · 9–10' })).toBeInTheDocument()
+    expect(screen.queryByText(/Loved \(5/)).toBeNull()
+  })
+
+  it('20. the mood pill accessible name says "Film mood" (not the user\'s mood)', () => {
+    mockCtx = ctx()
+    render(<History />)
+    expect(screen.getByRole('img', { name: 'Film mood: Tender' })).toBeInTheDocument()
+  })
+
+  it('21. the review is labelled "Your review"', () => {
+    mockCtx = ctx()
+    render(<History />)
+    expect(screen.getByText('Your review')).toBeInTheDocument()
+    expect(screen.getByText(/Quiet and aching/)).toBeInTheDocument()
+  })
+
+  it('22-25. search matches title / director / review but NOT film mood', () => {
+    mockCtx = ctx({
+      entries: [
+        entry({ id: 'e1', movieId: 1, title: 'Past Lives', dir: 'Celine Song', review: 'aching', filmMood: 'Tender' }),
+        entry({ id: 'e2', movieId: 2, title: 'Aftersun', dir: 'Charlotte Wells', review: 'sunlit grief', filmMood: 'Melancholy' }),
+      ],
+      stats: stats({ totalLogged: 2 }),
+    })
+    render(<History />)
+    const search = screen.getByLabelText('Search the diary')
+
+    fireEvent.change(search, { target: { value: 'aftersun' } })       // title
+    expect(screen.queryByText('Aftersun')).toBeInTheDocument(); expect(screen.queryByText('Past Lives')).toBeNull()
+
+    fireEvent.change(search, { target: { value: 'celine' } })         // director
+    expect(screen.queryByText('Past Lives')).toBeInTheDocument(); expect(screen.queryByText('Aftersun')).toBeNull()
+
+    fireEvent.change(search, { target: { value: 'sunlit' } })         // review
+    expect(screen.queryByText('Aftersun')).toBeInTheDocument()
+
+    fireEvent.change(search, { target: { value: 'melancholy' } })     // FILM MOOD → no match
+    expect(screen.queryByText('Past Lives')).toBeNull()
+    expect(screen.queryByText('Aftersun')).toBeNull()
+    expect(screen.getByText(/match/i)).toBeInTheDocument()            // filtered-empty notice
+  })
+
+  it('27/28. one persistent polite/atomic live region + pending Remove control', () => {
+    mockCtx = ctx({ isRemoving: (id) => id === 'e1' })
+    const { container } = render(<History />)
+    expect(container.querySelectorAll('[role="status"][aria-live="polite"][aria-atomic="true"]')).toHaveLength(1)
+    const btn = screen.getByRole('button', { name: 'Removing Past Lives' })
+    expect(btn).toBeDisabled()
+    expect(btn).toHaveAttribute('aria-busy', 'true')
+  })
+})

--- a/src/features/history/__tests__/HistoryDataStates.test.jsx
+++ b/src/features/history/__tests__/HistoryDataStates.test.jsx
@@ -13,8 +13,8 @@ vi.mock('../useHistoryData', () => ({
 
 import History from '../History'
 
-const baseStats = { totalLogged: 0, totalHours: 0, avgRating: 0, thisMonthCount: 0, streakDays: 0 }
-const entry = (over = {}) => ({ id: 'e1', movieId: 1, tmdbId: 101, title: 'A', year: 2020, runtime: 100, dir: 'D', date: 'Mar 9', month: 'Mar 2026', day: 9, rating: 5, mood: 'Tender', moodHex: '#A78BFA', context: 'Evening · Monday', note: null, poster: null, fav: true, ...over })
+const baseStats = { totalLogged: 0, totalHours: 0, avgRating: 0, thisMonthCount: 0 }
+const entry = (over = {}) => ({ id: 'e1', movieId: 1, tmdbId: 101, title: 'A', year: 2020, runtime: 100, dir: 'D', date: 'Mar 9', month: 'Mar 2026', day: 9, rating: 5, filmMood: 'Tender', mood: 'Tender', moodHex: '#A78BFA', context: 'Evening · Monday', review: null, note: null, poster: null, fav: true, ...over })
 
 function ctx(over = {}) {
   return {
@@ -58,32 +58,33 @@ describe('Diary live region + announcements (F6.3)', () => {
     expect(container.querySelectorAll('[role="status"][aria-live="polite"][aria-atomic="true"]')).toHaveLength(1)
   })
 
-  it('43. success announces after settlement', async () => {
-    vi.spyOn(window, 'confirm').mockReturnValue(true)
+  it('43/36. success announces after settlement (via the confirmation dialog)', async () => {
     mockCtx = ctx({ entries: [entry({ title: 'A' })], stats: { ...baseStats, totalLogged: 1 } })
     render(<History />)
-    fireEvent.click(screen.getByRole('button', { name: 'Remove A from diary' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Remove A from diary' }))           // opens dialog
+    fireEvent.click(screen.getByRole('button', { name: 'Remove from Diary' }))              // confirms
     await waitFor(() => expect(screen.getByText('Removed A from your Diary.')).toBeInTheDocument())
   })
 
-  it('44. failure announces failure (entry retained)', async () => {
-    vi.spyOn(window, 'confirm').mockReturnValue(true)
+  it('44/37. failure announces failure (entry retained)', async () => {
     mockCtx = ctx({
       entries: [entry({ title: 'A' })], stats: { ...baseStats, totalLogged: 1 },
       removeEntry: vi.fn(async () => ({ ok: false, action: 'remove_failed', entryId: 'e1', movieId: 1 })),
     })
     render(<History />)
     fireEvent.click(screen.getByRole('button', { name: 'Remove A from diary' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Remove from Diary' }))
     await waitFor(() => expect(screen.getByText('Could not remove A from your Diary. Try again.')).toBeInTheDocument())
   })
 
-  it('confirm cancel does not call removeEntry', () => {
-    vi.spyOn(window, 'confirm').mockReturnValue(false)
+  it('32. cancelling the dialog ("Keep entry") performs no delete', () => {
     const removeEntry = vi.fn(async () => ({ ok: true }))
     mockCtx = ctx({ entries: [entry({ title: 'A' })], stats: { ...baseStats, totalLogged: 1 }, removeEntry })
     render(<History />)
     fireEvent.click(screen.getByRole('button', { name: 'Remove A from diary' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Keep entry' }))
     expect(removeEntry).not.toHaveBeenCalled()
+    expect(screen.queryByRole('dialog')).toBeNull() // dialog closed
   })
 })
 

--- a/src/features/history/components/RemoveDiaryEntryDialog.jsx
+++ b/src/features/history/components/RemoveDiaryEntryDialog.jsx
@@ -1,0 +1,76 @@
+// src/features/history/components/RemoveDiaryEntryDialog.jsx
+// F6.5 — accessible confirmation for removing a watched entry from the Diary. The copy
+// is honest about what removal does (and does NOT do): it removes only the chronological
+// watched entry; the user's rating and review stay with the film. "Keep entry" is the
+// safe default and takes initial focus; "Remove from Diary" carries no destructive red
+// styling that would imply the rating/review is also erased.
+//
+// Self-contained a11y: role="dialog" + aria-modal, labelled heading + described body,
+// Escape cancels, Tab is trapped between the two actions (document-level capture so the
+// trap holds without keyboard handlers on non-interactive nodes). Focus restoration to
+// the original trigger (on cancel/failure) and focus-next (on success) are handled by the
+// page via onCancel / onConfirm, matching the F6.3 focus model.
+
+import { useEffect, useRef } from 'react'
+import { HP, HP_GRAD } from '../data'
+
+export default function RemoveDiaryEntryDialog({ title, onConfirm, onCancel }) {
+  const keepRef = useRef(null)
+  const removeRef = useRef(null)
+  const headingId = 'ff-diary-remove-heading'
+  const bodyId = 'ff-diary-remove-body'
+
+  useEffect(() => {
+    keepRef.current?.focus()
+    function onKey(e) {
+      if (e.key === 'Escape') { e.preventDefault(); onCancel(); return }
+      if (e.key !== 'Tab') return
+      const els = [keepRef.current, removeRef.current].filter(Boolean)
+      if (els.length === 0) return
+      const first = els[0]
+      const last = els[els.length - 1]
+      const active = document.activeElement
+      if (e.shiftKey && active === first) { e.preventDefault(); last.focus() }
+      else if (!e.shiftKey && active === last) { e.preventDefault(); first.focus() }
+      else if (active !== first && active !== last) { e.preventDefault(); first.focus() }
+    }
+    document.addEventListener('keydown', onKey, true)
+    return () => document.removeEventListener('keydown', onKey, true)
+  }, [onCancel])
+
+  return (
+    <div className="ff-hist-dialog-backdrop" style={{ position:'fixed', inset:0, zIndex:120, display:'flex', alignItems:'center', justifyContent:'center', padding:20, background:'rgba(0,0,0,0.6)' }}>
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={headingId}
+        aria-describedby={bodyId}
+        className="ff-hist-dialog"
+        style={{ width:'100%', maxWidth:440, background:HP.bgDeep, border:`1px solid ${HP.borderStrong}`, borderRadius:12, padding:'28px 26px', boxShadow:'0 28px 70px -20px rgba(0,0,0,0.75)' }}
+      >
+        <h2 id={headingId} style={{ fontFamily:'Outfit, Inter, sans-serif', fontSize:22, fontWeight:600, color:HP.text, margin:'0 0 12px 0', letterSpacing:'-0.02em' }}>
+          Remove from Diary?
+        </h2>
+        <p id={bodyId} style={{ margin:'0 0 24px 0', fontSize:14, lineHeight:1.55, color:HP.textSoft, fontFamily:'Outfit, Inter, sans-serif' }}>
+          This removes the watched entry for &ldquo;{title}&rdquo;. Your rating and review will stay with the film.
+        </p>
+        <div style={{ display:'flex', gap:12, justifyContent:'flex-end', flexWrap:'wrap' }}>
+          <button
+            ref={keepRef}
+            type="button"
+            onClick={onCancel}
+            className="ff-hist-dialog-btn"
+            style={{ minHeight:44, padding:'11px 20px', borderRadius:999, background:HP_GRAD, border:'none', color:'#fff', fontFamily:'Outfit', fontSize:13, fontWeight:600, cursor:'pointer' }}
+          >Keep entry</button>
+          <button
+            ref={removeRef}
+            type="button"
+            onClick={onConfirm}
+            className="ff-hist-dialog-btn"
+            style={{ minHeight:44, padding:'11px 20px', borderRadius:999, background:'transparent', border:`1px solid ${HP.border}`, color:HP.textSoft, fontFamily:'Outfit', fontSize:13, fontWeight:600, cursor:'pointer' }}
+          >Remove from Diary</button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/history/components/__tests__/RemoveDiaryEntryDialog.test.jsx
+++ b/src/features/history/components/__tests__/RemoveDiaryEntryDialog.test.jsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import RemoveDiaryEntryDialog from '../RemoveDiaryEntryDialog'
+
+afterEach(() => cleanup())
+
+function setup(over = {}) {
+  const onConfirm = vi.fn()
+  const onCancel = vi.fn()
+  render(<RemoveDiaryEntryDialog title="Past Lives" onConfirm={onConfirm} onCancel={onCancel} {...over} />)
+  return { onConfirm, onCancel }
+}
+
+describe('RemoveDiaryEntryDialog — honest, accessible confirmation (F6.5)', () => {
+  it('30/31. is a labelled modal dialog whose copy says only the WATCHED ENTRY is removed + rating/review stay', () => {
+    setup()
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    expect(screen.getByRole('heading', { name: 'Remove from Diary?' })).toBeInTheDocument()
+    expect(screen.getByText(/removes the watched entry for/i)).toBeInTheDocument()
+    expect(screen.getByText(/Your rating and review will stay with the film/i)).toBeInTheDocument()
+    // not destructive-sounding about the rating/review
+    expect(dialog.textContent).not.toMatch(/delete your rating|erase|permanently|lose your review/i)
+  })
+
+  it('38. initial focus is on the safe default ("Keep entry")', () => {
+    setup()
+    expect(screen.getByRole('button', { name: 'Keep entry' })).toHaveFocus()
+  })
+
+  it('Escape and "Keep entry" both cancel; "Remove from Diary" confirms', () => {
+    const a = setup()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(a.onCancel).toHaveBeenCalledTimes(1)
+    cleanup()
+
+    const b = setup()
+    fireEvent.click(screen.getByRole('button', { name: 'Keep entry' }))
+    expect(b.onCancel).toHaveBeenCalledTimes(1)
+    expect(b.onConfirm).not.toHaveBeenCalled()
+    cleanup()
+
+    const c = setup()
+    fireEvent.click(screen.getByRole('button', { name: 'Remove from Diary' }))
+    expect(c.onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('both actions are ≥44px tall', () => {
+    setup()
+    for (const name of ['Keep entry', 'Remove from Diary']) {
+      expect(screen.getByRole('button', { name }).style.minHeight).toBe('44px')
+    }
+  })
+})

--- a/src/features/history/derive/__tests__/historyDerive.test.js
+++ b/src/features/history/derive/__tests__/historyDerive.test.js
@@ -1,113 +1,122 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
 
 import {
-  WEEKDAY_NAMES, capitalize, dayKey, dayPart, moodHexFor,
-  deriveEntries, deriveStats,
+  WEEKDAY_NAMES, capitalize, dayPart, moodHexFor,
+  deriveEntries, deriveStats, matchesQuery,
 } from '../historyDerive'
 
-// F6.2 — pins CURRENT History/Diary derivation behavior. The `avgRating` scope
-// (averaged over ALL user_ratings, not just diary films) is pinned ON PURPOSE so the
-// F6.5 scope fix is a deliberate, reviewable test change. Same for the film-mood pill.
+// F6.5 — the Diary derivation is now data-truthful: the average is DIARY-SCOPED (only
+// rated films actually in the watched Diary), streak is GONE, film mood + review are
+// named for their real provenance. (The F6.2 all-ratings-average + streak + dayKey pins
+// were removed deliberately — that behavior no longer exists.)
 
 afterEach(() => vi.useRealTimers())
 
 const hRow = (over = {}) => ({
   movie_id: 1, watched_at: '2026-03-09T20:30:00',
-  movies: { id: 11, tmdb_id: 101, title: 'A', director_name: 'D', release_date: '2020-01-01', runtime: 120, mood_tags: ['tender'], poster_path: '/p.jpg', ...over.movies },
+  movies: { id: 11, tmdb_id: 101, title: 'A', director_name: 'D', release_date: '2020-06-15', runtime: 120, mood_tags: ['tender'], poster_path: '/p.jpg', ...over.movies },
   ...over,
 })
 
 describe('helpers', () => {
-  it('capitalize / dayPart / dayKey (local) / moodHexFor', () => {
+  it('capitalize / dayPart / moodHexFor (no dayKey/streak helpers anymore)', () => {
     expect(capitalize('feel_good')).toBe('Feel good')
     expect(dayPart(8)).toBe('Morning'); expect(dayPart(13)).toBe('Afternoon')
     expect(dayPart(19)).toBe('Evening'); expect(dayPart(2)).toBe('Late')
-    expect(dayKey(new Date(2026, 2, 9))).toBe('2026-03-09') // local Y-M-D
     expect(typeof moodHexFor('Tender')).toBe('string')
     expect(WEEKDAY_NAMES).toHaveLength(7)
   })
 })
 
 describe('deriveEntries', () => {
-  it('filters out null watched_at, sorts newest-first', () => {
+  it('12/13. filters out null watched_at, sorts newest-first (chronological)', () => {
     const rows = [
       hRow({ movie_id: 1, watched_at: '2026-03-01T10:00:00' }),
       hRow({ movie_id: 2, watched_at: null }),
       hRow({ movie_id: 3, watched_at: '2026-03-05T10:00:00' }),
     ]
-    const out = deriveEntries(rows, [])
-    expect(out.map(e => e.movieId)).toEqual([3, 1]) // movie 2 (null watched_at) dropped
+    expect(deriveEntries(rows, []).map(e => e.movieId)).toEqual([3, 1])
   })
 
-  it('maps rating 1-10 → 1-5 stars, mood = FILM mood_tags[0], note = review_text', () => {
-    const rows = [hRow()]
-    const ratings = [{ movie_id: 1, rating: 9, review_text: 'Stayed with me.' }]
-    const [e] = deriveEntries(rows, ratings)
-    expect(e.rating).toBe(5)          // round(9/2) = 5
-    expect(e.mood).toBe('Tender')     // the FILM's generated mood tag (pinned — F6.5 clarifies)
-    expect(e.note).toBe('Stayed with me.')
-    expect(e.fav).toBe(true)          // raw rating ≥ 9
-    expect(e.rewatch).toBe(false)
-    expect(e.poster).toContain('w342')
-    expect(e.context).toMatch(/Evening · (Sunday|Monday)/) // 20:30 local
+  it('6/14/15. rating 1-10 → 1-5 stars; filmMood from movie mood_tags; review = review_text', () => {
+    const [e] = deriveEntries([hRow()], [{ movie_id: 1, rating: 9, review_text: 'Stayed with me.' }])
+    expect(e.rating).toBe(5)              // round(9/2)
+    expect(e.filmMood).toBe('Tender')     // FILM mood (explicit field)
+    expect(e.mood).toBe('Tender')         // retained alias
+    expect(e.review).toBe('Stayed with me.')
+    expect(e.note).toBe('Stayed with me.') // retained alias
+    expect(e.fav).toBe(true)              // raw ≥ 9
+    expect(e.context).toMatch(/Evening · (Sunday|Monday)/)
   })
 
-  it('fav fires at raw 9 and 10, not at 8; no rating → 0 stars', () => {
+  it('fav fires at raw 9 and 10, not 8; no rating → 0 stars; id fallback', () => {
     const mk = (rt) => deriveEntries([hRow()], rt == null ? [] : [{ movie_id: 1, rating: rt }])[0]
     expect(mk(8).fav).toBe(false)
     expect(mk(9).fav).toBe(true)
     expect(mk(10).fav).toBe(true)
     expect(mk(null).rating).toBe(0)
-  })
-
-  it('id falls back to `${movie_id}-${watched_at}` when no row id', () => {
-    const [e] = deriveEntries([hRow({ id: undefined, movie_id: 7, watched_at: '2026-03-09T20:30:00' })], [])
-    expect(e.id).toBe('7-2026-03-09T20:30:00')
+    expect(deriveEntries([hRow({ id: undefined, movie_id: 7, watched_at: '2026-03-09T20:30:00' })], [])[0].id).toBe('7-2026-03-09T20:30:00')
   })
 })
 
-describe('deriveStats', () => {
-  it('totalLogged = rows; totalHours = summed runtime/60 rounded', () => {
-    const history = [hRow({ movies: { runtime: 120 } }), hRow({ movie_id: 2, movies: { runtime: 90 } })]
+describe('deriveStats — Diary-scoped average (F6.5)', () => {
+  it('7/8/9. totalLogged + totalHours (missing runtime → 0) unchanged', () => {
+    const history = [hRow({ movies: { runtime: 120 } }), hRow({ movie_id: 2, movies: { runtime: 90 } }), hRow({ movie_id: 3, movies: { runtime: undefined } })]
     const s = deriveStats({ history, ratings: [] })
-    expect(s.totalLogged).toBe(2)
-    expect(s.totalHours).toBe(4) // (120+90)/60 = 3.5 → round 4
+    expect(s.totalLogged).toBe(3)
+    expect(s.totalHours).toBe(4) // (120+90+0)/60 = 3.5 → 4
   })
 
-  it('PINNED (F6.5 target): avgRating averages ALL user_ratings, even films NOT in history', () => {
-    const history = [hRow({ movie_id: 1 })] // only movie 1 is in the diary
+  it('1/2/3. average uses ONLY ratings for films in the Diary — rated-but-unwatched & removed films excluded', () => {
+    const history = [hRow({ movie_id: 1 })] // only movie 1 is watched/in the Diary
     const ratings = [
-      { movie_id: 1, rating: 8 },   // in history
-      { movie_id: 999, rating: 4 }, // NOT in history — but still counted today
+      { movie_id: 1, rating: 8 },    // in Diary → counts (display 4.0)
+      { movie_id: 999, rating: 2 },  // rated but NOT in Diary → MUST be excluded
     ]
-    const s = deriveStats({ history, ratings })
-    // ((8 + 4) / 2) / 2 = 3.0  → includes movie 999 which is not a diary entry.
-    expect(s.avgRating).toBe(3)
+    // old (buggy) scope would average (8+2)/2/2 = 2.5; Diary-scoped = 8/2 = 4.0
+    expect(deriveStats({ history, ratings }).avgRating).toBe(4)
   })
 
-  it('avgRating is 0 with no ratings', () => {
-    expect(deriveStats({ history: [hRow()], ratings: [] }).avgRating).toBe(0)
+  it('3b. a rating whose film was REMOVED from the Diary (no history row) does not count', () => {
+    const history = [hRow({ movie_id: 1, watched_at: '2026-03-09T20:00:00' })]
+    const ratings = [{ movie_id: 1, rating: 6 }, { movie_id: 2, rating: 10 }] // 2 was removed from Diary
+    expect(deriveStats({ history, ratings }).avgRating).toBe(3) // 6/2 only
   })
 
-  it('streak counts consecutive local days back from today (today-or-yesterday alive)', () => {
-    vi.useFakeTimers(); vi.setSystemTime(new Date(2026, 2, 10, 12, 0, 0)) // Mar 10 local
-    const day = (d) => `2026-03-${String(d).padStart(2, '0')}T18:00:00`
-    const history = [hRow({ watched_at: day(10) }), hRow({ movie_id: 2, watched_at: day(9) }), hRow({ movie_id: 3, watched_at: day(8) })]
-    expect(deriveStats({ history, ratings: [] }).streakDays).toBe(3) // 10,9,8 consecutive
+  it('4/5. unrated Diary films excluded from the denominator; zero rated Diary films → 0', () => {
+    const history = [hRow({ movie_id: 1 }), hRow({ movie_id: 2 })]
+    expect(deriveStats({ history, ratings: [{ movie_id: 1, rating: 10 }] }).avgRating).toBe(5) // only movie 1 rated → 10/2
+    expect(deriveStats({ history, ratings: [] }).avgRating).toBe(0)
   })
 
-  it('streak breaks on a gap and is 0 when neither today nor yesterday has a watch', () => {
-    vi.useFakeTimers(); vi.setSystemTime(new Date(2026, 2, 10, 12, 0, 0))
-    const day = (d) => `2026-03-${String(d).padStart(2, '0')}T18:00:00`
-    // today (10) + a gap at 9 then 8 → streak is just today
-    expect(deriveStats({ history: [hRow({ watched_at: day(10) }), hRow({ movie_id: 2, watched_at: day(8) })], ratings: [] }).streakDays).toBe(1)
-    // last watch was Mar 5 → neither today nor yesterday alive → 0
-    expect(deriveStats({ history: [hRow({ watched_at: day(5) })], ratings: [] }).streakDays).toBe(0)
+  it('12. a rating for a film with null watched_at (not in the visible Diary) is excluded', () => {
+    const history = [hRow({ movie_id: 1, watched_at: null })]
+    expect(deriveStats({ history, ratings: [{ movie_id: 1, rating: 10 }] }).avgRating).toBe(0)
   })
 
-  it('thisMonthCount counts only rows in the current local month', () => {
+  it('11. NO streak field is returned', () => {
+    const s = deriveStats({ history: [hRow()], ratings: [] })
+    expect(s).not.toHaveProperty('streakDays')
+    expect(Object.keys(s).sort()).toEqual(['avgRating', 'thisMonthCount', 'totalHours', 'totalLogged'])
+  })
+
+  it('10. thisMonthCount counts only rows in the current local month', () => {
     vi.useFakeTimers(); vi.setSystemTime(new Date(2026, 2, 10, 12, 0, 0)) // March
     const history = [hRow({ watched_at: '2026-03-02T10:00:00' }), hRow({ movie_id: 2, watched_at: '2026-02-27T10:00:00' })]
     expect(deriveStats({ history, ratings: [] }).thisMonthCount).toBe(1)
+  })
+})
+
+describe('matchesQuery — Diary search (title / director / review, NOT film mood)', () => {
+  const e = { title: 'Past Lives', dir: 'Celine Song', review: 'Quiet and aching.', filmMood: 'Tender' }
+  it('22/23/24. matches title, director, and review; empty query matches all', () => {
+    expect(matchesQuery(e, 'past')).toBe(true)
+    expect(matchesQuery(e, 'celine')).toBe(true)
+    expect(matchesQuery(e, 'aching')).toBe(true)
+    expect(matchesQuery(e, '')).toBe(true)
+  })
+  it('25. does NOT match on the FILM mood (it is not a user note)', () => {
+    expect(matchesQuery(e, 'tender')).toBe(false)
+    expect(matchesQuery(e, 'zzz')).toBe(false)
   })
 })

--- a/src/features/history/derive/historyDerive.js
+++ b/src/features/history/derive/historyDerive.js
@@ -1,10 +1,17 @@
 // src/features/history/derive/historyDerive.js
-// F6.2 — pure History/Diary derivations, extracted verbatim from useHistoryData.jsx
-// (the provider is now a thin caller). NO behavior change: every function body is
-// byte-for-byte identical to the inlined originals, so the rendered Diary output is
-// unchanged. The current `avgRating` scope (averaged over ALL user_ratings, not just
-// diary films) is preserved AS-IS and pinned by tests on purpose — the F6.5 scope fix
-// will then show up as a deliberate, reviewable test change.
+// FeelFlick — pure History/Diary derivations. The Diary is a chronological record of
+// what the user WATCHED and what they thought — not a streak tracker or a rating
+// database detached from watched history.
+//
+// F6.5 data-truth corrections:
+//   • avgRating is now DIARY-SCOPED — averaged only over ratings whose film is actually
+//     in the watched Diary (rated-but-unwatched and removed films no longer count).
+//   • streak derivation is removed entirely (no gamification).
+//   • mood is explicitly the FILM's mood (from movie mood_tags), not the user's viewing
+//     mood; review_text is film-level review, not a watch-event note. (Labelling lives in
+//     the page; the data is named honestly here.)
+// Frozen: the 1-10 → 1-5 display mapping, watched_at filtering, chronological ordering,
+// loved/fav (raw ≥9), total-hours, and thisMonthCount are unchanged.
 
 import { formatShortDate, formatShortMonthYear } from '@/shared/lib/format/date'
 import { HP, MOOD_HEX, tmdbImg } from '../data'
@@ -13,14 +20,6 @@ export const WEEKDAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thurs
 
 export function capitalize(s) {
   return s ? s.charAt(0).toUpperCase() + s.slice(1).replace(/_/g, ' ') : ''
-}
-
-export function dayKey(date) {
-  // YYYY-MM-DD in local time — matches how a user thinks about "a day".
-  const y = date.getFullYear()
-  const m = String(date.getMonth() + 1).padStart(2, '0')
-  const d = String(date.getDate()).padStart(2, '0')
-  return `${y}-${m}-${d}`
 }
 
 export function dayPart(hour) {
@@ -47,7 +46,9 @@ export function deriveEntries(history, ratings) {
       const r = ratingByMovieId.get(h.movie_id) || {}
       const d = new Date(h.watched_at)
       const moodTag = (m.mood_tags || [])[0]
-      const mood = capitalize(moodTag) || 'Mixed'
+      // `filmMood` makes provenance explicit: this is the FILM's tone, NOT the user's
+      // mood while watching. `mood` is retained as an alias for existing consumers.
+      const filmMood = capitalize(moodTag) || 'Mixed'
       return {
         id: h.id || `${h.movie_id}-${h.watched_at}`,
         movieId: h.movie_id,
@@ -61,17 +62,18 @@ export function deriveEntries(history, ratings) {
         day: d.getDate(),
         // user_ratings.rating is on the 1-10 scale; map to 1-5 for star display.
         rating: r.rating ? Math.round(r.rating / 2) : 0,
-        mood,
-        moodHex: moodHexFor(mood),
+        filmMood,
+        mood: filmMood,
+        moodHex: moodHexFor(filmMood),
         context: `${dayPart(d.getHours())} · ${WEEKDAY_NAMES[d.getDay()]}`,
+        // review_text is the user's film-level review (not a per-watch note).
+        review: r.review_text || null,
         note: r.review_text || null,
         poster: m.poster_path ? tmdbImg(m.poster_path, 'w342') : null,
-        // Rewatches aren't currently tracked in user_history (the app
-        // dedupes by (user, movie)). Leaving rewatch=false until that
-        // changes. ♥ fav fires for any 5★-display rating (raw 9 or 10 on
-        // the 1-10 scale) — matches what the star row shows. Previously
-        // gated on rating===10, which left favorites permanently dead for
-        // users who rate at 9.
+        // Rewatches aren't tracked in user_history yet (the app dedupes by
+        // (user, movie)). Rewatch support is future work (it also needs the
+        // removal to key off the history row id — see provider note). ♥ fav
+        // fires for raw 9 or 10 (5★ display).
         rewatch: false,
         fav: typeof r.rating === 'number' && r.rating >= 9,
       }
@@ -81,40 +83,36 @@ export function deriveEntries(history, ratings) {
 export function deriveStats({ history, ratings }) {
   const totalLogged = history.length
   const totalHours = Math.round(history.reduce((s, h) => s + (h.movies?.runtime || 0), 0) / 60)
-  const rated = ratings.filter(r => r.rating != null)
-  const avgRating = rated.length > 0
-    ? Math.round((rated.reduce((s, r) => s + r.rating, 0) / rated.length / 2) * 10) / 10
+
+  // F6.5: DIARY-SCOPED average — average only ratings whose movie is in the current
+  // watched Diary. Rated-but-unwatched films and removed Diary films do not count;
+  // unrated Diary films are excluded from the denominator. No rating scale changes.
+  const historyMovieIds = new Set(
+    history.filter(h => h.watched_at).map(h => h.movie_id)
+  )
+  const diaryRatings = ratings.filter(
+    r => r.rating != null && historyMovieIds.has(r.movie_id)
+  )
+  const avgRating = diaryRatings.length > 0
+    ? Math.round((diaryRatings.reduce((s, r) => s + r.rating, 0) / diaryRatings.length / 2) * 10) / 10
     : 0
+
   const now = new Date()
   const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1)
   const thisMonthCount = history.filter(h => h.watched_at && new Date(h.watched_at) >= startOfMonth).length
 
-  // Streak: consecutive days back from today (or yesterday if today has no
-  // entries yet) with at least one watched entry.
-  const days = new Set()
-  for (const h of history) {
-    if (!h.watched_at) continue
-    days.add(dayKey(new Date(h.watched_at)))
-  }
-  let streakDays = 0
-  if (days.size > 0) {
-    const today = new Date()
-    const todayK = dayKey(today)
-    const yesterdayK = (() => { const d = new Date(); d.setDate(d.getDate() - 1); return dayKey(d) })()
-    const alive = days.has(todayK) || days.has(yesterdayK)
-    if (alive) {
-      const cursor = new Date(today)
-      // If today is empty but yesterday has a watch, start counting from yesterday.
-      if (!days.has(todayK)) cursor.setDate(cursor.getDate() - 1)
-      for (let i = 0; i < 365; i++) {
-        if (days.has(dayKey(cursor))) {
-          streakDays += 1
-          cursor.setDate(cursor.getDate() - 1)
-        } else {
-          break
-        }
-      }
-    }
-  }
-  return { totalLogged, totalHours, avgRating, thisMonthCount, streakDays }
+  return { totalLogged, totalHours, avgRating, thisMonthCount }
+}
+
+// Pure Diary search: matches a derived entry against a free-text query over the
+// user's own content — title, director, and review. The FILM's generated mood is
+// intentionally NOT searched (it isn't a user note).
+export function matchesQuery(entry, query) {
+  const q = (query || '').trim().toLowerCase()
+  if (!q) return true
+  return (
+    String(entry.title || '').toLowerCase().includes(q) ||
+    String(entry.dir || '').toLowerCase().includes(q) ||
+    String(entry.review || '').toLowerCase().includes(q)
+  )
 }

--- a/src/features/history/history.css
+++ b/src/features/history/history.css
@@ -89,3 +89,14 @@
 [data-library-fallback]:focus {
   outline: none;
 }
+
+/* F6.5 — Remove-from-Diary confirmation dialog: visible focus rings on its actions
+   and a comfortable narrow-screen fit. */
+.ff-hist-dialog-btn:focus-visible {
+  outline: 2px solid #a78bfa;
+  outline-offset: 3px;
+}
+@media (max-width: 480px) {
+  .ff-hist-dialog { padding: 22px 18px; }
+  .ff-hist-dialog-btn { flex: 1; }
+}

--- a/src/features/history/useHistoryData.jsx
+++ b/src/features/history/useHistoryData.jsx
@@ -20,7 +20,7 @@ const HistoryDataContext = createContext(null)
 
 const INITIAL = {
   entries: [],
-  stats: { totalLogged: 0, totalHours: 0, avgRating: 0, thisMonthCount: 0, streakDays: 0 },
+  stats: { totalLogged: 0, totalHours: 0, avgRating: 0, thisMonthCount: 0 },
   loading: true,
   error: null,                  // F6.3: 'load_error' | null — never a raw backend message
   removingEntryIds: new Set(),  // F6.3: entry ids with a removal in flight

--- a/src/features/movie/__tests__/YourTakeReflectionVisibility.test.jsx
+++ b/src/features/movie/__tests__/YourTakeReflectionVisibility.test.jsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+
+vi.mock('framer-motion', () => ({ useReducedMotion: () => false }))
+
+// Configurable rating-hook stub so we can simulate "user already has a reflection".
+let ratingState
+vi.mock('../hooks/useUserRating', () => ({
+  useUserRating: () => ratingState,
+  REACTION_TO_SENTIMENT: { 'Loved it': 'loved' },
+}))
+vi.mock('../useMovieData', () => ({ useMovieData: () => ({ mv: { id: 1, title: 'Parasite' } }) }))
+
+import { YourTake } from '../sections-bottom'
+
+beforeAll(() => { vi.stubGlobal('IntersectionObserver', class { observe() {} unobserve() {} disconnect() {} }) })
+afterAll(() => { vi.unstubAllGlobals() })
+beforeEach(() => { cleanup(); ratingState = { stars: 0, reviewText: '', reaction: '', setStars: vi.fn(), setReviewText: vi.fn(), setReaction: vi.fn(), saveStatus: 'idle', hydrated: true } })
+
+const renderTake = (isWatched) => render(<YourTake isWatched={isWatched} userId="u1" internalId={7} onSaved={() => {}} onError={() => {}} />)
+const isEditable = (container) => container.querySelector('[role="radiogroup"][aria-label="Your star rating"]') !== null
+const isLocked = (container) => container.querySelector('.ff-movie-your-take-compact') !== null
+
+describe('Your Take — existing reflection stays accessible after Diary removal (F6.5)', () => {
+  it('40/45. unwatched + NO existing reflection stays locked — no new unwatched rating', () => {
+    ratingState = { ...ratingState, stars: 0, reviewText: '', reaction: '' }
+    const { container } = renderTake(false)
+    expect(isLocked(container)).toBe(true)
+    expect(isEditable(container)).toBe(false)
+    expect(screen.getByText(/Mark this film watched above to rate it/i)).toBeInTheDocument()
+  })
+
+  it('41. watched + no reflection can create one (editable controls render)', () => {
+    const { container } = renderTake(true)
+    expect(isEditable(container)).toBe(true)
+    expect(isLocked(container)).toBe(false)
+  })
+
+  it('42. unwatched + existing RATING displays the editable Your Take', () => {
+    ratingState = { ...ratingState, stars: 4 }
+    const { container } = renderTake(false)
+    expect(isEditable(container)).toBe(true)
+    expect(isLocked(container)).toBe(false)
+  })
+
+  it('43. unwatched + existing REVIEW displays the editable Your Take', () => {
+    ratingState = { ...ratingState, reviewText: 'Stayed with me.' }
+    const { container } = renderTake(false)
+    expect(isEditable(container)).toBe(true)
+  })
+
+  it('43b. unwatched + existing REACTION displays the editable Your Take', () => {
+    ratingState = { ...ratingState, reaction: 'Loved it' }
+    const { container } = renderTake(false)
+    expect(isEditable(container)).toBe(true)
+  })
+
+  it('44/46. the surfaced reflection is editable on the UNCHANGED 1–5 star scale (5 radios), not a new control', () => {
+    ratingState = { ...ratingState, stars: 3 }
+    renderTake(false)
+    const stars = screen.getAllByRole('radio', { name: /star/i })
+    expect(stars).toHaveLength(5) // display scale unchanged
+    expect(screen.getByPlaceholderText(/one sentence on what stuck/i)).toBeEnabled()
+  })
+
+  it('47. hierarchy unchanged — the editable card still uses the "Unlocked · How did it land?" eyebrow', () => {
+    ratingState = { ...ratingState, stars: 5 }
+    renderTake(false)
+    expect(screen.getByText(/Unlocked · How did it land\?/i)).toBeInTheDocument()
+  })
+
+  it('does not flash the editable form before hydration settles (unwatched + not yet hydrated → locked)', () => {
+    ratingState = { ...ratingState, stars: 4, hydrated: false }
+    const { container } = renderTake(false)
+    expect(isLocked(container)).toBe(true)
+  })
+})

--- a/src/features/movie/sections-bottom.jsx
+++ b/src/features/movie/sections-bottom.jsx
@@ -554,12 +554,19 @@ function DirectorShelf({ goToMovie }) {
 }
 
 // ── Your Take (locked → unlocked after watched) ──────────────────
+// F6.5: render the reflection surface in BOTH states. YourTakeUnlocked decides whether
+// to show the editable form or the compact locked prompt — it unlocks when the film is
+// watched OR when the user already has a reflection, so a rating/review survives Diary
+// removal and stays visible + editable even when isWatched is false. This never enables
+// a brand-new unwatched rating (no existing reflection + unwatched stays locked).
 function YourTake({ isWatched, userId, internalId, onSaved, onError }) {
-  if (isWatched) return <YourTakeUnlocked userId={userId} internalId={internalId} onSaved={onSaved} onError={onError} />;
+  return <YourTakeUnlocked isWatched={isWatched} userId={userId} internalId={internalId} onSaved={onSaved} onError={onError} />;
+}
 
-  // F5.5: compact-until-watched. A small, discoverable prompt that does NOT
-  // interrupt the decision path or imply a rating already exists — the rating
-  // controls (and the Mark Watched action) live in the Hero / sticky bar.
+// Compact-until-watched prompt (F5.5): a small, discoverable cue that does NOT interrupt
+// the decision path or imply a rating already exists — the rating controls (and the Mark
+// Watched action) live in the Hero / sticky bar.
+function YourTakeLockedPrompt() {
   return (
     <section className="ff-movie-section ff-movie-your-take-compact" style={{ padding:'28px 88px', borderTop:`1px solid ${HP.border}` }}>
       <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.22em', textTransform:'uppercase', color: HP.purple, marginBottom:8 }}>After watching</div>
@@ -573,7 +580,7 @@ function YourTake({ isWatched, userId, internalId, onSaved, onError }) {
 
 const REACTION_TAGS = ['Loved it', 'Liked it', 'Mixed', "Didn't connect"];
 
-function YourTakeUnlocked({ userId, internalId, onSaved, onError }) {
+function YourTakeUnlocked({ isWatched, userId, internalId, onSaved, onError }) {
   const { mv } = useMovieData();
   // DNADelta's projected motifs are still Parasite-specific until real
   // before/after deltas land. Gate to Parasite only so auto-generated
@@ -590,6 +597,10 @@ function YourTakeUnlocked({ userId, internalId, onSaved, onError }) {
   // status that flashes after a write.
   const hasPersistedData = hydrated && (stars > 0 || reviewText || reaction);
   const showIdleSavedHint = saveStatus === 'idle' && hasPersistedData;
+  // F6.5: editable when the film is watched OR an existing reflection is present.
+  // Hydration-pending + unwatched stays locked until we know whether data exists, so
+  // we never flash an empty editable form for an unwatched film with no reflection.
+  const unlocked = isWatched || hasPersistedData;
 
   // F5.4: surface the LATEST settled rating outcome through the page live region
   // once — onSaved/onError fire on each saveStatus transition (not on every render).
@@ -601,6 +612,9 @@ function YourTakeUnlocked({ userId, internalId, onSaved, onError }) {
     if (saveStatus === 'saved') onSaved?.();
     else if (saveStatus === 'error') onError?.();
   }, [saveStatus, onSaved, onError]);
+
+  // Unwatched + no existing reflection → compact locked prompt (no new unwatched rating).
+  if (!unlocked) return <YourTakeLockedPrompt />;
 
   return (
     <section className="ff-movie-section" style={{ padding:'56px 88px', borderTop:`1px solid ${HP.border}`, animation:'mv-fade-in 0.6s ease both' }}>


### PR DESCRIPTION
**F6.5 — Correct Diary data truth and reflection integrity.** Make `/history` a trustworthy, memory-first Diary and resolve the cross-surface watched/reflection lifecycle issues. **Watchlist is untouched** (byte-identical); recommendation scoring, rating values, sentiment mappings, routes, schema, and RLS are unchanged.

## Diary-scoped average-rating correction (data-truth)
`deriveStats` now averages **only** ratings whose film is in the current watched Diary (`historyMovieIds` = rows with `watched_at`). Rated-but-unwatched films, films removed from the Diary, and unrated Diary films no longer distort the statistic; zero rated Diary films stays an honest `0`. The 1-10 → 1-5 display scale and all stored values are unchanged.

## Streak removal
No streak derivation, no streak card, no "{n}-day streak" kicker — and no replacement behavioural-pressure metric. The pulse strip is now three Diary-scoped facts (logged, hours, average) + the neutral "This month" count.

## Film-mood / review provenance clarification
Each entry exposes `filmMood` (the **film's** tone from `mood_tags`, explicitly *not* the user's viewing mood) and `review` (the user's **film-level** `review_text`, not a per-watch note). The mood pill's accessible name is **"Film mood: {mood}"**; the review is labelled **"Your review"**. Search (title / director / review) deliberately does **not** match the film mood — a pure `matchesQuery` helper makes this testable.

## Removal semantics + honest confirmation
Removal still deletes **only** the `user_history` row (`user_id` + `movie_id`) and **never** touches `user_ratings` or feedback. The bare `window.confirm` is replaced by an accessible **`RemoveDiaryEntryDialog`** (`role="dialog"`, `aria-modal`, labelled heading + described body, **Escape** cancels, **Tab** trapped, **initial focus on the safe "Keep entry"**). Copy is honest — *"This removes the watched entry for {title}. Your rating and review will stay with the film."* Cancel restores focus to the trigger; success uses F6.3 focus-next; "Remove from Diary" carries no destructive-red styling.

## Retained reflection visibility on the Film File
`YourTake` now renders the reflection surface in **both** states; `YourTakeUnlocked` unlocks when `isWatched` **OR** an existing reflection is present (rating / review / reaction), so a rating that survives Diary removal stays **visible + editable** even when unwatched. Unwatched **+ no** existing reflection stays locked (no brand-new unwatched rating). This reuses the existing `useUserRating` hydration — **no duplicate fetch, no parent change**. Rating scale, payload, debounce, serialization, announcements, and the Your-Take hierarchy are unchanged.

## Explicit Discover `watched_at`
Discover's "Already watched" insert now writes `watched_at: new Date().toISOString()` so Discover-marked films appear in the Diary like every other watched path. `source:'discover_marked'`, the ids, the impression/interaction payloads, and the success/failure/progression behavior are all unchanged. (Payload-completeness fix — not a schema change.)

## F6.3 reliability preservation
Settled removal + resolved-`{error}` inspection, duplicate-click guard (dialog closes on confirm + provider in-flight guard), per-id pending state, the one persistent polite/atomic live region, sanitized `load_error`, and focus recovery — all preserved.

## Frozen-contract / no-live-write confirmation
Only `src/features/history/**`, `movie/sections-bottom.jsx` (+ its Your-Take tests), and `discover/useDiscoverResultActions.js` (+ its test) changed. No Watchlist change, no shared-engine/service change, no schema/RLS/migration, no route change, no rating/feedback deletion, no new unwatched-rating path. **No live route opened; no live write.**

## Tests + validation
Full **1232 → 1254**. The F6.2 all-ratings-average + streak + dayKey pins were removed deliberately and replaced by Diary-scoped-average pins (rated-but-unwatched / removed / unrated excluded; null `watched_at` excluded; **no streak field**) + `matchesQuery` + `filmMood`/`review` provenance. New: `RemoveDiaryEntryDialog` test (copy + focus + Escape + actions), `DiaryTrust` (identity, no streak, "Loved · 9–10", Film-mood accessible name, "Your review", search incl/excl), `YourTakeReflectionVisibility` (unwatched-with-reflection unlocks, unwatched-empty stays locked, 1–5 scale + hierarchy unchanged), and the Discover `watched_at` payload assertion (ISO + unchanged source/ids/impression). **All Watchlist F6.4 tests unchanged + green.** `npm run lint` clean · targeted **495 ×3** · full **1254** · `npm run build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
