### PR TITLE
Canonicalize Cinematic DNA evidence and add Profile safety tests

### DIFF
--- a/src/features/history/derive/historyDerive.js
+++ b/src/features/history/derive/historyDerive.js
@@ -15,6 +15,7 @@
 
 import { formatShortDate, formatShortMonthYear } from '@/shared/lib/format/date'
 import { HP, MOOD_HEX, tmdbImg } from '../data'
+import { dedupeHistoryByMovie } from '@/shared/lib/canonicalHistory'
 
 export const WEEKDAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
 
@@ -36,27 +37,11 @@ export function moodHexFor(name) {
 
 // === Derivers ============================================================
 
-// F6.10: collapse user_history to ONE canonical row per film. The DB allows multiple
-// rows per (user, movie) (its only uniqueness is (user_id, movie_id, watched_at)), and
-// different watch paths stamp fresh watched_at values, so the same film can have 2–3 rows.
-// The CURRENT Diary contract is one entry per film — multiple rows are collapsed to the
-// LATEST watch (this is NOT a rewatch; first-class rewatches + any DB cleanup are future
-// architecture). Pure: the input is never mutated, no DB row is touched, and the selected
-// canonical row's fields are preserved verbatim (older rows are never merged/synthesized).
-export function dedupeHistoryByMovie(history = []) {
-  const byMovie = new Map()
-  for (let i = 0; i < history.length; i++) {
-    const row = history[i]
-    if (!row || row.movie_id == null) continue                 // rule 1: need a movie_id
-    const t = row.watched_at ? new Date(row.watched_at).getTime() : NaN
-    if (!Number.isFinite(t)) continue                          // rule 2: need a valid watched_at (Diary rule)
-    const existing = byMovie.get(row.movie_id)
-    // rule 4/5: keep the most-recent watched_at; on a tie keep the EARLIER original-array
-    // row (replace only when STRICTLY newer → stable, deterministic).
-    if (!existing || t > existing.t) byMovie.set(row.movie_id, { row, t })
-  }
-  return [...byMovie.values()].map(v => v.row)                 // rules 6/7: new array, original row refs
-}
+// F6.10's canonical one-row-per-film rule now lives in the neutral shared module
+// (src/shared/lib/canonicalHistory.js, imported above) so Profile + fingerprinting don't
+// depend on this Diary feature module (F7.3). Re-exported to preserve the F6 public/test
+// contract (consumers importing dedupeHistoryByMovie from here keep working).
+export { dedupeHistoryByMovie }
 
 export function deriveEntries(history, ratings) {
   const ratingByMovieId = new Map(ratings.map(r => [r.movie_id, r]))

--- a/src/features/profile/TasteProfile.jsx
+++ b/src/features/profile/TasteProfile.jsx
@@ -40,7 +40,7 @@ function SelfProfile({ authUser }) {
   const data = useProfileDataFetch({ userId: authUser?.id, authUser, isSelf: true })
 
   if (data.loading) return <PageSkeleton />
-  if (data.error) return <PageError error={data.error} />
+  if (data.error) return <PageError onRetry={data.retry} />
 
   return (
     <ProfileDataProvider value={{ ...data, isSelf: true, viewingUserId: authUser?.id }}>
@@ -115,13 +115,22 @@ function PageSkeleton() {
   )
 }
 
-function PageError({ error }) {
+// F7.3: fixed, safe error copy off the stable `load_error` classification — the raw backend
+// message is never rendered. One h1, role="alert", a real in-SPA retry, and a safe exit.
+function PageError({ onRetry }) {
+  const btn = { fontFamily:'Outfit, Inter, sans-serif', fontSize:14, fontWeight:600, minHeight:44, padding:'11px 20px', borderRadius:8, cursor:'pointer' }
   return (
     <div className="ff-profile-v2" style={{ minHeight:'100vh', background: HP.bgDeep, color: HP.text, display:'flex', alignItems:'center', justifyContent:'center', padding:24, fontFamily:'Inter, sans-serif' }}>
-      <div style={{ textAlign:'center', maxWidth:520 }}>
-        <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color: HP.purple, marginBottom:18 }}>Profile · error</div>
-        <h1 style={{ fontFamily:'Outfit, Inter, sans-serif', fontSize:36, fontWeight:500, color: HP.text, margin:'0 0 18px 0', letterSpacing:'-0.025em' }}>Couldn&rsquo;t load your DNA.</h1>
-        <p style={{ margin:0, color:'rgba(250,250,250,0.6)', fontSize:14, lineHeight:1.6 }}>{error}</p>
+      <div role="alert" style={{ textAlign:'center', maxWidth:520 }}>
+        <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color: HP.purple, marginBottom:18 }}>Cinematic DNA</div>
+        <h1 style={{ fontFamily:'Outfit, Inter, sans-serif', fontSize:36, fontWeight:500, color: HP.text, margin:'0 0 14px 0', letterSpacing:'-0.025em' }}>We couldn&rsquo;t load your Cinematic DNA.</h1>
+        <p style={{ margin:'0 0 28px 0', color:'rgba(250,250,250,0.6)', fontSize:14, lineHeight:1.6 }}>Try refreshing in a moment.</p>
+        <div style={{ display:'flex', gap:12, justifyContent:'center', flexWrap:'wrap' }}>
+          {typeof onRetry === 'function' && (
+            <button type="button" onClick={onRetry} style={{ ...btn, color:'#0A0510', background:HP.text, border:'none' }}>Try again</button>
+          )}
+          <a href="/home" style={{ ...btn, color:HP.text, background:'transparent', border:`1px solid ${HP.border}`, textDecoration:'none', display:'inline-flex', alignItems:'center' }}>Go to Home</a>
+        </div>
       </div>
     </div>
   )

--- a/src/features/profile/__tests__/ProfileErrorState.test.jsx
+++ b/src/features/profile/__tests__/ProfileErrorState.test.jsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+
+// F7.3 — the Profile route error state must render fixed, safe copy off the stable
+// `load_error` classification, with role="alert", a real retry, and a safe exit — and must
+// NEVER surface raw backend text.
+
+const retrySpy = vi.fn()
+vi.mock('../useProfileData', () => ({
+  useProfileDataFetch: () => ({ error: 'load_error', retry: retrySpy }),
+  ProfileDataProvider: ({ children }) => children,
+  useProfileData: () => ({}),
+}))
+vi.mock('@/shared/hooks/useAuthSession', () => ({ useAuthSession: () => ({ user: { id: 'self-1' } }) }))
+vi.mock('@/shared/hooks/usePageMeta', () => ({ usePageMeta: () => {} }))
+
+import TasteProfile from '../TasteProfile'
+
+const renderSelf = () => render(
+  <MemoryRouter initialEntries={['/profile']}>
+    <Routes><Route path="/profile" element={<TasteProfile />} /></Routes>
+  </MemoryRouter>
+)
+
+describe('Profile error state — F7.3 sanitized', () => {
+  it('renders fixed safe copy with role=alert; the raw classification is never shown', () => {
+    renderSelf()
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/couldn.t load your cinematic dna/i)
+    expect(screen.getByText(/try refreshing in a moment/i)).toBeInTheDocument()
+    expect(screen.queryByText(/load_error/i)).not.toBeInTheDocument()   // classification not surfaced
+    expect(screen.getByRole('link', { name: /go to home/i })).toBeInTheDocument()
+  })
+
+  it('"Try again" invokes the real retry path', () => {
+    renderSelf()
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }))
+    expect(retrySpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/features/profile/__tests__/ProfileProviderCanonical.test.jsx
+++ b/src/features/profile/__tests__/ProfileProviderCanonical.test.jsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+
+// F7.3 — provider wiring: useProfileDataFetch must canonicalise the owner's raw history at the
+// boundary, so the downstream derivations (and the visible stats) count each film once; and a
+// failed query must surface the safe `load_error` classification, never raw backend text.
+
+// getTasteFingerprint is exercised by its own canonical test — stub it here so this test isolates
+// the orchestrator's history canonicalisation.
+vi.mock('@/shared/services/tasteCache', () => ({
+  getTasteFingerprint: () => Promise.resolve({ topMoodTags: [{ key: 'tender', count: 1, share: 1 }], topToneTags: [], topFitProfiles: [], total: 2 }),
+}))
+
+// Controllable per-table Supabase result. Duplicate Film A (×3) + Film B once. A fresh editorial
+// row makes the self-view regen a no-op (no Edge Function / fetch / cache write in the test).
+let historyResult
+const FRESH_EDITORIAL = { editorial_summary: 's', editorial_signature: 'g', editorial_archetype: ['a', 'b', 'c'], editorial_generated_at: '2999-01-01T00:00:00Z' }
+const A = (watched_at) => ({ movie_id: 1, watched_at, movies: { runtime: 120, mood_tags: ['tender'], tone_tags: ['quiet'], fit_profile: 'slow', director_name: 'D', release_date: '2021-01-01', title: 'A' } })
+const ROWS = [A('2026-03-01T20:00:00Z'), A('2026-03-02T20:00:00Z'), A('2026-03-03T20:00:00Z'),
+  { movie_id: 2, watched_at: '2026-03-04T20:00:00Z', movies: { runtime: 90, mood_tags: ['cozy'], tone_tags: ['warm'], fit_profile: 'easy', director_name: 'E', release_date: '2019-01-01', title: 'B' } }]
+
+function makeQuery(result) {
+  const promise = Promise.resolve(result)
+  const chain = {
+    select: () => chain, eq: () => chain, order: () => chain, limit: () => chain, in: () => chain,
+    maybeSingle: () => Promise.resolve({ data: Array.isArray(result.data) ? (result.data[0] ?? null) : (result.data ?? null), error: result.error ?? null }),
+    then: (res, rej) => promise.then(res, rej),
+    catch: (fn) => promise.catch(fn),
+  }
+  return chain
+}
+vi.mock('@/shared/lib/supabase/client', () => ({
+  supabase: {
+    from: (table) => {
+      if (table === 'user_history') return makeQuery(historyResult)
+      if (table === 'user_profiles_computed') return makeQuery({ data: FRESH_EDITORIAL })
+      return makeQuery({ data: [] })
+    },
+  },
+}))
+
+import { useProfileDataFetch } from '../useProfileData'
+
+beforeEach(() => { historyResult = { data: ROWS, error: null } })
+
+describe('useProfileDataFetch — canonical history at the boundary (F7.3)', () => {
+  it('visible stats count each film once (3 duplicate rows of A → films logged 2, not 4)', async () => {
+    const { result } = renderHook(() => useProfileDataFetch({ userId: 'u1', authUser: { id: 'u1' }, isSelf: true }))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).toBeNull()
+    expect(result.current.stats.filmsLogged).toBe(2)            // canonical, not 4
+    expect(result.current.stats.hoursWatched).toBe(4)           // (120 + 90)/60, not (360 + 90)/60
+  })
+
+  it('a failed history query surfaces the safe load_error classification (no raw text)', async () => {
+    historyResult = { data: null, error: { message: 'permission denied for table user_history' } }
+    const { result } = renderHook(() => useProfileDataFetch({ userId: 'u1', authUser: { id: 'u1' }, isSelf: true }))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).toBe('load_error')
+    expect(result.current.error).not.toMatch(/permission denied/)
+    expect(typeof result.current.retry).toBe('function')
+  })
+})

--- a/src/features/profile/__tests__/profileCanonicalEvidence.test.js
+++ b/src/features/profile/__tests__/profileCanonicalEvidence.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { dedupeHistoryByMovie } from '@/shared/lib/canonicalHistory'
+import { deriveUser, deriveStats, deriveDirectors, deriveDecades, deriveRuntime, deriveDaypart, deriveYIR, deriveTrajectory } from '../derive'
+import { aggregateWatchHistorySignals } from '../buildSummaryRequest'
+
+// F7.3 — duplicate-resistance. Film A is logged via three watch paths (onboarding, Discover,
+// Home) with distinct watched_at; Film B once. Once Profile feeds CANONICAL history to every
+// derivation, Film A contributes exactly once everywhere — and the raw (un-deduped) input is
+// shown to inflate, proving the canonical boundary is what corrects it.
+
+const movieA = { director_name: 'Mara Vance', runtime: 120, mood_tags: ['tender'], tone_tags: ['quiet'], fit_profile: 'slow-burn', release_date: '2021-04-01', title: 'Lantern Hill' }
+const movieB = { director_name: 'Cole Park', runtime: 90, mood_tags: ['cozy'], tone_tags: ['warm'], fit_profile: 'easy', release_date: '2019-01-01', title: 'Winter Tenants' }
+const A = (watched_at, src) => ({ movie_id: 1, watched_at, id: `a-${src}`, source: src, movies: movieA })
+const B = { movie_id: 2, watched_at: '2026-03-05T12:00:00Z', id: 'b', movies: movieB }
+
+const dupRows = [
+  A('2026-03-01T20:00:00Z', 'onboarding'),
+  A('2026-03-02T20:00:00Z', 'discover_marked'),
+  A('2026-03-03T20:00:00Z', 'home'),   // latest A
+  B,
+]
+const canonical = dedupeHistoryByMovie(dupRows)   // → [A(Mar 3), B]
+
+afterEach(() => vi.useRealTimers())
+
+describe('Profile derivations count each film once from canonical history (F7.3)', () => {
+  it('canonical history has one row per film, at A\'s latest watch', () => {
+    expect(canonical).toHaveLength(2)
+    expect(canonical.find(r => r.movie_id === 1)).toMatchObject({ watched_at: '2026-03-03T20:00:00Z', source: 'home' })
+  })
+
+  it('Quick stats: films logged + hours count A once (raw input would inflate)', () => {
+    vi.useFakeTimers(); vi.setSystemTime(new Date('2026-03-20T12:00:00Z'))
+    const sCanon = deriveStats({ history: canonical, ratings: [], fingerprint: null })
+    const sRaw = deriveStats({ history: dupRows, ratings: [], fingerprint: null })
+    expect(sCanon.filmsLogged).toBe(2)              // not 4
+    expect(sCanon.hoursWatched).toBe(4)             // round((120+90)/60) = 4, not round(450/60)=8
+    expect(sCanon.filmsThisMonth).toBe(2)           // A (Mar) + B (Mar), once each
+    expect(sRaw.filmsLogged).toBe(4)                // raw inflates → boundary matters
+    expect(sRaw.hoursWatched).toBe(8)
+  })
+
+  it('deriveUser films logged counts A once', () => {
+    expect(deriveUser({ authUser: null, dbUser: null, history: canonical }).filmsLogged).toBe(2)
+    expect(deriveUser({ authUser: null, dbUser: null, history: dupRows }).filmsLogged).toBe(4)
+  })
+
+  it('Director affinity: a film watched 3× does NOT become a false "signature director"', () => {
+    const dCanon = deriveDirectors({ history: canonical, ratingsByMovieId: new Map() })
+    const dRaw = deriveDirectors({ history: dupRows, ratingsByMovieId: new Map() })
+    // raw input: A's director shows 3 films (the ≥2 "signature" gate is met by ONE duplicated film)
+    expect(dRaw.find(d => d.name === 'Mara Vance')?.films).toBe(3)
+    // canonical: A counts once (< 2) → correctly NOT a signature director
+    expect(dCanon.find(d => d.name === 'Mara Vance')).toBeUndefined()
+  })
+
+  it('Decades / runtime / daypart / YIR / trajectory: fed canonical = fed one-row-per-film', () => {
+    const uniques = [canonical.find(r => r.movie_id === 1), canonical.find(r => r.movie_id === 2)]
+    for (const derive of [deriveDecades, deriveRuntime, deriveDaypart, deriveYIR, deriveTrajectory]) {
+      expect(derive({ history: canonical })).toEqual(derive({ history: uniques }))
+      // and the raw (duplicated) input produces a different result → duplicates were inflating
+      expect(derive({ history: dupRows })).not.toEqual(derive({ history: canonical }))
+    }
+  })
+
+  it('Generated-summary evidence: each title + tag appears once', () => {
+    const sigCanon = aggregateWatchHistorySignals(canonical)
+    const sigRaw = aggregateWatchHistorySignals(dupRows)
+    expect(sigCanon.watchedFilms).toEqual(['Lantern Hill', 'Winter Tenants'])      // A once
+    expect(sigRaw.watchedFilms.filter(t => t === 'Lantern Hill')).toHaveLength(3)  // raw repeats A ×3
+    const tenderCanon = sigCanon.taggedTasteSignature.topMoodTags.find(t => t.tag === 'tender')
+    expect(tenderCanon.count).toBe(1)
+  })
+})

--- a/src/features/profile/useProfileData.jsx
+++ b/src/features/profile/useProfileData.jsx
@@ -5,9 +5,10 @@
 // section components consume. Each section hides when its data source is
 // empty.
 
-import { createContext, useContext, useEffect, useState } from 'react'
+import { createContext, useContext, useEffect, useState, useCallback } from 'react'
 import { supabase } from '@/shared/lib/supabase/client'
 import { getTasteFingerprint } from '@/shared/services/tasteCache'
+import { dedupeHistoryByMovie } from '@/shared/lib/canonicalHistory'
 
 import {
   deriveUser, deriveStats, deriveMoods, deriveDirectors, deriveMotifs,
@@ -62,6 +63,10 @@ const INITIAL_STATE = {
 
 export function useProfileDataFetch({ userId, authUser, isSelf = false }) {
   const [state, setState] = useState(INITIAL_STATE)
+  // F7.3: in-SPA retry for the error state — bumping reloadKey re-runs the fetch effect
+  // (the existing refetch path), so the safe error UI can offer a real "Try again".
+  const [reloadKey, setReloadKey] = useState(0)
+  const retry = useCallback(() => setReloadKey(k => k + 1), [])
 
   useEffect(() => {
     if (!userId) return
@@ -111,6 +116,12 @@ export function useProfileDataFetch({ userId, authUser, isSelf = false }) {
         if (historyRes.error) throw historyRes.error
 
         const history = historyRes.data || []
+        // F7.3: canonicalise the owner's history ONCE at the Profile boundary — one row per
+        // film (latest valid watched_at) — and feed it to EVERY Profile-owned derivation,
+        // the fingerprint inputs (via getTasteFingerprint, canonicalised there), and the
+        // generated-summary evidence, so duplicate watch events can't inflate any visible
+        // identity number. Raw `history` is not read by any downstream derivation below.
+        const canonicalHistory = dedupeHistoryByMovie(history)
         const ratings = ratingsRes.data || []
         const ratingsByMovieId = new Map(ratings.map(r => [r.movie_id, r]))
         const dbUser = userRes.data || null
@@ -147,28 +158,28 @@ export function useProfileDataFetch({ userId, authUser, isSelf = false }) {
           }
         }
 
-        const statsDerived = deriveStats({ history, ratings, fingerprint })
+        const statsDerived = deriveStats({ history: canonicalHistory, ratings, fingerprint })
         setState({
-          user: deriveUser({ authUser, dbUser, history }),
+          user: deriveUser({ authUser, dbUser, history: canonicalHistory }),
           stats: statsDerived,
           moods: deriveMoods(fingerprint),
-          directors: deriveDirectors({ history, ratingsByMovieId }),
-          motifs: deriveMotifs({ history }),
-          mixtape: deriveMixtape({ history, ratingsByMovieId }),
-          trajectory: deriveTrajectory({ history }),
-          trajectoryAllTime: deriveTrajectoryAllTime({ history }),
-          decades: deriveDecades({ history }),
-          runtime: deriveRuntime({ history }),
-          daypart: deriveDaypart({ history }),
+          directors: deriveDirectors({ history: canonicalHistory, ratingsByMovieId }),
+          motifs: deriveMotifs({ history: canonicalHistory }),
+          mixtape: deriveMixtape({ history: canonicalHistory, ratingsByMovieId }),
+          trajectory: deriveTrajectory({ history: canonicalHistory }),
+          trajectoryAllTime: deriveTrajectoryAllTime({ history: canonicalHistory }),
+          decades: deriveDecades({ history: canonicalHistory }),
+          runtime: deriveRuntime({ history: canonicalHistory }),
+          daypart: deriveDaypart({ history: canonicalHistory }),
           editorial,
           friends: deriveFriends({
             simARows: simARes?.data || [],
             simBRows: simBRes?.data || [],
             filmsByFriendId,
           }),
-          skews: deriveSkews({ stats: statsDerived, history, ratings, feelflickStats }),
+          skews: deriveSkews({ stats: statsDerived, history: canonicalHistory, ratings, feelflickStats }),
           communityMood: deriveCommunityMood(feelflickStats),
-          yir: deriveYIR({ history }),
+          yir: deriveYIR({ history: canonicalHistory }),
           loading: false,
           error: null,
         })
@@ -176,8 +187,8 @@ export function useProfileDataFetch({ userId, authUser, isSelf = false }) {
         // Self-view: regenerate editorial summary + signature when missing or
         // stale (>24 h). Archetype is deterministic so it's always live; we
         // persist it alongside for resilience when viewing other users.
-        if (isSelf && shouldRegenerateEditorial(editorial) && history.length > 0) {
-          regenerateEditorial({ userId, history, archetypeFromFp })
+        if (isSelf && shouldRegenerateEditorial(editorial) && canonicalHistory.length > 0) {
+          regenerateEditorial({ userId, history: canonicalHistory, archetypeFromFp })
             .then((updated) => {
               if (abort || !updated) return
               setState((s) => ({ ...s, editorial: { ...s.editorial, ...updated } }))
@@ -190,15 +201,17 @@ export function useProfileDataFetch({ userId, authUser, isSelf = false }) {
         }
       } catch (e) {
         if (abort) return
+        // F7.3: never surface raw backend text to the UI. Diagnostics stay in the console;
+        // the page renders fixed, safe copy off this stable classification.
         console.error('[useProfileDataFetch]', e)
-        setState(s => ({ ...s, loading: false, error: e?.message || 'Failed to load' }))
+        setState(s => ({ ...s, loading: false, error: 'load_error' }))
       }
     })()
 
     return () => { abort = true }
-  }, [userId, authUser, isSelf])
+  }, [userId, authUser, isSelf, reloadKey])
 
-  return state
+  return { ...state, retry }
 }
 
 export function ProfileDataProvider({ value, children }) {

--- a/src/shared/lib/__tests__/canonicalHistory.test.js
+++ b/src/shared/lib/__tests__/canonicalHistory.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { dedupeHistoryByMovie } from '../canonicalHistory'
+
+// F7.3 — the shared canonical one-row-per-film rule (used by Diary, Profile, fingerprint,
+// generated-summary). Behaviour must stay exactly aligned with F6.10.
+const row = (movie_id, watched_at, over = {}) => ({ movie_id, watched_at, id: `${movie_id}-${watched_at}`, ...over })
+
+describe('dedupeHistoryByMovie (shared canonical history)', () => {
+  it('1. one row stays one row', () => {
+    expect(dedupeHistoryByMovie([row(1, '2026-03-01T20:00:00Z')])).toHaveLength(1)
+  })
+  it('2/3. two/three rows for one film collapse to one', () => {
+    expect(dedupeHistoryByMovie([row(1, '2026-03-01T20:00:00Z'), row(1, '2026-03-02T20:00:00Z')])).toHaveLength(1)
+    expect(dedupeHistoryByMovie([row(1, '2026-03-01T20:00:00Z'), row(1, '2026-03-02T20:00:00Z'), row(1, '2026-03-03T20:00:00Z')])).toHaveLength(1)
+  })
+  it('3. most-recent valid watched_at wins', () => {
+    const out = dedupeHistoryByMovie([row(1, '2026-03-01T20:00:00Z', { src: 'old' }), row(1, '2026-03-09T20:00:00Z', { src: 'new' }), row(1, '2026-03-05T20:00:00Z', { src: 'mid' })])
+    expect(out[0]).toMatchObject({ watched_at: '2026-03-09T20:00:00Z', src: 'new' })
+  })
+  it('4. equal timestamps use deterministic stable input order (earlier wins)', () => {
+    const out = dedupeHistoryByMovie([row(1, '2026-03-09T20:00:00Z', { src: 'first' }), row(1, '2026-03-09T20:00:00Z', { src: 'second' })])
+    expect(out[0].src).toBe('first')
+  })
+  it('5/6. invalid movie_id and null/invalid watched_at rows are excluded', () => {
+    expect(dedupeHistoryByMovie([{ watched_at: '2026-03-09T20:00:00Z' }, row(2, '2026-03-09T20:00:00Z')]).map(r => r.movie_id)).toEqual([2])
+    expect(dedupeHistoryByMovie([row(1, null), row(1, 'not-a-date')])).toEqual([])
+  })
+  it('7. input is not mutated', () => {
+    const h = [row(1, '2026-03-01T20:00:00Z'), row(1, '2026-03-02T20:00:00Z')]
+    const snap = JSON.stringify(h)
+    dedupeHistoryByMovie(h)
+    expect(JSON.stringify(h)).toBe(snap)
+    expect(h).toHaveLength(2)
+  })
+  it('8/9. selected row fields preserved; distinct films stay separate', () => {
+    const h = [row(1, '2026-03-09T20:00:00Z', { movies: { title: 'A' }, src: 'x' }), row(2, '2026-03-08T20:00:00Z', { movies: { title: 'B' } })]
+    const out = dedupeHistoryByMovie(h)
+    expect(out.map(r => r.movie_id).sort()).toEqual([1, 2])
+    expect(out.find(r => r.movie_id === 1)).toMatchObject({ movies: { title: 'A' }, src: 'x' })
+  })
+  it('10. no rewatch/synthetic field is introduced', () => {
+    const out = dedupeHistoryByMovie([row(1, '2026-03-01T20:00:00Z'), row(1, '2026-03-02T20:00:00Z')])
+    expect(out[0]).not.toHaveProperty('rewatch')
+    expect(out[0]).not.toHaveProperty('watchCount')
+  })
+})

--- a/src/shared/lib/canonicalHistory.js
+++ b/src/shared/lib/canonicalHistory.js
@@ -1,0 +1,41 @@
+// src/shared/lib/canonicalHistory.js
+// One canonical row per film, shared by every taste computation.
+//
+// user_history is an append-only event log: the DB's only uniqueness is
+// (user_id, movie_id, watched_at), and different watch paths (onboarding, Discover,
+// Home, Film File) stamp fresh watched_at values, so the same film can have 2–3 rows.
+// Any surface that counts taste evidence — the Diary, the Profile / Cinematic DNA
+// metrics, the taste fingerprint, the generated-summary input — must collapse those
+// rows to ONE per film FIRST, or duplicate watches inflate the result.
+//
+// This is the neutral home for that rule (introduced for the Diary in F6.10, lifted out
+// of the history feature in F7.3 so Profile + fingerprinting don't depend on a Diary
+// module). The rule is intentionally identical to F6.10:
+//
+//   1. one canonical row per valid movie_id
+//   2. exclude rows without a valid movie_id
+//   3. exclude rows without a valid watched_at (the Diary "watched" rule)
+//   4. keep the row with the most-recent valid watched_at
+//   5. on a tie, keep the EARLIER original-array row (stable, deterministic)
+//   6. preserve the complete selected row (fields verbatim)
+//   7. never merge fields from older rows
+//   8. never mutate the input
+//   9. never create a rewatch count or synthetic field
+//  10. never touch the database
+//
+// CONTRACT: the product shows one entry per film; multiple history rows are collapsed to
+// the latest watch until an explicit rewatch product model exists (this is NOT a rewatch).
+export function dedupeHistoryByMovie(history = []) {
+  const byMovie = new Map()
+  for (let i = 0; i < history.length; i++) {
+    const row = history[i]
+    if (!row || row.movie_id == null) continue                 // rule 1/2: need a movie_id
+    const t = row.watched_at ? new Date(row.watched_at).getTime() : NaN
+    if (!Number.isFinite(t)) continue                          // rule 3: need a valid watched_at
+    const existing = byMovie.get(row.movie_id)
+    // rule 4/5: keep the most-recent watched_at; replace only when STRICTLY newer, so a tie
+    // keeps the earlier original-array row → stable + deterministic.
+    if (!existing || t > existing.t) byMovie.set(row.movie_id, { row, t })
+  }
+  return [...byMovie.values()].map(v => v.row)                 // rules 6/7/8: new array, original row refs
+}

--- a/src/shared/services/__tests__/tasteCacheCanonical.test.js
+++ b/src/shared/services/__tests__/tasteCacheCanonical.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// F7.3 — the taste fingerprint must aggregate from CANONICAL history (one row per film),
+// so duplicate watch events don't multiply a film's mood/tone/fit weight or inflate `total`.
+// Fixture: 5 distinct films (so MIN_FILMS_FOR_FINGERPRINT=5 is met by canonical count) where
+// film 1 (unique mood 'tender') is logged 4× via different paths. 'tender' must count ONCE.
+
+const M = (mood, tone, fit) => ({ mood_tags: [mood], tone_tags: [tone], fit_profile: fit })
+const r = (movie_id, watched_at, movies) => ({ movie_id, watched_at, movies })
+const HISTORY = [
+  r(1, '2026-03-01T20:00:00Z', M('tender', 'quiet', 'slow')),   // film 1 ×4 (duplicates)
+  r(1, '2026-03-02T20:00:00Z', M('tender', 'quiet', 'slow')),
+  r(1, '2026-03-03T20:00:00Z', M('tender', 'quiet', 'slow')),
+  r(1, '2026-03-04T20:00:00Z', M('tender', 'quiet', 'slow')),
+  r(2, '2026-03-05T20:00:00Z', M('cozy', 'warm', 'easy')),
+  r(3, '2026-03-06T20:00:00Z', M('tense', 'cold', 'hard')),
+  r(4, '2026-03-07T20:00:00Z', M('bright', 'light', 'fun')),
+  r(5, '2026-03-08T20:00:00Z', M('bleak', 'grey', 'heavy')),
+]
+
+const updateSpy = vi.fn()
+const insertSpy = vi.fn()
+vi.mock('@/shared/lib/supabase/client', () => ({
+  supabase: {
+    from: (table) => {
+      if (table === 'user_history') {
+        return { select: () => ({ eq: () => Promise.resolve({ data: HISTORY }) }) }
+      }
+      // user_profiles_computed — cache miss + write spies
+      return {
+        select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: null }) }) }),
+        update: (...a) => { updateSpy(...a); return { eq: () => Promise.resolve({}) } },
+        insert: (...a) => { insertSpy(...a); return Promise.resolve({}) },
+      }
+    },
+    // viewer is NOT the target user → fingerprint must not persist (owner-gated write)
+    auth: { getUser: () => Promise.resolve({ data: { user: { id: 'someone-else' } } }) },
+  },
+}))
+
+import { getTasteFingerprint } from '../tasteCache'
+
+beforeEach(() => { updateSpy.mockClear(); insertSpy.mockClear() })
+
+describe('getTasteFingerprint — canonical evidence (F7.3)', () => {
+  it('aggregates from one-row-per-film: the duplicated mood counts once and total is the film count', async () => {
+    const fp = await getTasteFingerprint('target-user')
+    expect(fp).not.toBeNull()
+    expect(fp.total).toBe(5)                                    // 5 distinct films, not 8 rows
+    const tender = fp.topMoodTags.find(t => t.key === 'tender')
+    expect(tender.count).toBe(1)                                // not 4 (the duplicates)
+    expect(tender.share).toBeCloseTo(1 / 5)                     // denominator is canonical film count
+  })
+
+  it('stays owner-gated: computing another user\'s fingerprint writes nothing', async () => {
+    await getTasteFingerprint('target-user')
+    expect(updateSpy).not.toHaveBeenCalled()
+    expect(insertSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/shared/services/tasteCache.js
+++ b/src/shared/services/tasteCache.js
@@ -8,6 +8,7 @@
  */
 
 import { supabase } from '@/shared/lib/supabase/client'
+import { dedupeHistoryByMovie } from '@/shared/lib/canonicalHistory'
 
 // === CONFIG ===
 
@@ -109,17 +110,23 @@ async function computeFingerprint(userId) {
   // call to 400 with `column user_history.status does not exist`.
   const { data: history, error } = await supabase
     .from('user_history')
-    .select('movies(mood_tags, tone_tags, fit_profile)')
+    .select('movie_id, watched_at, movies(mood_tags, tone_tags, fit_profile)')
     .eq('user_id', userId)
 
   if (error || !history) return null
+
+  // F7.3: collapse duplicate watch events to ONE row per film (latest valid watched_at)
+  // before aggregating, so a film watched via several paths doesn't multiply-weight its
+  // mood/tone/fit tags or inflate `total`. movie_id + watched_at are selected only to make
+  // this canonicalisation possible; the aggregation + weights are otherwise unchanged.
+  const canonical = dedupeHistoryByMovie(history)
 
   const moods = {}
   const tones = {}
   const fits = {}
   let total = 0
 
-  for (const h of history) {
+  for (const h of canonical) {
     const m = h.movies
     if (!m) continue
     total++


### PR DESCRIPTION
**F7.3 — Canonicalize Cinematic DNA evidence and add the Profile safety net.** Fixes the remaining F7.1 data-truth P1.

## The P1
Profile / Cinematic DNA computed visible identity claims from **raw `user_history` events**. A film logged via multiple watch paths (onboarding, Discover, Home, Film File) created several rows and inflated: films logged, hours, this-month, director affinity, motifs, decade/runtime/daypart %, trajectory, Year-in-Review, DNA confidence, the **taste fingerprint**, the **generated-summary input**, and the shareable Profile. F6.10 canonicalised only the Diary.

## One canonical evidence boundary
- **Shared helper:** extracted F6.10's rule into a neutral `src/shared/lib/canonicalHistory.js` (`dedupeHistoryByMovie`) so Profile + fingerprinting don't depend on a Diary module. `historyDerive.js` imports + **re-exports** it → F6 public/test contract preserved; **the 24 Diary tests pass unchanged** (Diary output identical).
- **Profile boundary** (`useProfileData.jsx`): one `canonicalHistory = dedupeHistoryByMovie(historyRes.data || [])` created immediately after the history query settles and passed to **every** derivation + the editorial regen (so `aggregateWatchHistorySignals` builds the summary request from canonical evidence) + the regen guard. Raw `history` is no longer read downstream. The Profile derivers are unchanged — they just receive deduped input (one canonical set, not per-function dedup). *Canonicalisation happens **before** every metric, fingerprint, cache request, and summary input — not after.*

## Every Profile output corrected
films logged · hours · this month · director affinity · motifs · decades · runtime · daypart · trajectory · Year-in-Review · DNA-confidence history component · fingerprint inputs · generated-summary evidence · share-card data — each now counts a film once.

## Fingerprint correction
`tasteCache.computeFingerprint` now selects `movie_id, watched_at` (only to enable canonicalisation) and aggregates mood/tone/fit weights + `total` from `dedupeHistoryByMovie(history)`. Formula/weights/caps unchanged. Shared by Home/Discover/recommendations — **all those suites pass** (dedup is a no-op on non-duplicate fixtures). `total` is now distinct-film-count (a correct data effect, not a threshold change).

## Generated-summary input correction
The orchestrator passes canonical history into `regenerateEditorial → aggregateWatchHistorySignals`, so duplicated titles/moods/tags/counts appear once. The prompt, output schema, prose style, presentation, and Edge Function are unchanged.

## Cache decision
Fingerprint + editorial caches use a 24h TTL (no version column). Per the no-migration/no-live-mutation rules: **structured metrics correct immediately** (recomputed from canonical history each render); a previously cached fingerprint/editorial derived from duplicates corrects on its **next recompute within the existing 24h TTL**. No migration, no new column, no live-cache mutation, no Edge Function call. (Proactive invalidation would need cache redesign — **deferred to F7.6**.)

## Safe-error correction
`useProfileData` sets the stable `error: 'load_error'` (diagnostics stay in `console.error`); the route's `PageError` renders fixed copy ("We couldn't load your Cinematic DNA." / "Try refreshing in a moment."), `role="alert"`, one h1, a real in-SPA **Try again** (new `reloadKey` retry) and **Go to Home**, ≥44px controls. **No raw backend text is ever rendered.**

## Formula / copy / layout frozen
LLM summary/signature wording, provenance labelling, archetype wording, DNA-confidence integer display + formula, chart percentages, small-sample behavior, charts, hierarchy, section order, social sections, share, Account privacy copy — all **unchanged** (F7.4+ concerns). Any visible numeric change is solely from removing duplicate counting.

## F7.2 privacy frozen
Owner-only behavioral RLS, self-only Profile, cross-user private state, removed privacy toggles — all unchanged; the F7.2 self-only tests are untouched and still pass.

## Tests (+20 → full 1324)
canonical-history helper (10 rules) · Profile duplicate-resistance (Film A ×3 paths + Film B once → every output counts A once; raw shown to inflate, incl. a duplicated film creating a **false "signature director"**) · fingerprint canonical + owner-gated no-write · provider wiring (orchestrator canonicalises → films-logged 2 not 4; failed query → `load_error`, raw text absent; retry is a function) · Profile error UI (role=alert, fixed copy, no raw classification, Try again → retry).

## No-live-write proof
No live `/profile` opened; no Edge Function call; no cache write — all verification via pure tests + mocked Supabase/Edge/auth. No schema/RLS/migration; no visual baseline.

## Validation
`npm run lint` clean · changed tests **53 ×3** · affected consumers **635** · full **1304 → 1324** · `npm run build` ✓.

## Deferred F7.4 trust items
Provenance labels on the LLM summary/signature, editorial maturity floor, de-precision the DNA-confidence %, small-N percentage guards, chart accessibility/contrast — all F7.4+. Proactive cache invalidation → F7.6.

**This PR is a data-truth + error-sanitisation + test-foundation change only.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
