### PR TITLE
Harden Cinematic DNA trust and maturity framing

### DIFF
--- a/src/features/profile/DnaConfidence.jsx
+++ b/src/features/profile/DnaConfidence.jsx
@@ -12,14 +12,11 @@
 import { Link } from 'react-router-dom'
 import Eyebrow from '@/shared/ui/Eyebrow'
 import { HP, HP_GRAD, RADIUS, SPACE } from './data'
+import { deriveConfidenceBand } from './derive/profilePresentation'
 
-// Tier label from the confidence value — LABELING ONLY (mirrors QuickStats'
-// low/medium/high thresholds). Never recomputes or reinterprets the number.
-function tierFor(confidence) {
-  if (confidence >= 80) return { key: 'high', label: 'Reading you well' }
-  if (confidence >= 40) return { key: 'medium', label: 'Getting sharper' }
-  return { key: 'low', label: 'Still learning' }
-}
+// F7.4: the confidence value is the SHARED computeDnaConfidence number (unchanged), but it is
+// now presented as a qualitative evidence-maturity BAND — never an exact percentage and never a
+// completion meter. deriveConfidenceBand owns the label; this component only frames it.
 
 /**
  * @param {object} props
@@ -31,24 +28,17 @@ function tierFor(confidence) {
  */
 export default function DnaConfidence({ confidence, filmsLogged = 0, filmsRated = 0, moodSignals = 0 }) {
   if (!Number.isFinite(confidence)) return null
-  const pct = Math.max(0, Math.min(100, Math.round(confidence)))
-  const tier = tierFor(pct)
-  const cold = tier.key === 'low'
+  const band = deriveConfidenceBand(confidence)
+  const cold = band.key === 'forming'
 
   return (
     <section className="ff-profile-section" style={{ padding: `${SPACE.sectionMd}px ${SPACE.gutter}px`, borderTop: `1px solid ${HP.border}` }}>
       <div className="ff-profile-dnaconf-grid" style={{ display: 'grid', gridTemplateColumns: '1fr 1.3fr', gap: 64, alignItems: 'flex-start' }}>
-        {/* Left — the number, tier, bar, and the evidence it's built from */}
+        {/* Left — the maturity band (no % / no completion meter) + the evidence it's built from */}
         <div>
           <Eyebrow rule color={HP.purple} style={{ marginBottom: 16 }}>DNA confidence</Eyebrow>
-          <div style={{ display: 'flex', alignItems: 'baseline', gap: 14, flexWrap: 'wrap' }}>
-            <span style={{ fontFamily: 'Outfit', fontSize: 72, fontWeight: 200, color: HP.text, letterSpacing: '-0.05em', lineHeight: 1, fontVariantNumeric: 'tabular-nums' }}>{pct}%</span>
-            <span style={{ fontFamily: 'Outfit', fontSize: 14, fontWeight: 500, color: cold ? HP.textMuted : HP.purple, fontStyle: 'italic' }}>{tier.label}</span>
-          </div>
-          <div role="presentation" style={{ marginTop: 18, height: 6, background: 'rgba(255,255,255,0.06)', borderRadius: RADIUS.pill, overflow: 'hidden', maxWidth: 320 }}>
-            <div style={{ height: '100%', width: `${pct}%`, background: HP_GRAD, borderRadius: RADIUS.pill, transition: 'width 0.9s cubic-bezier(0.2,0.8,0.2,1)' }} />
-          </div>
-          <div style={{ marginTop: 18, fontSize: 12, color: HP.textMuted, fontFamily: 'Outfit', letterSpacing: '0.02em' }}>
+          <div style={{ fontFamily: 'Outfit', fontSize: 48, fontWeight: 300, color: HP.text, letterSpacing: '-0.04em', lineHeight: 1.05 }}>{band.label}</div>
+          <div style={{ marginTop: 22, fontSize: 12, color: HP.textMuted, fontFamily: 'Outfit', letterSpacing: '0.02em' }}>
             Built from <span style={{ color: HP.textSoft, fontWeight: 600 }}>{filmsLogged}</span> logged ·{' '}
             <span style={{ color: HP.textSoft, fontWeight: 600 }}>{filmsRated}</span> rated ·{' '}
             <span style={{ color: HP.textSoft, fontWeight: 600 }}>{moodSignals}</span> mood signal{moodSignals === 1 ? '' : 's'}

--- a/src/features/profile/__tests__/DnaConfidence.test.jsx
+++ b/src/features/profile/__tests__/DnaConfidence.test.jsx
@@ -6,33 +6,54 @@ import DnaConfidence from '../DnaConfidence'
 
 const renderAt = (props) => render(<MemoryRouter><DnaConfidence {...props} /></MemoryRouter>)
 
-// F7 trust contract: DNA confidence is framed as taste *evidence*, never as
-// accuracy / a guarantee / a grade on the user, and it connects to Tonight.
-describe('DnaConfidence — honest framing (F7)', () => {
-  it('frames the number as taste evidence, not accuracy or certainty', () => {
+// F7 trust contract: DNA confidence is framed as taste *evidence*, never accuracy / a guarantee.
+// F7.4: it is presented as a qualitative MATURITY BAND — never an exact percentage and never a
+// completion meter. The internal numeric value (computeDnaConfidence) is unchanged.
+describe('DnaConfidence — evidence-maturity band (F7.4)', () => {
+  it('frames it as taste evidence and shows NO percentage anywhere', () => {
     renderAt({ confidence: 64, filmsLogged: 30, filmsRated: 12, moodSignals: 6 })
-    expect(screen.getByText('64%')).toBeInTheDocument()
+    expect(screen.getByText('Taking shape')).toBeInTheDocument()        // 40–69 → Taking shape
+    expect(screen.queryByText('64%')).not.toBeInTheDocument()
+    expect(screen.queryByText(/\d+%/)).not.toBeInTheDocument()          // no exact % rendered
     expect(screen.getByText(/taste evidence/i)).toBeInTheDocument()
     expect(screen.getByText(/not a measure of accuracy/i)).toBeInTheDocument()
-    expect(screen.queryByText(/guarantee/i)).not.toBeInTheDocument()
-    // Connects the profile to the nightly ritual.
     expect(screen.getByText(/one film each night/i)).toBeInTheDocument()
+    // no progressbar/meter semantics
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+    expect(screen.queryByRole('meter')).not.toBeInTheDocument()
   })
 
-  it('cold-start: "still learning" guidance + a Tonight CTA', () => {
+  it('boundary mapping: <40 → Still forming, 40–69 → Taking shape, 70+ → Well established', () => {
+    const band = (confidence) => {
+      const { unmount } = renderAt({ confidence, filmsLogged: 10, filmsRated: 4, moodSignals: 5 })
+      const found = ['Still forming', 'Taking shape', 'Well established'].find(l => screen.queryByText(l))
+      unmount()
+      return found
+    }
+    expect(band(0)).toBe('Still forming')
+    expect(band(39)).toBe('Still forming')
+    expect(band(40)).toBe('Taking shape')
+    expect(band(69)).toBe('Taking shape')
+    expect(band(70)).toBe('Well established')
+    expect(band(100)).toBe('Well established')
+  })
+
+  it('low evidence (forming band): cannot show a mature band; gives guidance + a Tonight CTA', () => {
     renderAt({ confidence: 12, filmsLogged: 2, filmsRated: 0, moodSignals: 1 })
-    expect(screen.getByText('Still learning')).toBeInTheDocument() // tier label
+    expect(screen.getByText('Still forming')).toBeInTheDocument()
+    expect(screen.queryByText('Well established')).not.toBeInTheDocument()
     expect(screen.getByText(/completely normal when you/i)).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /see tonight.s pick/i })).toBeInTheDocument()
   })
 
-  it('warm: "reading you well" and no cold-start CTA', () => {
+  it('high evidence (established band): no cold-start CTA, no percentage', () => {
     renderAt({ confidence: 88, filmsLogged: 120, filmsRated: 40, moodSignals: 10 })
-    expect(screen.getByText('Reading you well')).toBeInTheDocument() // exact tier label
+    expect(screen.getByText('Well established')).toBeInTheDocument()
+    expect(screen.queryByText(/\d+%/)).not.toBeInTheDocument()
     expect(screen.queryByRole('link', { name: /see tonight.s pick/i })).not.toBeInTheDocument()
   })
 
-  it('shows the evidence it is built from', () => {
+  it('still shows the evidence it is built from (counts, not percentages)', () => {
     renderAt({ confidence: 50, filmsLogged: 30, filmsRated: 12, moodSignals: 6 })
     expect(screen.getByText('30')).toBeInTheDocument()
     expect(screen.getByText('12')).toBeInTheDocument()

--- a/src/features/profile/__tests__/ProfileEditorialGate.test.jsx
+++ b/src/features/profile/__tests__/ProfileEditorialGate.test.jsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+
+// F7.4 cardinal rule: maturity gates GENERATION, not just rendering. A forming profile must
+// never call the editorial Edge Function (preserving cost + the "identity from one film" trust
+// problem would otherwise survive a UI-only fix).
+
+vi.stubEnv('VITE_SUPABASE_URL', 'https://test.supabase.co')
+vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'anon-test-key')
+
+vi.mock('@/shared/services/tasteCache', () => ({
+  getTasteFingerprint: () => Promise.resolve({ topMoodTags: [{ key: 'a', count: 1, share: 1 }], topToneTags: [], topFitProfiles: [], total: 3 }),
+}))
+
+let historyRows
+let ratingRows
+function makeQuery(result) {
+  const promise = Promise.resolve(result)
+  const chain = {
+    select: () => chain, eq: () => chain, order: () => chain, limit: () => chain, in: () => chain,
+    maybeSingle: () => Promise.resolve({ data: Array.isArray(result.data) ? (result.data[0] ?? null) : (result.data ?? null), error: result.error ?? null }),
+    then: (res, rej) => promise.then(res, rej),
+    catch: (fn) => promise.catch(fn),
+  }
+  return chain
+}
+vi.mock('@/shared/lib/supabase/client', () => ({
+  supabase: {
+    from: (table) => {
+      if (table === 'user_history') return makeQuery({ data: historyRows })
+      if (table === 'user_ratings') return makeQuery({ data: ratingRows })
+      if (table === 'user_profiles_computed') return makeQuery({ data: null })   // missing editorial → regen-eligible
+      return makeQuery({ data: [] })
+    },
+  },
+}))
+
+import { useProfileDataFetch } from '../useProfileData'
+
+const film = (id) => ({ movie_id: id, watched_at: `2026-03-${String(id).padStart(2, '0')}T20:00:00Z`, movies: { runtime: 100, mood_tags: ['a'], tone_tags: ['b'], fit_profile: 'c', director_name: 'D', release_date: '2021-01-01', title: `Film ${id}` } })
+const films = (n) => Array.from({ length: n }, (_, i) => film(i + 1))
+
+let fetchSpy
+beforeEach(() => {
+  fetchSpy = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ summary: 's', signature: 'g' }) }))
+  vi.stubGlobal('fetch', fetchSpy)
+})
+
+describe('useProfileDataFetch — editorial generation maturity gate (F7.4)', () => {
+  it('FORMING profile (3 watched / 0 rated) NEVER calls the editorial Edge Function', async () => {
+    historyRows = films(3); ratingRows = []
+    const { result } = renderHook(() => useProfileDataFetch({ userId: 'u1', authUser: { id: 'u1' }, isSelf: true }))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    await new Promise(r => setTimeout(r, 0))   // let any (wrongly-fired) regen run
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('ESTABLISHED profile (15 watched / 5 rated) with missing editorial calls it once', async () => {
+    historyRows = films(15); ratingRows = Array.from({ length: 5 }, (_, i) => ({ movie_id: i + 1, rating: 8 }))
+    const { result } = renderHook(() => useProfileDataFetch({ userId: 'u1', authUser: { id: 'u1' }, isSelf: true }))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled())
+    expect(String(fetchSpy.mock.calls[0][0])).toMatch(/generate-taste-summary/)
+  })
+})

--- a/src/features/profile/__tests__/ProfileTrustPresentation.test.jsx
+++ b/src/features/profile/__tests__/ProfileTrustPresentation.test.jsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+vi.mock('html-to-image', () => ({ toPng: vi.fn(() => Promise.resolve('data:image/png;base64,x')) }))
+vi.mock('@/shared/components/FollowButton', () => ({ default: () => null }))
+
+import { ProfileDataProvider } from '../useProfileData'
+import { Masthead } from '../sections-top'
+import { PatternPanel, ShareCard } from '../sections-bottom'
+
+const renderWith = (Comp, value) => render(
+  <MemoryRouter>
+    <ProfileDataProvider value={{ isSelf: true, viewingUserId: 'u1', ...value }}><Comp /></ProfileDataProvider>
+  </MemoryRouter>
+)
+
+const GEN = 'A precise, witty machine-written identity sentence.'
+const SIG = 'A generated signature line.'
+
+describe('Masthead — F7.4 provenance + maturity gating', () => {
+  it('FORMING: no generated summary/signature, no provenance label, honest forming copy + evidence', () => {
+    renderWith(Masthead, {
+      user: { name: 'Ada Lovelace', handle: '@ada', joined: 'May 2026', filmsLogged: 3, hoursWatched: 5 },
+      stats: { filmsLogged: 3, filmsRated: 0 },
+      editorial: { summary: GEN, signature: SIG, archetype: ['X', 'Y', 'Z'] },
+    })
+    expect(screen.queryByText(new RegExp(GEN))).not.toBeInTheDocument()       // generated prose suppressed
+    expect(screen.queryByText(new RegExp(SIG))).not.toBeInTheDocument()       // generated signature suppressed
+    expect(screen.queryByText(/FeelFlick reflection/i)).not.toBeInTheDocument()
+    expect(screen.getByText(/still forming/i)).toBeInTheDocument()
+    expect(screen.getByText('Based on 3 watched films')).toBeInTheDocument()
+  })
+
+  it('ESTABLISHED: generated summary + signature render WITH a visible FeelFlick-reflection label; archetype marked derived', () => {
+    renderWith(Masthead, {
+      user: { name: 'Ada Lovelace', handle: '@ada', joined: 'May 2026', filmsLogged: 30, hoursWatched: 60 },
+      stats: { filmsLogged: 30, filmsRated: 12 },
+      editorial: { summary: GEN, signature: SIG, archetype: ['The Watcher', 'The Quiet', 'The Patient'] },
+    })
+    expect(screen.getByText(new RegExp(GEN))).toBeInTheDocument()
+    expect(screen.getByText(new RegExp(SIG))).toBeInTheDocument()
+    expect(screen.getAllByText(/FeelFlick reflection/i).length).toBeGreaterThan(0)  // provenance on summary + signature
+    expect(screen.getByText(/generated interpretation of your film activity, not a measured fact/i)).toBeInTheDocument()
+    expect(screen.getByText(/Derived from your film signals/i)).toBeInTheDocument()  // archetype = derived, not generated
+    expect(screen.getByText('Based on 30 watched films and 12 ratings')).toBeInTheDocument()
+  })
+})
+
+describe('PatternPanel — F7.4 small-sample percentage guard', () => {
+  const data = {
+    decades: [{ d: '2020s', pct: 75 }, { d: '2010s', pct: 25 }],
+    runtime: { median: 110, band: 'standard', share: 0.6, shortest: { title: 'A', value: 80 }, longest: { title: 'B', value: 140 } },
+    daypart: [{ label: 'Late', pct: 80 }, { label: 'Evening', pct: 20 }],
+  }
+  it('FORMING (< 5 watched): exact percentages are suppressed; labels remain', () => {
+    renderWith(PatternPanel, { ...data, stats: { filmsLogged: 3, filmsRated: 0 } })
+    expect(screen.queryByText(/\d+%/)).not.toBeInTheDocument()
+    expect(screen.getByText('2020s')).toBeInTheDocument()              // label kept (qualitative)
+    expect(screen.getByText('Late')).toBeInTheDocument()
+  })
+  it('established sample (≥ 5 watched): exact percentages render', () => {
+    renderWith(PatternPanel, { ...data, stats: { filmsLogged: 20, filmsRated: 8 } })
+    expect(screen.getByText('75%')).toBeInTheDocument()
+    expect(screen.getByText('80%')).toBeInTheDocument()
+  })
+})
+
+describe('ShareCard — F7.4 trust alignment', () => {
+  it('FORMING: does not export a generated identity; no reflection label; no percentage', () => {
+    renderWith(ShareCard, {
+      user: { name: 'Ada Lovelace', filmsLogged: 3, hoursWatched: 5 },
+      stats: { filmsLogged: 3, filmsRated: 0 },
+      editorial: { signature: SIG, archetype: ['X', 'Y', 'Z'] },
+    })
+    expect(screen.queryByText(new RegExp(SIG))).not.toBeInTheDocument()
+    expect(screen.queryByText(/FeelFlick reflection/i)).not.toBeInTheDocument()
+    expect(screen.getByText(/still forming/i)).toBeInTheDocument()
+    expect(screen.queryByText(/\d+%/)).not.toBeInTheDocument()
+  })
+  it('ESTABLISHED: exports the generated signature WITH a reflection label, no confidence %', () => {
+    renderWith(ShareCard, {
+      user: { name: 'Ada Lovelace', filmsLogged: 30, hoursWatched: 60 },
+      stats: { filmsLogged: 30, filmsRated: 12 },
+      editorial: { signature: SIG, archetype: ['The Watcher', 'The Quiet', 'The Patient'] },
+    })
+    expect(screen.getByText(new RegExp(SIG))).toBeInTheDocument()
+    expect(screen.getByText(/FeelFlick reflection/i)).toBeInTheDocument()
+    expect(screen.queryByText(/\d+%/)).not.toBeInTheDocument()         // no confidence percentage on the card
+  })
+})

--- a/src/features/profile/derive/__tests__/profilePresentation.test.js
+++ b/src/features/profile/derive/__tests__/profilePresentation.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import {
+  classifyProfileMaturity, deriveConfidenceBand, formatEvidenceSummary, presentSampleShare, MATURITY,
+} from '../profilePresentation'
+
+// F7.4 — pure presentation helpers. Thresholds are product judgements (forming < 5 watched OR
+// < 2 rated; established ≥ 15 watched AND ≥ 5 rated; emerging between).
+describe('classifyProfileMaturity', () => {
+  const cases = [
+    [{ watchedCount: 0,  ratedCount: 0 }, MATURITY.FORMING],
+    [{ watchedCount: 1,  ratedCount: 0 }, MATURITY.FORMING],
+    [{ watchedCount: 4,  ratedCount: 2 }, MATURITY.FORMING],   // < 5 watched
+    [{ watchedCount: 5,  ratedCount: 1 }, MATURITY.FORMING],   // < 2 rated
+    [{ watchedCount: 5,  ratedCount: 2 }, MATURITY.EMERGING],  // floor met
+    [{ watchedCount: 14, ratedCount: 5 }, MATURITY.EMERGING],  // < 15 watched
+    [{ watchedCount: 15, ratedCount: 4 }, MATURITY.EMERGING],  // < 5 rated
+    [{ watchedCount: 15, ratedCount: 5 }, MATURITY.ESTABLISHED],
+    [{ watchedCount: 200, ratedCount: 90 }, MATURITY.ESTABLISHED],
+  ]
+  it.each(cases)('%o → %s', (input, expected) => {
+    expect(classifyProfileMaturity(input)).toBe(expected)
+  })
+  it('invalid / null inputs degrade to forming, never throw', () => {
+    expect(classifyProfileMaturity()).toBe(MATURITY.FORMING)
+    expect(classifyProfileMaturity({})).toBe(MATURITY.FORMING)
+    expect(classifyProfileMaturity({ watchedCount: null, ratedCount: undefined })).toBe(MATURITY.FORMING)
+    expect(classifyProfileMaturity({ watchedCount: NaN, ratedCount: NaN })).toBe(MATURITY.FORMING)
+  })
+})
+
+describe('deriveConfidenceBand (no percentage; internal number unchanged upstream)', () => {
+  it('maps below 40 → Still forming, 40–69 → Taking shape, 70+ → Well established', () => {
+    expect(deriveConfidenceBand(0).label).toBe('Still forming')
+    expect(deriveConfidenceBand(39).label).toBe('Still forming')
+    expect(deriveConfidenceBand(40).label).toBe('Taking shape')
+    expect(deriveConfidenceBand(69).label).toBe('Taking shape')
+    expect(deriveConfidenceBand(70).label).toBe('Well established')
+    expect(deriveConfidenceBand(100).label).toBe('Well established')
+  })
+  it('the band label never contains a percentage; invalid → forming band', () => {
+    for (const c of [0, 40, 70, 100]) expect(deriveConfidenceBand(c).label).not.toMatch(/%|\d/)
+    expect(deriveConfidenceBand(undefined).key).toBe('forming')
+    expect(deriveConfidenceBand(NaN).key).toBe('forming')
+  })
+})
+
+describe('formatEvidenceSummary', () => {
+  it('uses canonical counts, correct grammar, omits empty segments', () => {
+    expect(formatEvidenceSummary({ watchedCount: 18, ratedCount: 11 })).toBe('Based on 18 watched films and 11 ratings')
+    expect(formatEvidenceSummary({ watchedCount: 1, ratedCount: 1 })).toBe('Based on 1 watched film and 1 rating')
+    expect(formatEvidenceSummary({ watchedCount: 7, ratedCount: 0 })).toBe('Based on 7 watched films')
+    expect(formatEvidenceSummary({ watchedCount: 0, ratedCount: 0 })).toBeNull()
+    expect(formatEvidenceSummary()).toBeNull()
+  })
+})
+
+describe('presentSampleShare (small-sample percentage presentation)', () => {
+  it('under 5 applicable films → no exact %, count-led', () => {
+    expect(presentSampleShare({ pct: 67, count: 2, total: 3 })).toMatchObject({ showPercent: false, text: '2 films' })
+    expect(presentSampleShare({ pct: 100, count: 1, total: 1 })).toMatchObject({ showPercent: false, text: '1 film' })
+    expect(presentSampleShare({ pct: 50, total: 0 })).toMatchObject({ showPercent: false, text: 'Early signal' })
+    expect(presentSampleShare({ pct: 50, total: 4 }).showPercent).toBe(false)
+  })
+  it('5–9 applicable films → provisional, still no bare exact %', () => {
+    expect(presentSampleShare({ pct: 42, count: 3, total: 7 })).toMatchObject({ showPercent: false, mode: 'provisional' })
+    expect(presentSampleShare({ pct: 42, count: 3, total: 9 }).showPercent).toBe(false)
+  })
+  it('10+ applicable films → exact % with sample context', () => {
+    expect(presentSampleShare({ pct: 42, count: 8, total: 19 })).toMatchObject({ showPercent: true, text: '42% · 8 of 19 films' })
+    expect(presentSampleShare({ pct: 30, count: 6, total: 20 }).showPercent).toBe(true)
+  })
+})

--- a/src/features/profile/derive/profilePresentation.js
+++ b/src/features/profile/derive/profilePresentation.js
@@ -1,0 +1,60 @@
+// src/features/profile/derive/profilePresentation.js
+// F7.4 — pure PRESENTATION helpers for Cinematic DNA trust framing. These never recompute or
+// change any metric/formula/canonical evidence (F7.3); they decide how a corrected claim is
+// QUALIFIED and whether generated identity prose is eligible to render at all.
+//
+// One source of truth for "how much evidence does the Profile have" — masthead eligibility,
+// editorial GENERATION gating, and confidence presentation all consume this. Thresholds are
+// product judgements about when a claim is worth making, not statistical guarantees.
+
+export const MATURITY = { FORMING: 'forming', EMERGING: 'emerging', ESTABLISHED: 'established' }
+
+// Evidence maturity from canonical counts. forming → too little evidence for generated
+// identity prose; emerging → cautious generated interpretation; established → full presentation.
+export function classifyProfileMaturity({ watchedCount = 0, ratedCount = 0 } = {}) {
+  const w = Number.isFinite(watchedCount) ? watchedCount : 0
+  const r = Number.isFinite(ratedCount) ? ratedCount : 0
+  if (w < 5 || r < 2) return MATURITY.FORMING
+  if (w >= 15 && r >= 5) return MATURITY.ESTABLISHED
+  return MATURITY.EMERGING
+}
+
+export const isForming = (maturity) => maturity === MATURITY.FORMING
+
+// Qualitative band for the DNA-confidence number — the exact integer % is never shown to the
+// user. The numeric value is preserved upstream (computeDnaConfidence) for internal consumers
+// and regression tests; this only labels it as evidence maturity.
+//   below 40 → Still forming · 40–69 → Taking shape · 70+ → Well established
+export function deriveConfidenceBand(confidence) {
+  const n = Number.isFinite(confidence) ? confidence : 0
+  if (n >= 70) return { key: 'established', label: 'Well established', copy: 'FeelFlick has a strong read on your taste.' }
+  if (n >= 40) return { key: 'taking-shape', label: 'Taking shape', copy: 'Keep logging and rating — your profile keeps sharpening.' }
+  return { key: 'forming', label: 'Still forming', copy: 'A light read so far — the more you watch and rate, the more personal it gets.' }
+}
+
+// "Based on 18 watched films and 11 ratings" — canonical counts only; a segment is omitted when
+// its value is unavailable; correct singular/plural; never implies every film was rated.
+export function formatEvidenceSummary({ watchedCount = 0, ratedCount = 0 } = {}) {
+  const w = Number.isFinite(watchedCount) ? watchedCount : 0
+  const r = Number.isFinite(ratedCount) ? ratedCount : 0
+  const parts = []
+  if (w > 0) parts.push(`${w} watched film${w === 1 ? '' : 's'}`)
+  if (r > 0) parts.push(`${r} rating${r === 1 ? '' : 's'}`)
+  if (parts.length === 0) return null
+  return `Based on ${parts.join(' and ')}`
+}
+
+// Small-sample presentation for a per-user proportional claim. `total` is the applicable film
+// count (the real denominator). Under 5 → no exact %, count-led; 5–9 → provisional; 10+ → % with
+// sample context. The underlying pct is never recomputed — this only decides how it's shown.
+export function presentSampleShare({ pct = null, count = null, total = 0 } = {}) {
+  const t = Number.isFinite(total) ? total : 0
+  const p = Number.isFinite(pct) ? Math.round(pct) : null
+  if (t < 5) {
+    return { mode: 'forming', showPercent: false, text: count != null ? `${count} film${count === 1 ? '' : 's'}` : 'Early signal' }
+  }
+  if (t < 10) {
+    return { mode: 'provisional', showPercent: false, text: count != null && p != null ? `~${p}% · ${count} of ${t}` : 'A growing signal' }
+  }
+  return { mode: 'established', showPercent: true, text: p != null && count != null ? `${p}% · ${count} of ${t} films` : (p != null ? `${p}%` : '') }
+}

--- a/src/features/profile/sections-bottom.jsx
+++ b/src/features/profile/sections-bottom.jsx
@@ -4,6 +4,7 @@ import { toPng } from 'html-to-image'
 import { HP, HP_GRAD, RADIUS, USER as USER_DEFAULT } from './data'
 import { ActionButton, SecondaryActionButton } from '@/shared/components/ActionButton'
 import { useProfileData } from './useProfileData'
+import { classifyProfileMaturity, MATURITY } from './derive/profilePresentation'
 
 // FeelFlick — /profile · Directors, Motifs, Trajectory, Decades+Runtime, Mixtape, Skew, Friends, Share card, Footer.
 // All sections read the live context and self-hide when their data source is
@@ -159,8 +160,13 @@ function Trajectory() {
 
 // Decades + Runtime + Daypart — derived from live history
 function PatternPanel() {
-  const { decades, runtime, daypart } = useProfileData();
+  const { decades, runtime, daypart, stats } = useProfileData();
   if ((!decades || decades.length === 0) && !runtime && (!daypart || daypart.length === 0)) return null;
+  // F7.4 small-sample guard: an exact share from a handful of films reads as misleading
+  // precision. Below 5 canonical watched films we keep the labels + relative bars (qualitative)
+  // but suppress the exact percentage. (Per-distribution denominators + "% · X of Y" context are
+  // an F7.5 refinement.)
+  const showShares = (stats?.filmsLogged ?? 0) >= 5;
   const dayTone = (() => {
     if (!daypart?.length) return null;
     const top = [...daypart].sort((a, b) => b.pct - a.pct)[0];
@@ -182,7 +188,7 @@ function PatternPanel() {
                 <div key={d.d}>
                   <div style={{ display:'flex', justifyContent:'space-between', alignItems:'baseline', marginBottom:6 }}>
                     <span style={{ fontFamily:'Outfit', fontSize:14, color:HP.text, fontWeight:500 }}>{d.d}</span>
-                    <span style={{ fontFamily:'Outfit', fontSize:12, color:HP.textMuted }}>{d.pct}%</span>
+                    {showShares && <span style={{ fontFamily:'Outfit', fontSize:12, color:HP.textMuted }}>{d.pct}%</span>}
                   </div>
                   <div style={{ height:2, background:'rgba(255,255,255,0.06)', borderRadius:RADIUS.pill, overflow:'hidden' }}>
                     <div style={{ width:`${d.pct}%`, height:'100%', background:HP.purple, opacity:0.7 }} />
@@ -198,7 +204,7 @@ function PatternPanel() {
           <div>
             <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.22em', textTransform:'uppercase', color:HP.purple, marginBottom:14 }}>Runtime sweet spot</div>
             <div style={{ fontFamily:'Outfit', fontSize:72, fontWeight:200, color:HP.text, letterSpacing:'-0.045em', lineHeight:1 }}>{runtime.median}<span style={{ fontSize:18, color:HP.textMuted, marginLeft:4 }}>min</span></div>
-            <div style={{ marginTop:8, fontSize:12, color:HP.textSoft, fontFamily:'Outfit', fontStyle:'italic' }}>median · {runtime.band} band · {Math.round(runtime.share*100)}% of films</div>
+            <div style={{ marginTop:8, fontSize:12, color:HP.textSoft, fontFamily:'Outfit', fontStyle:'italic' }}>median · {runtime.band} band{showShares ? ` · ${Math.round(runtime.share*100)}% of films` : ''}</div>
             <div style={{ marginTop:20, paddingTop:18, borderTop:`1px solid ${HP.border}`, fontSize:12, color:HP.textMuted, fontFamily:'Outfit', display:'flex', flexDirection:'column', gap:6 }}>
               <div>Shortest: <span style={{ color:HP.textSoft }}>{runtime.shortest.title} · {runtime.shortest.value}m</span></div>
               <div>Longest: <span style={{ color:HP.textSoft }}>{runtime.longest.title} · {runtime.longest.value}m</span></div>
@@ -215,7 +221,7 @@ function PatternPanel() {
                 <div key={d.label}>
                   <div style={{ display:'flex', justifyContent:'space-between', alignItems:'baseline', marginBottom:6 }}>
                     <span style={{ fontFamily:'Outfit', fontSize:14, color:HP.text }}>{d.label}</span>
-                    <span style={{ fontFamily:'Outfit', fontSize:12, color:HP.textMuted }}>{d.pct}%</span>
+                    {showShares && <span style={{ fontFamily:'Outfit', fontSize:12, color:HP.textMuted }}>{d.pct}%</span>}
                   </div>
                   <div style={{ height:2, background:'rgba(255,255,255,0.06)', borderRadius:RADIUS.pill, overflow:'hidden' }}>
                     <div style={{ width:`${d.pct}%`, height:'100%', background:HP.pink, opacity:0.7 }} />
@@ -415,7 +421,7 @@ function FriendsRanked() {
 
 // Shareable card preview — Instagram-story shape
 function ShareCard() {
-  const { user, editorial } = useProfileData();
+  const { user, editorial, stats } = useProfileData();
   const [copied, setCopied] = useState(false);
   const [exporting, setExporting] = useState(false);
   const previewRef = useRef(null);
@@ -423,7 +429,11 @@ function ShareCard() {
   const lastName = (user?.name || USER_DEFAULT.name).split(' ').slice(1).join(' ');
   const filmsLogged = user?.filmsLogged ?? USER_DEFAULT.filmsLogged;
   const hoursWatched = user?.hoursWatched ?? USER_DEFAULT.hoursWatched;
-  const signature = editorial?.signature || USER_DEFAULT.signature;
+  // F7.4: a forming profile must NOT export a generated identity. Above the floor the exported
+  // signature is the generated reflection (labelled); below it, a neutral honest line.
+  const maturity = classifyProfileMaturity({ watchedCount: stats?.filmsLogged ?? filmsLogged, ratedCount: stats?.filmsRated ?? 0 });
+  const hasGenerated = maturity !== MATURITY.FORMING && Boolean(editorial?.signature);
+  const signature = hasGenerated ? editorial.signature : 'Cinematic DNA — still forming.';
   const archetype = Array.isArray(editorial?.archetype) && editorial.archetype.length === 3
     ? editorial.archetype
     : USER_DEFAULT.archetype;
@@ -494,9 +504,12 @@ function ShareCard() {
             <div style={{ fontFamily:'Outfit', fontWeight:300, fontSize:28, color:HP.text, letterSpacing:'-0.04em', lineHeight:1 }}>{firstName}{lastName && <><br/><em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>{lastName}.</em></>}</div>
           </div>
           <div style={{ position:'relative' }}>
-            <div style={{ fontFamily:'Outfit', fontSize:14, fontWeight:400, color:HP.text, fontStyle:'italic', letterSpacing:'-0.01em', lineHeight:1.35, marginBottom:14 }}>
+            <div style={{ fontFamily:'Outfit', fontSize:14, fontWeight:400, color:HP.text, fontStyle:'italic', letterSpacing:'-0.01em', lineHeight:1.35, marginBottom: hasGenerated ? 6 : 14 }}>
               &ldquo;{signature}&rdquo;
             </div>
+            {hasGenerated && (
+              <div style={{ fontSize:6, fontWeight:700, letterSpacing:'0.14em', textTransform:'uppercase', color:HP.purple, marginBottom:14 }}>FeelFlick reflection</div>
+            )}
             <div style={{ display:'flex', gap:6, flexWrap:'wrap' }}>
               {archetype.map(a => (
                 <span key={a} style={{ padding:'3px 7px', borderRadius:3, background:'rgba(167,139,250,0.18)', border:`1px solid ${HP.purple}55`, fontSize:8, color:HP.text, fontFamily:'Outfit', letterSpacing:'0.06em', textTransform:'uppercase' }}>{a}</span>

--- a/src/features/profile/sections-top.jsx
+++ b/src/features/profile/sections-top.jsx
@@ -3,6 +3,11 @@ import { useNavigate } from 'react-router-dom'
 import FollowButton from '@/shared/components/FollowButton'
 import { USER as USER_DEFAULT, HP, HP_GRAD, RADIUS } from './data'
 import { useProfileData } from './useProfileData'
+import { classifyProfileMaturity, MATURITY, formatEvidenceSummary } from './derive/profilePresentation'
+
+// F7.4 — honest "still forming" copy when there isn't enough canonical evidence for a generated
+// identity. NOT styled or framed as a generated reflection.
+const FORMING_SUMMARY = 'Your Cinematic DNA is still forming. Watch and rate a few more films to reveal stronger patterns.'
 
 // FeelFlick — /profile · Top sections: masthead, archetype card, mood radar.
 // Edit profile + Share my DNA actions live in the masthead corner — the page
@@ -31,12 +36,21 @@ function formatUpdated(isoString) {
 
 function Masthead() {
   const navigate = useNavigate();
-  const { user, isSelf, viewingUserId, editorial } = useProfileData();
+  const { user, isSelf, viewingUserId, editorial, stats } = useProfileData();
   const name = user?.name || USER_DEFAULT.name;
   const firstName = (name.split(' ')[0] || '').trim();
   const lastName = name.split(' ').slice(1).join(' ').trim();
-  const summary    = editorial?.summary   || USER_DEFAULT.summary;
-  const signature  = editorial?.signature || USER_DEFAULT.signature;
+  // F7.4: maturity gates whether GENERATED identity prose renders. Below the floor (forming) we
+  // never show the LLM summary/signature — even a cached one — only honest "still forming" copy.
+  const watchedCount = stats?.filmsLogged ?? user?.filmsLogged ?? 0;
+  const ratedCount   = stats?.filmsRated ?? 0;
+  const maturity = classifyProfileMaturity({ watchedCount, ratedCount });
+  const hasGenerated = maturity !== MATURITY.FORMING && Boolean(editorial?.summary);
+  const summary    = hasGenerated ? editorial.summary : FORMING_SUMMARY;
+  const signature  = hasGenerated ? (editorial?.signature || null) : null;
+  const evidenceLine = formatEvidenceSummary({ watchedCount, ratedCount });
+  // The deterministic archetype is always real (computed locally from taste signals); show it
+  // once there's any signal, distinct from the generated prose.
   const archetype  = Array.isArray(editorial?.archetype) && editorial.archetype.length === 3
     ? editorial.archetype
     : USER_DEFAULT.archetype;
@@ -119,9 +133,23 @@ function Masthead() {
           <h1 className="ff-profile-masthead-h1" style={{ fontFamily:'Outfit', fontSize:96, lineHeight:0.92, fontWeight:300, letterSpacing:'-0.055em', color:HP.text, margin:0, textWrap:'balance' }}>
             {firstName}{lastName && <> <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>{lastName}</em></>}.
           </h1>
-          <p className="ff-profile-masthead-summary" style={{ marginTop:18, fontFamily:'Outfit, Inter, sans-serif', fontSize:21, fontStyle:'italic', color:HP.textSoft, letterSpacing:'-0.012em', maxWidth:720, textWrap:'pretty' }}>
-            “{summary}”
-          </p>
+          {hasGenerated ? (
+            <>
+              <p id="ff-dna-summary" className="ff-profile-masthead-summary" aria-describedby="ff-dna-provenance" style={{ marginTop:18, fontFamily:'Outfit, Inter, sans-serif', fontSize:21, fontStyle:'italic', color:HP.textSoft, letterSpacing:'-0.012em', maxWidth:720, textWrap:'pretty' }}>
+                “{summary}”
+              </p>
+              <p id="ff-dna-provenance" style={{ marginTop:10, fontSize:11.5, color:HP.textMuted, fontFamily:'Outfit, Inter, sans-serif', letterSpacing:'0.01em', maxWidth:720 }}>
+                <span style={{ color:HP.purple, fontWeight:600 }}>FeelFlick reflection</span> — a generated interpretation of your film activity, not a measured fact.
+              </p>
+            </>
+          ) : (
+            <p className="ff-profile-masthead-summary" style={{ marginTop:18, fontFamily:'Outfit, Inter, sans-serif', fontSize:20, color:HP.textMuted, letterSpacing:'-0.012em', maxWidth:720, textWrap:'pretty', lineHeight:1.5 }}>
+              {summary}
+            </p>
+          )}
+          {evidenceLine && (
+            <p style={{ marginTop:14, fontSize:12, color:HP.textMuted, fontFamily:'Outfit', letterSpacing:'0.03em' }}>{evidenceLine}</p>
+          )}
           <div style={{ marginTop:20, display:'flex', alignItems:'center', gap:14, fontSize:11, color:HP.textMuted, fontFamily:'Outfit', letterSpacing:'0.08em', textTransform:'uppercase', flexWrap:'wrap' }}>
             <span>{user?.handle || USER_DEFAULT.handle}</span>
             <span style={{ width:3, height:3, borderRadius:RADIUS.pill, background:HP.textFaint }} />
@@ -135,21 +163,29 @@ function Masthead() {
 
         {/* Archetype card — deterministic taxonomy from taste fingerprint */}
         <div style={{ padding:'22px 26px', borderRadius:RADIUS.sm, background:'rgba(255,255,255,0.025)', border:`1px solid ${HP.border}`, minWidth:240 }}>
-          <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.22em', textTransform:'uppercase', color:HP.purple, marginBottom:14 }}>Archetype</div>
+          <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.22em', textTransform:'uppercase', color:HP.purple, marginBottom:14 }}>Taste pattern</div>
           <div style={{ display:'flex', flexDirection:'column', gap:8 }}>
             {archetype.map((a, i) => (
               <div key={a} style={{ fontFamily:'Outfit', fontSize:i===0?20:16, fontWeight:i===0?500:400, color:i===0?HP.text:HP.textSoft, fontStyle:i===0?'normal':'italic', letterSpacing:'-0.015em' }}>{a}</div>
             ))}
           </div>
+          {/* F7.4: clarify this is computed locally from real signals — derived, not generated. */}
+          <div style={{ marginTop:14, fontSize:10.5, color:HP.textFaint, fontFamily:'Outfit, Inter, sans-serif', fontStyle:'italic', letterSpacing:'0.01em' }}>Derived from your film signals</div>
         </div>
       </div>
 
-      {/* Signature — LLM-generated short caption, falls back to USER_DEFAULT */}
-      <div style={{ marginTop:64, paddingTop:48, borderTop:`1px solid ${HP.border}` }}>
-        <p className="ff-profile-signature" style={{ fontFamily:'Outfit', fontSize:64, lineHeight:1.05, fontWeight:300, letterSpacing:'-0.04em', color:HP.text, margin:0, textWrap:'balance', textAlign:'center' }}>
-          <em style={{ fontStyle:'italic', fontWeight:400, background:HP_GRAD, WebkitBackgroundClip:'text', WebkitTextFillColor:'transparent' }}>{signature}</em>
-        </p>
-      </div>
+      {/* Signature — LLM-generated short caption. F7.4: rendered ONLY above the maturity floor
+          (signature is null when forming) and labelled as a FeelFlick reflection. */}
+      {signature && (
+        <div style={{ marginTop:64, paddingTop:48, borderTop:`1px solid ${HP.border}` }}>
+          <p className="ff-profile-signature" style={{ fontFamily:'Outfit', fontSize:64, lineHeight:1.05, fontWeight:300, letterSpacing:'-0.04em', color:HP.text, margin:0, textWrap:'balance', textAlign:'center' }}>
+            <em style={{ fontStyle:'italic', fontWeight:400, background:HP_GRAD, WebkitBackgroundClip:'text', WebkitTextFillColor:'transparent' }}>{signature}</em>
+          </p>
+          <p style={{ marginTop:18, textAlign:'center', fontSize:11, color:HP.textMuted, fontFamily:'Outfit, Inter, sans-serif', letterSpacing:'0.03em' }}>
+            <span style={{ color:HP.purple, fontWeight:600 }}>FeelFlick reflection</span> — generated from your film signals, not a measured fact.
+          </p>
+        </div>
+      )}
     </section>
   );
 }

--- a/src/features/profile/useProfileData.jsx
+++ b/src/features/profile/useProfileData.jsx
@@ -9,6 +9,7 @@ import { createContext, useContext, useEffect, useState, useCallback } from 'rea
 import { supabase } from '@/shared/lib/supabase/client'
 import { getTasteFingerprint } from '@/shared/services/tasteCache'
 import { dedupeHistoryByMovie } from '@/shared/lib/canonicalHistory'
+import { classifyProfileMaturity, MATURITY } from './derive/profilePresentation'
 
 import {
   deriveUser, deriveStats, deriveMoods, deriveDirectors, deriveMotifs,
@@ -184,10 +185,13 @@ export function useProfileDataFetch({ userId, authUser, isSelf = false }) {
           error: null,
         })
 
-        // Self-view: regenerate editorial summary + signature when missing or
-        // stale (>24 h). Archetype is deterministic so it's always live; we
-        // persist it alongside for resilience when viewing other users.
-        if (isSelf && shouldRegenerateEditorial(editorial) && canonicalHistory.length > 0) {
+        // Self-view: regenerate editorial summary + signature when missing or stale (>24 h).
+        // F7.4: the maturity floor gates GENERATION, not just rendering — a "forming" profile
+        // (too little canonical evidence) never calls the editorial Edge Function or writes the
+        // cache, so the cost + the "identity from one film" trust problem are both avoided.
+        // Archetype is deterministic so it's always live.
+        const profileMaturity = classifyProfileMaturity({ watchedCount: canonicalHistory.length, ratedCount: ratings.length })
+        if (isSelf && shouldRegenerateEditorial(editorial) && profileMaturity !== MATURITY.FORMING) {
           regenerateEditorial({ userId, history: canonicalHistory, archetypeFromFp })
             .then((updated) => {
               if (abort || !updated) return


### PR DESCRIPTION
**F7.4 — Harden Cinematic DNA trust and maturity framing.** Presents the now-canonical (F7.3) Profile claims with honest provenance, maturity gating, and no unsupported precision. **Presentation/eligibility only** — no metric/formula, canonical-evidence, privacy/RLS, route, hierarchy, or editorial-prompt change.

## Provenance treatment
The LLM masthead **summary + signature** now carry a visible **"FeelFlick reflection — a generated interpretation of your film activity, not a measured fact"** label (`aria-describedby` on the summary; a labelled caption under the signature). The deterministic **archetype** is relabelled **"Taste pattern" + "Derived from your film signals"** so it reads as computed, not generated. No model/provider exposed; generated text unchanged.

## Maturity thresholds (one shared helper `derive/profilePresentation.js`)
`classifyProfileMaturity` — **forming**: <5 watched OR <2 rated · **established**: ≥15 watched AND ≥5 rated · **emerging** between. The masthead, editorial generation, confidence band, and share card all consume this single source.

## Forming-state behavior + editorial-call suppression (the cardinal rule)
A forming profile shows honest **"still forming"** copy, renders **no** generated summary/signature (even a cached one), and `useProfileData` no longer calls the `generate-taste-summary` Edge Function or writes the cache when forming — the guard changed from `canonicalHistory.length > 0` to **maturity ≠ forming**. Gating both **rendering and generation** is what prevents a one-film profile from preserving the cost + trust problem. Moving to emerging uses the existing generation flow. No schema/TTL change; proactive invalidation stays F7.6.

## Evidence summary
One concise **"Based on N watched films and M ratings"** line near the top, from data already on the page (no new query, no percentages, no second dashboard block).

## Confidence-band mapping
The opaque exact integer % is replaced by a qualitative **band (label only)**: `<40 Still forming · 40–69 Taking shape · 70+ Well established`. No percentage in visible text or accessible names; the completion-meter bar is removed; the evidence line + "taste evidence, not accuracy" explanation + Tonight CTA remain. **`computeDnaConfidence` is unchanged** and preserved for regression.

## Small-sample rule
Decade / daypart / runtime exact **% text is suppressed below 5 canonical watched films** (labels + relative bars remain — qualitative); shown at ≥5. Chart geometry unchanged (visible-label suppression only). Per-distribution denominators + "% · X of Y films" context → **F7.5**.

## Share-card alignment
The Profile ShareCard no longer exports a generated identity when forming (neutral "Cinematic DNA — still forming." line); above the floor the exported signature carries a compact **"FeelFlick reflection"** label. No exact confidence %, no private review/history added, sharing mechanics unchanged. *(The `share/ShareCard.jsx` Tonight's-Pick card is a separate surface, untouched.)*

## Formula / data / privacy frozen
F7.3 canonical evidence · fingerprint + Profile metric formulas · `computeDnaConfidence` number · hierarchy/section order · chart source values/geometry · generated editorial text + schema · editorial cache TTL · F7.2 owner-only RLS + self-only Profile · recommendation scoring · routes — **all unchanged**.

## Tests (+25 → full 1349)
maturity classification (all boundaries + null/invalid) · confidence band mapping + no-% + no progressbar/meter · provenance (forming suppresses generated summary/signature **and** generation; established shows them labelled; archetype marked derived) · small-sample suppression below floor · share-card forming-vs-established · **editorial generation gate** (forming → zero Edge calls; established+missing → one call). F7.2 self-only + F7.3 canonical tests untouched and green.

## No-live-write proof
No live `/profile` opened; no Edge Function call; no cache write — all verification via pure tests + mocked Supabase/Edge/auth. No schema/RLS/migration; no visual baseline.

## Validation
`npm run lint` clean · profile tests **44 ×3** · regression **68** · recommendation consumers **519** · full **1324 → 1349** · `npm run build` ✓.

## Deferred F7.5 / F7.6
F7.5: per-distribution denominators + "% · X of Y" context, full chart accessibility/textual equivalents + contrast on load-bearing labels, MoodRadar weight qualifier. F7.6: proactive versioned cache invalidation. F7.7: intercepted authenticated browser coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
