### PR TITLE
Unify Watchlist and Diary under the Library identity

### DIFF
--- a/src/app/header/Header.jsx
+++ b/src/app/header/Header.jsx
@@ -209,7 +209,7 @@ function AvatarMenu({ userName, userInitial, userEmail, userAvatar, onSignOut })
             <DropdownLink to="/account"     icon={UserIcon}    onClick={() => setOpen(false)}>Account</DropdownLink>
             <DropdownLink to="/browse"      icon={LayoutGrid}  onClick={() => setOpen(false)}>Browse</DropdownLink>
             <DropdownLink to="/watchlist"   icon={Bookmark}    onClick={() => setOpen(false)}>Watchlist</DropdownLink>
-            <DropdownLink to="/history"     icon={Clock}       onClick={() => setOpen(false)}>Watch history</DropdownLink>
+            <DropdownLink to="/history"     icon={Clock}       onClick={() => setOpen(false)}>Diary</DropdownLink>
             <DropdownLink to="/people"      icon={Users}       onClick={() => setOpen(false)}>People</DropdownLink>
             <DropdownLink to="/lists"       icon={ListVideo}   onClick={() => setOpen(false)}>Lists</DropdownLink>
             <DropdownLink to="/preferences" icon={Settings}    onClick={() => setOpen(false)}>Settings</DropdownLink>

--- a/src/app/header/__tests__/HeaderMenu.test.jsx
+++ b/src/app/header/__tests__/HeaderMenu.test.jsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, afterEach, beforeAll, afterAll, vi } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+class Observer { observe() {} unobserve() {} disconnect() {} }
+beforeAll(() => { vi.stubGlobal('ResizeObserver', Observer); vi.stubGlobal('IntersectionObserver', Observer) })
+afterAll(() => vi.unstubAllGlobals())
+
+vi.mock('@/shared/hooks/useAuthSession', () => ({
+  useAuthSession: () => ({ user: { id: 'u1', email: 'a@b.com', user_metadata: { full_name: 'Ada' } }, isAuthenticated: true }),
+}))
+vi.mock('@/shared/hooks/useGoogleAuth', () => ({ useGoogleAuth: () => ({ signInWithGoogle: vi.fn(), isAuthenticating: false }) }))
+vi.mock('@/shared/lib/supabase/client', () => ({ supabase: { auth: { signOut: vi.fn(async () => ({ error: null })) } } }))
+vi.mock('@/features/onboarding/draft', () => ({ clearDraft: vi.fn() }))
+
+import Header from '../Header'
+
+afterEach(() => { cleanup(); vi.clearAllMocks() })
+
+function openMenu() {
+  render(<MemoryRouter><Header /></MemoryRouter>)
+  fireEvent.click(screen.getByRole('button', { name: 'Account menu' }))
+  return screen.getByRole('button', { name: 'Account menu' }).closest('div')?.parentElement || document.body
+}
+
+describe('Header utility menu — Library terminology (F6.6)', () => {
+  it('34/35/36. shows Watchlist + Diary; "Watch history" is gone', () => {
+    openMenu()
+    expect(screen.getByRole('link', { name: 'Watchlist' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Diary' })).toBeInTheDocument()
+    expect(screen.queryByText('Watch history')).toBeNull()
+  })
+
+  it('37. the Diary item routes to /history (destination unchanged)', () => {
+    openMenu()
+    expect(screen.getByRole('link', { name: 'Diary' })).toHaveAttribute('href', '/history')
+    expect(screen.getByRole('link', { name: 'Watchlist' })).toHaveAttribute('href', '/watchlist')
+  })
+
+  it('38. no new global "Library" navigation item was added', () => {
+    openMenu()
+    expect(screen.queryByRole('link', { name: /^Library$/i })).toBeNull()
+  })
+
+  it('39/40. existing menu order is stable and sign-out is still present', () => {
+    openMenu()
+    const labels = screen.getAllByRole('link').map(l => l.textContent.trim()).filter(Boolean)
+    // Watchlist immediately precedes Diary (the only changed label), order otherwise intact
+    expect(labels).toEqual(expect.arrayContaining(['Account', 'Browse', 'Watchlist', 'Diary', 'People', 'Lists', 'Settings']))
+    expect(labels.indexOf('Diary')).toBe(labels.indexOf('Watchlist') + 1)
+    expect(screen.getByRole('button', { name: /sign out/i })).toBeInTheDocument()
+  })
+})

--- a/src/features/history/History.jsx
+++ b/src/features/history/History.jsx
@@ -15,6 +15,7 @@ import { HP, HP_GRAD } from './data'
 import { HistoryDataProvider, useHistoryData } from './useHistoryData'
 import { matchesQuery } from './derive/historyDerive'
 import RemoveDiaryEntryDialog from './components/RemoveDiaryEntryDialog'
+import LibrarySectionNav from '@/features/library/LibrarySectionNav'
 import { useLibraryAnnouncement } from '@/features/library/useLibraryAnnouncement'
 import { scheduleFocus, findRemoveControl, findFallback, nextFocusId } from '@/features/library/focusAfterRemoval'
 import './history.css'
@@ -25,18 +26,24 @@ const RESET_BTN = {
   color:'inherit', textAlign:'left', cursor:'pointer', display:'block',
 };
 
-// ── Masthead — kicker bar only; the URL/nav already say "Diary" ──
+// ── Masthead — shared "Your library" identity + the Diary headline ──
 function Masthead() {
   const { stats } = useHistoryData();
   return (
     <section className="ff-hist-section ff-hist-section--masthead" style={{ padding:'40px 88px 12px' }}>
-      <div style={{ display:'flex', alignItems:'center', gap:14, flexWrap:'wrap' }}>
-        <Eyebrow spacing="0.32em" size={10}>Diary</Eyebrow>
+      <div style={{ display:'flex', alignItems:'center', gap:14, marginBottom:18, flexWrap:'wrap' }}>
+        <Eyebrow spacing="0.32em" size={10}>Your library</Eyebrow>
         <div style={{ height:1, width:38, background:HP.purple, opacity:0.5 }} />
         <Eyebrow tone="meta" weight={500} size={10}>
           {stats.totalLogged} film{stats.totalLogged === 1 ? '' : 's'} · {stats.totalHours} hours
         </Eyebrow>
       </div>
+      <h1 className="ff-hist-hero" style={{ fontFamily:'Outfit', fontSize:72, lineHeight:0.96, fontWeight:300, letterSpacing:'-0.045em', color:HP.text, margin:0, textWrap:'balance' }}>
+        Your <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>diary.</em>
+      </h1>
+      <p style={{ marginTop:16, fontFamily:'Outfit, Inter, sans-serif', fontSize:16, color:HP.textSoft, maxWidth:620, lineHeight:1.55 }}>
+        A chronological record of what you watched and what you thought.
+      </p>
     </section>
   );
 }
@@ -366,13 +373,24 @@ function HistoryShell() {
   }, [pendingRemoval, filtered, removeEntry, announce]);
 
   if (loading) return <PageSkeleton />;
-  if (error) return <PageError onRetry={refresh} onHome={() => navigate('/home')} />;
+  // Error state keeps the section nav (no data dependency) so the user can still reach the
+  // Watchlist; PageError keeps the only h1 + role="alert".
+  if (error) return (
+    <>
+      <section className="ff-hist-section" style={{ padding:'40px 88px 0' }}>
+        <LibrarySectionNav current="diary" />
+      </section>
+      <PageError onRetry={refresh} onHome={() => navigate('/home')} />
+    </>
+  );
 
   if (stats.totalLogged === 0) {
     return (
       <>
-        <h1 className="sr-only">Your diary</h1>
         <Masthead />
+        <section className="ff-hist-section" style={{ padding:'0 88px 8px' }}>
+          <LibrarySectionNav current="diary" />
+        </section>
         <PulseStrip />
         <EmptyState />
       </>
@@ -381,9 +399,11 @@ function HistoryShell() {
 
   return (
     <div ref={containerRef}>
-      <h1 className="sr-only">Your diary</h1>
       <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">{announcement}</div>
       <Masthead />
+      <section className="ff-hist-section" style={{ padding:'0 88px 8px' }}>
+        <LibrarySectionNav current="diary" />
+      </section>
       <PulseStrip />
       <FilterBar filter={filter} setFilter={setFilter} sort={sort} setSort={setSort} query={query} setQuery={setQuery} />
       <div data-library-fallback tabIndex={-1} aria-label="Your diary entries" style={{ outline:'none' }}>

--- a/src/features/history/__tests__/DiaryTrust.test.jsx
+++ b/src/features/history/__tests__/DiaryTrust.test.jsx
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { render, screen, fireEvent, cleanup, within } from '@testing-library/react'
 
 const navigate = vi.fn()
-vi.mock('react-router-dom', () => ({ useNavigate: () => navigate }))
+vi.mock('react-router-dom', () => ({ useNavigate: () => navigate, Link: ({ to, children, ...props }) => <a href={to} {...props}>{children}</a> }))
 vi.mock('@/shared/hooks/usePageMeta', () => ({ usePageMeta: () => {} }))
 
 let mockCtx
@@ -97,5 +97,44 @@ describe('Diary — data-truth + reflection labelling (F6.5)', () => {
     const btn = screen.getByRole('button', { name: 'Removing Past Lives' })
     expect(btn).toBeDisabled()
     expect(btn).toHaveAttribute('aria-busy', 'true')
+  })
+})
+
+describe('Diary — shared Library identity + cross-navigation (F6.6)', () => {
+  it('23/24/25/28. eyebrow "Your library", h1 "Your diary.", chronological supporting copy, one h1', () => {
+    mockCtx = ctx()
+    const { container } = render(<History />)
+    expect(screen.getByText('Your library')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 1, name: /Your diary\./i })).toBeInTheDocument()
+    expect(screen.getByText(/A chronological record of what you watched and what you thought/i)).toBeInTheDocument()
+    expect(container.querySelectorAll('h1')).toHaveLength(1)
+  })
+
+  it('26/27. the Library nav marks Diary active and links Watchlist → /watchlist', () => {
+    mockCtx = ctx()
+    render(<History />)
+    const nav = screen.getByRole('navigation', { name: 'Library sections' })
+    expect(within(nav).getByRole('link', { name: 'Diary' })).toHaveAttribute('aria-current', 'page')
+    expect(within(nav).getByRole('link', { name: 'Watchlist' })).toHaveAttribute('href', '/watchlist')
+  })
+
+  it('29/30. statistics + search/filter/sort controls remain', () => {
+    mockCtx = ctx({ stats: stats({ avgRating: 4.5, totalLogged: 2, totalHours: 4 }) })
+    render(<History />)
+    expect(screen.getByText('4.5')).toBeInTheDocument()                       // average stat
+    expect(screen.getByLabelText('Search the diary')).toBeInTheDocument()      // search
+    expect(screen.getByRole('radio', { name: 'Loved · 9–10' })).toBeInTheDocument() // filter
+    expect(screen.getByRole('combobox', { name: 'Sort diary' })).toBeInTheDocument() // sort
+  })
+
+  it('31/32. the section nav is present in the empty AND the load-error states (one h1 each)', () => {
+    mockCtx = ctx({ entries: [], stats: stats({ totalLogged: 0 }) })
+    const { rerender } = render(<History />)
+    expect(screen.getByRole('navigation', { name: 'Library sections' })).toBeInTheDocument()
+    mockCtx = ctx({ error: 'load_error' })
+    rerender(<History />)
+    expect(screen.getByRole('navigation', { name: 'Library sections' })).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(document.querySelectorAll('h1')).toHaveLength(1)
   })
 })

--- a/src/features/history/__tests__/HistoryDataStates.test.jsx
+++ b/src/features/history/__tests__/HistoryDataStates.test.jsx
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
 
 const navigate = vi.fn()
-vi.mock('react-router-dom', () => ({ useNavigate: () => navigate }))
+vi.mock('react-router-dom', () => ({ useNavigate: () => navigate, Link: ({ to, children, ...props }) => <a href={to} {...props}>{children}</a> }))
 vi.mock('@/shared/hooks/usePageMeta', () => ({ usePageMeta: () => {} }))
 
 let mockCtx

--- a/src/features/history/history.css
+++ b/src/features/history/history.css
@@ -100,3 +100,9 @@
   .ff-hist-dialog { padding: 22px 18px; }
   .ff-hist-dialog-btn { flex: 1; }
 }
+
+/* F6.6 — the Diary masthead now has a visible headline; clamp it on phones like the
+   Watchlist hero so the two Library mastheads behave consistently. */
+@media (max-width: 720px) {
+  .ff-hist-hero { font-size: clamp(40px, 12vw, 72px) !important; line-height: 1 !important; }
+}

--- a/src/features/library/LibrarySectionNav.jsx
+++ b/src/features/library/LibrarySectionNav.jsx
@@ -1,0 +1,37 @@
+// src/features/library/LibrarySectionNav.jsx
+// F6.6 — restrained cross-navigation between the two Library sections (Watchlist + Diary).
+// Direction A: TWO focused routes under one shared "Your library" identity — NOT tabs, NOT
+// a merged dataset, NOT a /library route. These are real links (route navigation), so this
+// is a <nav> with native <Link>s, never role="tablist"/"tab" and never arrow-key behavior.
+//
+// Active state is driven by an explicit `current` prop (not NavLink path-matching) so the
+// /watched compatibility alias — which renders the Diary surface — correctly marks Diary
+// active. Presentation-only: no data fetch, no context, no Supabase/auth, no side effects.
+
+import { Link } from 'react-router-dom'
+import './library.css'
+
+const SECTIONS = [
+  { key: 'watchlist', to: '/watchlist', label: 'Watchlist' },
+  { key: 'diary',     to: '/history',   label: 'Diary' },
+]
+
+export default function LibrarySectionNav({ current }) {
+  return (
+    <nav aria-label="Library sections" className="ff-library-nav">
+      {SECTIONS.map(s => {
+        const active = current === s.key
+        return (
+          <Link
+            key={s.key}
+            to={s.to}
+            aria-current={active ? 'page' : undefined}
+            className={active ? 'ff-library-nav__link ff-library-nav__link--active' : 'ff-library-nav__link'}
+          >
+            {s.label}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/src/features/library/__tests__/LibrarySectionNav.test.jsx
+++ b/src/features/library/__tests__/LibrarySectionNav.test.jsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, within, cleanup } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import LibrarySectionNav from '../LibrarySectionNav'
+
+afterEach(() => cleanup())
+const renderNav = (current) => render(<MemoryRouter><LibrarySectionNav current={current} /></MemoryRouter>)
+
+describe('LibrarySectionNav — shared Library cross-navigation (F6.6)', () => {
+  it('1/2/3/4/5. a <nav aria-label="Library sections"> with exactly two links: Watchlist → /watchlist, Diary → /history', () => {
+    renderNav('watchlist')
+    const nav = screen.getByRole('navigation', { name: 'Library sections' })
+    const links = within(nav).getAllByRole('link')
+    expect(links).toHaveLength(2)
+    expect(links.map(l => l.textContent)).toEqual(['Watchlist', 'Diary'])
+    expect(screen.getByRole('link', { name: 'Watchlist' })).toHaveAttribute('href', '/watchlist')
+    expect(screen.getByRole('link', { name: 'Diary' })).toHaveAttribute('href', '/history')
+  })
+
+  it('6/8. on Watchlist: the Watchlist link is aria-current="page"; Diary is not', () => {
+    renderNav('watchlist')
+    expect(screen.getByRole('link', { name: 'Watchlist' })).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByRole('link', { name: 'Diary' })).not.toHaveAttribute('aria-current')
+  })
+
+  it('7/9. on Diary (incl. the /watched alias passing current="diary"): the Diary link is aria-current="page"; Watchlist is not', () => {
+    renderNav('diary')
+    expect(screen.getByRole('link', { name: 'Diary' })).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByRole('link', { name: 'Watchlist' })).not.toHaveAttribute('aria-current')
+  })
+
+  it('active state carries a non-colour indicator (bold weight + the active class)', () => {
+    renderNav('watchlist')
+    const active = screen.getByRole('link', { name: 'Watchlist' })
+    expect(active.className).toContain('ff-library-nav__link--active')
+  })
+
+  it('10. uses links, NOT tab semantics', () => {
+    renderNav('watchlist')
+    expect(screen.queryByRole('tablist')).toBeNull()
+    expect(screen.queryByRole('tab')).toBeNull()
+  })
+
+  it('11. renders no count or score', () => {
+    renderNav('diary')
+    expect(screen.getByRole('navigation', { name: 'Library sections' }).textContent).toBe('WatchlistDiary')
+  })
+
+  it('12. is presentation-only — renders with no data provider / context / side effects', () => {
+    // (no provider is wrapped; a crash here would prove a hidden data dependency)
+    expect(() => renderNav('watchlist')).not.toThrow()
+  })
+})

--- a/src/features/library/library.css
+++ b/src/features/library/library.css
@@ -1,0 +1,42 @@
+/* src/features/library/library.css — shared Library section navigation (F6.6).
+   Two underlined links; the active one is distinguished by WEIGHT + an underline border
+   (not colour alone). Inline-flex so the two labels wrap naturally and never force a
+   horizontal scroll at any width; each link is ≥44px tall for touch. */
+
+.ff-library-nav {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.ff-library-nav__link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 8px 14px;
+  border-bottom: 2px solid transparent;   /* non-colour active indicator reserves space */
+  color: rgba(250, 250, 250, 0.55);
+  font-family: 'Outfit', 'Inter', sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  text-decoration: none;
+  transition: color 0.18s ease, border-color 0.18s ease;
+}
+
+.ff-library-nav__link:hover {
+  color: rgba(250, 250, 250, 0.85);
+}
+
+.ff-library-nav__link--active {
+  color: #faf5ff;
+  font-weight: 700;                         /* weight = non-colour indicator */
+  border-bottom-color: #a78bfa;             /* underline = second non-colour indicator */
+}
+
+.ff-library-nav__link:focus-visible {
+  outline: 2px solid #a78bfa;
+  outline-offset: 3px;
+  border-radius: 4px;
+}

--- a/src/features/watchlist/Watchlist.jsx
+++ b/src/features/watchlist/Watchlist.jsx
@@ -16,6 +16,7 @@ import { WatchlistDataProvider, useWatchlistData } from './useWatchlistData'
 import { sortItems } from './derive/watchlistDerive'
 import { useLibraryAnnouncement } from '@/features/library/useLibraryAnnouncement'
 import { scheduleFocus, findRemoveControl, findFallback, nextFocusId } from '@/features/library/focusAfterRemoval'
+import LibrarySectionNav from '@/features/library/LibrarySectionNav'
 import './watchlist.css'
 
 const RESET_BTN = {
@@ -31,7 +32,7 @@ function Masthead() {
       <div style={{ position:'absolute', inset:0, pointerEvents:'none', background:'radial-gradient(ellipse 60% 35% at 10% 0%, rgba(167,139,250,0.12), transparent 60%)' }} />
       <div style={{ position:'relative' }}>
         <div style={{ display:'flex', alignItems:'center', gap:14, marginBottom:24, flexWrap:'wrap' }}>
-          <Eyebrow spacing="0.32em" size={10}>Watchlist</Eyebrow>
+          <Eyebrow spacing="0.32em" size={10}>Your library</Eyebrow>
           <div style={{ height:1, width:38, background:HP.purple, opacity:0.5 }} />
           <Eyebrow tone="meta" weight={500} size={10}>{total} film{total === 1 ? '' : 's'} saved</Eyebrow>
         </div>
@@ -199,12 +200,24 @@ function WatchlistShell() {
   }, [isRemoving, visible, removeFromWatchlist, announce]);
 
   if (loading) return <PageSkeleton />;
-  if (error) return <PageError onRetry={refresh} onHome={() => navigate('/home')} />;
+  // Error state keeps the section nav (it has no data dependency) so the user can still
+  // reach the Diary; PageError keeps the only h1 + role="alert".
+  if (error) return (
+    <>
+      <section className="ff-wl-section" style={{ padding:'40px 88px 0' }}>
+        <LibrarySectionNav current="watchlist" />
+      </section>
+      <PageError onRetry={refresh} onHome={() => navigate('/home')} />
+    </>
+  );
 
   return (
     <div ref={containerRef}>
       <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">{announcement}</div>
       <Masthead />
+      <section className="ff-wl-section" style={{ padding:'0 88px 28px' }}>
+        <LibrarySectionNav current="watchlist" />
+      </section>
       {total === 0 ? (
         <EmptyState />
       ) : (

--- a/src/features/watchlist/__tests__/WatchlistDataStates.test.jsx
+++ b/src/features/watchlist/__tests__/WatchlistDataStates.test.jsx
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
 
 const navigate = vi.fn()
-vi.mock('react-router-dom', () => ({ useNavigate: () => navigate }))
+vi.mock('react-router-dom', () => ({ useNavigate: () => navigate, Link: ({ to, children, ...props }) => <a href={to} {...props}>{children}</a> }))
 vi.mock('@/shared/hooks/usePageMeta', () => ({ usePageMeta: () => {} }))
 
 let mockCtx

--- a/src/features/watchlist/__tests__/WatchlistTrust.test.jsx
+++ b/src/features/watchlist/__tests__/WatchlistTrust.test.jsx
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, fireEvent, cleanup, within } from '@testing-library/react'
 
 const navigate = vi.fn()
-vi.mock('react-router-dom', () => ({ useNavigate: () => navigate }))
+vi.mock('react-router-dom', () => ({ useNavigate: () => navigate, Link: ({ to, children, ...props }) => <a href={to} {...props}>{children}</a> }))
 vi.mock('@/shared/hooks/usePageMeta', () => ({ usePageMeta: () => {} }))
 
 let mockCtx
@@ -115,5 +115,41 @@ describe('Watchlist empty + filtered-empty states (F6.4)', () => {
     expect(screen.getByText('No saved films match this mood.')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Show all' }))
     expect(screen.getByRole('heading', { name: 'A' })).toBeInTheDocument() // collection restored
+  })
+})
+
+describe('Watchlist — shared Library identity + cross-navigation (F6.6)', () => {
+  it('13/14/17. eyebrow is "Your library", h1 stays "Saved for later.", exactly one h1', () => {
+    mockCtx = withItems(1)
+    const { container } = render(<Watchlist />)
+    expect(screen.getByText('Your library')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 1, name: /Saved for later\./i })).toBeInTheDocument()
+    expect(container.querySelectorAll('h1')).toHaveLength(1)
+  })
+
+  it('15/16. the Library nav marks Watchlist active and links Diary → /history', () => {
+    mockCtx = withItems(1)
+    render(<Watchlist />)
+    const nav = screen.getByRole('navigation', { name: 'Library sections' })
+    expect(within(nav).getByRole('link', { name: 'Watchlist' })).toHaveAttribute('aria-current', 'page')
+    expect(within(nav).getByRole('link', { name: 'Diary' })).toHaveAttribute('href', '/history')
+  })
+
+  it('18/19. the saved count and the sort control remain', () => {
+    mockCtx = withItems(2)
+    render(<Watchlist />)
+    expect(screen.getByText(/2 films saved/i)).toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: 'Sort saved films' })).toBeInTheDocument()
+  })
+
+  it('20/21. the section nav is present in the empty AND the load-error states (one h1 each)', () => {
+    mockCtx = ctx({ items: [], total: 0 })
+    const { rerender } = render(<Watchlist />)
+    expect(screen.getByRole('navigation', { name: 'Library sections' })).toBeInTheDocument()
+    mockCtx = ctx({ error: 'load_error' })
+    rerender(<Watchlist />)
+    expect(screen.getByRole('navigation', { name: 'Library sections' })).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(document.querySelectorAll('h1')).toHaveLength(1) // PageError's, not a competing masthead h1
   })
 })


### PR DESCRIPTION
**F6.6 — Unify Watchlist and Diary under the Library identity.** Direction A made visible: **two focused routes** (`/watchlist`, `/history`) under one shared **"Your library"** identity, with restrained cross-navigation. **IA / terminology / navigation only** — no data, provider, derivation, statistic, sort/filter, removal, rating, write, scoring, schema, or route change. `/watched` stays a compatibility alias.

## Direction A confirmation
Separate routes, shared identity. **No `/library` route**, no merged providers, no in-page tabs/tab state.

## Shared Library section navigation
New presentation-only `src/features/library/LibrarySectionNav.jsx`: a `<nav aria-label="Library sections">` with two native `<Link>`s — **Watchlist → /watchlist**, **Diary → /history**. NOT tabs (no `role="tablist"`/`"tab"`, no arrow-key behavior), no counts, no data fetch, no context, no side effects. Rendered once below each masthead and **retained in the empty and load-error states** (no data dependency) so the user can always reach the other section.

## Active-link semantics + /watched compatibility
Active state is driven by an explicit `current` prop (not NavLink path-matching), so the **`/watched` alias — which renders the Diary surface — correctly marks Diary active**. The active link gets `aria-current="page"` plus a **non-colour** indicator (bold weight + underline border). `/watched` routing is unchanged (no redirect, alias preserved).

## Masthead terminology
Watchlist eyebrow `Watchlist` → **`Your library`** (h1 "Saved for later." + the saved count unchanged). The Diary masthead now carries the shared identity explicitly: eyebrow **`Your library`** + a **visible h1 "Your diary."** (replacing the prior sr-only h1 → still exactly one h1) + supporting copy *"A chronological record of what you watched and what you thought."* The words **Watchlist** and **Diary** remain present (section nav + page metadata); neither page is renamed.

## Header/menu terminology
Avatar menu **"Watch history" → "Diary"** (destination `/history` + Clock icon unchanged); "Watchlist" stays. **No new global Library item**; order otherwise intact.

## Metadata
Unchanged — "Watchlist — FeelFlick" / "Diary — FeelFlick" (shared identity lives in the masthead + cross-nav, not the title).

## No data/write/stat/removal change
Verified byte-identical / unchanged: both providers + both derivations, the F6.3 announcement/focus helpers, **the router** (no `/library` route, no `/watched` change), Watchlist sorting/filtering, Diary statistics, removal semantics, rating/reflection, Discover `watched_at`, route guards, Library announcements/focus recovery.

## Accessibility outcomes
One `<h1>` per page (incl. the error state — PageError's, not a competing masthead h1); `<nav aria-label="Library sections">` with native links; `aria-current="page"` on the active link; **no tab semantics**; active state has a non-colour indicator (weight + underline); ≥44px targets; focus-visible rings; no focus movement or extra live announcement merely from rendering the nav.

## Responsive reasoning (source-grounded; browser proof is F6.8)
`inline-flex` + `flex-wrap` so the two short labels never force a horizontal scroll at 360–1440; each link ≥44px tall; the active underline/border stays visible; the nav sits below the headline and the controls below wrap independently; no fixed pixel width, no animated pill, no bottom-nav overlap introduced.

## Tests + validation
LibrarySectionNav (nav semantics, two links + hrefs, active `aria-current` incl. the `/watched`→Diary case, no tab roles, no counts, presentation-only); Watchlist + Diary integration (eyebrow "Your library", headlines, active link, cross link, count/controls/stats retained, nav in empty + error, one h1); Header menu (Watchlist + Diary present, "Watch history" gone, `/history` destination, no new Library item, stable order + sign-out). The page-test react-router mocks gained a `<Link>` stub. **All F6.3/F6.4/F6.5 Watchlist + Diary behavior tests remain green.** `npm run lint` clean · targeted **95 ×3** · full **1254 → 1273** · `npm run build` ✓.

**No live route opened; no live write.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
