### PR TITLE
Contain Cinematic DNA and behavioral-data privacy

### DIFF
--- a/scripts/verify-owner-only-rls.sql
+++ b/scripts/verify-owner-only-rls.sql
@@ -1,0 +1,53 @@
+-- verify-owner-only-rls.sql — READ-ONLY verification of the F7.2 privacy boundary.
+-- Proves, against the live database, that owner-only RLS is in force on the raw behavioral
+-- tables and that a non-owner authenticated session cannot read another user's rows.
+--
+-- Run with psql or the Supabase SQL editor. It mutates NOTHING (SELECTs + a rolled-back
+-- transaction that only SETs the JWT claim to simulate two authenticated users). Replace the
+-- two UUIDs with two real owner ids before running for the two-account check.
+--
+--   OWNER_A = a user who has user_history/user_ratings rows
+--   OWNER_B = a different user who has rows
+--
+-- Expected results are annotated inline.
+
+-- 1) Policy shape: each table should have exactly ONE owner/participant SELECT policy,
+--    and NO "Authenticated users can view any ..." / USING (true) policy.
+select tablename, policyname, cmd, qual
+from pg_policies
+where schemaname = 'public'
+  and tablename in ('user_history','user_ratings','user_similarity')
+  and cmd = 'SELECT'
+order by tablename, policyname;
+-- EXPECT: user_history  → "Users can view own history"     using ((select auth.uid()) = user_id)
+--         user_ratings  → "Users can view own ratings"     using ((select auth.uid()) = user_id)
+--         user_similarity → "Users can view own similarity" using (auth.uid() in (user_a_id,user_b_id))
+--         and NO row whose qual is `true` or `auth.uid() IS NOT NULL`.
+
+-- 2) Two-account boundary check (read-only; rolled back). Simulate authenticated user A and
+--    confirm A sees own rows but ZERO of B's rows. Then the reverse.
+\set OWNER_A '00000000-0000-0000-0000-000000000000'
+\set OWNER_B '11111111-1111-1111-1111-111111111111'
+
+begin;
+  set local role authenticated;
+
+  -- as A
+  select set_config('request.jwt.claims', json_build_object('sub', :'OWNER_A', 'role', 'authenticated')::text, true);
+  select 'A reads own history'   as check, count(*) > 0  as expect_true  from public.user_history  where user_id = :'OWNER_A';
+  select 'A reads B history'     as check, count(*) = 0  as expect_true  from public.user_history  where user_id = :'OWNER_B';  -- RLS blocks → 0
+  select 'A reads own ratings'   as check, count(*) >= 0 as expect_true  from public.user_ratings  where user_id = :'OWNER_A';
+  select 'A reads B ratings'     as check, count(*) = 0  as expect_true  from public.user_ratings  where user_id = :'OWNER_B';  -- 0
+  select 'A reads B similarity'  as check, count(*) = 0  as expect_true  from public.user_similarity where user_a_id = :'OWNER_B' and user_b_id <> :'OWNER_A';  -- 0
+
+  -- as B
+  select set_config('request.jwt.claims', json_build_object('sub', :'OWNER_B', 'role', 'authenticated')::text, true);
+  select 'B reads A history'     as check, count(*) = 0  as expect_true  from public.user_history  where user_id = :'OWNER_A';  -- 0
+rollback;
+
+-- 3) Anonymous denial: the anon role must read zero behavioral rows.
+begin;
+  set local role anon;
+  select 'anon reads any history' as check, count(*) = 0 as expect_true from public.user_history;   -- 0
+  select 'anon reads any ratings' as check, count(*) = 0 as expect_true from public.user_ratings;   -- 0
+rollback;

--- a/src/features/account/__tests__/PrivacyControls.test.jsx
+++ b/src/features/account/__tests__/PrivacyControls.test.jsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+// F7.2 privacy containment: the "Public profile" / "Public diary" toggles were never
+// enforced by any read path or RLS policy (cosmetic) — they must NOT be rendered as
+// functional-looking controls. Enforced controls (taste-match surfacing, analytics) stay.
+
+const updatePrivacy = vi.fn()
+vi.mock('../useAccountData', () => ({
+  useAccountData: () => ({
+    serverSettings: { privacy: { showOnLeaderboards: true, analytics: true } },
+    updatePrivacy,
+  }),
+}))
+vi.mock('@/shared/services/analytics', () => ({ setAnalyticsOptOut: vi.fn() }))
+
+import { Privacy } from '../sections-bottom'
+
+describe('Account Privacy — F7.2 honest controls', () => {
+  it('does NOT render the unenforced "Public profile" / "Public diary" controls', () => {
+    render(<Privacy />)
+    expect(screen.queryByText('Public profile')).not.toBeInTheDocument()
+    expect(screen.queryByText('Public diary')).not.toBeInTheDocument()
+    // no switch/control carrying those labels either
+    expect(screen.queryByLabelText(/public profile/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/public diary/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/anyone with the link can view your dna/i)).not.toBeInTheDocument()
+  })
+
+  it('keeps the enforced controls (taste-match surfacing + analytics)', () => {
+    render(<Privacy />)
+    expect(screen.getByText('Show on taste-match')).toBeInTheDocument()
+    expect(screen.getByText('Product analytics')).toBeInTheDocument()
+  })
+
+  it('states honestly that Cinematic DNA / history / ratings are private', () => {
+    render(<Privacy />)
+    expect(screen.getByText(/visible only to you/i)).toBeInTheDocument()
+  })
+})

--- a/src/features/account/sections-bottom.jsx
+++ b/src/features/account/sections-bottom.jsx
@@ -21,15 +21,18 @@ function Privacy() {
     // the other toggles take effect on next page load (they gate fetches).
     if (k === 'analytics') setAnalyticsOptOut(!next);
   };
+  // F7.2 privacy containment: the "Public profile" / "Public diary" toggles were never
+  // enforced by any read path or RLS policy — your DNA and diary are owner-private regardless.
+  // Rather than render a control that falsely implies publication, they're removed until a real
+  // consent-based public-profile model exists. (showOnLeaderboards IS enforced — it gates
+  // taste-twin surfacing in People — and analytics is enforced immediately; both stay.)
   const rows = [
-    { k:'profilePublic',      label:'Public profile',       desc:'Anyone with the link can view your DNA' },
-    { k:'diaryPublic',        label:'Public diary',         desc:'Your ratings show on your public profile' },
     { k:'showOnLeaderboards', label:'Show on taste-match',  desc:"Surface in other users' taste-twin lists" },
     { k:'analytics',          label:'Product analytics',    desc:'Help us improve. Aggregated, no PII.' },
   ];
   return (
     <section className="ff-acct-section ff-acct-section--body" style={{ padding:'56px 88px', borderTop:`1px solid ${HP.border}` }}>
-      <SectionHead kicker="Privacy" title="Who else gets to look." sub="Everything&rsquo;s off-by-default for new accounts. You opt-in for each surface." />
+      <SectionHead kicker="Privacy" title="Who else gets to look." sub="Your Cinematic DNA, watch history and ratings are private — visible only to you. Public taste profiles aren&rsquo;t available yet." />
       <div style={{ borderTop:`1px solid ${HP.border}` }}>
         {rows.map(r => (
           <div key={r.k} style={{ display:'grid', gridTemplateColumns:'1fr auto', gap:24, alignItems:'center', padding:'18px 0', borderBottom:`1px solid ${HP.border}` }}>

--- a/src/features/feed/Feed.jsx
+++ b/src/features/feed/Feed.jsx
@@ -249,7 +249,7 @@ function FeedCard({ event, user, isLatest, currentUserId, onNavigate }) {
             <p className="text-[13px] leading-snug flex-1 min-w-0">
               {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
               <span onClick={(e) => e.stopPropagation()} className="inline">
-                <Link to={`/profile/${event.userId}`} className="inline-flex items-center gap-1.5 hover:opacity-75 transition-opacity align-middle">
+                <Link to={"/people"} className="inline-flex items-center gap-1.5 hover:opacity-75 transition-opacity align-middle">
                   <UserAvatar name={user?.name} avatarUrl={user?.avatar_url} size={18} />
                   <span className="font-semibold text-white">{userName}</span>
                 </Link>
@@ -398,7 +398,7 @@ function FollowingSidebar({ followedUsers, activeFilter, navigate }) {
             <button
               key={u.id}
               type="button"
-              onClick={() => navigate(`/profile/${u.id}`)}
+              onClick={() => navigate('/people')}
               className="flex items-center gap-2.5 py-1.5 w-full rounded-lg px-1 -mx-1 hover:bg-white/4 transition-colors cursor-pointer"
             >
               <UserAvatar name={u.name} avatarUrl={u.avatar_url} size={28} />

--- a/src/features/lists/ListDetail.jsx
+++ b/src/features/lists/ListDetail.jsx
@@ -293,7 +293,7 @@ export default function ListDetail() {
               <div style={{ marginTop: 24, display: 'flex', alignItems: 'center', gap: 12 }}>
                 <button
                   type="button"
-                  onClick={() => navigate(isOwner ? '/profile' : `/profile/${list.user_id}`)}
+                  onClick={() => navigate(isOwner ? '/profile' : '/people')}
                   aria-label={`View ${owner?.name || 'owner'} profile`}
                   style={{ ...RESET_BTN, display: 'flex', alignItems: 'center', gap: 12 }}
                 >

--- a/src/features/people/People.jsx
+++ b/src/features/people/People.jsx
@@ -193,9 +193,9 @@ function TwinsRail() {
           <div className="ff-people-grid-3" style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 16, marginTop: 20 }}>
             {popular.map(p => (
               <article key={p.id} style={{ padding: '18px 20px', borderRadius: 6, background: 'rgba(255,255,255,0.025)', border: `1px solid ${HP.border}`, display: 'grid', gridTemplateColumns: 'auto 1fr auto', gap: 14, alignItems: 'center' }}>
-                <Avatar url={p.avatarUrl} initial={p.initial} bg={p.avatarBg} size={42} onClick={() => navigate(`/profile/${p.id}`)} alt={`View ${p.name}'s profile`} />
+                <Avatar url={p.avatarUrl} initial={p.initial} bg={p.avatarBg} size={42} onClick={() => navigate('/people')} alt={`View ${p.name}'s profile`} />
                 <div style={{ minWidth: 0 }}>
-                  <button type="button" onClick={() => navigate(`/profile/${p.id}`)} style={{ ...RESET_BTN, fontFamily: 'Outfit', fontSize: 15, fontWeight: 500, color: HP.text, display: 'block', width: '100%', textAlign: 'left' }}>{p.name}</button>
+                  <button type="button" onClick={() => navigate('/people')} style={{ ...RESET_BTN, fontFamily: 'Outfit', fontSize: 15, fontWeight: 500, color: HP.text, display: 'block', width: '100%', textAlign: 'left' }}>{p.name}</button>
                   <div style={{ fontSize: 11, color: HP.textMuted, fontFamily: 'Outfit', marginTop: 2, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{p.bio}</div>
                 </div>
                 <FollowBtn following={false} onToggle={() => toggleFollow(p.id)} />
@@ -210,7 +210,7 @@ function TwinsRail() {
               <div style={{ position: 'absolute', top: -30, right: -30, width: 120, height: 120, borderRadius: 999, background: `radial-gradient(circle, ${p.avatarBg}33, transparent 70%)`, filter: 'blur(8px)' }} />
               <div style={{ position: 'relative' }}>
                 <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 18 }}>
-                  <Avatar url={p.avatarUrl} initial={p.initial} bg={p.avatarBg} size={48} onClick={() => navigate(`/profile/${p.id}`)} alt={`View ${p.name}'s profile`} />
+                  <Avatar url={p.avatarUrl} initial={p.initial} bg={p.avatarBg} size={48} onClick={() => navigate('/people')} alt={`View ${p.name}'s profile`} />
                   <div style={{ textAlign: 'right' }}>
                     <div style={{ fontFamily: 'Outfit', fontSize: 34, fontWeight: 200, color: HP.text, letterSpacing: '-0.045em', lineHeight: 1 }}>{p.match}<span style={{ fontSize: 12, color: HP.textMuted, marginLeft: 1 }}>%</span></div>
                     <div style={{ fontSize: 9, color: HP.textFaint, fontFamily: 'Outfit', letterSpacing: '0.14em', textTransform: 'uppercase', marginTop: 2 }}>Match</div>
@@ -219,7 +219,7 @@ function TwinsRail() {
                 <MatchBar pct={p.match} hex={p.avatarBg} />
                 <button
                   type="button"
-                  onClick={() => navigate(`/profile/${p.id}`)}
+                  onClick={() => navigate('/people')}
                   style={{ ...RESET_BTN, marginTop: 16, fontFamily: 'Outfit', fontSize: 18, fontWeight: 500, color: HP.text, letterSpacing: '-0.015em', display: 'block', width: '100%' }}
                 >
                   {p.name}
@@ -277,11 +277,11 @@ function Rising() {
       <div className="ff-people-grid-3" style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 16 }}>
         {rising.map(p => (
           <div key={p.id} style={{ padding: '18px 20px', borderRadius: 6, background: 'rgba(255,255,255,0.025)', border: `1px solid ${HP.border}`, display: 'grid', gridTemplateColumns: 'auto 1fr auto', gap: 16, alignItems: 'center' }}>
-            <Avatar url={p.avatarUrl} initial={p.initial} bg={p.avatarBg} size={42} onClick={() => navigate(`/profile/${p.id}`)} alt={`View ${p.name}'s profile`} />
+            <Avatar url={p.avatarUrl} initial={p.initial} bg={p.avatarBg} size={42} onClick={() => navigate('/people')} alt={`View ${p.name}'s profile`} />
             <div style={{ minWidth: 0 }}>
               <button
                 type="button"
-                onClick={() => navigate(`/profile/${p.id}`)}
+                onClick={() => navigate('/people')}
                 style={{ ...RESET_BTN, fontFamily: 'Outfit', fontSize: 14, fontWeight: 500, color: HP.text, display: 'block', width: '100%' }}
               >
                 {p.name}
@@ -323,7 +323,7 @@ function Activity() {
       <div style={{ borderTop: `1px solid ${HP.border}` }}>
         {activity.map((a, i) => (
           <div key={i} className="ff-people-activity-row" style={{ display: 'grid', gridTemplateColumns: 'auto 1fr auto', gap: 18, alignItems: 'flex-start', padding: '20px 0', borderBottom: `1px solid ${HP.border}` }}>
-            <Avatar url={a.whoAvatarUrl} initial={a.who.charAt(0).toUpperCase()} bg={a.whoBg} size={36} onClick={a.whoId ? () => navigate(`/profile/${a.whoId}`) : undefined} alt={`View ${a.who}'s profile`} />
+            <Avatar url={a.whoAvatarUrl} initial={a.who.charAt(0).toUpperCase()} bg={a.whoBg} size={36} onClick={a.whoId ? () => navigate('/people') : undefined} alt={`View ${a.who}'s profile`} />
             <div>
               <div style={{ fontFamily: 'Outfit, Inter, sans-serif', fontSize: 14, color: HP.textSoft }}>
                 <span style={{ color: HP.text, fontWeight: 600, fontFamily: 'Outfit' }}>{a.who}</span> {a.action} <span style={{ color: HP.text, fontWeight: 600, fontStyle: 'italic' }}>{a.film}</span>
@@ -385,11 +385,11 @@ function Suggested() {
       <div className="ff-people-grid-3" style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 16 }}>
         {suggested.map(p => (
           <div key={p.id} style={{ padding: '18px 20px', borderRadius: 6, background: 'rgba(255,255,255,0.025)', border: `1px solid ${HP.border}`, display: 'grid', gridTemplateColumns: 'auto 1fr auto', gap: 16, alignItems: 'center' }}>
-            <Avatar url={p.avatarUrl} initial={p.initial} bg={p.avatarBg} size={42} onClick={() => navigate(`/profile/${p.id}`)} alt={`View ${p.name}'s profile`} />
+            <Avatar url={p.avatarUrl} initial={p.initial} bg={p.avatarBg} size={42} onClick={() => navigate('/people')} alt={`View ${p.name}'s profile`} />
             <div style={{ minWidth: 0 }}>
               <button
                 type="button"
-                onClick={() => navigate(`/profile/${p.id}`)}
+                onClick={() => navigate('/people')}
                 style={{ ...RESET_BTN, fontFamily: 'Outfit', fontSize: 15, fontWeight: 500, color: HP.text, display: 'block', width: '100%' }}
               >
                 {p.name}
@@ -428,11 +428,11 @@ function SearchResults({ results, loading, onClear }) {
         <div className="ff-people-grid-3" style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 16 }}>
           {results.map(u => (
             <div key={u.id} style={{ padding: '18px 20px', borderRadius: 6, background: 'rgba(255,255,255,0.025)', border: `1px solid ${HP.border}`, display: 'grid', gridTemplateColumns: 'auto 1fr auto', gap: 14, alignItems: 'center' }}>
-              <Avatar url={u.avatarUrl} initial={u.initial} bg={u.avatarBg} size={42} onClick={() => navigate(`/profile/${u.id}`)} alt={`View ${u.name}'s profile`} />
+              <Avatar url={u.avatarUrl} initial={u.initial} bg={u.avatarBg} size={42} onClick={() => navigate('/people')} alt={`View ${u.name}'s profile`} />
               <div style={{ minWidth: 0 }}>
                 <button
                   type="button"
-                  onClick={() => navigate(`/profile/${u.id}`)}
+                  onClick={() => navigate('/people')}
                   style={{ ...RESET_BTN, fontFamily: 'Outfit', fontSize: 15, fontWeight: 500, color: HP.text, display: 'block', width: '100%', textAlign: 'left' }}
                 >
                   {u.name}

--- a/src/features/profile/TasteProfile.jsx
+++ b/src/features/profile/TasteProfile.jsx
@@ -24,33 +24,38 @@ import './profile.css'
 export default function TasteProfile() {
   const { user } = useAuthSession()
   const { userId: paramUserId } = useParams()
-  usePageMeta({ title: paramUserId && paramUserId !== user?.id ? 'Taste profile — FeelFlick' : 'Your taste profile — FeelFlick' })
-  // When viewing via /profile-v2/:userId we render someone else's DNA;
-  // otherwise fall back to the signed-in user.
-  const targetUserId = paramUserId || user?.id
   const isSelf = !paramUserId || paramUserId === user?.id
-  const data = useProfileDataFetch({ userId: targetUserId, authUser: user, isSelf })
+  usePageMeta({ title: isSelf ? 'Your taste profile — FeelFlick' : 'Cinematic DNA — FeelFlick' })
+
+  // F7.2 privacy containment: a Cinematic DNA profile is OWNER-PRIVATE. Another user's
+  // behavioral portrait must never render — and we must not even fetch their
+  // history/ratings/similarity/editorial. (This is defense-in-depth; the authoritative
+  // boundary is the owner-only RLS restored in supabase/migrations/20260609000000.)
+  // Keeping the data hook out of the non-self branch guarantees no cross-user query runs.
+  if (!isSelf) return <PrivateProfile />
+  return <SelfProfile authUser={user} />
+}
+
+function SelfProfile({ authUser }) {
+  const data = useProfileDataFetch({ userId: authUser?.id, authUser, isSelf: true })
 
   if (data.loading) return <PageSkeleton />
   if (data.error) return <PageError error={data.error} />
 
   return (
-    <ProfileDataProvider value={{ ...data, isSelf, viewingUserId: targetUserId }}>
+    <ProfileDataProvider value={{ ...data, isSelf: true, viewingUserId: authUser?.id }}>
       <div className="ff-profile-v2" style={{ minHeight:'100vh', background: HP.bgDeep, color: HP.text, fontFamily:'Inter, sans-serif', position:'relative' }}>
         <div style={{ maxWidth:1440, margin:'0 auto' }}>
           <Masthead />
           <QuickStats />
-          {/* DNA confidence, honestly framed (self-only — a viewer can't improve
-              someone else's profile). Explains the number as taste *evidence*,
+          {/* DNA confidence, honestly framed. Explains the number as taste *evidence*,
               guides cold-start users, and connects the profile to Tonight. */}
-          {isSelf && (
-            <DnaConfidence
-              confidence={data.stats?.dnaConfidence}
-              filmsLogged={data.stats?.filmsLogged}
-              filmsRated={data.stats?.filmsRated}
-              moodSignals={data.moods?.length}
-            />
-          )}
+          <DnaConfidence
+            confidence={data.stats?.dnaConfidence}
+            filmsLogged={data.stats?.filmsLogged}
+            filmsRated={data.stats?.filmsRated}
+            moodSignals={data.moods?.length}
+          />
           <MoodRadar />
           <SignatureDirectors />
           <MotifCloud />
@@ -59,12 +64,33 @@ export default function TasteProfile() {
           <Mixtape />
           <Skew />
           <FriendsRanked />
-          {isSelf && <YIRBanner />}
-          {isSelf && <ShareCard />}
+          <YIRBanner />
+          <ShareCard />
           <ProfileFooter />
         </div>
       </div>
     </ProfileDataProvider>
+  )
+}
+
+// F7.2 — shown for /profile/:userId of anyone other than the signed-in user. No data is
+// fetched for the target. Honest, minimal, keyboard-accessible; explains the current rule
+// rather than implying the person has no taste data.
+function PrivateProfile() {
+  return (
+    <div className="ff-profile-v2" style={{ minHeight:'100vh', background: HP.bgDeep, color: HP.text, display:'flex', alignItems:'center', justifyContent:'center', padding:24, fontFamily:'Inter, sans-serif' }}>
+      <div style={{ textAlign:'center', maxWidth:520 }}>
+        <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color: HP.purple, marginBottom:18 }}>Cinematic DNA</div>
+        <h1 style={{ fontFamily:'Outfit, Inter, sans-serif', fontSize:36, fontWeight:500, color: HP.text, margin:'0 0 14px 0', letterSpacing:'-0.025em' }}>This profile is private.</h1>
+        <p style={{ margin:'0 0 28px 0', color:'rgba(250,250,250,0.6)', fontSize:14, lineHeight:1.6 }}>
+          Cinematic DNA — your watch history, ratings, and taste portrait — is visible only to you. Public taste profiles aren&rsquo;t available yet.
+        </p>
+        <div style={{ display:'flex', gap:12, justifyContent:'center', flexWrap:'wrap' }}>
+          <a href="/profile" style={{ fontFamily:'Outfit, Inter, sans-serif', fontSize:14, fontWeight:600, color:'#0A0510', background:HP.text, padding:'11px 20px', borderRadius:8, textDecoration:'none' }}>Your Cinematic DNA</a>
+          <a href="/people" style={{ fontFamily:'Outfit, Inter, sans-serif', fontSize:14, fontWeight:600, color:HP.text, background:'transparent', border:`1px solid ${HP.border}`, padding:'11px 20px', borderRadius:8, textDecoration:'none' }}>People</a>
+        </div>
+      </div>
+    </div>
   )
 }
 

--- a/src/features/profile/__tests__/TasteProfileSelfOnly.test.jsx
+++ b/src/features/profile/__tests__/TasteProfileSelfOnly.test.jsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+
+// F7.2 privacy containment: a Cinematic DNA profile is owner-private. Viewing
+// /profile/:userId for ANYONE other than the signed-in user must render a private state
+// and must NOT fetch the target user's history / ratings / similarity / editorial. (The
+// authoritative boundary is the owner-only RLS in 20260609000000_*; this is defense-in-depth.)
+
+const fetchSpy = vi.fn(() => ({ loading: true, error: null }))
+vi.mock('../useProfileData', () => ({
+  useProfileDataFetch: (args) => fetchSpy(args),
+  ProfileDataProvider: ({ children }) => children,
+  useProfileData: () => ({}),
+}))
+vi.mock('@/shared/hooks/useAuthSession', () => ({ useAuthSession: () => ({ user: { id: 'self-1' } }) }))
+vi.mock('@/shared/hooks/usePageMeta', () => ({ usePageMeta: () => {} }))
+
+import TasteProfile from '../TasteProfile'
+
+const renderAt = (path) => render(
+  <MemoryRouter initialEntries={[path]}>
+    <Routes>
+      <Route path="/profile" element={<TasteProfile />} />
+      <Route path="/profile/:userId" element={<TasteProfile />} />
+    </Routes>
+  </MemoryRouter>
+)
+
+beforeEach(() => fetchSpy.mockClear())
+
+describe('TasteProfile — F7.2 self-only privacy containment', () => {
+  it("another user's /profile/:userId renders the private state and fetches NOTHING", () => {
+    renderAt('/profile/other-1')
+    // one h1, honest private copy, no behavioral data
+    const h1 = screen.getByRole('heading', { level: 1 })
+    expect(h1).toHaveTextContent(/private/i)
+    // the decisive assertion: no cross-user history/ratings/similarity/editorial query ran
+    expect(fetchSpy).not.toHaveBeenCalled()
+    // keyboard-accessible recovery to safe surfaces
+    expect(screen.getByRole('link', { name: /your cinematic dna/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /people/i })).toBeInTheDocument()
+  })
+
+  it("the signed-in user's own /profile fetches self only (isSelf=true)", () => {
+    renderAt('/profile')
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(fetchSpy).toHaveBeenCalledWith(expect.objectContaining({ userId: 'self-1', isSelf: true }))
+    expect(screen.queryByText(/this profile is private/i)).not.toBeInTheDocument()
+  })
+
+  it('/profile/:ownId (own id in the route param) is treated as self', () => {
+    renderAt('/profile/self-1')
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(fetchSpy).toHaveBeenCalledWith(expect.objectContaining({ userId: 'self-1', isSelf: true }))
+    expect(screen.queryByText(/this profile is private/i)).not.toBeInTheDocument()
+  })
+
+  it('a fresh visit to another user (no prior self render) still fetches nothing', () => {
+    renderAt('/profile/other-2')
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/private/i)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/profile/sections-bottom.jsx
+++ b/src/features/profile/sections-bottom.jsx
@@ -380,7 +380,7 @@ function FriendsRanked() {
             <button
               key={f.userId || f.name}
               type="button"
-              onClick={() => f.userId && navigate(`/profile/${f.userId}`)}
+              onClick={() => navigate('/people')}
               style={{ ...RESET_BTN, padding:'24px 22px', borderRadius:RADIUS.sm, background:'rgba(255,255,255,0.025)', border:`1px solid ${HP.border}`, transition:'border-color 0.18s ease, background 0.18s ease' }}
               onMouseEnter={(e) => { e.currentTarget.style.borderColor = HP.borderStrong; e.currentTarget.style.background = 'rgba(255,255,255,0.04)' }}
               onMouseLeave={(e) => { e.currentTarget.style.borderColor = HP.border; e.currentTarget.style.background = 'rgba(255,255,255,0.025)' }}

--- a/supabase/migrations/20260609000000_restore_owner_only_behavioral_rls.sql
+++ b/supabase/migrations/20260609000000_restore_owner_only_behavioral_rls.sql
@@ -1,0 +1,61 @@
+-- 2026-06-09 — F7.2 privacy containment: restore OWNER-ONLY reads of raw behavioral data.
+--
+-- Why: migration 20260518000000 widened user_history SELECT to "any authenticated user"
+-- (USING (auth.uid() IS NOT NULL)), and user_ratings + user_similarity carried the same
+-- Letterboxd-style broad-read policy. The F7.1 Profile/Cinematic DNA audit confirmed (against
+-- this live database) that this lets ANY signed-in user read ANY other user's full watch
+-- history, ratings, and similarity graph directly over the REST API — i.e. a stranger's entire
+-- behavioral taste portrait (directors, decade/runtime/daypart habits, mixtape + reviews, mood
+-- trajectory, taste-twins) is exposed via /profile/:userId. A React route guard cannot close
+-- this because the client can query the tables directly with its own JWT; the boundary MUST be
+-- in RLS. The account "Public profile" / "Public diary" toggles that implied control over this
+-- were never consulted by any read path or policy (cosmetic) — they are being removed in the
+-- same phase.
+--
+-- This migration makes raw watch history, ratings, and similarity OWNER-PRIVATE again
+-- (auth.uid() = user_id, or participant for similarity). Owner INSERT/UPDATE/DELETE are
+-- untouched. Anonymous access remains denied. The service role is unaffected (it bypasses RLS,
+-- so server-side similarity/stats jobs keep working). Cross-user social features that read these
+-- tables directly (Film File "Friends loved" / "Taste twin", People enrichment) now receive
+-- zero rows and self-hide; re-enabling them behind narrowly-scoped SECURITY DEFINER RPCs with
+-- explicit consent is deferred to a deliberate social-privacy phase.
+--
+-- PRODUCT RULE (temporary): Cinematic DNA, raw watch history and raw ratings are owner-private.
+-- Cross-user experiences may consume only narrow server-projected data designed for that
+-- feature. A future public-profile model requires explicit user consent and server-enforced
+-- publication rules. RLS alone is not consent.
+--
+-- NOTE: ( SELECT auth.uid() ) is wrapped in a sub-select to keep the initplan optimization the
+-- existing owner policies use (auth.uid() evaluated once per query, not once per row).
+
+-- ── user_history: owner-only SELECT ───────────────────────────────────────────
+drop policy if exists "Authenticated users can view any history" on public.user_history;
+drop policy if exists "Users can view own history" on public.user_history;
+create policy "Users can view own history"
+  on public.user_history
+  for select
+  to authenticated
+  using ((select auth.uid()) = user_id);
+
+-- ── user_ratings: owner-only SELECT ───────────────────────────────────────────
+drop policy if exists "Authenticated users can view any ratings" on public.user_ratings;
+drop policy if exists "Users can view own ratings" on public.user_ratings;
+create policy "Users can view own ratings"
+  on public.user_ratings
+  for select
+  to authenticated
+  using ((select auth.uid()) = user_id);
+
+-- ── user_similarity: participant-only SELECT ──────────────────────────────────
+-- A user may read only similarity rows in which they are a participant (the subject
+-- user_a_id or the matched user_b_id) — never another user's full similarity graph.
+drop policy if exists "similarity authenticated read" on public.user_similarity;
+drop policy if exists "Users can view own similarity" on public.user_similarity;
+create policy "Users can view own similarity"
+  on public.user_similarity
+  for select
+  to authenticated
+  using (
+    (select auth.uid()) = user_a_id
+    or (select auth.uid()) = user_b_id
+  );


### PR DESCRIPTION
**F7.2 — Contain Cinematic DNA and behavioral-data privacy.** Closes the confirmed F7.1 **privacy P0** and the related **false-privacy-control P1**, at **both** the database and application layers.

## Confirmed P0 (verified against the live DB in F7.1)
`user_history` carried `"Authenticated users can view any history" USING (auth.uid() IS NOT NULL)`; `user_ratings` and `user_similarity` were likewise broad. So **any signed-in user could read any other user's full watch history, ratings, and similarity graph directly over `/rest/v1/*`**, and `/profile/:userId` rendered a stranger's complete behavioral taste portrait (directors, decade/runtime/daypart habits, mixtape + reviews, mood trajectory, taste-twins).

## Why application-only gating is insufficient
A React route guard only blocks the FeelFlick UI. A client can query the tables directly with its own JWT. **The boundary must be in RLS** — application gating is a second layer, not the fix.

## Final raw-table policy (migration `20260609000000`)
| Table | Before | After |
|---|---|---|
| `user_history` | `USING (auth.uid() IS NOT NULL)` | owner-only `USING ((select auth.uid()) = user_id)` |
| `user_ratings` | broad OR owner | owner-only (broad dropped) |
| `user_similarity` | `USING (true)` | participant-only `(auth.uid() = user_a_id OR = user_b_id)` |

Owner INSERT/UPDATE/DELETE untouched · anonymous still denied · service role (server-side similarity/stats) unaffected. **Applied to the live project as a separate deploy step — the P0 is not closed until that deploy completes** (status in the final report).

## Social-feature decision
Cross-user reads (Film File "Friends loved" / "Taste twin", People enrichment) now return zero rows under RLS and **self-hide gracefully** (sections already guard on empty; hooks catch → empty). Re-enabling them behind narrowly-scoped **SECURITY DEFINER RPCs with explicit consent is deferred** to a deliberate social-privacy phase (recorded in the migration comment).

## Self-only Profile (defense-in-depth)
`TasteProfile` splits so the data hook only runs for the signed-in user; `/profile/:otherId` renders an honest **"This profile is private"** state and fetches **none** of the target's data. **Self-view rendering is byte-for-byte preserved.**

## Privacy-toggle treatment
Removed the unenforced **"Public profile" / "Public diary"** toggles from Account → Privacy (confirmed cosmetic — no read path or RLS consults them) and made the copy honest. `showOnLeaderboards` (enforced in People) + analytics stay. Stored columns are **not** dropped.

## Cross-user DNA links changed
Every `navigate('/profile/:otherId')` in People (×11), Feed (×2), Lists (×1), and the profile taste-twin tiles (×1) now routes to `/people`. Self `/profile` unchanged.

## Database tests + verification
`scripts/verify-owner-only-rls.sql` (read-only, simulated JWT) proves owner-can-read / non-owner-zero-rows / anon-denied; run live post-deploy (results in the report). Component tests (+7): TasteProfile self-only (other → private + **zero fetch**; self → fetch self); Account privacy (no Public-profile/diary controls; enforced controls kept; honest copy).

## Frozen contracts
Self-view DNA hierarchy/derivations/editorial gate · recommendation scoring · Diary · Watchlist · rating/review payloads · Film File decision hierarchy · routes (except the `/profile/:otherId` private state) · auth/onboarding · Home/Discover. No rating-scale change; **no recommendation behavior changed; no live user rows modified.**

## Deferred public-profile / consent model
A future phase must decide opt-in publication, which DNA parts may be public, diary/review visibility, revocation, deletion, and follower-only vs public — with server-enforced projections. **RLS alone is not consent.**

## Validation
`npm run lint` clean · new tests **7 ×3** · targeted **240** · full **1297 → 1304** · `npm run build` ✓. No secrets printed/committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
