### PR TITLE
Secure Cinematic DNA projections and fix reflection persistence

### DIFF
--- a/e2e/app/profile.e2e.js
+++ b/e2e/app/profile.e2e.js
@@ -149,6 +149,26 @@ test.describe('Cinematic DNA — authenticated, intercepted', () => {
     expect(ledger.writes).toEqual([])
   })
 
+  // J — Edge success + cache-WRITE failure must settle to an honest error (no false durable success)
+  test('J — refresh: Edge success + cache-write failure → honest error, no false "updated"', async ({ page }) => {
+    const ledger = await installProfileFixture(page, { mode: 'established_missing', edgeMode: 'success', cacheWriteMode: 'failure' })
+    await openProfile(page)
+    await page.getByRole('button', { name: /generate reflection/i }).click()
+    await expect(page.getByText(/We couldn’t refresh your reflection/i).first()).toBeVisible({ timeout: 10_000 })
+    expect(ledger.edgeCalls, 'Edge succeeded exactly once').toHaveLength(1)
+    expect(ledger.writes, 'exactly one cache write attempted').toHaveLength(1)
+    await expect(page.getByText('Your FeelFlick reflection is updated.')).toHaveCount(0) // no false success announcement
+    await expect(page.getByText(/A freshly generated reflection/)).toHaveCount(0)        // fresh prose NOT shown as current
+    await expect(page.getByRole('button', { name: /generate reflection/i })).toBeEnabled() // re-enabled / retryable
+    expect(ledger.unexpectedRequests, 'fixture still fails closed').toEqual([])
+    // retry succeeds once the transient write failure clears
+    ledger.setCacheWriteMode('success')
+    await page.getByRole('button', { name: /generate reflection/i }).click()
+    await expect(page.getByText(/A freshly generated reflection/)).toBeVisible({ timeout: 10_000 })
+    expect(ledger.edgeCalls).toHaveLength(2)
+    expect(ledger.unexpectedRequests).toEqual([])
+  })
+
   // M — private other-user route: no behavioral query for the target, no Edge/write
   test('M — /profile/:otherId is private, fetches nothing for the target', async ({ page }) => {
     const ledger = await installProfileFixture(page)

--- a/scripts/verify-taste-projection-privacy.sql
+++ b/scripts/verify-taste-projection-privacy.sql
@@ -1,0 +1,85 @@
+-- verify-taste-projection-privacy.sql — READ-ONLY verification of the F7.9 privacy boundary.
+-- Proves, against the live database, that the Cinematic DNA taste projection is no longer
+-- readable by browser roles directly, that the dormant similarity view is gone, and that the
+-- People taste-match feature's only cross-user read is the narrow authenticated RPC
+-- public.get_discoverable_taste_profiles() (authenticated-only, opt-in gated, least-data).
+--
+-- It mutates NOTHING: catalog privilege checks (has_*_privilege never error) plus one rolled-back
+-- transaction that only SETs the JWT claim to simulate an authenticated caller. Replace the two
+-- UUID placeholders with real users before running the two-account block.
+--
+--   OWNER_A      = an authenticated user who satisfies the opt-in (showOnLeaderboards != false)
+--   OPTED_OUT_B  = a user whose user_settings.privacy.showOnLeaderboards = false (if one exists)
+
+-- ── 1) Catalog: browser roles have NO access to the projection view ───────────────────────────
+select 'anon SELECT user_fingerprint_public'          as check, has_table_privilege('anon','public.user_fingerprint_public','SELECT')          as got, false as expect;
+select 'authenticated SELECT user_fingerprint_public' as check, has_table_privilege('authenticated','public.user_fingerprint_public','SELECT') as got, false as expect;
+-- write-style grants must also be gone for both browser roles
+select 'anon INSERT user_fingerprint_public'          as check, has_table_privilege('anon','public.user_fingerprint_public','INSERT')          as got, false as expect;
+select 'authenticated UPDATE user_fingerprint_public' as check, has_table_privilege('authenticated','public.user_fingerprint_public','UPDATE') as got, false as expect;
+
+-- ── 2) Catalog: the dormant similarity view is dropped entirely ────────────────────────────────
+select 'user_similarity_discoverable dropped' as check, to_regclass('public.user_similarity_discoverable') is null as got, true as expect;
+
+-- ── 3) Catalog: the People RPC is authenticated-only, SECURITY DEFINER, search_path pinned ─────
+select 'anon EXECUTE rpc'          as check, has_function_privilege('anon','public.get_discoverable_taste_profiles()','EXECUTE')          as got, false as expect;
+select 'public EXECUTE rpc'        as check, has_function_privilege('public','public.get_discoverable_taste_profiles()','EXECUTE')        as got, false as expect;
+select 'authenticated EXECUTE rpc' as check, has_function_privilege('authenticated','public.get_discoverable_taste_profiles()','EXECUTE') as got, true  as expect;
+select 'rpc is SECURITY DEFINER'   as check, p.prosecdef as got, true as expect
+  from pg_proc p join pg_namespace n on n.oid=p.pronamespace
+  where n.nspname='public' and p.proname='get_discoverable_taste_profiles';
+select 'rpc search_path pinned'    as check, coalesce(array_to_string(p.proconfig,','),'(none)') as got, 'search_path=pg_catalog, public' as expect_like
+  from pg_proc p join pg_namespace n on n.oid=p.pronamespace
+  where n.nspname='public' and p.proname='get_discoverable_taste_profiles';
+-- least-data: the RETURNS TABLE exposes only the five non-sensitive columns
+select 'rpc returns least-data columns only' as check, pg_get_function_result(p.oid) as got
+  from pg_proc p join pg_namespace n on n.oid=p.pronamespace
+  where n.nspname='public' and p.proname='get_discoverable_taste_profiles';
+-- EXPECT: TABLE(user_id uuid, top_mood_tags jsonb, top_tone_tags jsonb, top_fit_profiles jsonb, total integer)
+--         — NO history/ratings/reviews/editorial/timestamps/email.
+
+-- ── 4) Base-table RLS unchanged (F7.2 owner/participant boundary still intact) ─────────────────
+select tablename, policyname, cmd, qual
+  from pg_policies
+ where schemaname='public'
+   and tablename in ('user_history','user_ratings','user_similarity','user_profiles_computed')
+   and cmd='SELECT'
+ order by tablename;
+-- EXPECT: owner-only on history/ratings/user_profiles_computed; participant-only on user_similarity.
+
+-- ── 5) Anonymous role: cannot execute the RPC; raw tables inaccessible ─────────────────────────
+-- (has_*_privilege under the real anon role; we do NOT attempt the denied SELECTs, which would error.)
+select 'anon EXECUTE rpc (role)'        as check, has_function_privilege('anon','public.get_discoverable_taste_profiles()','EXECUTE') as got, false as expect;
+select 'anon SELECT user_history'       as check, has_table_privilege('anon','public.user_history','SELECT')           as got, true  as expect_note;  -- grant exists, but RLS yields 0 rows for anon
+select 'anon SELECT user_profiles_computed' as check, has_table_privilege('anon','public.user_profiles_computed','SELECT') as got, true as expect_note;
+-- NOTE: anon retains a table-level SELECT grant on the base tables, but RLS (auth.uid() = user_id)
+--       returns ZERO rows for an anon caller (auth.uid() is null). The exposure was the SECURITY
+--       DEFINER views (now closed), never the RLS-protected base tables.
+
+-- ── 6) Authenticated caller: RPC works + returns opted-in least-data; opted-out user absent ────
+\set OWNER_A     '00000000-0000-0000-0000-000000000000'
+\set OPTED_OUT_B '11111111-1111-1111-1111-111111111111'
+
+begin;
+  set local role authenticated;
+  select set_config('request.jwt.claims', json_build_object('sub', :'OWNER_A', 'role', 'authenticated')::text, true);
+
+  -- A can execute the RPC and gets at least their own row.
+  select 'A: RPC returns rows'           as check, count(*) > 0 as expect_true from public.get_discoverable_taste_profiles();
+  -- A's own row is always present.
+  select 'A: own row present'            as check, count(*) = 1 as expect_true from public.get_discoverable_taste_profiles() where user_id = :'OWNER_A';
+  -- The opted-out user must NOT appear (if such a fixture user exists; otherwise this returns 0
+  -- and is vacuously true — verify the predicate from §3 / source if no opted-out user is seeded).
+  select 'B(opted-out): absent from RPC' as check, count(*) = 0 as expect_true from public.get_discoverable_taste_profiles() where user_id = :'OPTED_OUT_B';
+  -- A cannot read B's raw behavior through the base tables (owner-only RLS).
+  select 'A: cannot read B history'      as check, count(*) = 0 as expect_true from public.user_history where user_id = :'OPTED_OUT_B';
+  select 'A: cannot read B profile'      as check, count(*) = 0 as expect_true from public.user_profiles_computed where user_id = :'OPTED_OUT_B';
+rollback;
+
+-- ── 7) Owner still reads their own data (sanity) ──────────────────────────────────────────────
+begin;
+  set local role authenticated;
+  select set_config('request.jwt.claims', json_build_object('sub', :'OWNER_A', 'role', 'authenticated')::text, true);
+  select 'owner reads own history'  as check, count(*) >= 0 as expect_true from public.user_history          where user_id = :'OWNER_A';
+  select 'owner reads own profile'  as check, count(*) >= 0 as expect_true from public.user_profiles_computed where user_id = :'OWNER_A';
+rollback;

--- a/src/features/people/__tests__/PeopleProjectionPrivacy.test.jsx
+++ b/src/features/people/__tests__/PeopleProjectionPrivacy.test.jsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import peopleSource from '../usePeopleData.jsx?raw'
+
+// F7.9 — People taste-match must read the cross-user fingerprint through the narrow authenticated
+// RPC (get_discoverable_taste_profiles), never the now browser-inaccessible projection views. The
+// RPC's behavioral contract (authenticated-only, opt-in gating, least-data, opted-out absence,
+// own-row inclusion) is proven against the live database by scripts/verify-taste-projection-privacy.sql
+// + the post-deploy role checks — the correct layer for a SQL function. Here we prove the JS
+// data-access migration + honest degradation.
+
+let rpcResult
+const rpcSpy = vi.fn(() => Promise.resolve(rpcResult))
+function chain() {
+  const c = {}
+  for (const m of ['select', 'in', 'eq', 'neq', 'order', 'limit', 'gte', 'lte', 'not', 'or', 'contains', 'is']) c[m] = () => c
+  c.maybeSingle = () => Promise.resolve({ data: null, error: null })
+  c.single = () => Promise.resolve({ data: null, error: null })
+  c.then = (res, rej) => Promise.resolve({ data: [], error: null }).then(res, rej)
+  c.catch = (fn) => Promise.resolve({ data: [], error: null }).catch(fn)
+  return c
+}
+vi.mock('@/shared/lib/supabase/client', () => ({
+  supabase: { from: () => chain(), rpc: (...a) => rpcSpy(...a) },
+}))
+// Stable references — a fresh object each render would re-fire the load effect (deps include
+// `session`) and loop forever.
+const AUTH_USER = { id: 'me' }
+const AUTH_SESSION = { user: { id: 'me', email: 'me@example.co' } }
+vi.mock('@/shared/hooks/useAuthSession', () => ({
+  useAuthSession: () => ({ user: AUTH_USER, session: AUTH_SESSION }),
+}))
+
+import { PeopleDataProvider, usePeopleData } from '../usePeopleData'
+
+function Consumer({ onState }) { onState(usePeopleData()); return null }
+const renderPeople = (onState) => render(<PeopleDataProvider><Consumer onState={onState} /></PeopleDataProvider>)
+
+beforeEach(() => { rpcSpy.mockClear(); rpcResult = { data: [], error: null } })
+
+describe('F7.9 — People reads the safe RPC, never the projection views', () => {
+  it('source uses the RPC and never queries either projection view directly', () => {
+    const src = peopleSource
+    expect(src).toContain("rpc('get_discoverable_taste_profiles')")
+    expect(src).not.toMatch(/\.from\(\s*['"]user_fingerprint_public['"]\s*\)/)
+    expect(src).not.toMatch(/\.from\(\s*['"]user_similarity_discoverable['"]\s*\)/)
+  })
+
+  it('calls get_discoverable_taste_profiles and settles honestly (no error) with adaptable rows', async () => {
+    // an opted-in row in RPC column shape — the provider normalizes top_mood_tags → topMoodTags etc.
+    rpcResult = { data: [{ user_id: 'me', top_mood_tags: [{ key: 'tender' }], top_tone_tags: [], top_fit_profiles: [], total: 9 }], error: null }
+    let last
+    renderPeople(s => { last = s })
+    await waitFor(() => expect(last.loading).toBe(false))
+    expect(rpcSpy).toHaveBeenCalledWith('get_discoverable_taste_profiles')
+    expect(last.error).toBeFalsy()
+    expect(Array.isArray(last.twins)).toBe(true)
+  })
+
+  it('an RPC failure degrades honestly — no crash, empty rails, no raw error as data', async () => {
+    rpcResult = { data: null, error: { message: 'permission denied' } }
+    let last
+    renderPeople(s => { last = s })
+    await waitFor(() => expect(last.loading).toBe(false))
+    expect(rpcSpy).toHaveBeenCalledWith('get_discoverable_taste_profiles')
+    expect(Array.isArray(last.twins)).toBe(true)
+    expect(Array.isArray(last.suggested)).toBe(true)
+  })
+})

--- a/src/features/people/usePeopleData.jsx
+++ b/src/features/people/usePeopleData.jsx
@@ -548,16 +548,12 @@ export function PeopleDataProvider({ children }) {
               .select('id, name, avatar_url')
               .in('id', allLookupIds)
           : Promise.resolve({ data: [] }),
-        // Read from the public fingerprint view, not user_profiles_computed
-        // directly — the latter is RLS-locked to the owning user. The view
-        // exposes only top mood/tone/fit aggregates + total count, gated by
-        // privacy.showOnLeaderboards. See 20260524_user_fingerprint_public.sql.
-        allLookupIds.length
-          ? supabase
-              .from('user_fingerprint_public')
-              .select('user_id, top_mood_tags, top_tone_tags, top_fit_profiles, total')
-              .in('user_id', allLookupIds)
-          : Promise.resolve({ data: [] }),
+        // F7.9: cross-user fingerprints come through the narrow authenticated RPC, never the
+        // (now browser-inaccessible) user_fingerprint_public view. The RPC returns the least-data
+        // top mood/tone/fit aggregates + total for the caller's own row plus every OTHER user who
+        // is opted in (privacy.showOnLeaderboards), bounded — so one call covers the twin, FOF
+        // and popular rails and no per-set follow-up fetch is needed.
+        supabase.rpc('get_discoverable_taste_profiles'),
         // Cold-start "Popular on FeelFlick" — pull users with their real
         // user_history(count) via the PostgREST relationship aggregate.
         // We avoid users.total_movies_watched because it's been observed
@@ -585,16 +581,9 @@ export function PeopleDataProvider({ children }) {
       )
       const meta = buildTwinMeta(twinRatingsRes.data || [], twinHistoryRes.data || [])
 
-      // Viewer's own taste fingerprint — used to mood-weight the Activity
-      // rail when we're in twin-fallback mode. Drawn from the same public
-      // view so RLS isn't a concern. (The viewer's own row is always
-      // included in the view.)
-      const { data: myFpRes } = await supabase
-        .from('user_fingerprint_public')
-        .select('top_mood_tags')
-        .eq('user_id', userId)
-        .maybeSingle()
-      const viewerTopMoods = (myFpRes?.top_mood_tags || []).slice(0, 3).map(t => t.key)
+      // Viewer's own taste fingerprint — used to mood-weight the Activity rail in twin-fallback
+      // mode. The RPC always returns the caller's own row, so read it straight from the map.
+      const viewerTopMoods = (fingerprintByUser.get(userId)?.topMoodTags || []).slice(0, 3).map(t => t.key)
 
       const twins = deriveTwins(similarityRows, followingIds, meta, fingerprintByUser)
       const rising = deriveRising(similarityRows, followingIds, meta, fingerprintByUser)
@@ -647,19 +636,9 @@ export function PeopleDataProvider({ children }) {
             .select('id, name, avatar_url, user_history(count)')
             .in('id', candidateIds)
           for (const u of candUsers || []) usersById.set(u.id, u)
-          // Also fetch their fingerprints
-          const { data: candFp } = await supabase
-            .from('user_fingerprint_public')
-            .select('user_id, top_mood_tags, top_tone_tags, top_fit_profiles, total')
-            .in('user_id', candidateIds)
-          for (const r of candFp || []) {
-            fingerprintByUser.set(r.user_id, {
-              topMoodTags: r.top_mood_tags || [],
-              topToneTags: r.top_tone_tags || [],
-              topFitProfiles: r.top_fit_profiles || [],
-              total: r.total || 0,
-            })
-          }
+          // F7.9: FOF candidates' fingerprints are already in the map — the RPC returned every
+          // opted-in user up front, so no follow-up fetch is needed. Opted-out candidates fall
+          // back to the "Building taste" bio, exactly as before.
         }
         // Exclude users already surfaced on this page: similarity-derived
         // Suggested + the four Twin cards + the three Rising cards.
@@ -695,27 +674,8 @@ export function PeopleDataProvider({ children }) {
         }))
         .filter(u => u.films_count > 0)
         .sort((a, b) => b.films_count - a.films_count)
-      // Fetch fingerprints for popular users we didn't already pull for
-      // similarity. Small follow-up round-trip, only when we'll use it.
-      if (twins.length === 0 && popularRows.length > 0) {
-        const popularIdsMissing = popularRows
-          .map(u => u.id)
-          .filter(id => !fingerprintByUser.has(id))
-        if (popularIdsMissing.length) {
-          const { data: extraFp } = await supabase
-            .from('user_fingerprint_public')
-            .select('user_id, top_mood_tags, top_tone_tags, top_fit_profiles, total')
-            .in('user_id', popularIdsMissing)
-          for (const r of extraFp || []) {
-            fingerprintByUser.set(r.user_id, {
-              topMoodTags: r.top_mood_tags || [],
-              topToneTags: r.top_tone_tags || [],
-              topFitProfiles: r.top_fit_profiles || [],
-              total: r.total || 0,
-            })
-          }
-        }
-      }
+      // F7.9: popular users' fingerprints are already in the map (the RPC returned every opted-in
+      // user up front) — no follow-up fetch. Missing/opted-out users use the bio fallback as before.
       const popular = twins.length === 0
         ? derivePopular(popularRows, followingIds, userId, fingerprintByUser)
         : []

--- a/src/features/profile/__tests__/ProfileEditorialRefresh.test.jsx
+++ b/src/features/profile/__tests__/ProfileEditorialRefresh.test.jsx
@@ -20,13 +20,14 @@ const films = (n) => Array.from({ length: n }, (_, i) => film(i + 1))
 const ratings = (n) => Array.from({ length: n }, (_, i) => ({ movie_id: i + 1, rating: 8 }))
 
 let writes
+let writeError = null   // F7.9: simulate an editorial cache-write {error} (Edge OK, persistence fails)
 function makeQuery(result) {
   const p = Promise.resolve(result)
   const chain = {
     select: () => chain, eq: () => chain, order: () => chain, limit: () => chain, in: () => chain,
     maybeSingle: () => Promise.resolve({ data: result.data, error: null }),
-    update: () => { writes++; return { eq: () => Promise.resolve({ error: null }) } },
-    insert: () => { writes++; return Promise.resolve({ error: null }) },
+    update: () => { writes++; return { eq: () => Promise.resolve({ error: writeError }) } },
+    insert: () => { writes++; return Promise.resolve({ error: writeError }) },
     then: (res, rej) => p.then(res, rej), catch: (fn) => p.catch(fn),
   }
   return chain
@@ -48,7 +49,7 @@ const CURRENT_EDITORIAL = { user_id: 'u1', editorial_summary: 'cached summary', 
 
 let fetchSpy
 beforeEach(() => {
-  fetchOk = true; writes = 0
+  fetchOk = true; writes = 0; writeError = null
   fetchSpy = vi.fn(() => Promise.resolve({ ok: fetchOk, json: () => Promise.resolve({ summary: 'fresh summary', signature: 'fresh sig' }) }))
   vi.stubGlobal('fetch', fetchSpy)
 })
@@ -131,5 +132,46 @@ describe('F7.6 — explicit refresh action', () => {
     await waitFor(() => expect(result.current.loading).toBe(false))
     await act(async () => { await result.current.refreshEditorial() })
     expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})
+
+// F7.9 — an Edge success followed by a cache-WRITE failure must NOT announce durable success.
+describe('F7.9 — editorial cache-write failure settles honestly', () => {
+  it('UPDATE path write error → status error, NOT current; prior reflection preserved; retryable', async () => {
+    fpEditorialVersion = 2; editorialRow = CURRENT_EDITORIAL   // existing row → UPDATE path; starts 'current'
+    const { result } = mountSelf()
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    writeError = { code: 'MOCK', message: 'mock write failure' }
+    await act(async () => { await result.current.refreshEditorial() })
+    expect(fetchSpy).toHaveBeenCalledTimes(1)          // Edge DID succeed
+    expect(writes).toBe(1)                              // a write was attempted
+    expect(result.current.refreshStatus).toBe('error') // settled to error, not success
+    expect(result.current.editorial.summary).toBe('cached summary') // prior reflection intact
+    await waitFor(() => expect(result.current.loading).toBe(false))
+  })
+
+  it('INSERT path write error → status error, NOT current; no partial reflection becomes current', async () => {
+    fpEditorialVersion = undefined; editorialRow = null    // no existing row → INSERT path; starts 'none'
+    const { result } = mountSelf()
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    writeError = { code: 'MOCK', message: 'mock insert failure' }
+    await act(async () => { await result.current.refreshEditorial() })
+    expect(result.current.refreshStatus).toBe('error')
+    expect(result.current.editorialStatus).not.toBe('current')   // no false current
+    expect(result.current.editorial.summary).toBeFalsy()         // the fresh summary did NOT become current
+  })
+
+  it('retry after a write failure can persist successfully', async () => {
+    fpEditorialVersion = undefined; editorialRow = null
+    const { result } = mountSelf()
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    writeError = { code: 'MOCK', message: 'transient' }
+    await act(async () => { await result.current.refreshEditorial() })
+    expect(result.current.refreshStatus).toBe('error')
+    writeError = null                                  // the transient failure clears
+    await act(async () => { await result.current.refreshEditorial() })
+    expect(result.current.refreshStatus).toBe('success')
+    expect(result.current.editorialStatus).toBe('current')
+    expect(result.current.editorial.summary).toBe('fresh summary')
   })
 })

--- a/src/features/profile/useProfileData.jsx
+++ b/src/features/profile/useProfileData.jsx
@@ -316,10 +316,17 @@ async function regenerateEditorial({ userId, history, archetypeFromFp }) {
     taste_fingerprint: nextFingerprint,
   }
 
+  // F7.9: the editorial result is only durable if the cache write SUCCEEDS. The Supabase client
+  // RESOLVES (does not reject) on a DB-level error, so we MUST inspect { error } and throw —
+  // otherwise refreshEditorial would announce "updated" + mark the reflection current on a write
+  // that silently failed (it would then revert on reload). Throwing here settles the refresh to
+  // 'error', leaving the prior valid reflection intact and the action retryable.
   if (existing) {
-    await supabase.from('user_profiles_computed').update(fields).eq('user_id', userId)
+    const { error } = await supabase.from('user_profiles_computed').update(fields).eq('user_id', userId)
+    if (error) throw error
   } else {
-    await supabase.from('user_profiles_computed').insert({ user_id: userId, profile: {}, ...fields })
+    const { error } = await supabase.from('user_profiles_computed').insert({ user_id: userId, profile: {}, ...fields })
+    if (error) throw error
   }
 
   return { summary, signature, archetype: archetypeFromFp, generatedAt }

--- a/supabase/migrations/20260610000000_secure_taste_projection_access.sql
+++ b/supabase/migrations/20260610000000_secure_taste_projection_access.sql
@@ -1,0 +1,70 @@
+-- 20260610000000_secure_taste_projection_access.sql
+-- F7.9 — Close the F7.8 P0 privacy exposure of the Cinematic DNA taste projection.
+--
+-- F7.8 confirmed (anon-role simulation returned real cross-user rows) that two SECURITY DEFINER
+-- views were granted to `anon` and `authenticated` and BYPASS the owner-only RLS restored in F7.2:
+--   * public.user_fingerprint_public      — every non-opted-out user's taste fingerprint
+--   * public.user_similarity_discoverable — the cross-user similarity graph (no app consumer)
+-- A logged-out client with the public anon key could read both via PostgREST.
+--
+-- Both views are DROPPED (dependency inspection: 0 dependents each; the authenticated People
+-- taste-match feature now reads through the narrow RPC below; nothing else references them). This
+-- removes the browser-role access AND clears both SECURITY DEFINER advisor errors outright. No
+-- base-table RLS is changed, NO user data is mutated, NO fingerprints are deleted, and NO public
+-- Profile/Diary model is re-enabled. Idempotent.
+
+-- ── 1) Drop both projection views ─────────────────────────────────────────────────────────────
+-- Dropping removes every browser-role + PUBLIC grant along with the view, and eliminates the
+-- SECURITY DEFINER advisor error. The base tables (user_profiles_computed owner-only,
+-- user_similarity participant-only) are untouched and keep working through normal owner paths.
+drop view if exists public.user_similarity_discoverable;
+drop view if exists public.user_fingerprint_public;
+
+-- ── 2) Narrow authenticated RPC for the People taste-match feature ────────────────────────────
+-- The ONLY sanctioned cross-user taste read. SECURITY DEFINER *only* because the opted-in
+-- cross-user projection must be read through the owner-only RLS on user_profiles_computed (an
+-- invoker-rights function would see only the caller's own row and break taste discovery). It:
+--   * derives the caller exclusively from auth.uid() and accepts NO caller-supplied identity;
+--   * rejects anonymous callers (execute revoked from anon/public; the predicate also requires a
+--     non-null auth.uid());
+--   * returns ONLY the least-data fields People consumes (the exact columns the old view exposed);
+--   * gates OTHER users on the EXISTING enforced opt-in
+--     (user_settings.settings->'privacy'->>'showOnLeaderboards', default-on) — UNCHANGED here;
+--   * always returns the caller's OWN row (already readable via owner RLS), so People's "your own
+--     moods" path keeps working regardless of the caller's opt-in;
+--   * never returns raw history/ratings/reviews/editorial prose/cache timestamps/emails/private
+--     account fields, is schema-qualified, has a pinned search_path, and is bounded.
+create or replace function public.get_discoverable_taste_profiles()
+returns table (
+  user_id          uuid,
+  top_mood_tags    jsonb,
+  top_tone_tags    jsonb,
+  top_fit_profiles jsonb,
+  total            integer
+)
+language sql
+security definer
+set search_path = pg_catalog, public
+stable
+as $$
+  select
+    p.user_id,
+    p.taste_fingerprint -> 'topMoodTags'       as top_mood_tags,
+    p.taste_fingerprint -> 'topToneTags'       as top_tone_tags,
+    p.taste_fingerprint -> 'topFitProfiles'    as top_fit_profiles,
+    (p.taste_fingerprint ->> 'total')::integer as total
+  from public.user_profiles_computed p
+  left join public.user_settings s on s.user_id = p.user_id
+  where (select auth.uid()) is not null
+    and p.taste_fingerprint is not null
+    and (
+      p.user_id = (select auth.uid())  -- always your own row
+      -- others: the EXISTING enforced opt-in (default-on), matching the retired view's predicate
+      or coalesce((s.settings -> 'privacy' ->> 'showOnLeaderboards')::boolean, true) <> false
+    )
+  limit 500;
+$$;
+
+-- ── 3) Lock the RPC to authenticated callers only ─────────────────────────────────────────────
+revoke all on function public.get_discoverable_taste_profiles() from public, anon;
+grant execute on function public.get_discoverable_taste_profiles() to authenticated;


### PR DESCRIPTION
**F7.9 — Secure Cinematic DNA projections and fix reflection persistence.** Closes the two F7.8 blockers: the P0 anonymous/broad client access to the taste projection, and the P1 false durable-success on cache-write failure.

## Confirmed P0/P1 evidence (F7.8)
- **P0:** `public.user_fingerprint_public` + `public.user_similarity_discoverable` were SECURITY DEFINER views granted to `anon` + `authenticated`, bypassing the F7.2 owner-only RLS. An anon-role simulation read **3 users' fingerprints + a 7-user similarity graph** with only the public anon key.
- **P1:** `regenerateEditorial()` wrote `user_profiles_computed` without checking the returned `{ error }`, returned truthy, and announced "updated" + marked the reflection `current` even when persistence failed (reverting on reload).

## Prior grants / view definitions + dependency inspection
Both views: SECURITY DEFINER (advisor ERROR), `anon`+`authenticated`+`service_role` granted SELECT (+ erroneous write-style grants). `user_fingerprint_public` definition projected `top_mood_tags/top_tone_tags/top_fit_profiles/total` from `user_profiles_computed`, gated by `settings.privacy.showOnLeaderboards <> false`. Dependency inspection: **0 dependents each**; the only app consumer was People (`usePeopleData.jsx`, 4 reads of `user_fingerprint_public`); `user_similarity_discoverable` had **no** app consumer. No existing reusable RPC.

## Chosen RPC design + least-data fields + opt-in predicate
`public.get_discoverable_taste_profiles()` — SECURITY DEFINER **only** because the opted-in cross-user projection must be read through the owner-only RLS on `user_profiles_computed` (an invoker-rights function would see only the caller's own row and break taste discovery). Derives the caller from `auth.uid()`, **no caller-supplied identity**, rejects anon. Returns **least-data only**: `user_id, top_mood_tags, top_tone_tags, top_fit_profiles, total`. Opt-in predicate replicates the retired view exactly: `coalesce((s.settings->'privacy'->>'showOnLeaderboards')::boolean, true) <> false`, **plus** the caller's own row always (already owner-readable). Bounded `limit 500`.

## Grant changes / SECURITY DEFINER hardening
Both views **dropped** (removes all browser grants *and* clears both SECURITY DEFINER advisor ERRORs). RPC: `revoke all from public, anon` + `grant execute to authenticated`; `set search_path = pg_catalog, public`; schema-qualified; `language sql`, no dynamic SQL, no writes, no secrets. service_role untouched. Base-table RLS unchanged.

## People behavior preservation
The 4 direct view reads → one `supabase.rpc('get_discoverable_taste_profiles')` call; columns adapt to the existing `fingerprintByUser` shape so cards/bios/ranking/empty states are unchanged; one call covers the twin/FOF/popular rails (per-set follow-ups removed; opted-out users keep the "Building taste" bio). RPC failure → existing honest empty/degraded state (no raw error, no view fallback, no anon call). No `.from('user_fingerprint_public'|'user_similarity_discoverable')` remains.

## Editorial persistence fix + failure-state behavior
`regenerateEditorial()` captures `{ error }` on both UPDATE and INSERT and `throw`s; the new editorial is returned only after persistence succeeds. Edge-success + write-failure → `refreshStatus:'error'`, status stays stale/none, prior reflection intact, one failure announcement, retry enabled — no false "updated". Malformed/duplicate-guard/no-write-on-render unchanged.

## Migration application result + simulated checks + advisor result
Applied live (idempotent). **Advisors:** `user_fingerprint_public` + `user_similarity_discoverable` SECURITY DEFINER ERRORs **gone**; the RPC adds one **expected** WARN-level `authenticated_security_definer_function_executable` (mandated design; **not** anon-executable; same class as ~16 existing functions). **Anon role:** RPC execute denied; base tables RLS-protected (0 rows); views gone. **Authenticated role:** RPC returns the **3 opted-in users incl. the caller's own row**, least-data. **Catalog:** both views `null`; RPC authenticated-only, SECURITY DEFINER, `search_path=pg_catalog, public`; **3 owner-only base SELECT policies unchanged**.

## Test counts
+6 unit (full **1381**): Profile refresh write-failure ×3 (UPDATE/INSERT error → error-not-current, prior preserved, retry persists), People RPC/no-view/honest-degradation ×3. E2E scenario **J** (Edge success + cache-write failure → honest error, no false "updated", retryable, fail-closed). Read-only `scripts/verify-taste-projection-privacy.sql` added. Profile **66**, People **3**, regressions **407**.

## No-live-user-row-mutation confirmation
All DB work was DDL (drop views, create function) + grants + **read-only** verification (catalog checks + rolled-back role-simulation transactions). No `user_history`/`user_ratings`/`user_profiles_computed`/`user_settings` row was inserted, updated, or deleted; no fingerprint deleted; dev user not reset.

## Frozen-contract confirmation
Owner/participant base RLS, self-only Profile, private other-user state, canonical history, fingerprint formulas, maturity thresholds, provenance/confidence bands, chart a11y, evidence versioning, no-generation-on-render, explicit refresh, section order, **People visible behavior**, recommendation scoring, Account UI, routes/guards — all unchanged. Out of F7 scope (documented, untouched): pre-existing `list_follower_counts`/`vw_movies_scored` SECURITY DEFINER views + anon-executable diagnostic functions incl. `get_cron_secret`.

## Deployment note
The migration is live; the production People page degrades gracefully (bio fallback) for the brief window until this PR's client deploys — no crash, no exposure.

## Validation
lint clean · Profile 66 · People 3 · regressions 407 · full **1381** · build ✓ · Profile E2E **19 ×3** · authenticated visual **41** + public **2** (no drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
