### PR TITLE
Version Cinematic DNA caches and make reflection refresh explicit

### DIFF
--- a/src/features/profile/__tests__/ProfileEditorialGate.test.jsx
+++ b/src/features/profile/__tests__/ProfileEditorialGate.test.jsx
@@ -55,11 +55,16 @@ describe('useProfileDataFetch — editorial generation maturity gate (F7.4)', ()
     expect(fetchSpy).not.toHaveBeenCalled()
   })
 
-  it('ESTABLISHED profile (15 watched / 5 rated) with missing editorial calls it once', async () => {
+  it('F7.6: ESTABLISHED profile with MISSING editorial still makes ZERO calls on render', async () => {
+    // F7.6 supersedes F7.4 generation-on-render entirely: even an eligible profile with no
+    // editorial never auto-generates. Generation is the explicit refresh action only.
     historyRows = films(15); ratingRows = Array.from({ length: 5 }, (_, i) => ({ movie_id: i + 1, rating: 8 }))
     const { result } = renderHook(() => useProfileDataFetch({ userId: 'u1', authUser: { id: 'u1' }, isSelf: true }))
     await waitFor(() => expect(result.current.loading).toBe(false))
-    await waitFor(() => expect(fetchSpy).toHaveBeenCalled())
-    expect(String(fetchSpy.mock.calls[0][0])).toMatch(/generate-taste-summary/)
+    await new Promise(r => setTimeout(r, 0))
+    expect(fetchSpy).not.toHaveBeenCalled()
+    // the editorial is classified 'none' (missing) → the explicit refresh action is available
+    expect(result.current.editorialStatus).toBe('none')
+    expect(typeof result.current.refreshEditorial).toBe('function')
   })
 })

--- a/src/features/profile/__tests__/ProfileEditorialRefresh.test.jsx
+++ b/src/features/profile/__tests__/ProfileEditorialRefresh.test.jsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+
+// F7.6 cardinal contract: mounting/rerendering /profile makes ZERO editorial Edge Function calls
+// and ZERO cache writes for ANY editorial state. Generation happens ONLY via the explicit
+// refreshEditorial() action.
+
+vi.stubEnv('VITE_SUPABASE_URL', 'https://test.supabase.co')
+vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'anon-test-key')
+
+let fpEditorialVersion          // taste_fingerprint.editorialVersion the (mocked) fingerprint carries
+vi.mock('@/shared/services/tasteCache', () => ({
+  getTasteFingerprint: () => Promise.resolve({ topMoodTags: [{ key: 'a', count: 1, share: 1 }], topToneTags: [], topFitProfiles: [], total: 15, evidenceVersion: 2, editorialVersion: fpEditorialVersion }),
+}))
+
+let editorialRow                // user_profiles_computed editorial read
+let fetchOk
+const film = (id) => ({ movie_id: id, watched_at: `2026-03-${String(id).padStart(2, '0')}T20:00:00Z`, movies: { runtime: 100, mood_tags: ['a'], tone_tags: ['b'], fit_profile: 'c', director_name: 'D', release_date: '2021-01-01', title: `Film ${id}` } })
+const films = (n) => Array.from({ length: n }, (_, i) => film(i + 1))
+const ratings = (n) => Array.from({ length: n }, (_, i) => ({ movie_id: i + 1, rating: 8 }))
+
+let writes
+function makeQuery(result) {
+  const p = Promise.resolve(result)
+  const chain = {
+    select: () => chain, eq: () => chain, order: () => chain, limit: () => chain, in: () => chain,
+    maybeSingle: () => Promise.resolve({ data: result.data, error: null }),
+    update: () => { writes++; return { eq: () => Promise.resolve({ error: null }) } },
+    insert: () => { writes++; return Promise.resolve({ error: null }) },
+    then: (res, rej) => p.then(res, rej), catch: (fn) => p.catch(fn),
+  }
+  return chain
+}
+vi.mock('@/shared/lib/supabase/client', () => ({
+  supabase: {
+    from: (table) => {
+      if (table === 'user_history') return makeQuery({ data: films(15) })
+      if (table === 'user_ratings') return makeQuery({ data: ratings(5) })
+      if (table === 'user_profiles_computed') return makeQuery({ data: editorialRow })
+      return makeQuery({ data: [] })
+    },
+  },
+}))
+
+import { useProfileDataFetch } from '../useProfileData'
+
+const CURRENT_EDITORIAL = { user_id: 'u1', editorial_summary: 'cached summary', editorial_signature: 'cached sig', editorial_archetype: ['a', 'b', 'c'], editorial_generated_at: '2999-01-01T00:00:00Z', taste_fingerprint: {} }
+
+let fetchSpy
+beforeEach(() => {
+  fetchOk = true; writes = 0
+  fetchSpy = vi.fn(() => Promise.resolve({ ok: fetchOk, json: () => Promise.resolve({ summary: 'fresh summary', signature: 'fresh sig' }) }))
+  vi.stubGlobal('fetch', fetchSpy)
+})
+// Stable auth references — an inline object would change every render and re-fire the fetch effect.
+const AUTH = { id: 'u1' }
+const VIEWER = { id: 'viewer' }
+const mountSelf = () => renderHook(() => useProfileDataFetch({ userId: 'u1', authUser: AUTH, isSelf: true }))
+
+describe('F7.6 — zero editorial generation on render', () => {
+  it('CURRENT editorial → status current, ZERO Edge calls on mount + rerender', async () => {
+    fpEditorialVersion = 2; editorialRow = CURRENT_EDITORIAL
+    const { result, rerender } = mountSelf()
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    rerender()
+    await new Promise(r => setTimeout(r, 0))
+    expect(result.current.editorialStatus).toBe('current')
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(writes).toBe(0)
+  })
+
+  it('STALE editorial (version mismatch) → status stale, ZERO Edge calls on render', async () => {
+    fpEditorialVersion = 1; editorialRow = CURRENT_EDITORIAL   // editorial present but fingerprint.editorialVersion stale
+    const { result } = mountSelf()
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    await new Promise(r => setTimeout(r, 0))
+    expect(result.current.editorialStatus).toBe('stale')
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(writes).toBe(0)
+  })
+
+  it('MISSING editorial → status none, ZERO Edge calls on render', async () => {
+    fpEditorialVersion = undefined; editorialRow = null
+    const { result } = mountSelf()
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    await new Promise(r => setTimeout(r, 0))
+    expect(result.current.editorialStatus).toBe('none')
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(writes).toBe(0)
+  })
+})
+
+describe('F7.6 — explicit refresh action', () => {
+  it('one refresh() → exactly one Edge call; success → status current', async () => {
+    fpEditorialVersion = undefined; editorialRow = null
+    const { result } = mountSelf()
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    await act(async () => { await result.current.refreshEditorial() })
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(String(fetchSpy.mock.calls[0][0])).toMatch(/generate-taste-summary/)
+    expect(result.current.refreshStatus).toBe('success')
+    expect(result.current.editorialStatus).toBe('current')
+    expect(result.current.editorial.summary).toBe('fresh summary')
+  })
+
+  it('duplicate concurrent refresh() collapses to ONE Edge call', async () => {
+    fpEditorialVersion = undefined; editorialRow = null
+    const { result } = mountSelf()
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    await act(async () => { await Promise.all([result.current.refreshEditorial(), result.current.refreshEditorial()]) })
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('failure → status error, prior editorial preserved, no raw text; retry can succeed', async () => {
+    fpEditorialVersion = 2; editorialRow = CURRENT_EDITORIAL
+    const { result } = mountSelf()
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    fetchOk = false
+    await act(async () => { await result.current.refreshEditorial() })
+    expect(result.current.refreshStatus).toBe('error')
+    expect(result.current.editorial.summary).toBe('cached summary')   // prior reflection intact
+    fetchOk = true
+    await act(async () => { await result.current.refreshEditorial() })
+    expect(result.current.refreshStatus).toBe('success')
+    expect(result.current.editorial.summary).toBe('fresh summary')
+  })
+
+  it('non-self view: refresh() is a no-op (zero Edge calls)', async () => {
+    fpEditorialVersion = undefined; editorialRow = null
+    const { result } = renderHook(() => useProfileDataFetch({ userId: 'u1', authUser: VIEWER, isSelf: false }))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    await act(async () => { await result.current.refreshEditorial() })
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/profile/__tests__/ProfileTrustPresentation.test.jsx
+++ b/src/features/profile/__tests__/ProfileTrustPresentation.test.jsx
@@ -23,6 +23,7 @@ describe('Masthead — F7.4 provenance + maturity gating', () => {
     renderWith(Masthead, {
       user: { name: 'Ada Lovelace', handle: '@ada', joined: 'May 2026', filmsLogged: 3, hoursWatched: 5 },
       stats: { filmsLogged: 3, filmsRated: 0 },
+      editorialStatus: 'forming',
       editorial: { summary: GEN, signature: SIG, archetype: ['X', 'Y', 'Z'] },
     })
     expect(screen.queryByText(new RegExp(GEN))).not.toBeInTheDocument()       // generated prose suppressed
@@ -36,6 +37,7 @@ describe('Masthead — F7.4 provenance + maturity gating', () => {
     renderWith(Masthead, {
       user: { name: 'Ada Lovelace', handle: '@ada', joined: 'May 2026', filmsLogged: 30, hoursWatched: 60 },
       stats: { filmsLogged: 30, filmsRated: 12 },
+      editorialStatus: 'current',
       editorial: { summary: GEN, signature: SIG, archetype: ['The Watcher', 'The Quiet', 'The Patient'] },
     })
     expect(screen.getByText(new RegExp(GEN))).toBeInTheDocument()
@@ -71,17 +73,19 @@ describe('ShareCard — F7.4 trust alignment', () => {
     renderWith(ShareCard, {
       user: { name: 'Ada Lovelace', filmsLogged: 3, hoursWatched: 5 },
       stats: { filmsLogged: 3, filmsRated: 0 },
+      editorialStatus: 'forming',
       editorial: { signature: SIG, archetype: ['X', 'Y', 'Z'] },
     })
     expect(screen.queryByText(new RegExp(SIG))).not.toBeInTheDocument()
     expect(screen.queryByText(/FeelFlick reflection/i)).not.toBeInTheDocument()
-    expect(screen.getByText(/still forming/i)).toBeInTheDocument()
+    expect(screen.getByText(/A portrait of your film taste/i)).toBeInTheDocument() // neutral structured fallback
     expect(screen.queryByText(/\d+%/)).not.toBeInTheDocument()
   })
   it('ESTABLISHED: exports the generated signature WITH a reflection label, no confidence %', () => {
     renderWith(ShareCard, {
       user: { name: 'Ada Lovelace', filmsLogged: 30, hoursWatched: 60 },
       stats: { filmsLogged: 30, filmsRated: 12 },
+      editorialStatus: 'current',
       editorial: { signature: SIG, archetype: ['The Watcher', 'The Quiet', 'The Patient'] },
     })
     expect(screen.getByText(new RegExp(SIG))).toBeInTheDocument()

--- a/src/features/profile/sections-bottom.jsx
+++ b/src/features/profile/sections-bottom.jsx
@@ -4,7 +4,7 @@ import { toPng } from 'html-to-image'
 import { HP, HP_GRAD, RADIUS, USER as USER_DEFAULT } from './data'
 import { ActionButton, SecondaryActionButton } from '@/shared/components/ActionButton'
 import { useProfileData } from './useProfileData'
-import { classifyProfileMaturity, MATURITY, INK_LABEL } from './derive/profilePresentation'
+import { INK_LABEL } from './derive/profilePresentation'
 
 // FeelFlick — /profile · Directors, Motifs, Trajectory, Decades+Runtime, Mixtape, Skew, Friends, Share card, Footer.
 // All sections read the live context and self-hide when their data source is
@@ -424,7 +424,7 @@ function FriendsRanked() {
 
 // Shareable card preview — Instagram-story shape
 function ShareCard() {
-  const { user, editorial, stats } = useProfileData();
+  const { user, editorial, editorialStatus } = useProfileData();
   const [copied, setCopied] = useState(false);
   const [exporting, setExporting] = useState(false);
   const previewRef = useRef(null);
@@ -432,11 +432,11 @@ function ShareCard() {
   const lastName = (user?.name || USER_DEFAULT.name).split(' ').slice(1).join(' ');
   const filmsLogged = user?.filmsLogged ?? USER_DEFAULT.filmsLogged;
   const hoursWatched = user?.hoursWatched ?? USER_DEFAULT.hoursWatched;
-  // F7.4: a forming profile must NOT export a generated identity. Above the floor the exported
-  // signature is the generated reflection (labelled); below it, a neutral honest line.
-  const maturity = classifyProfileMaturity({ watchedCount: stats?.filmsLogged ?? filmsLogged, ratedCount: stats?.filmsRated ?? 0 });
-  const hasGenerated = maturity !== MATURITY.FORMING && Boolean(editorial?.signature);
-  const signature = hasGenerated ? editorial.signature : 'Cinematic DNA — still forming.';
+  // F7.4/F7.6: the share card exports the generated reflection ONLY when it is the CURRENT
+  // (version-matched, fresh, non-forming) editorial. A forming, stale or missing reflection
+  // exports a neutral structured line instead — never stale generated prose as if current.
+  const hasGenerated = editorialStatus === 'current' && Boolean(editorial?.signature);
+  const signature = hasGenerated ? editorial.signature : 'A portrait of your film taste.';
   const archetype = Array.isArray(editorial?.archetype) && editorial.archetype.length === 3
     ? editorial.archetype
     : USER_DEFAULT.archetype;

--- a/src/features/profile/sections-top.jsx
+++ b/src/features/profile/sections-top.jsx
@@ -34,20 +34,53 @@ function formatUpdated(isoString) {
   return `Updated ${new Date(isoString).toLocaleDateString('en-US', { month: 'short', year: 'numeric' })}`
 }
 
+// F7.6: the explicit, settled editorial refresh prompt — shown only for an eligible self profile
+// whose reflection is missing ('none') or stale/version-mismatched ('stale'). Generation happens
+// ONLY on click, never on render. Honest copy; no raw errors; no fabricated progress.
+function EditorialRefresh({ status, refreshStatus, onRefresh }) {
+  const generating = refreshStatus === 'generating';
+  const failed = refreshStatus === 'error';
+  const label = status === 'none' ? 'Generate reflection' : 'Refresh reflection';
+  const prompt = status === 'none'
+    ? 'Generate a reflection from your current film activity.'
+    : 'Your taste evidence has changed. Refresh the reflection when you’re ready.';
+  const body = generating ? 'Refreshing reflection…' : failed ? 'We couldn’t refresh your reflection. Try again.' : prompt;
+  return (
+    <div style={{ marginTop:18, maxWidth:720 }}>
+      <p style={{ marginBottom:8, fontSize:11.5, color:INK_LABEL, fontFamily:'Outfit, Inter, sans-serif', letterSpacing:'0.01em' }}>
+        <span style={{ color:HP.purple, fontWeight:600 }}>FeelFlick reflection</span>
+      </p>
+      <p style={{ marginBottom:16, fontFamily:'Outfit, Inter, sans-serif', fontSize:18, color:HP.textSoft, letterSpacing:'-0.01em', lineHeight:1.5 }}>{body}</p>
+      {typeof onRefresh === 'function' && (
+        <button
+          type="button"
+          onClick={onRefresh}
+          disabled={generating}
+          aria-busy={generating}
+          className="ff-tap"
+          style={{ minHeight:44, padding:'11px 20px', borderRadius:RADIUS.sm, background:generating?'rgba(255,255,255,0.06)':HP_GRAD, color:generating?INK_LABEL:'#fff', border:'none', cursor:generating?'wait':'pointer', fontFamily:'Outfit', fontSize:13, fontWeight:600, letterSpacing:'0.02em', opacity:generating?0.85:1 }}
+        >{generating ? 'Refreshing…' : label}</button>
+      )}
+    </div>
+  );
+}
+
 function Masthead() {
   const navigate = useNavigate();
-  const { user, isSelf, viewingUserId, editorial, stats } = useProfileData();
+  const { user, isSelf, viewingUserId, editorial, stats, editorialStatus, refreshStatus, refreshEditorial } = useProfileData();
   const name = user?.name || USER_DEFAULT.name;
   const firstName = (name.split(' ')[0] || '').trim();
   const lastName = name.split(' ').slice(1).join(' ').trim();
-  // F7.4: maturity gates whether GENERATED identity prose renders. Below the floor (forming) we
-  // never show the LLM summary/signature — even a cached one — only honest "still forming" copy.
+  // F7.6: editorialStatus (current | stale | none | forming) — computed in the provider from
+  // maturity + TTL + evidence VERSION — decides what the masthead editorial area shows. Only a
+  // 'current' (version-matched, fresh, non-forming) reflection renders as the reflection; 'stale'
+  // and 'none' show an explicit refresh prompt; 'forming' shows the honest still-forming copy.
   const watchedCount = stats?.filmsLogged ?? user?.filmsLogged ?? 0;
   const ratedCount   = stats?.filmsRated ?? 0;
-  const maturity = classifyProfileMaturity({ watchedCount, ratedCount });
-  const hasGenerated = maturity !== MATURITY.FORMING && Boolean(editorial?.summary);
-  const summary    = hasGenerated ? editorial.summary : FORMING_SUMMARY;
-  const signature  = hasGenerated ? (editorial?.signature || null) : null;
+  const status = editorialStatus || (classifyProfileMaturity({ watchedCount, ratedCount }) === MATURITY.FORMING ? 'forming' : 'none');
+  const showCurrent = status === 'current';
+  const summary    = showCurrent ? editorial?.summary : null;
+  const signature  = showCurrent ? (editorial?.signature || null) : null;
   const evidenceLine = formatEvidenceSummary({ watchedCount, ratedCount });
   // The deterministic archetype is always real (computed locally from taste signals); show it
   // once there's any signal, distinct from the generated prose.
@@ -133,7 +166,7 @@ function Masthead() {
           <h1 className="ff-profile-masthead-h1" style={{ fontFamily:'Outfit', fontSize:96, lineHeight:0.92, fontWeight:300, letterSpacing:'-0.055em', color:HP.text, margin:0, textWrap:'balance' }}>
             {firstName}{lastName && <> <em style={{ fontStyle:'italic', fontWeight:400, color:HP.textSoft }}>{lastName}</em></>}.
           </h1>
-          {hasGenerated ? (
+          {status === 'current' ? (
             <>
               <p id="ff-dna-summary" className="ff-profile-masthead-summary" aria-describedby="ff-dna-provenance" style={{ marginTop:18, fontFamily:'Outfit, Inter, sans-serif', fontSize:21, fontStyle:'italic', color:HP.textSoft, letterSpacing:'-0.012em', maxWidth:720, textWrap:'pretty' }}>
                 “{summary}”
@@ -142,11 +175,19 @@ function Masthead() {
                 <span style={{ color:HP.purple, fontWeight:600 }}>FeelFlick reflection</span> — a generated interpretation of your film activity, not a measured fact.
               </p>
             </>
-          ) : (
+          ) : status === 'forming' ? (
             <p className="ff-profile-masthead-summary" style={{ marginTop:18, fontFamily:'Outfit, Inter, sans-serif', fontSize:20, color:HP.textMuted, letterSpacing:'-0.012em', maxWidth:720, textWrap:'pretty', lineHeight:1.5 }}>
-              {summary}
+              {FORMING_SUMMARY}
             </p>
+          ) : (
+            <EditorialRefresh status={status} refreshStatus={refreshStatus} onRefresh={isSelf ? refreshEditorial : undefined} />
           )}
+          {/* F7.6: one persistent polite/atomic live region — announces a settled refresh once. */}
+          <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+            {refreshStatus === 'success' ? 'Your FeelFlick reflection is updated.'
+              : refreshStatus === 'error' ? 'We couldn’t refresh your reflection. Try again.'
+              : ''}
+          </div>
           {evidenceLine && (
             <p style={{ marginTop:14, fontSize:12, color:INK_LABEL, fontFamily:'Outfit', letterSpacing:'0.03em' }}>{evidenceLine}</p>
           )}

--- a/src/features/profile/useProfileData.jsx
+++ b/src/features/profile/useProfileData.jsx
@@ -5,11 +5,12 @@
 // section components consume. Each section hides when its data source is
 // empty.
 
-import { createContext, useContext, useEffect, useState, useCallback } from 'react'
+import { createContext, useContext, useEffect, useState, useCallback, useRef } from 'react'
 import { supabase } from '@/shared/lib/supabase/client'
 import { getTasteFingerprint } from '@/shared/services/tasteCache'
 import { dedupeHistoryByMovie } from '@/shared/lib/canonicalHistory'
 import { classifyProfileMaturity, MATURITY } from './derive/profilePresentation'
+import { PROFILE_EVIDENCE_VERSION, isEditorialVersionCurrent } from '@/shared/lib/profileEvidenceVersion'
 
 import {
   deriveUser, deriveStats, deriveMoods, deriveDirectors, deriveMotifs,
@@ -68,6 +69,39 @@ export function useProfileDataFetch({ userId, authUser, isSelf = false }) {
   // (the existing refetch path), so the safe error UI can offer a real "Try again".
   const [reloadKey, setReloadKey] = useState(0)
   const retry = useCallback(() => setReloadKey(k => k + 1), [])
+
+  // F7.6: explicit editorial refresh. idle | generating | success | error. The inputs the
+  // refresh needs are stashed by the fetch effect (no fetch is repeated); inFlightRef guards
+  // duplicate concurrent calls; mountedRef prevents late-completion state updates after unmount.
+  const [refreshStatus, setRefreshStatus] = useState('idle')
+  const regenInputsRef = useRef(null)
+  const inFlightRef = useRef(false)
+  const mountedRef = useRef(true)
+  useEffect(() => () => { mountedRef.current = false }, [])
+
+  const refreshEditorial = useCallback(async () => {
+    const inputs = regenInputsRef.current
+    // Eligible only for the signed-in user with a non-forming profile — never from forming,
+    // never from a non-self/private view. Duplicate rapid clicks collapse to one call.
+    if (!inputs || !inputs.isSelf || inputs.maturity === MATURITY.FORMING) return
+    if (inFlightRef.current) return
+    inFlightRef.current = true
+    setRefreshStatus('generating')
+    try {
+      const updated = await regenerateEditorial(inputs)
+      if (!updated) throw new Error('refresh_failed')
+      // Success — replace the reflection and mark it current. Prior editorial is only ever
+      // overwritten on success (a failed refresh leaves the last valid reflection intact).
+      if (mountedRef.current) {
+        setState(s => ({ ...s, editorial: { ...s.editorial, ...updated }, editorialStatus: 'current' }))
+        setRefreshStatus('success')
+      }
+    } catch {
+      if (mountedRef.current) setRefreshStatus('error')   // raw backend text never surfaced
+    } finally {
+      inFlightRef.current = false
+    }
+  }, [])
 
   useEffect(() => {
     if (!userId) return
@@ -139,6 +173,20 @@ export function useProfileDataFetch({ userId, authUser, isSelf = false }) {
           generatedAt: storedEditorial?.editorial_generated_at || null,
         }
 
+        // F7.6: classify the cached editorial. It is "current" ONLY when maturity is not forming,
+        // it is within TTL, AND its evidence version matches (stored on taste_fingerprint by the
+        // explicit refresh). A pre-F7.6 editorial has no version → "stale" (kept in memory as a
+        // rollback value, but never presented as the current reflection). No generation happens
+        // here — generation is an explicit user action only.
+        const profileMaturity = classifyProfileMaturity({ watchedCount: canonicalHistory.length, ratedCount: ratings.length })
+        const editorialTtlFresh = editorial.generatedAt && (Date.now() - new Date(editorial.generatedAt).getTime()) < EDITORIAL_TTL_MS
+        const editorialStatus = profileMaturity === MATURITY.FORMING ? 'forming'
+          : (editorial.summary && editorialTtlFresh && isEditorialVersionCurrent(fingerprint)) ? 'current'
+          : editorial.summary ? 'stale'
+          : 'none'
+        // Stash exactly what an explicit refresh needs — no fetch is repeated on refresh.
+        regenInputsRef.current = { userId, history: canonicalHistory, archetypeFromFp, maturity: profileMaturity, isSelf }
+
         // === Friend films count =================================
         // Need per-friend totals for the "X films logged" caption — one
         // grouped query after the similarity results resolve.
@@ -173,6 +221,7 @@ export function useProfileDataFetch({ userId, authUser, isSelf = false }) {
           runtime: deriveRuntime({ history: canonicalHistory }),
           daypart: deriveDaypart({ history: canonicalHistory }),
           editorial,
+          editorialStatus,
           friends: deriveFriends({
             simARows: simARes?.data || [],
             simBRows: simBRes?.data || [],
@@ -185,24 +234,9 @@ export function useProfileDataFetch({ userId, authUser, isSelf = false }) {
           error: null,
         })
 
-        // Self-view: regenerate editorial summary + signature when missing or stale (>24 h).
-        // F7.4: the maturity floor gates GENERATION, not just rendering — a "forming" profile
-        // (too little canonical evidence) never calls the editorial Edge Function or writes the
-        // cache, so the cost + the "identity from one film" trust problem are both avoided.
-        // Archetype is deterministic so it's always live.
-        const profileMaturity = classifyProfileMaturity({ watchedCount: canonicalHistory.length, ratedCount: ratings.length })
-        if (isSelf && shouldRegenerateEditorial(editorial) && profileMaturity !== MATURITY.FORMING) {
-          regenerateEditorial({ userId, history: canonicalHistory, archetypeFromFp })
-            .then((updated) => {
-              if (abort || !updated) return
-              setState((s) => ({ ...s, editorial: { ...s.editorial, ...updated } }))
-            })
-            .catch((err) => {
-              // Never break the page on a regen failure — the stored/fallback
-              // copy keeps rendering.
-              console.warn('[useProfileData] editorial regen failed:', err)
-            })
-        }
+        // F7.6: NO editorial generation on render. Mounting/rerendering the Profile makes ZERO
+        // Edge Function calls and ZERO cache writes — the editorial is (re)generated ONLY by the
+        // explicit refreshEditorial() action below. Structured metrics render independently.
       } catch (e) {
         if (abort) return
         // F7.3: never surface raw backend text to the UI. Diagnostics stay in the console;
@@ -215,7 +249,7 @@ export function useProfileDataFetch({ userId, authUser, isSelf = false }) {
     return () => { abort = true }
   }, [userId, authUser, isSelf, reloadKey])
 
-  return { ...state, retry }
+  return { ...state, retry, refreshStatus, refreshEditorial }
 }
 
 export function ProfileDataProvider({ value, children }) {
@@ -229,13 +263,6 @@ export function useProfileData() {
 }
 
 // === INTERNAL ===
-
-function shouldRegenerateEditorial(editorial) {
-  if (!editorial?.summary || !editorial?.signature) return true
-  if (!editorial.generatedAt) return true
-  const age = Date.now() - new Date(editorial.generatedAt).getTime()
-  return age > EDITORIAL_TTL_MS
-}
 
 async function regenerateEditorial({ userId, history, archetypeFromFp }) {
   const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL
@@ -266,21 +293,25 @@ async function regenerateEditorial({ userId, history, archetypeFromFp }) {
   if (!summary && !signature) return null
 
   const generatedAt = new Date().toISOString()
+
+  // Preserve any existing user_profiles_computed.profile row (NOT NULL with no default — bare
+  // upsert 400s when no recommendation profile has been built yet). Also read the existing
+  // taste_fingerprint so we can stamp editorialVersion onto it WITHOUT dropping the fingerprint
+  // data (F7.6: the editorial's evidence version lives on the same row, set only here).
+  const { data: existing } = await supabase
+    .from('user_profiles_computed')
+    .select('user_id, taste_fingerprint')
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  const nextFingerprint = { ...(existing?.taste_fingerprint || {}), editorialVersion: PROFILE_EVIDENCE_VERSION }
   const fields = {
     editorial_summary: summary,
     editorial_signature: signature,
     editorial_archetype: archetypeFromFp,
     editorial_generated_at: generatedAt,
+    taste_fingerprint: nextFingerprint,
   }
-
-  // Preserve any existing user_profiles_computed.profile row (NOT NULL with
-  // no default — bare upsert 400s when no recommendation profile has been
-  // built yet). Same guard pattern as tasteCache.js.
-  const { data: existing } = await supabase
-    .from('user_profiles_computed')
-    .select('user_id')
-    .eq('user_id', userId)
-    .maybeSingle()
 
   if (existing) {
     await supabase.from('user_profiles_computed').update(fields).eq('user_id', userId)

--- a/src/shared/lib/__tests__/profileEvidenceVersion.test.js
+++ b/src/shared/lib/__tests__/profileEvidenceVersion.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { PROFILE_EVIDENCE_VERSION, isFingerprintVersionCurrent, isEditorialVersionCurrent } from '../profileEvidenceVersion'
+
+// F7.6 — a cache hit is valid only when its stored evidence version matches the current one.
+describe('PROFILE_EVIDENCE_VERSION cache validity', () => {
+  const V = PROFILE_EVIDENCE_VERSION
+  it('is a number ≥ 2 (F7.3 canonical evidence)', () => {
+    expect(typeof V).toBe('number')
+    expect(V).toBeGreaterThanOrEqual(2)
+  })
+  it('fingerprint: current version valid; unversioned/previous/malformed/missing are stale', () => {
+    expect(isFingerprintVersionCurrent({ topMoodTags: [], evidenceVersion: V })).toBe(true)
+    expect(isFingerprintVersionCurrent({ topMoodTags: [] })).toBe(false)          // pre-F7.3 unversioned
+    expect(isFingerprintVersionCurrent({ evidenceVersion: V - 1 })).toBe(false)   // previous version
+    expect(isFingerprintVersionCurrent({ evidenceVersion: '2' })).toBe(false)     // malformed (string)
+    expect(isFingerprintVersionCurrent(null)).toBe(false)
+    expect(isFingerprintVersionCurrent(undefined)).toBe(false)
+  })
+  it('editorial: current editorialVersion valid; a versioned fingerprint alone is NOT a valid editorial', () => {
+    expect(isEditorialVersionCurrent({ editorialVersion: V })).toBe(true)
+    expect(isEditorialVersionCurrent({ evidenceVersion: V })).toBe(false)         // fingerprint versioned, editorial not
+    expect(isEditorialVersionCurrent({ editorialVersion: V - 1 })).toBe(false)
+    expect(isEditorialVersionCurrent({})).toBe(false)
+    expect(isEditorialVersionCurrent(null)).toBe(false)
+  })
+})

--- a/src/shared/lib/profileEvidenceVersion.js
+++ b/src/shared/lib/profileEvidenceVersion.js
@@ -1,0 +1,24 @@
+// src/shared/lib/profileEvidenceVersion.js
+// One canonical version for Cinematic DNA evidence-derived caches (fingerprint + editorial).
+//
+// Bump this ONLY when the canonical EVIDENCE algorithm changes — canonical-history de-dup
+// (F7.3), fingerprint inputs, or the generated-summary evidence inputs. Do NOT bump for copy,
+// CSS, or accessibility changes. A cache hit is valid only when its stored evidenceVersion
+// matches this value; TTL is a secondary freshness rule on top of the version match.
+//
+//   v1 (implicit, unstored) — pre-F7.3 caches derived from RAW duplicate history.
+//   v2 — F7.3 canonical evidence (de-duplicated history feeds metrics, fingerprint, summary).
+export const PROFILE_EVIDENCE_VERSION = 2
+
+// The fingerprint cache object stores its version inline (taste_fingerprint.evidenceVersion).
+// An unversioned (pre-F7.3) or mismatched fingerprint is stale and must be recomputed.
+export function isFingerprintVersionCurrent(fingerprint) {
+  return Boolean(fingerprint) && fingerprint.evidenceVersion === PROFILE_EVIDENCE_VERSION
+}
+
+// The editorial's evidence version is stored alongside the fingerprint on the same row
+// (taste_fingerprint.editorialVersion), set ONLY by an explicit refresh. A pre-F7.6 editorial
+// has no editorialVersion → stale → it must not be presented as the current reflection.
+export function isEditorialVersionCurrent(fingerprint) {
+  return Boolean(fingerprint) && fingerprint.editorialVersion === PROFILE_EVIDENCE_VERSION
+}

--- a/src/shared/services/__tests__/tasteCacheVersion.test.js
+++ b/src/shared/services/__tests__/tasteCacheVersion.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { PROFILE_EVIDENCE_VERSION } from '@/shared/lib/profileEvidenceVersion'
+
+// F7.6 — the fingerprint cache is valid only when fresh AND version-current. A pre-F7.3
+// (unversioned, duplicate-derived) fingerprint is recomputed from canonical history and the
+// freshly-computed result carries the current evidence version.
+
+const M = (mood) => ({ mood_tags: [mood], tone_tags: ['t'], fit_profile: 'f' })
+const HISTORY = [1, 2, 3, 4, 5].map((id) => ({ movie_id: id, watched_at: `2026-03-0${id}T20:00:00Z`, movies: M(`m${id}`) }))
+
+let cacheRow
+let historyReads
+function makeBuilder(table) {
+  if (table === 'user_history') {
+    return { select: () => ({ eq: () => { historyReads++; return Promise.resolve({ data: HISTORY }) } }) }
+  }
+  return {
+    select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: cacheRow }) }) }),
+    update: () => ({ eq: () => Promise.resolve({}) }),
+    insert: () => Promise.resolve({}),
+  }
+}
+vi.mock('@/shared/lib/supabase/client', () => ({
+  supabase: {
+    from: (t) => makeBuilder(t),
+    auth: { getUser: () => Promise.resolve({ data: { user: { id: 'someone-else' } } }) }, // not the target → no persist
+  },
+}))
+
+import { getTasteFingerprint } from '../tasteCache'
+
+const fresh = () => new Date(Date.now() - 60_000).toISOString()
+beforeEach(() => { historyReads = 0; cacheRow = null })
+
+describe('getTasteFingerprint — evidence-version cache validity (F7.6)', () => {
+  it('a fresh but UNVERSIONED (pre-F7.3) cache is stale → recomputed, and the result is versioned', async () => {
+    cacheRow = { taste_fingerprint: { topMoodTags: [{ key: 'old', count: 9, share: 1 }], total: 9 }, taste_fingerprint_computed_at: fresh() }
+    const fp = await getTasteFingerprint('target')
+    expect(historyReads).toBe(1)                              // recomputed from canonical history
+    expect(fp.evidenceVersion).toBe(PROFILE_EVIDENCE_VERSION) // freshly stamped
+    expect(fp.total).toBe(5)                                  // canonical count, not the stale 9
+  })
+
+  it('a fresh + CURRENT-version cache is reused without recomputing', async () => {
+    cacheRow = { taste_fingerprint: { topMoodTags: [{ key: 'cur', count: 5, share: 1 }], total: 5, evidenceVersion: PROFILE_EVIDENCE_VERSION }, taste_fingerprint_computed_at: fresh() }
+    const fp = await getTasteFingerprint('target')
+    expect(historyReads).toBe(0)                              // cache hit, no recompute
+    expect(fp.topMoodTags[0].key).toBe('cur')
+  })
+
+  it('a fresh cache with a PREVIOUS version is stale → recomputed', async () => {
+    cacheRow = { taste_fingerprint: { topMoodTags: [], total: 5, evidenceVersion: PROFILE_EVIDENCE_VERSION - 1 }, taste_fingerprint_computed_at: fresh() }
+    await getTasteFingerprint('target')
+    expect(historyReads).toBe(1)
+  })
+
+  it('recompute preserves a previously-stored editorialVersion on the same row', async () => {
+    cacheRow = { taste_fingerprint: { total: 9, editorialVersion: PROFILE_EVIDENCE_VERSION }, taste_fingerprint_computed_at: fresh() }
+    const fp = await getTasteFingerprint('target')
+    expect(historyReads).toBe(1)                              // unversioned fingerprint → recompute
+    expect(fp.evidenceVersion).toBe(PROFILE_EVIDENCE_VERSION)
+    expect(fp.editorialVersion).toBe(PROFILE_EVIDENCE_VERSION) // editorial version not dropped
+  })
+})

--- a/src/shared/services/tasteCache.js
+++ b/src/shared/services/tasteCache.js
@@ -9,6 +9,7 @@
 
 import { supabase } from '@/shared/lib/supabase/client'
 import { dedupeHistoryByMovie } from '@/shared/lib/canonicalHistory'
+import { PROFILE_EVIDENCE_VERSION, isFingerprintVersionCurrent } from '@/shared/lib/profileEvidenceVersion'
 
 // === CONFIG ===
 
@@ -37,13 +38,22 @@ export async function getTasteFingerprint(userId) {
   const isFresh = cached?.taste_fingerprint_computed_at &&
     (now - new Date(cached.taste_fingerprint_computed_at).getTime()) < CACHE_TTL_MS
 
-  if (isFresh && cached.taste_fingerprint) {
+  // F7.6: a cache hit is valid only when it is BOTH within TTL AND carries the current evidence
+  // version. A pre-F7.3 (unversioned) or mismatched-version fingerprint — derived from raw
+  // duplicate history — is stale and is recomputed from canonical history below.
+  if (isFresh && isFingerprintVersionCurrent(cached.taste_fingerprint)) {
     return cached.taste_fingerprint
   }
 
-  // Compute fresh from watch history
-  const result = await computeFingerprint(userId)
-  if (!result) return null
+  // Compute fresh from canonical watch history; stamp the current evidence version.
+  const computed = await computeFingerprint(userId)
+  if (!computed) return null
+  // Preserve a previously-stored editorial version on the same row (the editorial is versioned
+  // independently by the explicit refresh action — recomputing the fingerprint must not drop it).
+  const result = { ...computed, evidenceVersion: PROFILE_EVIDENCE_VERSION }
+  if (cached?.taste_fingerprint?.editorialVersion != null) {
+    result.editorialVersion = cached.taste_fingerprint.editorialVersion
+  }
 
   // Only persist when computing the signed-in user's own fingerprint —
   // RLS on user_profiles_computed (correctly) rejects writes for other


### PR DESCRIPTION
**F7.6 — Version Cinematic DNA caches and make reflection refresh explicit.** Closes the two architectural trust issues left by F7.3/F7.5: pre-canonical caches could stay valid for the 24h TTL, and opening an eligible self Profile could still call the editorial Edge Function + write the cache automatically.

## Existing cache-shape findings (live schema, read-only)
`user_profiles_computed` has a JSONB **`taste_fingerprint`** (fingerprint cache + `taste_fingerprint_computed_at` TTL) and editorial as `editorial_summary`/`_signature` (text), `_archetype` (jsonb array), `_generated_at` (timestamp). **No dedicated editorial-version column** — but `taste_fingerprint` JSONB is an additive slot, so both versions live there with merge-preserving writes. **No migration needed.**

## Evidence-version design
New `src/shared/lib/profileEvidenceVersion.js` — **`PROFILE_EVIDENCE_VERSION = 2`** (the canonical-evidence algorithm: F7.3 de-dup + fingerprint + summary inputs). One constant for both caches; `isFingerprintVersionCurrent` / `isEditorialVersionCurrent`. Bumped only for evidence changes, never copy/CSS/a11y.

## Fingerprint invalidation
A hit is valid only when within TTL **AND** `taste_fingerprint.evidenceVersion === current`. Unversioned (pre-F7.3) or mismatched → recomputed from canonical history; the fresh result is stamped and **preserves** any existing `editorialVersion` (recomputing the fingerprint must not drop the editorial marker). Formulas/weights/shape + owner-gating unchanged. Home/Discover/recommendation consumers all pass.

## Editorial invalidation
`editorialStatus` = **current | stale | none | forming**. `current` only when maturity ≠ forming **AND** TTL-fresh **AND** `taste_fingerprint.editorialVersion === current`. Pre-F7.6 editorials have no version → **stale** (kept in memory as a rollback value, never shown as current). Forming → cached editorial suppressed. A current editorial renders exactly as before.

## No-generation-on-render proof (the cardinal contract)
The on-render `regenerateEditorial` auto-call is **deleted**. Mounting/rerendering `/profile` — for **current, stale, OR missing** editorial — makes **zero Edge Function calls and zero cache writes**. A test asserts `fetchSpy` not called **and** `writes === 0` across all editorial states + rerender.

## Refresh action state model
`useProfileData` exposes `refreshEditorial()` + `refreshStatus` (**idle | generating | success | error**). Explicit click only; uses stashed canonical evidence + existing buildSummaryRequest + Edge Function + owner-gated write; stamps `taste_fingerprint.editorialVersion`; `inFlightRef` guards duplicate concurrent calls; `mountedRef` blocks late updates; unavailable for forming and non-self/private; never fires from mount/render/effect-deps/trajectory toggle.

## Stale/failure preservation
On **failure** the prior valid reflection is **never overwritten** (no partial cache write), the action stays retryable, and a retry can succeed. Stale cached prose is never displayed under the normal "FeelFlick reflection" label.

## Share behavior
The share card exports the generated signature **only** when `editorialStatus === 'current'`; forming/stale/missing export a neutral structured line ("A portrait of your film taste."), never stale prose as current; no Edge call from share; no version exposed.

## Schema decision
**No migration.** The version is stored additively in the existing `taste_fingerprint` JSONB (both writers merge-preserve). The Edge Function is **unchanged** — the evidence version is application-owned and written by the client cache layer; the model never sees or chooses it.

## Frozen contracts
canonical-history rule · metric + fingerprint formulas · maturity thresholds · confidence bands · provenance labels · chart semantics (F7.5) · section order · route · RLS · recommendation scoring — all unchanged.

## Tests (+14 → full 1375)
version rules (current/unversioned/previous/malformed/missing, additive); fingerprint cache (unversioned→recompute+stamp, current→reuse-no-recompute, previous→recompute, editorialVersion preserved); **cardinal** no-gen-on-render (zero Edge + zero writes for current/stale/none + rerender); explicit refresh (one click=one call, duplicate=one, success→current, failure→error with prior reflection intact + retry succeeds, non-self no-op); share stale-safety. F7.4 presentation tests updated to pass `editorialStatus` (intentional gate change); F7.2/F7.3/F7.5 untouched.

## No-live-write proof
No live `/profile` opened; no Edge Function call; no cache write — all mocked. No schema/RLS/migration; no baseline.

## Validation
`npm run lint` clean · profile/cache **467 ×3** · recommendation consumers **620** · full **1361 → 1375** · `npm run build` ✓.

## Deferred F7.7
Intercepted authenticated browser/axe proof of the Profile route (incl. confirming zero Edge calls/writes on render in a real browser, the refresh-action settlement, the shell-level skip link, and rendered-contrast + 200%-zoom verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
