### PR TITLE
Correct Library history truth and reaction idempotency

### DIFF
--- a/e2e/app/library.e2e.js
+++ b/e2e/app/library.e2e.js
@@ -213,6 +213,33 @@ test.describe('User Library — Diary, authenticated, intercepted', () => {
     expect(ledger.unexpectedRequests).toEqual([])
   })
 
+  test('G2 — F6.10: duplicate user_history rows for one film collapse to ONE Diary entry + uninflated stats', async ({ page }) => {
+    // 6 raw rows (3 for Lantern Hill across watch paths + 9202/9203/9204) → 4 canonical films.
+    const ledger = await installLibraryFixture(page, { duplicateHistory: true })
+    await openDiary(page)
+
+    const rows = page.getByRole('listitem')
+    await expect(rows).toHaveCount(4)                                           // not 6
+    await expect(page.getByRole('heading', { name: 'Lantern Hill', exact: true })).toHaveCount(1) // film shown once
+    await expect(rows.first().getByRole('heading', { level: 3 })).toHaveText('Lantern Hill')       // its LATEST watch (Feb 13) → newest-first
+
+    // stats count each film once (not inflated by dupes): masthead "4 films · 7 hours"
+    // (Logged + Hours) + the per-card values located by exact label.
+    await expect(page.getByText('4 films · 7 hours')).toBeVisible()
+    const card = (label) => page.locator('.ff-hist-pulse-grid > div').filter({ has: page.getByText(label, { exact: true }) })
+    await expect(card('Logged')).toContainText('4')
+    await expect(card('Hours watched')).toContainText('7h')
+    await expect(card('This month')).toContainText('2')
+
+    // rating + review remain attached to the canonical Lantern Hill entry
+    const lantern = rows.filter({ has: page.getByRole('heading', { name: 'Lantern Hill', exact: true }) })
+    await expect(lantern.getByRole('img', { name: '5 of 5 stars' })).toBeVisible()
+    await expect(lantern.getByText('Your review')).toBeVisible()
+    await expect(lantern.getByText(/A patient film about repair/)).toBeVisible()
+
+    expect(ledger.unexpectedRequests).toEqual([])
+  })
+
   test('H — Diary filter (aria-pressed), search and reset', async ({ page }) => {
     const ledger = await installLibraryFixture(page)
     await openDiary(page)

--- a/e2e/fixtures/library.js
+++ b/e2e/fixtures/library.js
@@ -40,6 +40,17 @@ export const HISTORY = [
   { movie_id: 9203, watched_at: '2026-01-20T19:00:00Z', movies: diMovie({ id: 9203, tmdb_id: 920003, title: 'Winter Tenants', director_name: 'Cole Park', release_date: '2017-09-01', runtime: 96, mood_tags: ['melancholy'], poster_path: null }) },
   { movie_id: 9204, watched_at: '2026-01-19T18:00:00Z', movies: diMovie({ id: 9204, tmdb_id: 920004, title: 'The Long Field', director_name: 'Lena Cho', release_date: '2019-06-01', runtime: 133, mood_tags: ['tense'], poster_path: '/di-field.jpg' }) },
 ]
+// F6.10 duplicate-history scenario (opt-in via { duplicateHistory: true } — NOT the default,
+// so the visual baselines stay stable). The DB allows multiple user_history rows per
+// (user, movie); here Lantern Hill (9201) has THREE rows from different watch paths with
+// distinct watched_at + ids. The canonical (one-per-film) derivation must collapse them to
+// the LATEST watch (Feb 13), so the Diary shows 4 entries (not 6) and stats count once.
+export const DUPLICATE_HISTORY = [
+  { movie_id: 9201, watched_at: '2026-02-10T18:00:00Z', id: 'h-9201-onb', source: 'onboarding',      movies: diMovie({ id: 9201, tmdb_id: 920001, title: 'Lantern Hill', director_name: 'Mara Vance', release_date: '2021-04-01', runtime: 114, mood_tags: ['tender'], poster_path: '/di-lantern.jpg' }) },
+  { movie_id: 9201, watched_at: '2026-02-12T21:00:00Z', id: 'h-9201-ff',  source: 'film_file',       movies: diMovie({ id: 9201, tmdb_id: 920001, title: 'Lantern Hill', director_name: 'Mara Vance', release_date: '2021-04-01', runtime: 114, mood_tags: ['tender'], poster_path: '/di-lantern.jpg' }) },
+  { movie_id: 9201, watched_at: '2026-02-13T08:00:00Z', id: 'h-9201-dsc', source: 'discover_marked', movies: diMovie({ id: 9201, tmdb_id: 920001, title: 'Lantern Hill', director_name: 'Mara Vance', release_date: '2021-04-01', runtime: 114, mood_tags: ['tender'], poster_path: '/di-lantern.jpg' }) },
+  ...HISTORY.slice(1), // 9202, 9203, 9204 (one row each)
+]
 export const RATINGS = [
   { movie_id: 9201, rating: 9, review_text: 'A patient film about repair — it earns its silences, and the long northern evening it unfolds across feels like a held breath that never quite lets go.', rated_at: '2026-02-12T21:30:00Z' },
   { movie_id: 9202, rating: 7, review_text: null, rated_at: '2026-02-11T20:30:00Z' },
@@ -73,12 +84,12 @@ const REDACT = (s) => String(s).replace(/(apikey|access_token|authorization|emai
 
 // ── installer ──────────────────────────────────────────────────────────────────────
 export async function installLibraryFixture(page, options = {}) {
-  const opts = { mode: 'loaded', removeMode: 'success', reducedMotion: false, ...options }
+  const opts = { mode: 'loaded', removeMode: 'success', reducedMotion: false, duplicateHistory: false, ...options }
 
   // Mutable in-memory state so removals are reflected by subsequent reads (and cross-nav).
   const state = {
     watchlist: WATCHLIST.map(r => ({ ...r })),
-    history: HISTORY.map(r => ({ ...r })),
+    history: (opts.duplicateHistory ? DUPLICATE_HISTORY : HISTORY).map(r => ({ ...r })),
     ratings: RATINGS.map(r => ({ ...r })),
     removedWatchlistIds: [],
     removedHistoryIds: [],

--- a/src/features/history/derive/__tests__/historyDerive.test.js
+++ b/src/features/history/derive/__tests__/historyDerive.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach, vi } from 'vitest'
 
 import {
   WEEKDAY_NAMES, capitalize, dayPart, moodHexFor,
-  deriveEntries, deriveStats, matchesQuery,
+  deriveEntries, deriveStats, matchesQuery, dedupeHistoryByMovie,
 } from '../historyDerive'
 
 // F6.5 — the Diary derivation is now data-truthful: the average is DIARY-SCOPED (only
@@ -118,5 +118,90 @@ describe('matchesQuery — Diary search (title / director / review, NOT film moo
   it('25. does NOT match on the FILM mood (it is not a user note)', () => {
     expect(matchesQuery(e, 'tender')).toBe(false)
     expect(matchesQuery(e, 'zzz')).toBe(false)
+  })
+})
+
+// F6.10 — canonical (one-per-film) history dedup. user_history allows multiple rows per
+// (user, movie); the Diary contract is one entry per film, collapsed to the LATEST watch.
+describe('dedupeHistoryByMovie (canonical one-per-film history)', () => {
+  const r = (movie_id, watched_at, over = {}) => ({ movie_id, watched_at, id: `${movie_id}-${watched_at}`, movies: { id: movie_id * 10, runtime: 100 }, ...over })
+
+  it('1. one row stays one row', () => {
+    const h = [r(1, '2026-03-09T20:00:00Z')]
+    expect(dedupeHistoryByMovie(h)).toHaveLength(1)
+  })
+  it('2/3/4. two and three rows for one film collapse to one — the most-recent watched_at wins', () => {
+    const two = [r(1, '2026-03-01T20:00:00Z', { source: 'old' }), r(1, '2026-03-09T20:00:00Z', { source: 'new' })]
+    expect(dedupeHistoryByMovie(two)).toEqual([expect.objectContaining({ movie_id: 1, watched_at: '2026-03-09T20:00:00Z', source: 'new' })])
+    const three = [r(1, '2026-03-01T20:00:00Z'), r(1, '2026-03-15T20:00:00Z', { source: 'latest' }), r(1, '2026-03-09T20:00:00Z')]
+    const out = dedupeHistoryByMovie(three)
+    expect(out).toHaveLength(1)
+    expect(out[0]).toMatchObject({ watched_at: '2026-03-15T20:00:00Z', source: 'latest' })
+  })
+  it('5. rows with null/invalid watched_at are excluded (Diary rule preserved)', () => {
+    expect(dedupeHistoryByMovie([r(1, null), r(1, 'not-a-date')])).toEqual([])
+    // a valid row still wins even if an invalid one for the same film exists
+    expect(dedupeHistoryByMovie([r(1, null), r(1, '2026-03-09T20:00:00Z')])).toHaveLength(1)
+  })
+  it('6. rows missing movie_id are excluded', () => {
+    expect(dedupeHistoryByMovie([{ watched_at: '2026-03-09T20:00:00Z' }, r(1, '2026-03-09T20:00:00Z')]).map(x => x.movie_id)).toEqual([1])
+  })
+  it('7. the input array is not mutated', () => {
+    const h = [r(1, '2026-03-01T20:00:00Z'), r(1, '2026-03-09T20:00:00Z')]
+    const snapshot = JSON.stringify(h)
+    dedupeHistoryByMovie(h)
+    expect(JSON.stringify(h)).toBe(snapshot)
+    expect(h).toHaveLength(2)
+  })
+  it('8. equal timestamps tie-break to the EARLIER original-array row (deterministic)', () => {
+    const h = [r(1, '2026-03-09T20:00:00Z', { source: 'first' }), r(1, '2026-03-09T20:00:00Z', { source: 'second' })]
+    expect(dedupeHistoryByMovie(h)[0].source).toBe('first')
+  })
+  it('9/10. different movies stay separate; the selected canonical row keeps all its fields', () => {
+    const h = [r(1, '2026-03-09T20:00:00Z', { movies: { id: 10, runtime: 100, title: 'A' } }), r(2, '2026-03-08T20:00:00Z', { movies: { id: 20, runtime: 90, title: 'B' } })]
+    const out = dedupeHistoryByMovie(h)
+    expect(out.map(x => x.movie_id).sort()).toEqual([1, 2])
+    expect(out.find(x => x.movie_id === 1).movies).toEqual({ id: 10, runtime: 100, title: 'A' })
+  })
+})
+
+describe('deriveEntries / deriveStats over duplicate history (F6.10)', () => {
+  const dup = (over = {}) => ({ movie_id: 1, movies: { id: 11, tmdb_id: 101, title: 'A', director_name: 'D', release_date: '2020-06-15', runtime: 120, mood_tags: ['tender'], poster_path: '/p.jpg' }, ...over })
+  // three rows for movie 1 (distinct watched_at + source) + one unique movie 2
+  const history = [
+    dup({ watched_at: '2026-02-01T20:00:00Z', id: 'a', source: 'onboarding' }),
+    dup({ watched_at: '2026-03-09T21:00:00Z', id: 'b', source: 'discover_marked' }),
+    dup({ watched_at: '2026-02-15T20:00:00Z', id: 'c', source: 'hero_slider' }),
+    { movie_id: 2, watched_at: '2026-03-05T20:00:00Z', id: 'd', movies: { id: 12, tmdb_id: 102, title: 'B', director_name: 'E', release_date: '2019-01-01', runtime: 90, mood_tags: ['cozy'], poster_path: '/q.jpg' } },
+  ]
+  const ratings = [{ movie_id: 1, rating: 8, review_text: 'Stayed with me.' }] // movie 2 unrated
+
+  it('11/12/13. the duplicated film shows ONCE, at its most-recent watch, newest-first', () => {
+    const entries = deriveEntries(history, ratings)
+    expect(entries).toHaveLength(2)                         // movie 1 (once) + movie 2
+    expect(entries.filter(e => e.movieId === 1)).toHaveLength(1)
+    expect(entries[0].movieId).toBe(1)                      // Mar 9 (latest) is newest-first
+    expect(entries[0].date).toMatch(/Mar 9/)               // uses the most-recent watched_at
+    expect(entries.map(e => e.movieId)).toEqual([1, 2])
+  })
+  it('18/19/20. the canonical entry keeps its rating/review/film-mood and adds no rewatch/synthetic field', () => {
+    const [e1] = deriveEntries(history, ratings)
+    expect(e1.rating).toBe(4)                               // round(8/2)
+    expect(e1.review).toBe('Stayed with me.')
+    expect(e1.filmMood).toBe('Tender')
+    expect(e1.rewatch).toBe(false)                          // no "watched twice" / rewatch count
+    expect(e1).not.toHaveProperty('watchCount')
+    expect(e1).not.toHaveProperty('previousWatches')
+  })
+  it('14/15/16. Logged counts the film once, Hours counts its runtime once, This month counts it once', () => {
+    vi.useFakeTimers(); vi.setSystemTime(new Date('2026-03-20T12:00:00Z')) // March
+    const s = deriveStats({ history, ratings })
+    expect(s.totalLogged).toBe(2)                           // 2 unique films (not 4 rows)
+    expect(s.totalHours).toBe(4)                            // (120 + 90)/60 = 3.5 → 4 (runtime once each)
+    expect(s.thisMonthCount).toBe(2)                        // movie 1 (latest Mar 9) + movie 2 (Mar 5) — once each
+  })
+  it('17. average rating counts the duplicated film once (denominator + numerator unaffected by dupes)', () => {
+    const s = deriveStats({ history, ratings })
+    expect(s.avgRating).toBe(4)                             // only movie 1 rated (8) → 8/2; movie 2 unrated excluded
   })
 })

--- a/src/features/history/derive/historyDerive.js
+++ b/src/features/history/derive/historyDerive.js
@@ -36,10 +36,32 @@ export function moodHexFor(name) {
 
 // === Derivers ============================================================
 
+// F6.10: collapse user_history to ONE canonical row per film. The DB allows multiple
+// rows per (user, movie) (its only uniqueness is (user_id, movie_id, watched_at)), and
+// different watch paths stamp fresh watched_at values, so the same film can have 2–3 rows.
+// The CURRENT Diary contract is one entry per film — multiple rows are collapsed to the
+// LATEST watch (this is NOT a rewatch; first-class rewatches + any DB cleanup are future
+// architecture). Pure: the input is never mutated, no DB row is touched, and the selected
+// canonical row's fields are preserved verbatim (older rows are never merged/synthesized).
+export function dedupeHistoryByMovie(history = []) {
+  const byMovie = new Map()
+  for (let i = 0; i < history.length; i++) {
+    const row = history[i]
+    if (!row || row.movie_id == null) continue                 // rule 1: need a movie_id
+    const t = row.watched_at ? new Date(row.watched_at).getTime() : NaN
+    if (!Number.isFinite(t)) continue                          // rule 2: need a valid watched_at (Diary rule)
+    const existing = byMovie.get(row.movie_id)
+    // rule 4/5: keep the most-recent watched_at; on a tie keep the EARLIER original-array
+    // row (replace only when STRICTLY newer → stable, deterministic).
+    if (!existing || t > existing.t) byMovie.set(row.movie_id, { row, t })
+  }
+  return [...byMovie.values()].map(v => v.row)                 // rules 6/7: new array, original row refs
+}
+
 export function deriveEntries(history, ratings) {
   const ratingByMovieId = new Map(ratings.map(r => [r.movie_id, r]))
-  return history
-    .filter(h => h.watched_at)
+  // One visible entry per film, from the canonical (deduplicated) history set.
+  return dedupeHistoryByMovie(history)
     .sort((a, b) => new Date(b.watched_at) - new Date(a.watched_at))
     .map(h => {
       const m = h.movies || {}
@@ -81,15 +103,18 @@ export function deriveEntries(history, ratings) {
 }
 
 export function deriveStats({ history, ratings }) {
-  const totalLogged = history.length
-  const totalHours = Math.round(history.reduce((s, h) => s + (h.movies?.runtime || 0), 0) / 60)
+  // F6.10: every Diary fact is computed from the SAME canonical (one-per-film) history
+  // set, so duplicate rows never inflate Logged / Hours / This-month.
+  const canonical = dedupeHistoryByMovie(history)
+  const totalLogged = canonical.length                                   // unique films
+  const totalHours = Math.round(canonical.reduce((s, h) => s + (h.movies?.runtime || 0), 0) / 60) // runtime once/film
 
-  // F6.5: DIARY-SCOPED average — average only ratings whose movie is in the current
+  // F6.5: DIARY-SCOPED average — average only ratings whose movie is in the canonical
   // watched Diary. Rated-but-unwatched films and removed Diary films do not count;
   // unrated Diary films are excluded from the denominator. No rating scale changes.
-  const historyMovieIds = new Set(
-    history.filter(h => h.watched_at).map(h => h.movie_id)
-  )
+  // (Ratings are keyed per movie, so a duplicate history row affects neither numerator
+  // nor denominator — the canonical set makes this explicit.)
+  const historyMovieIds = new Set(canonical.map(h => h.movie_id))
   const diaryRatings = ratings.filter(
     r => r.rating != null && historyMovieIds.has(r.movie_id)
   )
@@ -99,7 +124,8 @@ export function deriveStats({ history, ratings }) {
 
   const now = new Date()
   const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1)
-  const thisMonthCount = history.filter(h => h.watched_at && new Date(h.watched_at) >= startOfMonth).length
+  // Count each film once, by its selected latest watched_at.
+  const thisMonthCount = canonical.filter(h => new Date(h.watched_at) >= startOfMonth).length
 
   return { totalLogged, totalHours, avgRating, thisMonthCount }
 }

--- a/src/features/movie/hooks/__tests__/useUserRating.test.js
+++ b/src/features/movie/hooks/__tests__/useUserRating.test.js
@@ -18,11 +18,11 @@ function makeBuilder() {
   for (const m of ['select', 'eq', 'not', 'order', 'limit']) b[m] = vi.fn(() => b)
   b.maybeSingle = vi.fn(() => Promise.resolve({ data: null, error: null }))
   for (const op of ['upsert', 'insert', 'delete']) {
-    b[op] = vi.fn((payload) => {
+    b[op] = vi.fn((payload, opts) => {
       // delete().eq().eq() is awaited on the chain tail; upsert/insert are awaited
       // directly. Record + return a thenable tied to the next deferred.
       const d = nextDeferred()
-      const rec = { op, payload }
+      const rec = { op, payload, opts }
       writeCalls.push(rec)
       const thenable = {
         eq: vi.fn(() => thenable),
@@ -116,17 +116,62 @@ describe('useUserRating — F5.4 serialization', () => {
     expect(result.current.saveStatus).toBe('saved')
   })
 
-  it('35. reaction uses the user_movie_feedback table with the unchanged payload', async () => {
+  // F6.10: reaction persistence is now an idempotent UPSERT (was a plain insert that threw
+  // 23505 on a later change against UNIQUE(user_id, movie_id)). Payload + behavior unchanged.
+  it('F6.10-1/2/3/6. first reaction UPSERTs (not insert) on user_id,movie_id with the unchanged payload', async () => {
     const { result } = renderHook(() => useUserRating({ userId: 'u1', internalId: 7 }))
     await act(async () => {})
     writeCalls.length = 0
     act(() => { result.current.setReaction('Loved it') })
     await act(async () => { vi.advanceTimersByTime(600) })
-    const insert = writeCalls.find(w => w.op === 'insert')
-    expect(insert.payload).toMatchObject({
+    const reactionWrites = writeCalls.filter(w => w.payload?.feedback_type === 'sentiment')
+    expect(reactionWrites).toHaveLength(1)
+    expect(reactionWrites[0].op).toBe('upsert')                       // not a plain insert
+    expect(writeCalls.some(w => w.op === 'insert')).toBe(false)       // no insert anywhere for the reaction
+    expect(reactionWrites[0].opts).toEqual({ onConflict: 'user_id,movie_id' })
+    expect(reactionWrites[0].payload).toMatchObject({
       user_id: 'u1', movie_id: 7, sentiment: 'loved',
       feedback_type: 'sentiment', placement: 'movie_detail_v2_your_take', watched_confirmed: true,
     })
+  })
+
+  it('F6.10-4/5/8. changing the reaction later UPSERTs again with the latest value → saved', async () => {
+    const { result } = renderHook(() => useUserRating({ userId: 'u1', internalId: 7 }))
+    await act(async () => {})
+    writeCalls.length = 0
+    act(() => { result.current.setReaction('Loved it') })
+    await act(async () => { vi.advanceTimersByTime(600) })
+    await act(async () => { await settleAll() })
+    act(() => { result.current.setReaction('Liked it') })            // change in a later "session"
+    await act(async () => { vi.advanceTimersByTime(600) })
+    await act(async () => { await settleAll() })
+    const reactionWrites = writeCalls.filter(w => w.payload?.feedback_type === 'sentiment')
+    expect(reactionWrites).toHaveLength(2)                            // a second upsert, not a 23505
+    expect(reactionWrites.every(w => w.op === 'upsert')).toBe(true)
+    expect(reactionWrites[1].payload.sentiment).toBe('liked')        // latest value persisted (Liked it → liked)
+    expect(result.current.saveStatus).toBe('saved')
+  })
+
+  it('F6.10-9/10. a genuine reaction upsert error reaches error state (no false success)', async () => {
+    const { result } = renderHook(() => useUserRating({ userId: 'u1', internalId: 7 }))
+    await act(async () => {})
+    writeCalls.length = 0
+    act(() => { result.current.setReaction('Loved it') })
+    await act(async () => { vi.advanceTimersByTime(600) })
+    await act(async () => { for (const d of deferreds) d.reject(); await Promise.resolve(); await Promise.resolve(); await Promise.resolve() })
+    expect(result.current.saveStatus).toBe('error')
+    expect(result.current.saveStatus).not.toBe('saved')
+  })
+
+  it('F6.10-11. rapid different reactions coalesce to ONE upsert with the latest value (latest-wins)', async () => {
+    const { result } = renderHook(() => useUserRating({ userId: 'u1', internalId: 7 }))
+    await act(async () => {})
+    writeCalls.length = 0
+    act(() => { result.current.setReaction('Loved it'); result.current.setReaction('Mixed'); result.current.setReaction('Liked it') })
+    await act(async () => { vi.advanceTimersByTime(600) })
+    const reactionWrites = writeCalls.filter(w => w.payload?.feedback_type === 'sentiment')
+    expect(reactionWrites).toHaveLength(1)
+    expect(reactionWrites[0].payload.sentiment).toBe('liked')        // latest of the three
   })
 
   it('33. unmount clears pending timers without throwing (no state update after unmount)', async () => {

--- a/src/features/movie/hooks/useUserRating.js
+++ b/src/features/movie/hooks/useUserRating.js
@@ -182,16 +182,19 @@ export function useUserRating({ userId, internalId }) {
   const writeReaction = useCallback(async (nextReaction) => {
     if (!userId || !internalId) return
     const sentiment = nextReaction ? REACTION_TO_SENTIMENT[nextReaction] : 'neutral'
-    // Append-only — each chip click logs a new feedback row. Hydration reads the
-    // latest, so the most-recent value wins.
-    const { error } = await supabase.from('user_movie_feedback').insert({
+    // F6.10: UPSERT, not insert. user_movie_feedback has a UNIQUE (user_id, movie_id), so
+    // a plain insert threw 23505 on a later reaction change (false "Could not save"). The
+    // reaction is a single film-level reflection — upsert on the same conflict target the
+    // rating write uses, so it creates the row when none exists and updates it otherwise,
+    // latest-value-wins. Payload fields are unchanged. (No preliminary SELECT.)
+    const { error } = await supabase.from('user_movie_feedback').upsert({
       user_id: userId,
       movie_id: internalId,
       sentiment,
       feedback_type: 'sentiment',
       placement: 'movie_detail_v2_your_take',
       watched_confirmed: true,
-    })
+    }, { onConflict: 'user_id,movie_id' })
     if (error) throw error
   }, [userId, internalId])
 


### PR DESCRIPTION
**F6.10 — Correct Library history truth and reaction idempotency.** Resolves the two confirmed F6.9 P1 blockers. **Narrow data-truth + write-idempotency only** — no product/UI redesign, no route change, no schema/RLS migration, no rewatch UI, no Watchlist change, no recommendation-scoring change.

## P1-A — Diary duplicate entries + inflated stats
`user_history`'s only uniqueness is `(user_id, movie_id, watched_at)`, and every watch path (Film File, Discover, Home, onboarding) stamps a fresh `watched_at`, so the same film accumulates 2–3 rows; `deriveEntries` rendered each and `deriveStats` counted each → inflated Logged/Hours/This-month + repeated rows. The current Diary contract is **one entry per film**.

New pure helper **`historyDerive.js:dedupeHistoryByMovie(history)`** collapses to **one canonical row per `movie_id`** — the most-recent valid `watched_at` (strictly-newer replace → stable original-array tie-break), excluding rows without a valid `movie_id`/`watched_at` (preserving the Diary's watched_at rule), **never mutating** the input, **never merging/synthesizing** older-row fields, **never** representing a duplicate as a rewatch. Both `deriveEntries` and `deriveStats` now derive from that single canonical set: one visible entry per film placed by its latest watch (newest-first); Logged = unique films; Hours = runtime once per film; This-month = each film once by its latest watch. The F6.5 Diary-scoped average is unchanged (ratings are per-movie → dupes never affected numerator/denominator). **No schema migration, no DB cleanup, no `(user, movie)` constraint, no row-id removal, no rewatch UI** — documented as future architecture.

## P1-B — Film File reaction 23505 conflict
`user_movie_feedback` has `UNIQUE(user_id, movie_id)`, but `useUserRating.js:writeReaction` did a plain `.insert`, so changing a reaction later threw 23505 + a false "Could not save" while the prior reaction stayed stuck. Changed **only the persistence op** to `.upsert(payload, { onConflict: 'user_id,movie_id' })` (the same target the rating write uses). Payload fields, sentiment mapping, debounce, latest-value-wins serialization, stale-completion guard, save indicator, live announcements, retry, and hook API are **all unchanged**; **no preliminary SELECT**. The reaction now creates-or-updates idempotently, persists the latest value, and announces success only after the upsert settles.

## Canonical-row rule + no-rewatch boundary
One canonical row per `movie_id` = most-recent valid `watched_at`, stable tie-break, fields preserved verbatim. Multiple history rows are collapsed to the latest watch **until an explicit rewatch product model exists** — no "watched twice", no previous-dates UI, no session UI, no row-id removal, no constraint, no migration.

## Payload / frozen-contract confirmation
Reaction payload (`user_id`, `movie_id`, `sentiment`, `feedback_type`, `placement`, `watched_confirmed`) byte-identical. Watchlist + Diary UI/provider/CSS untouched (git-verified); Diary copy/search/filter/sort/removal, the four stat labels, rating/review retention, Discover `watched_at`, routes, provider query shapes, recommendation engine, Library nav, schema/RLS, and F6.8 interception safety all unchanged.

## Duplicate fixture / E2E evidence
Opt-in `duplicateHistory` fixture mode (Lantern Hill × 3 across watch paths + the 3 other films) → 6 raw rows. New intercepted **E2E G2** proves: 4 canonical entries (not 6), Lantern Hill once at its latest watch newest-first, masthead "4 films · 7 hours" + Logged 4 / Hours 7h / This-month 2 uninflated, rating/review attached, **unexpected ledger empty**. The duplicate mode is **opt-in**, so the default fixture + 16 visual baselines are byte-identical (**no drift, confirmed**).

## No-schema-change rationale
The fix lives entirely in the read/derivation + a client write op. A `(user, movie)` uniqueness constraint or duplicate-row cleanup would touch live data + every write path — deliberately deferred to a future rewatch-architecture decision; this phase restores Diary truth without it.

## No-live-write proof
No live route opened without the F6.8 fixture; all `/rest/v1` reads/writes intercepted; no live row touched.

## Validation
`npm run lint` clean · changed unit tests **34 ×3** · targeted **534** · full **1283 → 1297** · `npm run build` ✓ · Library E2E **31 ×3** · Library visuals **9** (no baseline drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
