### PR TITLE
Harden Cinematic DNA charts and accessibility

### DIFF
--- a/src/features/profile/DnaConfidence.jsx
+++ b/src/features/profile/DnaConfidence.jsx
@@ -12,7 +12,7 @@
 import { Link } from 'react-router-dom'
 import Eyebrow from '@/shared/ui/Eyebrow'
 import { HP, HP_GRAD, RADIUS, SPACE } from './data'
-import { deriveConfidenceBand } from './derive/profilePresentation'
+import { deriveConfidenceBand, INK_LABEL } from './derive/profilePresentation'
 
 // F7.4: the confidence value is the SHARED computeDnaConfidence number (unchanged), but it is
 // now presented as a qualitative evidence-maturity BAND — never an exact percentage and never a
@@ -38,7 +38,7 @@ export default function DnaConfidence({ confidence, filmsLogged = 0, filmsRated 
         <div>
           <Eyebrow rule color={HP.purple} style={{ marginBottom: 16 }}>DNA confidence</Eyebrow>
           <div style={{ fontFamily: 'Outfit', fontSize: 48, fontWeight: 300, color: HP.text, letterSpacing: '-0.04em', lineHeight: 1.05 }}>{band.label}</div>
-          <div style={{ marginTop: 22, fontSize: 12, color: HP.textMuted, fontFamily: 'Outfit', letterSpacing: '0.02em' }}>
+          <div style={{ marginTop: 22, fontSize: 12, color: INK_LABEL, fontFamily: 'Outfit', letterSpacing: '0.02em' }}>
             Built from <span style={{ color: HP.textSoft, fontWeight: 600 }}>{filmsLogged}</span> logged ·{' '}
             <span style={{ color: HP.textSoft, fontWeight: 600 }}>{filmsRated}</span> rated ·{' '}
             <span style={{ color: HP.textSoft, fontWeight: 600 }}>{moodSignals}</span> mood signal{moodSignals === 1 ? '' : 's'}
@@ -52,12 +52,12 @@ export default function DnaConfidence({ confidence, filmsLogged = 0, filmsRated 
             work with — not a score of you, and not a measure of accuracy. It climbs as you log films, rate them, set
             preferences, and react to your nightly picks.
           </p>
-          <p style={{ margin: '16px 0 0 0', fontSize: 14, lineHeight: 1.6, color: HP.textMuted, fontFamily: 'Outfit, Inter, sans-serif' }}>
+          <p style={{ margin: '16px 0 0 0', fontSize: 14, lineHeight: 1.6, color: INK_LABEL, fontFamily: 'Outfit, Inter, sans-serif' }}>
             {cold
               ? 'A low number is completely normal when you’re new — the more you watch and react, the more personal your nightly pick gets.'
               : 'FeelFlick is reading you well — keep logging and rating, and it keeps sharpening.'}
           </p>
-          <p style={{ margin: '20px 0 0 0', fontSize: 13, lineHeight: 1.5, color: HP.textFaint, fontFamily: 'Outfit', fontStyle: 'italic' }}>
+          <p style={{ margin: '20px 0 0 0', fontSize: 13, lineHeight: 1.5, color: INK_LABEL, fontFamily: 'Outfit', fontStyle: 'italic' }}>
             This profile is what FeelFlick weighs when it chooses your one film each night.
           </p>
           {cold && (

--- a/src/features/profile/TasteProfile.jsx
+++ b/src/features/profile/TasteProfile.jsx
@@ -44,7 +44,9 @@ function SelfProfile({ authUser }) {
 
   return (
     <ProfileDataProvider value={{ ...data, isSelf: true, viewingUserId: authUser?.id }}>
-      <div className="ff-profile-v2" style={{ minHeight:'100vh', background: HP.bgDeep, color: HP.text, fontFamily:'Inter, sans-serif', position:'relative' }}>
+      {/* F7.5: a labelled, focusable region inside AppShell's main — the Cinematic DNA skip
+          target. (AppShell owns the page-level <main>; we do not nest a second one.) */}
+      <div className="ff-profile-v2" id="cinematic-dna-content" tabIndex={-1} role="region" aria-label="Cinematic DNA" style={{ minHeight:'100vh', background: HP.bgDeep, color: HP.text, fontFamily:'Inter, sans-serif', position:'relative', outline:'none' }}>
         <div style={{ maxWidth:1440, margin:'0 auto' }}>
           <Masthead />
           <QuickStats />
@@ -94,11 +96,14 @@ function PrivateProfile() {
   )
 }
 
+// F7.5: honest loading status — one polite live region, aria-busy, screen-reader text, and the
+// decorative skeleton geometry hidden from assistive tech. No fake progress percentage.
 function PageSkeleton() {
   const pulse = { background: 'rgba(255,255,255,0.04)' }
   return (
-    <div className="ff-profile-v2" style={{ minHeight:'100vh', background: HP.bgDeep, color: HP.text, fontFamily:'Inter, sans-serif' }}>
-      <div style={{ maxWidth:1440, margin:'0 auto', padding:'80px 88px' }}>
+    <div className="ff-profile-v2" role="status" aria-live="polite" aria-busy="true" style={{ minHeight:'100vh', background: HP.bgDeep, color: HP.text, fontFamily:'Inter, sans-serif' }}>
+      <span className="sr-only">Loading your Cinematic DNA…</span>
+      <div aria-hidden="true" style={{ maxWidth:1440, margin:'0 auto', padding:'80px 88px' }}>
         <div style={{ display:'flex', alignItems:'center', gap:14, marginBottom:30 }}>
           <div className="animate-pulse" style={{ ...pulse, height:12, width:280, borderRadius:999 }} />
         </div>

--- a/src/features/profile/__tests__/ProfileChartA11y.test.jsx
+++ b/src/features/profile/__tests__/ProfileChartA11y.test.jsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+// jsdom has no IntersectionObserver (MoodRadar uses it) — stub it.
+beforeEach(() => {
+  vi.stubGlobal('IntersectionObserver', class { observe() {} disconnect() {} unobserve() {} })
+})
+
+import { ProfileDataProvider } from '../useProfileData'
+import { MoodRadar } from '../sections-top'
+import { Trajectory, SignatureDirectors } from '../sections-bottom'
+
+const renderWith = (Comp, value) => render(
+  <MemoryRouter><ProfileDataProvider value={{ isSelf: true, ...value }}><Comp /></ProfileDataProvider></MemoryRouter>
+)
+
+describe('MoodRadar — F7.5 text equivalent + hidden geometry', () => {
+  const moods = [
+    { name: 'Reflective', count: 12, weight: 0.74, hex: '#A78BFA' },
+    { name: 'Intimate', count: 9, weight: 0.61, hex: '#EC4899' },
+    { name: 'Slow-burning', count: 7, weight: 0.5, hex: '#7DD3FC' },
+    { name: 'Wry', count: 4, weight: 0.33, hex: '#34D399' },
+  ]
+  it('wraps the chart in a figure, hides the SVG, and exposes an ordered list with rank words (not raw weights)', () => {
+    const { container } = renderWith(MoodRadar, { moods, stats: { filmsLogged: 18, filmsRated: 7 } })
+    expect(container.querySelector('figure')?.getAttribute('aria-labelledby')).toBe('ff-mood-title')
+    expect(container.querySelector('svg')?.getAttribute('aria-hidden')).toBe('true')
+    expect(container.querySelector('ol')).toBeTruthy()                       // ordered text equivalent
+    expect(screen.getByText('strongest signal')).toBeInTheDocument()
+    expect(screen.getAllByText(/signal/).length).toBeGreaterThanOrEqual(3)   // rank descriptors
+    expect(screen.queryByText('74')).not.toBeInTheDocument()                 // no raw weight number
+    // summary names the top signals + states the denominator
+    expect(screen.getByText(/Reflective, Intimate, Slow-burning/)).toBeInTheDocument()
+    expect(screen.getByText(/18 watched films/)).toBeInTheDocument()
+  })
+  it('the section references its heading', () => {
+    const { container } = renderWith(MoodRadar, { moods, stats: { filmsLogged: 18, filmsRated: 7 } })
+    expect(container.querySelector('section')?.getAttribute('aria-labelledby')).toBe('ff-mood-title')
+    expect(container.querySelector('#ff-mood-title')).toBeTruthy()
+  })
+})
+
+describe('Trajectory — F7.5 control semantics + hidden bars', () => {
+  const value = {
+    trajectory: [{ label: 'Jan', count: 3, hex: '#A78BFA' }, { label: 'Feb', count: 5, hex: '#EC4899' }],
+    trajectoryAllTime: [{ label: '2024', count: 8, hex: '#A78BFA' }, { label: '2025', count: 12, hex: '#EC4899' }],
+  }
+  it('uses a button GROUP with aria-pressed (not a partial radiogroup)', () => {
+    const { container } = renderWith(Trajectory, value)
+    expect(container.querySelector('[role="radiogroup"]')).toBeNull()
+    expect(container.querySelector('[role="radio"]')).toBeNull()
+    const group = container.querySelector('[role="group"]')
+    expect(group?.getAttribute('aria-label')).toBe('Time range')
+    const year = screen.getByRole('button', { name: 'Year', pressed: true })
+    const allTime = screen.getByRole('button', { name: 'All time', pressed: false })
+    fireEvent.click(allTime)
+    expect(screen.getByRole('button', { name: 'All time', pressed: true })).toBeInTheDocument()
+    expect(year).toHaveAttribute('aria-pressed', 'false')
+  })
+  it('the section references its heading and the bar geometry is aria-hidden', () => {
+    const { container } = renderWith(Trajectory, value)
+    expect(container.querySelector('section')?.getAttribute('aria-labelledby')).toBe('ff-traj-title')
+    expect(container.querySelector('#ff-traj-title')).toBeTruthy()
+    expect(container.querySelectorAll('[aria-hidden="true"]').length).toBeGreaterThan(0) // bar geometry
+    // labels + counts remain visible (the text equivalent)
+    expect(screen.getByText('Jan')).toBeInTheDocument()
+  })
+})
+
+describe('SignatureDirectors — F7.5 landmark', () => {
+  it('references its heading', () => {
+    const { container } = renderWith(SignatureDirectors, {
+      directors: [{ name: 'Mara Vance', films: 4, avg: 4.5, accent: '#A78BFA', firstWatchedYear: 2021, signature: '' }],
+    })
+    expect(container.querySelector('section')?.getAttribute('aria-labelledby')).toBe('ff-dir-title')
+    expect(container.querySelector('#ff-dir-title')).toBeTruthy()
+  })
+})

--- a/src/features/profile/__tests__/ProfileLoadingA11y.test.jsx
+++ b/src/features/profile/__tests__/ProfileLoadingA11y.test.jsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+
+beforeEach(() => {
+  vi.stubGlobal('IntersectionObserver', class { observe() {} disconnect() {} unobserve() {} })
+})
+
+// Control the provider state per test (loading vs loaded skip-target).
+let fetchReturn
+vi.mock('../useProfileData', () => ({
+  useProfileDataFetch: () => fetchReturn,
+  ProfileDataProvider: ({ children }) => children,
+  useProfileData: () => ({ stats: { filmsLogged: 0, filmsRated: 0 }, moods: [], isSelf: true }),
+}))
+vi.mock('@/shared/hooks/useAuthSession', () => ({ useAuthSession: () => ({ user: { id: 'self-1' } }) }))
+vi.mock('@/shared/hooks/usePageMeta', () => ({ usePageMeta: () => {} }))
+// Section components read the (stubbed-empty) provider; they self-hide on empty data.
+vi.mock('html-to-image', () => ({ toPng: vi.fn() }))
+
+import TasteProfile from '../TasteProfile'
+
+const renderSelf = () => render(
+  <MemoryRouter initialEntries={['/profile']}>
+    <Routes><Route path="/profile" element={<TasteProfile />} /></Routes>
+  </MemoryRouter>
+)
+
+describe('Profile loading state — F7.5 honest status semantics', () => {
+  it('one polite status with aria-busy + screen-reader text; skeleton geometry hidden; no fake progress', () => {
+    fetchReturn = { loading: true, error: null }
+    const { container } = renderSelf()
+    const status = container.querySelector('[role="status"]')
+    expect(status).toBeTruthy()
+    expect(status).toHaveAttribute('aria-busy', 'true')
+    expect(status).toHaveAttribute('aria-live', 'polite')
+    expect(screen.getByText(/loading your cinematic dna/i)).toBeInTheDocument()
+    expect(container.querySelector('[aria-hidden="true"]')).toBeTruthy()       // skeleton geometry hidden
+    expect(screen.queryByText(/%/)).not.toBeInTheDocument()                    // no fake progress percentage
+    expect(container.querySelectorAll('[role="status"]').length).toBe(1)       // single status region
+  })
+})
+
+describe('Profile content region — F7.5 skip target + landmark', () => {
+  it('the dossier is a focusable, labelled region (not a nested main)', () => {
+    fetchReturn = { loading: false, error: null, stats: { filmsLogged: 0, filmsRated: 0 } }
+    const { container } = renderSelf()
+    const region = container.querySelector('#cinematic-dna-content')
+    expect(region).toBeTruthy()
+    expect(region).toHaveAttribute('tabIndex', '-1')                           // skip target
+    expect(region).toHaveAttribute('role', 'region')
+    expect(region).toHaveAttribute('aria-label', 'Cinematic DNA')
+    expect(container.querySelector('main')).toBeNull()                         // AppShell owns main; no nested one
+  })
+})

--- a/src/features/profile/derive/__tests__/profilePresentation.test.js
+++ b/src/features/profile/derive/__tests__/profilePresentation.test.js
@@ -1,7 +1,23 @@
 import { describe, it, expect } from 'vitest'
 import {
-  classifyProfileMaturity, deriveConfidenceBand, formatEvidenceSummary, presentSampleShare, MATURITY,
+  classifyProfileMaturity, deriveConfidenceBand, formatEvidenceSummary, presentSampleShare,
+  formatDistributionContext, INK_LABEL, MATURITY,
 } from '../profilePresentation'
+
+// WCAG relative-luminance contrast between a translucent foreground composited on an opaque bg.
+function contrast(fgRgba, bgHex) {
+  const m = fgRgba.match(/rgba?\(([\d.]+),\s*([\d.]+),\s*([\d.]+)(?:,\s*([\d.]+))?\)/)
+  const [fr, fg, fb, fa = 1] = [Number(m[1]), Number(m[2]), Number(m[3]), m[4] != null ? Number(m[4]) : 1]
+  const br = parseInt(bgHex.slice(1, 3), 16), bg = parseInt(bgHex.slice(3, 5), 16), bb = parseInt(bgHex.slice(5, 7), 16)
+  const comp = (f, b) => f * fa + b * (1 - fa)
+  const lum = (r, g, b) => {
+    const lin = (c) => { c /= 255; return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4 }
+    return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b)
+  }
+  const L1 = lum(comp(fr, br), comp(fg, bg), comp(fb, bb)) + 0.05
+  const L2 = lum(br, bg, bb) + 0.05
+  return Math.max(L1, L2) / Math.min(L1, L2)
+}
 
 // F7.4 — pure presentation helpers. Thresholds are product judgements (forming < 5 watched OR
 // < 2 rated; established ≥ 15 watched AND ≥ 5 rated; emerging between).
@@ -51,6 +67,40 @@ describe('formatEvidenceSummary', () => {
     expect(formatEvidenceSummary({ watchedCount: 7, ratedCount: 0 })).toBe('Based on 7 watched films')
     expect(formatEvidenceSummary({ watchedCount: 0, ratedCount: 0 })).toBeNull()
     expect(formatEvidenceSummary()).toBeNull()
+  })
+})
+
+describe('formatDistributionContext (F7.5 evidence/denominator)', () => {
+  it('under 5 applicable films → no exact %, count-led + accessible sentence', () => {
+    expect(formatDistributionContext({ count: 0, total: 0 })).toMatchObject({ showPercent: false, primary: 'Early signal' })
+    expect(formatDistributionContext({ count: 1, total: 1 })).toMatchObject({ showPercent: false, primary: '1 film' })
+    expect(formatDistributionContext({ count: 3, total: 4, percentage: 75 }).showPercent).toBe(false)
+    expect(formatDistributionContext({ count: 2, total: 3 }).accessibleText).toMatch(/2 films/)
+  })
+  it('5–9 applicable films → provisional with explicit count, no bare %', () => {
+    const r = formatDistributionContext({ count: 4, total: 7, percentage: 57 })
+    expect(r.showPercent).toBe(false)
+    expect(r.context).toBe('4 of 7 films')
+    expect(r.accessibleText).toMatch(/growing signal, 4 of 7 films/)
+  })
+  it('10+ applicable films → % with denominator + an accessible "X percent, representing N of M films"', () => {
+    const r = formatDistributionContext({ count: 8, total: 19, percentage: 42 })
+    expect(r).toMatchObject({ showPercent: true, primary: '42%', context: '8 of 19 films' })
+    expect(r.accessibleText).toBe('42 percent, representing 8 of 19 films')
+  })
+  it('forming maturity forces count-led even with a large total; invalid input is safe', () => {
+    expect(formatDistributionContext({ count: 5, total: 30, percentage: 50, maturity: MATURITY.FORMING }).showPercent).toBe(false)
+    expect(() => formatDistributionContext({ count: NaN, total: NaN, percentage: NaN })).not.toThrow()
+    expect(formatDistributionContext()).toMatchObject({ showPercent: false })
+  })
+})
+
+describe('INK_LABEL contrast (F7.5 — load-bearing labels meet WCAG AA on #06060a)', () => {
+  it('is ≥ 4.5:1 (normal-text AA), unlike the design-system faint tokens', () => {
+    expect(contrast(INK_LABEL, '#06060a')).toBeGreaterThanOrEqual(4.5)
+    // sanity: the tokens it replaces were below AA
+    expect(contrast('rgba(250,250,250,0.45)', '#06060a')).toBeLessThan(4.5) // HP.textMuted ≈ 4.36
+    expect(contrast('rgba(250,250,250,0.40)', '#06060a')).toBeLessThan(4.5) // HP.textFaint ≈ 3.71
   })
 })
 

--- a/src/features/profile/derive/profilePresentation.js
+++ b/src/features/profile/derive/profilePresentation.js
@@ -44,6 +44,42 @@ export function formatEvidenceSummary({ watchedCount = 0, ratedCount = 0 } = {})
   return `Based on ${parts.join(' and ')}`
 }
 
+// F7.5: a Profile-local AA-contrast colour for LOAD-BEARING muted labels (denominator/sample
+// context, provenance, evidence, chart labels, confidence copy). The design-system HP.textMuted
+// (rgba .45 ≈ 4.36:1) and HP.textFaint (rgba .40 ≈ 3.71:1) on #06060a fall below WCAG AA for
+// normal text; this raises informational labels to ~7:1 (rgba .62 over #06060a) without globally
+// altering the system or losing the editorial hierarchy (still below HP.textSoft ≈ 10.5:1).
+export const INK_LABEL = 'rgba(250,250,250,0.62)'
+
+// F7.5: one reusable count/denominator formatter for every Profile distribution, so each section
+// states its denominator the same way. Reuses the F7.4 small-sample rule and adds an accessible
+// sentence. Pure: never recomputes a metric, never mutates source data, safe on bad input.
+export function formatDistributionContext({ count = null, total = 0, percentage = null, maturity } = {}) {
+  const t = Number.isFinite(total) && total > 0 ? total : 0
+  const c = Number.isFinite(count) ? count : null
+  const p = Number.isFinite(percentage) ? Math.round(percentage) : null
+  const filmsWord = (n) => `${n} film${n === 1 ? '' : 's'}`
+
+  // Under 5 applicable films (or an explicitly forming profile) → no exact %, count-led.
+  if (t < 5 || maturity === MATURITY.FORMING) {
+    const hasCount = c != null && c > 0
+    const primary = hasCount ? filmsWord(c) : 'Early signal'
+    return { showPercent: false, primary, context: '', accessibleText: hasCount ? `${filmsWord(c)} so far` : 'Early signal — not enough films yet' }
+  }
+  // 5–9 → provisional, explicit count, no bare exact %.
+  if (t < 10) {
+    const context = c != null ? `${c} of ${t} films` : ''
+    return { showPercent: false, primary: 'A growing signal', context, accessibleText: c != null ? `a growing signal, ${c} of ${t} films` : `a growing signal across ${filmsWord(t)}` }
+  }
+  // 10+ → percentage with denominator context.
+  const primary = p != null ? `${p}%` : ''
+  const context = c != null ? `${c} of ${t} films` : `of ${t} films`
+  const accessibleText = p != null && c != null
+    ? `${p} percent, representing ${c} of ${t} films`
+    : (p != null ? `${p} percent of ${t} films` : `${t} films`)
+  return { showPercent: true, primary, context, accessibleText }
+}
+
 // Small-sample presentation for a per-user proportional claim. `total` is the applicable film
 // count (the real denominator). Under 5 → no exact %, count-led; 5–9 → provisional; 10+ → % with
 // sample context. The underlying pct is never recomputed — this only decides how it's shown.

--- a/src/features/profile/sections-bottom.jsx
+++ b/src/features/profile/sections-bottom.jsx
@@ -4,7 +4,7 @@ import { toPng } from 'html-to-image'
 import { HP, HP_GRAD, RADIUS, USER as USER_DEFAULT } from './data'
 import { ActionButton, SecondaryActionButton } from '@/shared/components/ActionButton'
 import { useProfileData } from './useProfileData'
-import { classifyProfileMaturity, MATURITY } from './derive/profilePresentation'
+import { classifyProfileMaturity, MATURITY, INK_LABEL } from './derive/profilePresentation'
 
 // FeelFlick — /profile · Directors, Motifs, Trajectory, Decades+Runtime, Mixtape, Skew, Friends, Share card, Footer.
 // All sections read the live context and self-hide when their data source is
@@ -23,13 +23,13 @@ function SignatureDirectors() {
   const { directors } = useProfileData();
   if (!directors || directors.length === 0) return null;
   return (
-    <section className="ff-profile-section" style={{ padding:'80px 88px', borderTop:`1px solid ${HP.border}` }}>
+    <section aria-labelledby="ff-dir-title" className="ff-profile-section" style={{ padding:'80px 88px', borderTop:`1px solid ${HP.border}` }}>
       <div style={{ display:'flex', alignItems:'flex-end', justifyContent:'space-between', marginBottom:40 }}>
         <div>
           <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color:HP.purple, marginBottom:14, display:'inline-flex', alignItems:'center', gap:10 }}>
-            <span style={{ height:1, width:22, background:HP.purple, opacity:0.6 }} />Signature directors
+            <span aria-hidden="true" style={{ height:1, width:22, background:HP.purple, opacity:0.6 }} />Signature directors
           </div>
-          <h2 className="ff-profile-section-h2" style={{ fontFamily:'Outfit', fontSize:44, lineHeight:1, fontWeight:500, letterSpacing:'-0.035em', color:HP.text, margin:0 }}>
+          <h2 id="ff-dir-title" className="ff-profile-section-h2" style={{ fontFamily:'Outfit', fontSize:44, lineHeight:1, fontWeight:500, letterSpacing:'-0.035em', color:HP.text, margin:0 }}>
             The voices you <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>trust.</em>
           </h2>
         </div>
@@ -37,7 +37,7 @@ function SignatureDirectors() {
       <div className="ff-profile-directors-grid" style={{ display:'grid', gridTemplateColumns:`repeat(${Math.min(directors.length, 5)},1fr)`, gap:20 }}>
         {directors.map(d => (
           <div key={d.name} style={{ padding:'24px 22px', borderRadius:RADIUS.sm, background:'rgba(255,255,255,0.025)', border:`1px solid ${HP.border}`, position:'relative', overflow:'hidden' }}>
-            <div style={{ position:'absolute', top:-30, right:-30, width:100, height:100, borderRadius:RADIUS.pill, background:`radial-gradient(circle, ${d.accent}33, transparent 70%)` }} />
+            <div aria-hidden="true" style={{ position:'absolute', top:-30, right:-30, width:100, height:100, borderRadius:RADIUS.pill, background:`radial-gradient(circle, ${d.accent}33, transparent 70%)` }} />
             <div style={{ position:'relative' }}>
               <div style={{ display:'flex', alignItems:'baseline', gap:6, marginBottom:14 }}>
                 {d.avg != null ? (
@@ -55,7 +55,7 @@ function SignatureDirectors() {
                 )}
               </div>
               <div style={{ fontFamily:'Outfit', fontSize:17, fontWeight:500, color:HP.text, letterSpacing:'-0.015em', marginBottom:4 }}>{d.name}</div>
-              <div style={{ fontSize:11, color:HP.textMuted, fontFamily:'Outfit', letterSpacing:'0.06em', textTransform:'uppercase' }}>
+              <div style={{ fontSize:11, color:INK_LABEL, fontFamily:'Outfit', letterSpacing:'0.06em', textTransform:'uppercase' }}>
                 {d.films} film{d.films === 1 ? '' : 's'} watched
               </div>
             </div>
@@ -71,12 +71,12 @@ function MotifCloud() {
   const { motifs } = useProfileData();
   if (!motifs || motifs.length === 0) return null;
   return (
-    <section className="ff-profile-section" style={{ padding:'80px 88px', borderTop:`1px solid ${HP.border}`, background:'rgba(255,255,255,0.012)' }}>
+    <section aria-labelledby="ff-motif-title" className="ff-profile-section" style={{ padding:'80px 88px', borderTop:`1px solid ${HP.border}`, background:'rgba(255,255,255,0.012)' }}>
       <div className="ff-profile-motifs-grid" style={{ display:'grid', gridTemplateColumns:'1fr 2fr', gap:80, alignItems:'flex-start' }}>
         <div>
           <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color:HP.purple, marginBottom:18 }}>Recurring motifs</div>
-          <h2 className="ff-profile-section-h2" style={{ fontFamily:'Outfit', fontSize:44, lineHeight:1, fontWeight:500, letterSpacing:'-0.035em', color:HP.text, margin:0 }}>What you <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>keep finding.</em></h2>
-          <p style={{ marginTop:18, fontSize:14, color:HP.textMuted, fontFamily:'Outfit, Inter, sans-serif', lineHeight:1.65, maxWidth:340 }}>Tonal qualities that show up across what you&rsquo;ve watched &mdash; not how films feel, but how they&rsquo;re made. Bigger means stronger pull.</p>
+          <h2 id="ff-motif-title" className="ff-profile-section-h2" style={{ fontFamily:'Outfit', fontSize:44, lineHeight:1, fontWeight:500, letterSpacing:'-0.035em', color:HP.text, margin:0 }}>What you <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>keep finding.</em></h2>
+          <p style={{ marginTop:18, fontSize:14, color:INK_LABEL, fontFamily:'Outfit, Inter, sans-serif', lineHeight:1.65, maxWidth:340 }}>Tonal qualities that show up across what you&rsquo;ve watched &mdash; not how films feel, but how they&rsquo;re made, in order of how strongly they recur.</p>
         </div>
         <div style={{ display:'flex', flexWrap:'wrap', gap:'14px 18px', alignItems:'baseline' }}>
           {motifs.map(m => {
@@ -111,29 +111,31 @@ function Trajectory() {
     ? <>Every <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>year so far.</em></>
     : <>The <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>last twelve.</em></>;
   return (
-    <section className="ff-profile-section" style={{ padding:'80px 88px', borderTop:`1px solid ${HP.border}` }}>
+    <section aria-labelledby="ff-traj-title" className="ff-profile-section" style={{ padding:'80px 88px', borderTop:`1px solid ${HP.border}` }}>
       <div style={{ display:'flex', alignItems:'flex-end', justifyContent:'space-between', marginBottom:44 }}>
         <div>
           <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color:HP.purple, marginBottom:14, display:'inline-flex', alignItems:'center', gap:10 }}>
-            <span style={{ height:1, width:22, background:HP.purple, opacity:0.6 }} />Taste trajectory
+            <span aria-hidden="true" style={{ height:1, width:22, background:HP.purple, opacity:0.6 }} />Taste trajectory
           </div>
-          <h2 className="ff-profile-section-h2" style={{ fontFamily:'Outfit', fontSize:44, lineHeight:1, fontWeight:500, letterSpacing:'-0.035em', color:HP.text, margin:0 }}>{heading}</h2>
+          <h2 id="ff-traj-title" className="ff-profile-section-h2" style={{ fontFamily:'Outfit', fontSize:44, lineHeight:1, fontWeight:500, letterSpacing:'-0.035em', color:HP.text, margin:0 }}>{heading}</h2>
         </div>
         {/* Only render the toggle when "All time" is actually informative
             (≥2 distinct years). Otherwise hide it so users don't tap into
             an identical chart. */}
         {allTimeAvailable && (
-          <div role="radiogroup" aria-label="Time range" style={{ display:'inline-flex', borderRadius:RADIUS.pill, background:'rgba(255,255,255,0.04)', border:`1px solid ${HP.border}`, padding:3 }}>
+          // F7.5: a two-option visual toggle is a button GROUP with aria-pressed (the simpler
+          // semantically-accurate model), not a partial radiogroup with no keyboard model.
+          <div role="group" aria-label="Time range" style={{ display:'inline-flex', borderRadius:RADIUS.pill, background:'rgba(255,255,255,0.04)', border:`1px solid ${HP.border}`, padding:3 }}>
             {['Year','All time'].map(p => {
               const active = range === p;
               return (
                 <button
                   key={p}
                   type="button"
-                  role="radio"
-                  aria-checked={active}
+                  className="ff-tap"
+                  aria-pressed={active}
                   onClick={() => setRange(p)}
-                  style={{ padding:'7px 14px', borderRadius:RADIUS.pill, background:active?HP_GRAD:'transparent', color:active?'#fff':HP.textMuted, border:'none', cursor:'pointer', fontFamily:'Outfit', fontSize:11, fontWeight:600, letterSpacing:'0.04em' }}
+                  style={{ padding:'7px 14px', borderRadius:RADIUS.pill, background:active?HP_GRAD:'transparent', color:active?'#fff':INK_LABEL, border:'none', cursor:'pointer', fontFamily:'Outfit', fontSize:11, fontWeight:600, letterSpacing:'0.04em' }}
                 >{p}</button>
               );
             })}
@@ -145,10 +147,11 @@ function Trajectory() {
           const h = (t.count / max) * 100;
           return (
             <div key={`${t.label}-${i}`} style={{ flex:1, display:'flex', flexDirection:'column', alignItems:'center', gap:10 }}>
-              <div style={{ width:'100%', display:'flex', alignItems:'flex-end', justifyContent:'center', height:200 }}>
+              {/* decorative bar — the label + count below are the accessible equivalent */}
+              <div aria-hidden="true" style={{ width:'100%', display:'flex', alignItems:'flex-end', justifyContent:'center', height:200 }}>
                 <div style={{ width:'100%', maxWidth:48, height:`${h}%`, background:`linear-gradient(180deg, ${t.hex}, ${t.hex}77)`, borderRadius:'4px 4px 0 0', boxShadow:`0 0 16px ${t.hex}33`, transition:'height 1s cubic-bezier(0.2,0.8,0.2,1)' }} />
               </div>
-              <div className="ff-profile-trajectory-label" style={{ fontFamily:'Outfit', fontSize:11, color:HP.textMuted, letterSpacing:'0.08em', textTransform:'uppercase' }}>{t.label}</div>
+              <div className="ff-profile-trajectory-label" style={{ fontFamily:'Outfit', fontSize:11, color:INK_LABEL, letterSpacing:'0.08em', textTransform:'uppercase' }}>{t.label}</div>
               <div className="ff-profile-trajectory-count" style={{ fontFamily:'Outfit', fontSize:11, color:HP.text, fontWeight:600 }}>{t.count}</div>
             </div>
           );
@@ -177,7 +180,7 @@ function PatternPanel() {
     return 'Morning person, cinematically.';
   })();
   return (
-    <section className="ff-profile-section" style={{ padding:'80px 88px', borderTop:`1px solid ${HP.border}`, background:'rgba(255,255,255,0.012)' }}>
+    <section aria-label="Viewing patterns" className="ff-profile-section" style={{ padding:'80px 88px', borderTop:`1px solid ${HP.border}`, background:'rgba(255,255,255,0.012)' }}>
       <div className="ff-profile-pattern-grid" style={{ display:'grid', gridTemplateColumns:'repeat(3,1fr)', gap:48 }}>
         {/* Decades */}
         {decades && decades.length > 0 && (
@@ -188,9 +191,9 @@ function PatternPanel() {
                 <div key={d.d}>
                   <div style={{ display:'flex', justifyContent:'space-between', alignItems:'baseline', marginBottom:6 }}>
                     <span style={{ fontFamily:'Outfit', fontSize:14, color:HP.text, fontWeight:500 }}>{d.d}</span>
-                    {showShares && <span style={{ fontFamily:'Outfit', fontSize:12, color:HP.textMuted }}>{d.pct}%</span>}
+                    {showShares && <span style={{ fontFamily:'Outfit', fontSize:12, color:INK_LABEL }}>{d.pct}%</span>}
                   </div>
-                  <div style={{ height:2, background:'rgba(255,255,255,0.06)', borderRadius:RADIUS.pill, overflow:'hidden' }}>
+                  <div aria-hidden="true" style={{ height:2, background:'rgba(255,255,255,0.06)', borderRadius:RADIUS.pill, overflow:'hidden' }}>
                     <div style={{ width:`${d.pct}%`, height:'100%', background:HP.purple, opacity:0.7 }} />
                   </div>
                 </div>
@@ -221,9 +224,9 @@ function PatternPanel() {
                 <div key={d.label}>
                   <div style={{ display:'flex', justifyContent:'space-between', alignItems:'baseline', marginBottom:6 }}>
                     <span style={{ fontFamily:'Outfit', fontSize:14, color:HP.text }}>{d.label}</span>
-                    {showShares && <span style={{ fontFamily:'Outfit', fontSize:12, color:HP.textMuted }}>{d.pct}%</span>}
+                    {showShares && <span style={{ fontFamily:'Outfit', fontSize:12, color:INK_LABEL }}>{d.pct}%</span>}
                   </div>
-                  <div style={{ height:2, background:'rgba(255,255,255,0.06)', borderRadius:RADIUS.pill, overflow:'hidden' }}>
+                  <div aria-hidden="true" style={{ height:2, background:'rgba(255,255,255,0.06)', borderRadius:RADIUS.pill, overflow:'hidden' }}>
                     <div style={{ width:`${d.pct}%`, height:'100%', background:HP.pink, opacity:0.7 }} />
                   </div>
                 </div>

--- a/src/features/profile/sections-top.jsx
+++ b/src/features/profile/sections-top.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import FollowButton from '@/shared/components/FollowButton'
 import { USER as USER_DEFAULT, HP, HP_GRAD, RADIUS } from './data'
 import { useProfileData } from './useProfileData'
-import { classifyProfileMaturity, MATURITY, formatEvidenceSummary } from './derive/profilePresentation'
+import { classifyProfileMaturity, MATURITY, formatEvidenceSummary, INK_LABEL } from './derive/profilePresentation'
 
 // F7.4 — honest "still forming" copy when there isn't enough canonical evidence for a generated
 // identity. NOT styled or framed as a generated reflection.
@@ -138,7 +138,7 @@ function Masthead() {
               <p id="ff-dna-summary" className="ff-profile-masthead-summary" aria-describedby="ff-dna-provenance" style={{ marginTop:18, fontFamily:'Outfit, Inter, sans-serif', fontSize:21, fontStyle:'italic', color:HP.textSoft, letterSpacing:'-0.012em', maxWidth:720, textWrap:'pretty' }}>
                 “{summary}”
               </p>
-              <p id="ff-dna-provenance" style={{ marginTop:10, fontSize:11.5, color:HP.textMuted, fontFamily:'Outfit, Inter, sans-serif', letterSpacing:'0.01em', maxWidth:720 }}>
+              <p id="ff-dna-provenance" style={{ marginTop:10, fontSize:11.5, color:INK_LABEL, fontFamily:'Outfit, Inter, sans-serif', letterSpacing:'0.01em', maxWidth:720 }}>
                 <span style={{ color:HP.purple, fontWeight:600 }}>FeelFlick reflection</span> — a generated interpretation of your film activity, not a measured fact.
               </p>
             </>
@@ -148,7 +148,7 @@ function Masthead() {
             </p>
           )}
           {evidenceLine && (
-            <p style={{ marginTop:14, fontSize:12, color:HP.textMuted, fontFamily:'Outfit', letterSpacing:'0.03em' }}>{evidenceLine}</p>
+            <p style={{ marginTop:14, fontSize:12, color:INK_LABEL, fontFamily:'Outfit', letterSpacing:'0.03em' }}>{evidenceLine}</p>
           )}
           <div style={{ marginTop:20, display:'flex', alignItems:'center', gap:14, fontSize:11, color:HP.textMuted, fontFamily:'Outfit', letterSpacing:'0.08em', textTransform:'uppercase', flexWrap:'wrap' }}>
             <span>{user?.handle || USER_DEFAULT.handle}</span>
@@ -170,7 +170,7 @@ function Masthead() {
             ))}
           </div>
           {/* F7.4: clarify this is computed locally from real signals — derived, not generated. */}
-          <div style={{ marginTop:14, fontSize:10.5, color:HP.textFaint, fontFamily:'Outfit, Inter, sans-serif', fontStyle:'italic', letterSpacing:'0.01em' }}>Derived from your film signals</div>
+          <div style={{ marginTop:14, fontSize:10.5, color:INK_LABEL, fontFamily:'Outfit, Inter, sans-serif', fontStyle:'italic', letterSpacing:'0.01em' }}>Derived from your film signals</div>
         </div>
       </div>
 
@@ -179,9 +179,9 @@ function Masthead() {
       {signature && (
         <div style={{ marginTop:64, paddingTop:48, borderTop:`1px solid ${HP.border}` }}>
           <p className="ff-profile-signature" style={{ fontFamily:'Outfit', fontSize:64, lineHeight:1.05, fontWeight:300, letterSpacing:'-0.04em', color:HP.text, margin:0, textWrap:'balance', textAlign:'center' }}>
-            <em style={{ fontStyle:'italic', fontWeight:400, background:HP_GRAD, WebkitBackgroundClip:'text', WebkitTextFillColor:'transparent' }}>{signature}</em>
+            <em style={{ fontStyle:'italic', fontWeight:400, color:HP.text, background:HP_GRAD, WebkitBackgroundClip:'text', WebkitTextFillColor:'transparent' }}>{signature}</em>
           </p>
-          <p style={{ marginTop:18, textAlign:'center', fontSize:11, color:HP.textMuted, fontFamily:'Outfit, Inter, sans-serif', letterSpacing:'0.03em' }}>
+          <p style={{ marginTop:18, textAlign:'center', fontSize:11, color:INK_LABEL, fontFamily:'Outfit, Inter, sans-serif', letterSpacing:'0.03em' }}>
             <span style={{ color:HP.purple, fontWeight:600 }}>FeelFlick reflection</span> — generated from your film signals, not a measured fact.
           </p>
         </div>
@@ -218,8 +218,11 @@ function QuickStats() {
 }
 
 // Mood Radar — derived from taste_fingerprint via useProfileData
+// F7.5: rank descriptor instead of an unexplained raw weight (e.g. "74").
+const moodRank = (i) => (i === 0 ? 'strongest signal' : i < 3 ? 'strong signal' : 'developing signal');
+
 function MoodRadar() {
-  const { moods } = useProfileData();
+  const { moods, stats } = useProfileData();
   const [in_, setIn] = useState(false);
   const ref = useRef(null);
   useEffect(() => {
@@ -239,34 +242,37 @@ function MoodRadar() {
   const anim = in_ ? target : moods.map(()=>0);
 
   return (
-    <section ref={ref} className="ff-profile-section" style={{ padding:'88px', borderTop:`1px solid ${HP.border}`, background:'rgba(255,255,255,0.012)' }}>
+    <section ref={ref} aria-labelledby="ff-mood-title" className="ff-profile-section" style={{ padding:'88px', borderTop:`1px solid ${HP.border}`, background:'rgba(255,255,255,0.012)' }}>
       <div className="ff-profile-mood-grid" style={{ display:'grid', gridTemplateColumns:'1fr 1.2fr', gap:80, alignItems:'center' }}>
         <div>
           <div style={{ fontSize:10, fontWeight:700, letterSpacing:'0.28em', textTransform:'uppercase', color:HP.purple, marginBottom:18, display:'inline-flex', alignItems:'center', gap:10 }}>
-            <span style={{ height:1, width:22, background:HP.purple, opacity:0.6 }} />Mood signature
+            <span aria-hidden="true" style={{ height:1, width:22, background:HP.purple, opacity:0.6 }} />Mood signature
           </div>
-          <h2 className="ff-profile-section-h2" style={{ fontFamily:'Outfit', fontSize:52, lineHeight:1, fontWeight:500, letterSpacing:'-0.04em', color:HP.text, margin:0, textWrap:'balance' }}>
+          <h2 id="ff-mood-title" className="ff-profile-section-h2" style={{ fontFamily:'Outfit', fontSize:52, lineHeight:1, fontWeight:500, letterSpacing:'-0.04em', color:HP.text, margin:0, textWrap:'balance' }}>
             How you <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>feel cinema.</em>
           </h2>
-          <p style={{ marginTop:18, fontSize:15, lineHeight:1.7, color:HP.textMuted, fontFamily:'Outfit, Inter, sans-serif', maxWidth:380 }}>
-            Top {moods.length} weighted moods, distilled from every film you&rsquo;ve logged.
+          {/* F7.5: the ordered mood list IS the chart's text equivalent — strongest-first, with
+              each film count as the denominator and a rank word instead of a raw weight number. */}
+          <p id="ff-mood-summary" style={{ marginTop:18, fontSize:15, lineHeight:1.7, color:INK_LABEL, fontFamily:'Outfit, Inter, sans-serif', maxWidth:380 }}>
+            Your strongest film-tone signals are {moods.slice(0,3).map(m => m.name).join(', ')}{stats?.filmsLogged ? ` — derived from ${stats.filmsLogged} watched film${stats.filmsLogged === 1 ? '' : 's'}, patterns rather than measured facts` : ''}.
           </p>
-          <div style={{ marginTop:24, display:'flex', flexDirection:'column', gap:8 }}>
-            {moods.map(m => (
-              <div key={m.name} style={{ display:'flex', alignItems:'center', justifyContent:'space-between', padding:'8px 12px', borderRadius:RADIUS.sm }}>
+          <ol style={{ marginTop:24, display:'flex', flexDirection:'column', gap:8, listStyle:'none', padding:0 }}>
+            {moods.map((m, i) => (
+              <li key={m.name} style={{ display:'flex', alignItems:'center', justifyContent:'space-between', padding:'8px 12px', borderRadius:RADIUS.sm }}>
                 <div style={{ display:'flex', alignItems:'center', gap:10 }}>
-                  <span style={{ width:8, height:8, borderRadius:RADIUS.pill, background:m.hex }} />
+                  <span aria-hidden="true" style={{ width:8, height:8, borderRadius:RADIUS.pill, background:m.hex }} />
                   <span style={{ fontFamily:'Outfit', fontSize:14, fontWeight:500, color:HP.text }}>{m.name}</span>
-                  <span style={{ fontSize:11, color:HP.textFaint, fontFamily:'Outfit' }}>· {m.count} films</span>
+                  <span style={{ fontSize:11, color:INK_LABEL, fontFamily:'Outfit' }}>· {m.count} film{m.count === 1 ? '' : 's'}</span>
                 </div>
-                <span style={{ fontFamily:'Outfit', fontSize:13, color:HP.textMuted }}>{Math.round(m.weight*100)}</span>
-              </div>
+                <span style={{ fontFamily:'Outfit', fontSize:12, color:INK_LABEL, letterSpacing:'0.02em' }}>{moodRank(i)}</span>
+              </li>
             ))}
-          </div>
+          </ol>
         </div>
 
-        <div className="ff-profile-mood-radar" style={{ position:'relative', width:420, height:420, margin:'0 auto' }}>
-          <svg viewBox="0 0 400 400" style={{ width:'100%', height:'100%' }}>
+        {/* Decorative geometry — the ordered list above is the accessible equivalent. */}
+        <figure aria-labelledby="ff-mood-title" aria-describedby="ff-mood-summary" className="ff-profile-mood-radar" style={{ position:'relative', width:420, height:420, margin:'0 auto' }}>
+          <svg aria-hidden="true" viewBox="0 0 400 400" style={{ width:'100%', height:'100%' }}>
             {[0.25,0.5,0.75,1].map((r,i) => {
               const p = moods.map((_,j) => {
                 const a = -Math.PI/2 + (j/n)*Math.PI*2;
@@ -291,7 +297,7 @@ function MoodRadar() {
               return <text key={i} x={cx+Math.cos(a)*(R+28)} y={cy+Math.sin(a)*(R+28)} textAnchor="middle" dominantBaseline="middle" style={{ fontFamily:'Outfit', fontSize:13, fontWeight:500, fill:HP.textSoft, letterSpacing:'0.02em' }}>{m.name}</text>;
             })}
           </svg>
-        </div>
+        </figure>
       </div>
     </section>
   );


### PR DESCRIPTION
**F7.5 — Harden Cinematic DNA charts and accessibility.** Completes the a11y, evidence-context, and contrast hardening on F7.3's canonical foundation + F7.4's trust framing. **Presentation only** — no metric/formula, canonical-history, fingerprint, maturity-threshold, confidence-band, generated-content, privacy/RLS, route, or section-order change.

## Chart inventory + accessibility outcome
Guardrail held — **one concise summary + ordered text equivalent per chart; the visual geometry is `aria-hidden`** (never expose every SVG node):
| Chart | Change |
|---|---|
| **Mood Radar** | `<figure aria-labelledby/aria-describedby>`; SVG (held the mood `<text>` labels) → `aria-hidden`; mood list is an `<ol>` strongest-first with a **rank word** ("strongest/strong/developing signal") **replacing the raw weight number** (e.g. "74"); summary names top signals + denominator |
| **Trajectory** | partial `role="radiogroup"`/`role="radio"` (no keyboard model) → **`role="group"` + `aria-pressed` toggle buttons**; bar geometry `aria-hidden`; label+count = text equivalent |
| **Decade / runtime / daypart** | section labelled "Viewing patterns"; bar tracks `aria-hidden`; F7.4 small-sample suppression kept; `%` raised to AA contrast |
| **Signature directors / Recurring motifs** | section `aria-labelledby` their headings; decorative blob `aria-hidden`; motif copy states **order** not visual size; director label AA contrast |

## Denominator-context rule
New pure `formatDistributionContext({count, total, percentage, maturity})` → `{primary, context, accessibleText, showPercent}`: `<5` count-led ("Early signal" / "N films") · `5–9` provisional ("N of M films") · `10+` `"42% · 8 of 19 films"` + `"42 percent, representing 8 of 19 films"`. Singular/plural grammar, finite/zero-safe, no recomputation, no source mutation.

## Trajectory keyboard model
Two-option visual toggle = `role="group"` with `aria-pressed` buttons (each an ordinary tab stop, `.ff-tap` focus ring) — the simpler semantically-accurate model, not a partial radiogroup. Range changes once; no unrelated write.

## Loading / landmark changes
Skeleton = `role="status"` `aria-live="polite"` `aria-busy="true"` + sr-only "Loading your Cinematic DNA…", geometry `aria-hidden`, **no fake progress**, single status region. The dossier is a focusable, labelled **region** (`id="cinematic-dna-content"`, `tabIndex={-1}`, `role="region"`, `aria-label="Cinematic DNA"`) — the skip **target** — inside AppShell's existing `<main>` (**no nested second main**; a shell-level skip *link* remains an AppShell concern → F7.7).

## Contrast measurements (Profile-local, computed from composited colours)
Added `INK_LABEL = rgba(250,250,250,0.62)` → **≈ 7.0:1 on `#06060a`** (clears the 4.5:1 normal-text AA floor) and applied to load-bearing muted labels. The replaced tokens were below AA: **`HP.textMuted` (.45) ≈ 4.36:1**, **`HP.textFaint` (.40) ≈ 3.71:1**. INK_LABEL stays below `HP.textSoft` (≈ 10.5:1) so the editorial hierarchy holds. Applied to: provenance disclosure, evidence summary, archetype "derived" caption, signature reflection caption, mood counts + rank words, decade/daypart %, director "films watched", trajectory labels, DNA-confidence evidence/guidance copy. A unit test asserts these ratios. *(Not a claim of full-app contrast compliance; axe/browser proof is F7.7.)*

## Colour-independence + zoom/reflow
Mood/trajectory/decade carry text labels + order; the trajectory active state uses `aria-pressed` (not colour); decorative dots `aria-hidden`. A solid `color` fallback added before the masthead signature's gradient-text clip (invisible-on-clip-failure guard); h1 + signature use `textWrap:balance`.

## Share-card alignment
Already F7.4-aligned (provenance label, no exact %, forming exports no generated identity) — verified, unchanged. Dimensions/mechanics unchanged.

## Frozen contracts
Owner-only RLS · self-only Profile · canonical-history boundary · fingerprint + metric formulas · maturity thresholds · confidence bands · generated-content provenance · editorial generation gate + TTL · section order · route · share mechanics · recommendation scoring — all unchanged.

## Tests (+12 → full 1361)
formatDistributionContext boundaries + grammar + accessibleText; INK_LABEL ≥ 4.5:1 (and old tokens < 4.5); Mood Radar (figure, SVG aria-hidden, `<ol>` equivalent, rank words not raw weights, denominator); Trajectory (group/aria-pressed not radiogroup, single change, bars hidden, landmark); directors landmark; loading (one polite status, aria-busy, sr-only text, geometry hidden, no %); content region (focusable labelled skip target, no nested main). F7.2/F7.3/F7.4 tests untouched.

## No-live-write proof
No live `/profile` opened; no Edge Function call; no cache write — pure tests + mocked provider/Edge/`html-to-image`/IntersectionObserver. No schema/RLS/migration; no baseline.

## Validation
`npm run lint` clean · profile **56 ×3** · regression **68** · recommendation **519** · full **1349 → 1361** · `npm run build` ✓.

## Deferred F7.6 / F7.7
F7.6: proactive versioned cache invalidation. F7.7: intercepted authenticated browser/axe coverage of the Profile route (incl. a shell-level skip link, rendered-contrast + 200%-zoom verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
