### PR TITLE
Secure People identity and follow access

### DIFF
--- a/scripts/verify-people-social-privacy.sql
+++ b/scripts/verify-people-social-privacy.sql
@@ -1,0 +1,72 @@
+-- verify-people-social-privacy.sql — READ-ONLY verification of the F8.2 People/social boundary.
+-- Proves: public.users + public.user_follows are not readable by anon; the full users row is
+-- owner-only (no cross-user email/last_active); the follow graph is participant-only; and the three
+-- People RPCs are authenticated-only, least-data. Mutates NOTHING (catalog checks + rolled-back
+-- role/JWT simulation). Replace the placeholder UUIDs with two real users before the two-account block.
+--
+--   OWNER_A = an authenticated user
+--   OTHER_B = a different user (ideally one with showOnLeaderboards explicitly false, if seeded)
+
+-- ── 1) Catalog: no anon SELECT grant / no anon-or-broad SELECT policy on the social tables ──────
+select 'anon SELECT users'        as check, has_table_privilege('anon','public.users','SELECT')         as got, false as expect;
+select 'anon SELECT user_follows' as check, has_table_privilege('anon','public.user_follows','SELECT')  as got, false as expect;
+select 'users SELECT policies (expect 1: own only)' as check, string_agg(polname,' | ') as policies
+  from pg_policy p join pg_class c on c.oid=p.polrelid join pg_namespace n on n.oid=c.relnamespace
+  where n.nspname='public' and c.relname='users' and p.polcmd='r';
+-- EXPECT: only "Users can view own profile" (no "Anon can read user profiles" / "Authenticated ... any profile").
+select 'user_follows SELECT policies (expect participant-only)' as check, string_agg(polname,' | ') as policies
+  from pg_policy p join pg_class c on c.oid=p.polrelid join pg_namespace n on n.oid=c.relnamespace
+  where n.nspname='public' and c.relname='user_follows' and p.polcmd='r';
+
+-- ── 2) Catalog: People RPCs authenticated-only, SECURITY DEFINER, search_path pinned ────────────
+select 'anon EXEC get_people_public_identities'  as check, has_function_privilege('anon','public.get_people_public_identities(uuid[])','EXECUTE')  as got, false as expect;
+select 'auth EXEC get_people_public_identities'  as check, has_function_privilege('authenticated','public.get_people_public_identities(uuid[])','EXECUTE') as got, true as expect;
+select 'anon EXEC search_people_by_name'         as check, has_function_privilege('anon','public.search_people_by_name(text)','EXECUTE')           as got, false as expect;
+select 'auth EXEC search_people_by_name'         as check, has_function_privilege('authenticated','public.search_people_by_name(text)','EXECUTE')  as got, true as expect;
+select 'anon EXEC get_follow_suggestions'        as check, has_function_privilege('anon','public.get_follow_suggestions()','EXECUTE')              as got, false as expect;
+select 'auth EXEC get_follow_suggestions'        as check, has_function_privilege('authenticated','public.get_follow_suggestions()','EXECUTE')     as got, true as expect;
+select 'anon EXEC get_discoverable_taste_profiles' as check, has_function_privilege('anon','public.get_discoverable_taste_profiles()','EXECUTE')   as got, false as expect;
+select p.proname, p.prosecdef as security_definer, array_to_string(p.proconfig,',') as config
+  from pg_proc p join pg_namespace n on n.oid=p.pronamespace and n.nspname='public'
+  where p.proname in ('get_people_public_identities','search_people_by_name','get_follow_suggestions','get_discoverable_taste_profiles')
+  order by p.proname;
+-- EXPECT: each prosecdef=true and config contains search_path=pg_catalog, public.
+-- least-data: identity RPC returns ONLY id/name/avatar
+select 'identity RPC least-data columns' as check, pg_get_function_result(p.oid) as got
+  from pg_proc p join pg_namespace n on n.oid=p.pronamespace and n.nspname='public'
+  where p.proname='get_people_public_identities';
+-- EXPECT: TABLE(id uuid, name text, avatar_url text) — NO email/last_active/settings/taste.
+
+-- ── 3) Anonymous role: zero rows / zero emails / RPCs denied ────────────────────────────────────
+begin;
+  set local role anon;
+  select 'ANON users rows'        as check, count(*) as got, 0 as expect from public.users;
+  select 'ANON emails'            as check, count(email) as got, 0 as expect from public.users;
+  select 'ANON last_active'       as check, count(last_active_at) as got, 0 as expect from public.users;
+  select 'ANON user_follows rows' as check, count(*) as got, 0 as expect from public.user_follows;
+rollback;
+-- (Anon cannot EXECUTE the RPCs at all — proven by the catalog has_function_privilege=false above.)
+
+-- ── 4) Authenticated OWNER: own full row + own edges + identity RPC ─────────────────────────────
+\set OWNER_A '00000000-0000-0000-0000-000000000000'
+\set OTHER_B '11111111-1111-1111-1111-111111111111'
+begin;
+  set local role authenticated;
+  select set_config('request.jwt.claims', json_build_object('sub', :'OWNER_A', 'role','authenticated')::text, true);
+  select 'OWNER reads own row'        as check, count(*) as got, 1 as expect from public.users where id = :'OWNER_A';
+  select 'OWNER reads B full row'     as check, count(*) as got, 0 as expect from public.users where id = :'OTHER_B';   -- owner-only RLS blocks
+  select 'OWNER cannot read B email'  as check, count(email) as got, 0 as expect from public.users where id = :'OTHER_B';
+  select 'OWNER identity RPC id/name/avatar only' as check, count(*) as got
+    from public.get_people_public_identities(array[:'OWNER_A'::uuid, :'OTHER_B'::uuid]);  -- returns rows w/o email
+  select 'OWNER follow-suggestions RPC executes' as check, count(*) >= 0 as expect_true from public.get_follow_suggestions();
+rollback;
+
+-- ── 5) Consent: opt-IN — explicit true discoverable; explicit false / missing excluded ──────────
+-- (Verify the predicate from §2 + the live RPC: a user with no settings row / null preference is
+-- NOT returned by get_discoverable_taste_profiles except as the caller's own row.)
+begin;
+  set local role authenticated;
+  select set_config('request.jwt.claims', json_build_object('sub', :'OWNER_A', 'role','authenticated')::text, true);
+  select 'discovery RPC: only opted-in others + self' as check, count(*) as discoverable_rows
+    from public.get_discoverable_taste_profiles();
+rollback;

--- a/src/features/account/__tests__/PrivacyControls.test.jsx
+++ b/src/features/account/__tests__/PrivacyControls.test.jsx
@@ -27,10 +27,20 @@ describe('Account Privacy — F7.2 honest controls', () => {
     expect(screen.queryByText(/anyone with the link can view your dna/i)).not.toBeInTheDocument()
   })
 
-  it('keeps the enforced controls (taste-match surfacing + analytics)', () => {
+  it('keeps the enforced controls (taste-match discovery + analytics)', () => {
     render(<Privacy />)
-    expect(screen.getByText('Show on taste-match')).toBeInTheDocument()
+    expect(screen.getByText('Appear in taste-match discovery')).toBeInTheDocument()
     expect(screen.getByText('Product analytics')).toBeInTheDocument()
+  })
+
+  it('F8.2: discovery copy enumerates the exposed fields AND what stays private', () => {
+    render(<Privacy />)
+    // exposed fields named
+    expect(screen.getByText(/name, avatar, your top film-taste tags and film count/i)).toBeInTheDocument()
+    // explicitly states the private data is NOT included
+    expect(screen.getByText(/watched films, Diary, ratings, reviews and Cinematic DNA reflection stay private/i)).toBeInTheDocument()
+    // not called a leaderboard
+    expect(screen.queryByText(/leaderboard/i)).not.toBeInTheDocument()
   })
 
   it('states honestly that Cinematic DNA / history / ratings are private', () => {

--- a/src/features/account/data.js
+++ b/src/features/account/data.js
@@ -30,7 +30,9 @@ export const SETTINGS = {
   privacy: {
     profilePublic:      true,
     diaryPublic:        false,
-    showOnLeaderboards: true,
+    // F8.2: taste-match discovery is now EXPLICIT OPT-IN — a user with no stored preference
+    // defaults to NOT discoverable (matches get_discoverable_taste_profiles' opt-in fallback).
+    showOnLeaderboards: false,
     analytics:          true,
     // `shareableCards` removed: no export feature exists for it to gate.
   },

--- a/src/features/account/sections-bottom.jsx
+++ b/src/features/account/sections-bottom.jsx
@@ -25,9 +25,11 @@ function Privacy() {
   // enforced by any read path or RLS policy — your DNA and diary are owner-private regardless.
   // Rather than render a control that falsely implies publication, they're removed until a real
   // consent-based public-profile model exists. (showOnLeaderboards IS enforced — it gates
-  // taste-twin surfacing in People — and analytics is enforced immediately; both stay.)
+  // taste-match discovery in People — and analytics is enforced immediately; both stay.)
+  // F8.2: discovery is now EXPLICIT OPT-IN (default off) and the copy enumerates exactly what
+  // becomes visible to other signed-in members.
   const rows = [
-    { k:'showOnLeaderboards', label:'Show on taste-match',  desc:"Surface in other users' taste-twin lists" },
+    { k:'showOnLeaderboards', label:'Appear in taste-match discovery',  desc:'When on, other signed-in members may see your name, avatar, your top film-taste tags and film count when FeelFlick suggests compatible people. Your watched films, Diary, ratings, reviews and Cinematic DNA reflection stay private.' },
     { k:'analytics',          label:'Product analytics',    desc:'Help us improve. Aggregated, no PII.' },
   ];
   return (

--- a/src/features/home/useHomeData.jsx
+++ b/src/features/home/useHomeData.jsx
@@ -528,10 +528,8 @@ export function HomeDataProvider({ children }) {
             .slice(0, 3)
             .map(([id, c]) => ({ id, common: c }))
           if (fallbackIds.length > 0) {
-            const { data: fallbackUsers } = await supabase
-              .from('users')
-              .select('id, name')
-              .in('id', fallbackIds.map(f => f.id))
+            // F8.2: cross-user names via the narrow authenticated identity RPC (users is owner-only).
+            const { data: fallbackUsers } = await supabase.rpc('get_people_public_identities', { requested_user_ids: fallbackIds.map(f => f.id) })
             const nameById = Object.fromEntries((fallbackUsers || []).map(u => [u.id, u.name]))
             // Estimated match % via Jaccard-ish: overlap / max(watchedIds.length, twin_count)
             // Twin's full count would need another query; we approximate with

--- a/src/features/legal/Privacy.jsx
+++ b/src/features/legal/Privacy.jsx
@@ -140,6 +140,26 @@ export default function Privacy() {
           </p>
         </section>
 
+        {/* Taste-match discovery (F8.2) */}
+        <section className="rounded-2xl bg-white/5 ring-1 ring-white/6 shadow-[0_8px_32px_rgba(0,0,0,0.5)] backdrop-blur-sm p-6 md:p-8">
+          <h2 className="text-2xl md:text-3xl font-black mb-4 flex items-center gap-2">
+            <FileText className="h-6 w-6 text-purple-300" />
+            Taste-match discovery
+          </h2>
+          <p className="text-white/70 text-sm leading-relaxed mb-4">
+            FeelFlick can suggest other members with compatible film taste. This is for signed-in
+            members only, and you take part only if you turn on <span className="text-white/90">Appear in
+            taste-match discovery</span> in your Account settings.
+          </p>
+          <ul className="list-disc list-inside text-white/70 text-sm space-y-1 mb-4">
+            <li>When you opt in, other signed-in members may see your name, avatar, your top
+              film-taste tags, and your film count as a suggested match.</li>
+            <li>Your watched film titles and dates, your Diary, your ratings, your reviews, and your
+              generated Cinematic DNA reflection are <span className="text-white/90">not</span> included.</li>
+            <li>You can withdraw from discovery at any time by turning the setting off.</li>
+          </ul>
+        </section>
+
         {/* What we never do */}
         <section className="rounded-2xl bg-white/5 border border-purple-500/40 bg-linear-to-br from-purple-500/10 to-pink-500/10 backdrop-blur-sm p-6 md:p-8">
           <h2 className="text-2xl md:text-3xl font-black mb-4 flex items-center gap-2">

--- a/src/features/lists/ListDetail.jsx
+++ b/src/features/lists/ListDetail.jsx
@@ -87,11 +87,9 @@ export default function ListDetail() {
         }
         setList(listRes.data)
 
-        const { data: ownerData } = await supabase
-          .from('users')
-          .select('id, name, avatar_url')
-          .eq('id', listRes.data.user_id)
-          .maybeSingle()
+        // F8.2: list-owner identity via the narrow authenticated RPC (users is owner-only).
+        const { data: ownerRows } = await supabase.rpc('get_people_public_identities', { requested_user_ids: [listRes.data.user_id] })
+        const ownerData = (ownerRows || [])[0] || null
         if (abort) return
         setOwner(ownerData)
 

--- a/src/features/lists/useListsData.jsx
+++ b/src/features/lists/useListsData.jsx
@@ -213,10 +213,7 @@ export function ListsDataProvider({ children }) {
               .limit(20)
           : Promise.resolve({ data: [] }),
         followingIds.length
-          ? supabase
-              .from('users')
-              .select('id, name')
-              .in('id', followingIds)
+          ? supabase.rpc('get_people_public_identities', { requested_user_ids: followingIds })
           : Promise.resolve({ data: [] }),
         // Public lists from anyone (not my own, not someone I follow).
         // Sort by `updated_at` desc as a proxy for "active"; the deriver
@@ -244,10 +241,7 @@ export function ListsDataProvider({ children }) {
       let authors = new Map((followedAuthorsRes.data || []).map(u => [u.id, u]))
       const missingAuthorIds = allFollowAuthorIds.filter(id => !authors.has(id))
       if (missingAuthorIds.length) {
-        const { data: extra } = await supabase
-          .from('users')
-          .select('id, name')
-          .in('id', missingAuthorIds)
+        const { data: extra } = await supabase.rpc('get_people_public_identities', { requested_user_ids: missingAuthorIds })
         for (const u of (extra || [])) authors.set(u.id, u)
       }
       // Filter popular pool: exclude lists by people I already follow
@@ -280,10 +274,7 @@ export function ListsDataProvider({ children }) {
       let popularPublic = []
       if (popularPublicRaw.length) {
         const popularAuthorIds = Array.from(new Set(popularPublicRaw.map(l => l.user_id)))
-        const { data: popularAuthors } = await supabase
-          .from('users')
-          .select('id, name')
-          .in('id', popularAuthorIds)
+        const { data: popularAuthors } = await supabase.rpc('get_people_public_identities', { requested_user_ids: popularAuthorIds })
         const popularAuthorMap = new Map((popularAuthors || []).map(u => [u.id, u]))
         popularPublic = popularPublicRaw
           .map(l => shapePopular(l, posters, counts, popularAuthorMap.get(l.user_id)))

--- a/src/features/people/People.jsx
+++ b/src/features/people/People.jsx
@@ -493,12 +493,9 @@ function PeopleV2Body() {
     setSearching(true)
     ;(async () => {
       try {
-        const { data, error } = await supabase
-          .from('users')
-          .select('id, name, avatar_url')
-          .ilike('name', `%${debouncedQuery}%`)
-          .neq('id', authUser.id)
-          .limit(20)
+        // F8.2: name search goes through the narrow authenticated RPC (id/name/avatar only) — the
+        // users table is now owner-only, so a direct cross-user name query is no longer possible.
+        const { data, error } = await supabase.rpc('search_people_by_name', { search_query: debouncedQuery })
         if (error) throw error
         if (!abort) {
           setResults((data || []).map(u => ({

--- a/src/features/people/__tests__/PeopleProjectionPrivacy.test.jsx
+++ b/src/features/people/__tests__/PeopleProjectionPrivacy.test.jsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, waitFor } from '@testing-library/react'
 import peopleSource from '../usePeopleData.jsx?raw'
+import peopleJsxSource from '../People.jsx?raw'
 
 // F7.9 — People taste-match must read the cross-user fingerprint through the narrow authenticated
 // RPC (get_discoverable_taste_profiles), never the now browser-inaccessible projection views. The
@@ -65,5 +66,30 @@ describe('F7.9 — People reads the safe RPC, never the projection views', () =>
     expect(rpcSpy).toHaveBeenCalledWith('get_discoverable_taste_profiles')
     expect(Array.isArray(last.twins)).toBe(true)
     expect(Array.isArray(last.suggested)).toBe(true)
+  })
+})
+
+describe('F8.2 — People resolves cross-user identity via narrow RPCs, never a direct users read', () => {
+  it('uses the identity, search and follow-suggestion RPCs', () => {
+    expect(peopleSource).toContain("rpc('get_people_public_identities'")
+    expect(peopleSource).toContain("rpc('get_follow_suggestions')")
+    expect(peopleJsxSource).toContain("rpc('search_people_by_name'")
+  })
+
+  it('makes ZERO direct public.users reads (no cross-user identity table access)', () => {
+    expect(peopleSource).not.toMatch(/\.from\(\s*['"]users['"]\s*\)/)
+    expect(peopleJsxSource).not.toMatch(/\.from\(\s*['"]users['"]\s*\)/)
+  })
+
+  it('never SELECTs email or last_active_at from any table (identity comes from the id/name/avatar RPC)', () => {
+    for (const src of [peopleSource, peopleJsxSource]) {
+      expect(src).not.toMatch(/\.select\([^)]*email/i)
+      expect(src).not.toMatch(/\.select\([^)]*last_active/i)
+    }
+  })
+
+  it('reads its own follows/followers but NOT the global follow graph (FOF goes through the RPC)', () => {
+    // own-edge reads stay; the only cross-user .in('follower_id', …) graph read is gone (→ RPC)
+    expect(peopleSource).not.toMatch(/from\(\s*['"]user_follows['"]\s*\)[\s\S]{0,120}\.in\(\s*['"]follower_id['"]/)
   })
 })

--- a/src/features/people/usePeopleData.jsx
+++ b/src/features/people/usePeopleData.jsx
@@ -542,11 +542,11 @@ export function PeopleDataProvider({ children }) {
               .order('watched_at', { ascending: false })
               .limit(60)
           : Promise.resolve({ data: [] }),
+        // F8.2: cross-user name/avatar comes through the narrow authenticated identity RPC, never a
+        // direct users read (users is now owner-only). The RPC returns id/name/avatar — no email,
+        // last_active, settings or taste fields — so the usersById map below is unchanged.
         allLookupIds.length
-          ? supabase
-              .from('users')
-              .select('id, name, avatar_url')
-              .in('id', allLookupIds)
+          ? supabase.rpc('get_people_public_identities', { requested_user_ids: allLookupIds })
           : Promise.resolve({ data: [] }),
         // F7.9: cross-user fingerprints come through the narrow authenticated RPC, never the
         // (now browser-inaccessible) user_fingerprint_public view. The RPC returns the least-data
@@ -554,16 +554,12 @@ export function PeopleDataProvider({ children }) {
         // is opted in (privacy.showOnLeaderboards), bounded — so one call covers the twin, FOF
         // and popular rails and no per-set follow-up fetch is needed.
         supabase.rpc('get_discoverable_taste_profiles'),
-        // Cold-start "Popular on FeelFlick" — pull users with their real
-        // user_history(count) via the PostgREST relationship aggregate.
-        // We avoid users.total_movies_watched because it's been observed
-        // stale at 0 even for users with many watches. Sort happens
-        // client-side after the count resolves.
-        supabase
-          .from('users')
-          .select('id, name, avatar_url, user_history(count)')
-          .neq('id', userId)
-          .limit(40),
+        // F8.2: the cold-start "popular by film count" rail read other users' rows + their
+        // user_history(count) directly. Both are now closed (users is owner-only; cross-user
+        // user_history is owner-only RLS, so the embedded count was already 0 → the rail already
+        // rendered empty after the films_count > 0 filter). Preserve that empty result here;
+        // repointing the popular rail to the discoverable-taste set is deferred to F8.5.
+        Promise.resolve({ data: [] }),
       ])
 
       const usersById = new Map((peopleUsersRes.data || []).map(u => [u.id, u]))
@@ -604,21 +600,18 @@ export function PeopleDataProvider({ children }) {
       let suggested = similaritySuggested
       if (suggested.length < 6 && followingArr.length > 0) {
         // Fetch follows-of-my-follows (skip my own follower row).
-        const { data: fofRows } = await supabase
-          .from('user_follows')
-          .select('follower_id, following_id')
-          .in('follower_id', followingArr)
-          .neq('following_id', userId)
-          .limit(120)
+        // F8.2: friend-of-follows discovery reads OTHER users' follow edges, which are no longer
+        // directly readable (user_follows is participant-only). The narrow RPC returns ONLY the
+        // caller's own FOF subgraph (suggested + via), never the global graph. Adapt to the existing
+        // { follower_id (via), following_id (suggested) } shape so deriveSuggestedFOF is unchanged.
+        const { data: fofRaw } = await supabase.rpc('get_follow_suggestions')
+        const fofRows = (fofRaw || []).map(r => ({ follower_id: r.via_user_id, following_id: r.suggested_user_id }))
         // Look up names of my follows so we can show "via {friend}".
         const followingNames = new Map()
         const followingUserIds = followingArr
         const namesNeeded = followingUserIds.filter(id => !usersById.has(id))
         if (namesNeeded.length) {
-          const { data: namesRes } = await supabase
-            .from('users')
-            .select('id, name')
-            .in('id', namesNeeded)
+          const { data: namesRes } = await supabase.rpc('get_people_public_identities', { requested_user_ids: namesNeeded })
           for (const u of namesRes || []) followingNames.set(u.id, u.name)
         }
         for (const id of followingUserIds) {
@@ -631,10 +624,8 @@ export function PeopleDataProvider({ children }) {
           .map(r => r.following_id)
           .filter(id => id && id !== userId && !followingIds.has(id) && !usersById.has(id))))
         if (candidateIds.length) {
-          const { data: candUsers } = await supabase
-            .from('users')
-            .select('id, name, avatar_url, user_history(count)')
-            .in('id', candidateIds)
+          // F8.2: resolve FOF candidate identities via the narrow RPC (id/name/avatar only).
+          const { data: candUsers } = await supabase.rpc('get_people_public_identities', { requested_user_ids: candidateIds })
           for (const u of candUsers || []) usersById.set(u.id, u)
           // F7.9: FOF candidates' fingerprints are already in the map — the RPC returned every
           // opted-in user up front, so no follow-up fetch is needed. Opted-out candidates fall

--- a/supabase/migrations/20260610000001_secure_people_identity_and_follow_access.sql
+++ b/supabase/migrations/20260610000001_secure_people_identity_and_follow_access.sql
@@ -1,0 +1,133 @@
+-- 20260610000001_secure_people_identity_and_follow_access.sql
+-- F8.2 — Close the F8.1 P0: public.users (incl. email, last_active_at) and public.user_follows were
+-- ANONYMOUSLY readable via /rest/v1 (USING(true) policies + anon SELECT grants) — a logged-out
+-- client with the public anon key could scrape every user's email + the follow graph (confirmed via
+-- anon-role simulation: 9 emails, 4 follow edges).
+--
+-- End state: users + user_follows are NOT readable by anon; the full users row is OWNER-ONLY (so a
+-- non-owner cannot read another user's email/last_active_at); the follow graph is PARTICIPANT-ONLY.
+-- Cross-user identity (id/name/avatar) for People/Home/Lists, name search, and friend-of-follows
+-- discovery are served by three narrow, authenticated, least-data SECURITY DEFINER RPCs (each
+-- SECURITY DEFINER ONLY because the projection must read owner-only tables; each derives the caller
+-- from auth.uid(), takes no caller authorization identity, has a pinned search_path, is read-only,
+-- bounded, and returns NO email/last_active/settings/taste/history/editorial). No base behavioral
+-- RLS is changed; NO user row is mutated. Idempotent.
+
+-- ── 1) public.users — close anon + broad cross-user reads; full row becomes OWNER-ONLY ──────────
+revoke select on table public.users from anon;
+drop policy if exists "Anon can read user profiles" on public.users;
+drop policy if exists "Authenticated users can view any profile" on public.users;
+drop policy if exists "Users can view own profile" on public.users;
+create policy "Users can view own profile" on public.users
+  for select to authenticated
+  using ((select auth.uid()) = id);
+-- Owner INSERT ("Users can create their own profile") + UPDATE ("Users can update their own
+-- profile") policies are intentionally left unchanged.
+
+-- ── 2) public.user_follows — close anon; SELECT becomes PARTICIPANT-ONLY ─────────────────────────
+revoke select on table public.user_follows from anon;
+drop policy if exists "Users can see all follows" on public.user_follows;
+drop policy if exists "Users can view participant follows" on public.user_follows;
+create policy "Users can view participant follows" on public.user_follows
+  for select to authenticated
+  using ((select auth.uid()) = follower_id or (select auth.uid()) = following_id);
+-- INSERT ("Users can follow others", check follower_id = auth.uid()) + DELETE ("Users can unfollow",
+-- using follower_id = auth.uid()) are intentionally left unchanged.
+
+-- ── 3) RPC: cross-user identity projection (id/name/avatar ONLY) ─────────────────────────────────
+-- The ONLY cross-user path to other users' name/avatar (People/Home/Lists). Bounded: dedupes the
+-- requested array and serves at most 200 ids per call.
+create or replace function public.get_people_public_identities(requested_user_ids uuid[])
+returns table (id uuid, name text, avatar_url text)
+language sql security definer set search_path = pg_catalog, public stable
+as $$
+  select u.id, u.name, u.avatar_url
+  from public.users u
+  where (select auth.uid()) is not null
+    and u.id in (select distinct t.rid from unnest(requested_user_ids) as t(rid) limit 200)
+$$;
+revoke all on function public.get_people_public_identities(uuid[]) from public, anon;
+grant execute on function public.get_people_public_identities(uuid[]) to authenticated;
+
+-- ── 4) RPC: People name search → identity (id/name/avatar ONLY) ──────────────────────────────────
+-- Preserves the People masthead search without reopening the users table. Excludes the caller,
+-- requires >= 2 chars, bounded to 20 results. (Gating search to opted-in users only is a deferred
+-- consent refinement; this preserves current behavior of finding members by name.)
+create or replace function public.search_people_by_name(search_query text)
+returns table (id uuid, name text, avatar_url text)
+language sql security definer set search_path = pg_catalog, public stable
+as $$
+  select u.id, u.name, u.avatar_url
+  from public.users u
+  where (select auth.uid()) is not null
+    and u.id <> (select auth.uid())
+    and char_length(btrim(coalesce(search_query, ''))) >= 2
+    and u.name ilike '%' || btrim(search_query) || '%'
+  order by u.name
+  limit 20
+$$;
+revoke all on function public.search_people_by_name(text) from public, anon;
+grant execute on function public.search_people_by_name(text) to authenticated;
+
+-- ── 5) RPC: friend-of-follows discovery subgraph (narrow; NOT the full graph) ────────────────────
+-- Preserves People's FOF "suggested via {friend}" rail under participant-only user_follows. Returns
+-- ONLY the caller's own friend-of-follows edges (people followed by people the caller follows, who
+-- the caller does not already follow) — never the global follow graph. Bounded to 120.
+create or replace function public.get_follow_suggestions()
+returns table (suggested_user_id uuid, via_user_id uuid)
+language sql security definer set search_path = pg_catalog, public stable
+as $$
+  with me as (select (select auth.uid()) as uid),
+  my_following as (
+    select f.following_id from public.user_follows f, me where f.follower_id = me.uid
+  )
+  select f.following_id as suggested_user_id, f.follower_id as via_user_id
+  from public.user_follows f, me
+  where me.uid is not null
+    and f.follower_id in (select following_id from my_following)
+    and f.following_id <> me.uid
+    and f.following_id not in (select following_id from my_following)
+  limit 120
+$$;
+revoke all on function public.get_follow_suggestions() from public, anon;
+grant execute on function public.get_follow_suggestions() to authenticated;
+
+-- ── 6) Discoverability becomes EXPLICIT OPT-IN (missing/null setting => NOT discoverable) ────────
+-- F8.2 consent decision: the taste-match projection was default-ON (a missing showOnLeaderboards
+-- was treated as discoverable). Flip the MISSING-VALUE fallback only: explicit true stays
+-- discoverable, explicit false stays hidden, and a missing/null preference is now NOT discoverable.
+-- This mutates NO settings rows (users with no stored value simply default to not-discoverable and
+-- can opt in from Account); the caller always still receives their OWN row. Everything else about
+-- the RPC (least-data columns, auth-only, search_path, bound) is unchanged from F7.9.
+create or replace function public.get_discoverable_taste_profiles()
+returns table (
+  user_id          uuid,
+  top_mood_tags    jsonb,
+  top_tone_tags    jsonb,
+  top_fit_profiles jsonb,
+  total            integer
+)
+language sql
+security definer
+set search_path = pg_catalog, public
+stable
+as $$
+  select
+    p.user_id,
+    p.taste_fingerprint -> 'topMoodTags'       as top_mood_tags,
+    p.taste_fingerprint -> 'topToneTags'       as top_tone_tags,
+    p.taste_fingerprint -> 'topFitProfiles'    as top_fit_profiles,
+    (p.taste_fingerprint ->> 'total')::integer as total
+  from public.user_profiles_computed p
+  left join public.user_settings s on s.user_id = p.user_id
+  where (select auth.uid()) is not null
+    and p.taste_fingerprint is not null
+    and (
+      p.user_id = (select auth.uid())  -- always your own row
+      -- F8.2: opt-IN — missing/null => NOT discoverable (was coalesce(..., true) in F7.9)
+      or coalesce((s.settings -> 'privacy' ->> 'showOnLeaderboards')::boolean, false) = true
+    )
+  limit 500;
+$$;
+revoke all on function public.get_discoverable_taste_profiles() from public, anon;
+grant execute on function public.get_discoverable_taste_profiles() to authenticated;


### PR DESCRIPTION
**F8.2 — Secure People identity and follow access.** Closes the F8.1 P0 (anonymous PII + follow-graph exposure) and makes taste-match discoverability consent-honest.

## Prior anonymous exposure
`public.users` (incl. **email, last_active_at**) and `public.user_follows` were anonymously readable via `/rest/v1` — `"Anon can read user profiles" USING(true)` + `"Users can see all follows" USING(true)` + anon SELECT grants. Anon-role simulation read **9 emails + 4 follow edges** with only the public anon key.

## Exact users/follows policies + grants changed
- **users:** `REVOKE SELECT … FROM anon`; **dropped** "Anon can read user profiles" + "Authenticated users can view any profile"; **added** owner-only `"Users can view own profile" USING ((select auth.uid()) = id)`. Owner INSERT/UPDATE unchanged.
- **user_follows:** `REVOKE SELECT … FROM anon`; **dropped** "Users can see all follows" `USING(true)`; **added** participant-only `USING (auth.uid() = follower_id OR auth.uid() = following_id)`. INSERT/DELETE unchanged.

## Identity RPC + least-data fields + grants
`get_people_public_identities(uuid[]) → TABLE(id uuid, name text, avatar_url text)` — the **only** cross-user identity path (People/Home/Lists). Dedupes + caps the array at **200**. Plus `search_people_by_name(text)` (People search, ≥2 chars, excludes caller, limit 20) and `get_follow_suggestions()` (the caller's own FOF subgraph, limit 120 — **not** the global graph). All three: SECURITY DEFINER (to read owner-only tables), `auth.uid()`-derived, **no caller identity**, pinned `search_path`, schema-qualified, read-only, bounded, least-data; `REVOKE … FROM public, anon` + `GRANT EXECUTE … TO authenticated`.

## Follow-graph visibility decision
Participant-only (you read edges where you're follower or following). Every existing consumer except the FOF read uses the caller's own edges; the one cross-user read (friend-of-follows) is replaced by the narrow `get_follow_suggestions()` RPC — the raw graph is never reopened.

## Discoverability consent decision
**Explicit opt-in.** `get_discoverable_taste_profiles()` missing-value fallback flipped `coalesce(..., true) → coalesce(..., false)`: explicit true stays discoverable, explicit false/missing are not; the caller always gets their own row. **No settings rows mutated** — aggregate state (2 explicit-true, 0 false, 7 with no settings row) confirmed this removes no participants by writing data; the 7 default-on users simply default to not-discoverable and can opt in. Account default flipped to `false`.

## Account / privacy copy
Account: "Show on taste-match" → **"Appear in taste-match discovery"**, with copy enumerating what other signed-in members may see (**name, avatar, top film-taste tags, film count**) and stating **watched films, Diary, ratings, reviews and Cinematic DNA reflection stay private**. Privacy page: a factual "Taste-match discovery" section (signed-in only, controlled by the setting, the projected fields, what is **not** included, how to withdraw). Not called a leaderboard.

## Provider changes
People/Home/Lists: every direct cross-user `.from('users')` read → `get_people_public_identities`; People search → `search_people_by_name`; FOF → `get_follow_suggestions`. The RLS-dead cold-start popular rail is preserved empty (repoint deferred to F8.5). Own-row reads (Home/Discover/Profile/Account) unchanged. Identity-RPC failure degrades to the existing honest state. *(User-approved scope expansion to Home + Lists since they share the `users` table.)*

## Live read-only verification (no user row mutated)
- **anon:** `permission denied` on `users` + `user_follows` (`has_table_privilege` false); RPCs anon-denied.
- **authenticated non-owner:** sees **only their own** `users` row (1 visible / 1 own email) — no other rows/emails.
- **identity RPC:** returns id/name/avatar, resolves names (People still works).
- **policies:** users owner-only, user_follows participant-only.
- **opt-in:** discoverable reduced **3 → 2** (non-opted-in excluded).
- **advisors:** **no new ERROR** (the 2 pre-existing SECURITY DEFINER view ERRORs are out of scope); the 3 new RPCs add expected **authenticated-only** WARNs (not anon-executable).

## Tests
+5 (full **1386**): People uses the 3 RPCs / zero direct `users` read / never `.select()`s email or last_active / no global follow-graph read (+3); Account consent copy enumerates exposed fields + states what stays private + not a "leaderboard" (+2, one existing updated). Read-only `scripts/verify-people-social-privacy.sql` added.

## No-user-row-mutation + frozen confirmation
All DB work was DDL (policies, grants, functions) + read-only verification — **no `users`/`user_settings`/`user_follows` row inserted/updated/deleted**. Frozen: People rail order/ranking/% Match, fingerprint fields/scoring, follow/unfollow payloads + behavior, behavioral-table owner/participant RLS, Home/Discover/Film File/Library/Profile flows, recommendation engine, routes, auth. **Deferred:** F8.3 similarity/terminology, F8.4 settled follow + block/report, F8.5 People hierarchy + popular repoint. **Known out-of-scope impact:** the admin CacheMonitoring dashboard's cross-user `users` read now returns only the admin's own row (admin tool; recommend a service-role/admin RPC). Peripheral global security backlog unchanged.

## Validation
lint clean · people+account **11 ×3** · consumers **585** · full **1386** · build ✓ · authenticated visual **41** + public **2** (no drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
