### PR TITLE
Harden People taste-match trust and evidence

### DIFF
--- a/src/features/people/People.jsx
+++ b/src/features/people/People.jsx
@@ -90,10 +90,10 @@ function Masthead({ onSearch, query, setQuery }) {
           <Eyebrow tone="meta" weight={500} size={10}>{user.following} following · {user.followers} followers</Eyebrow>
         </div>
         <h1 className="ff-people-hero" style={{ fontFamily: 'Outfit', fontSize: 88, lineHeight: 0.92, fontWeight: 300, letterSpacing: '-0.05em', color: HP.text, margin: 0, textWrap: 'balance' }}>
-          Your <em style={{ fontStyle: 'italic', fontWeight: 400, color: HP.textSoft }}>taste twins.</em>
+          Your <em style={{ fontStyle: 'italic', fontWeight: 400, color: HP.textSoft }}>taste matches.</em>
         </h1>
         <p style={{ marginTop: 18, fontFamily: 'Outfit, Inter, sans-serif', fontSize: 17, color: HP.textSoft, fontStyle: 'italic', maxWidth: 680, lineHeight: 1.55 }}>
-          Compatibility, not popularity. Friends whose ratings actually predict yours.
+          People whose film taste overlaps with yours — an estimate from your film activity, not a relationship.
         </p>
         <form
           onSubmit={(e) => { e.preventDefault(); onSearch(query) }}
@@ -209,14 +209,14 @@ function TwinsRail() {
             <article key={p.id} className="ff-people-twin-card" style={{ padding: '26px 24px', borderRadius: 8, background: 'rgba(255,255,255,0.025)', border: `1px solid ${HP.border}`, position: 'relative', overflow: 'hidden' }}>
               <div style={{ position: 'absolute', top: -30, right: -30, width: 120, height: 120, borderRadius: 999, background: `radial-gradient(circle, ${p.avatarBg}33, transparent 70%)`, filter: 'blur(8px)' }} />
               <div style={{ position: 'relative' }}>
-                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 18 }}>
+                <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: 18, gap: 12 }}>
                   <Avatar url={p.avatarUrl} initial={p.initial} bg={p.avatarBg} size={48} onClick={() => navigate('/people')} alt={`View ${p.name}'s profile`} />
-                  <div style={{ textAlign: 'right' }}>
-                    <div style={{ fontFamily: 'Outfit', fontSize: 34, fontWeight: 200, color: HP.text, letterSpacing: '-0.045em', lineHeight: 1 }}>{p.match}<span style={{ fontSize: 12, color: HP.textMuted, marginLeft: 1 }}>%</span></div>
-                    <div style={{ fontSize: 9, color: HP.textFaint, fontFamily: 'Outfit', letterSpacing: '0.14em', textTransform: 'uppercase', marginTop: 2 }}>Match</div>
+                  <div style={{ textAlign: 'right', maxWidth: 150 }}>
+                    <div style={{ fontFamily: 'Outfit', fontSize: 14, fontWeight: 500, color: p.matchPresentation.qualified ? HP.text : HP.textMuted, letterSpacing: '-0.01em', lineHeight: 1.25 }}>{p.matchPresentation.band || p.matchPresentation.caption}</div>
+                    {p.matchPresentation.evidence && <div style={{ fontSize: 10, color: HP.textMuted, fontFamily: 'Outfit', marginTop: 3 }}>{p.matchPresentation.evidence}</div>}
                   </div>
                 </div>
-                <MatchBar pct={p.match} hex={p.avatarBg} />
+                {p.matchPresentation.qualified && <div aria-hidden="true"><MatchBar pct={p.match} hex={p.avatarBg} /></div>}
                 <button
                   type="button"
                   onClick={() => navigate('/people')}
@@ -224,7 +224,7 @@ function TwinsRail() {
                 >
                   {p.name}
                 </button>
-                <div style={{ fontSize: 11, color: HP.textMuted, fontFamily: 'Outfit', marginTop: 2 }}>{p.handle} · {p.films} film{p.films === 1 ? '' : 's'}</div>
+                <div style={{ fontSize: 11, color: HP.textMuted, fontFamily: 'Outfit', marginTop: 2 }}>{p.handle}</div>
                 {p.bio && <p style={{ margin: '12px 0 0 0', fontSize: 12, color: HP.textSoft, fontFamily: 'Outfit, Inter, sans-serif', lineHeight: 1.5 }}>{p.bio}</p>}
                 <div style={{ marginTop: 14, paddingTop: 14, borderTop: `1px solid ${HP.border}`, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10 }}>
                   <div style={{ fontSize: 11, color: HP.textMuted, fontFamily: 'Outfit', fontStyle: 'italic' }}>{p.recent}</div>
@@ -244,8 +244,8 @@ function TwinsRail() {
 function ColdStartHint() {
   return (
     <div style={{ padding: '14px 18px', borderRadius: 6, background: 'rgba(167,139,250,0.06)', border: `1px solid ${HP.purple}33`, fontSize: 13, color: HP.textSoft, fontFamily: 'Outfit, Inter, sans-serif', lineHeight: 1.55 }}>
-      <strong style={{ color: HP.text, fontWeight: 500 }}>Twins unlock as you rate.</strong>{' '}
-      Rate ~12 films and we&rsquo;ll match you with people whose ratings actually predict yours. Until then, here&rsquo;s who&rsquo;s watching the most.
+      <strong style={{ color: HP.text, fontWeight: 500 }}>Matches unlock as you rate.</strong>{' '}
+      Rate ~12 films and we&rsquo;ll surface people whose film taste overlaps with yours. Until then, here&rsquo;s who&rsquo;s active.
     </div>
   )
 }
@@ -255,8 +255,8 @@ function ColdStartHint() {
 function ColdStartHero() {
   return (
     <EmptyState
-      label="No taste twins yet"
-      body="Rate a dozen films and we'll match you with people whose taste actually predicts yours."
+      label="No taste matches yet"
+      body="Rate a dozen films and we'll surface people whose film taste overlaps with yours."
     />
   )
 }
@@ -270,8 +270,8 @@ function Rising() {
     <section className="ff-people-section ff-people-rising" style={{ padding: '48px 88px', borderTop: `1px solid ${HP.border}`, background: 'rgba(255,255,255,0.012)' }}>
       <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', marginBottom: 24, flexWrap: 'wrap', gap: 16 }}>
         <div>
-          <Eyebrow rule size={10} style={{ marginBottom: 12 }}>On the rise</Eyebrow>
-          <h2 className="ff-people-h2-sm" style={{ fontFamily: 'Outfit', fontSize: 30, lineHeight: 1, fontWeight: 500, letterSpacing: '-0.03em', color: HP.text, margin: 0 }}>Building taste in <em style={{ fontStyle: 'italic', fontWeight: 400, color: HP.textSoft }}>your direction.</em></h2>
+          <Eyebrow rule size={10} style={{ marginBottom: 12 }}>More matches</Eyebrow>
+          <h2 className="ff-people-h2-sm" style={{ fontFamily: 'Outfit', fontSize: 30, lineHeight: 1, fontWeight: 500, letterSpacing: '-0.03em', color: HP.text, margin: 0 }}>More people to <em style={{ fontStyle: 'italic', fontWeight: 400, color: HP.textSoft }}>discover.</em></h2>
         </div>
       </div>
       <div className="ff-people-grid-3" style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 16 }}>
@@ -287,8 +287,8 @@ function Rising() {
                 {p.name}
               </button>
               <div style={{ fontSize: 11, color: HP.textMuted, fontFamily: 'Outfit', marginTop: 2, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{p.bio}</div>
-              <div style={{ marginTop: 8 }}><MatchBar pct={p.match} hex={p.avatarBg} /></div>
-              <div style={{ marginTop: 6, fontSize: 10, color: HP.textFaint, fontFamily: 'Outfit', letterSpacing: '0.06em' }}>{p.match}% match · {p.recent}</div>
+              {p.matchPresentation.qualified && <div style={{ marginTop: 8 }} aria-hidden="true"><MatchBar pct={p.match} hex={p.avatarBg} /></div>}
+              <div style={{ marginTop: 6, fontSize: 10, color: HP.textMuted, fontFamily: 'Outfit', letterSpacing: '0.04em' }}>{p.matchPresentation.evidence || p.matchPresentation.band || p.matchPresentation.caption}</div>
             </div>
             <FollowBtn following={p.following} onToggle={() => toggleFollow(p.id)} />
           </div>
@@ -307,8 +307,8 @@ function Activity() {
   // for both modes. (When they DO follow people, those events still appear
   // because followingIds takes precedence in the data layer.)
   const heading = user.following > 0
-    ? <>What your <em style={{ fontStyle: 'italic', fontWeight: 400, color: HP.textSoft }}>circle watched.</em></>
-    : <>What your <em style={{ fontStyle: 'italic', fontWeight: 400, color: HP.textSoft }}>twins watched.</em></>
+    ? <>Recent from <em style={{ fontStyle: 'italic', fontWeight: 400, color: HP.textSoft }}>people you follow.</em></>
+    : <>Recent from <em style={{ fontStyle: 'italic', fontWeight: 400, color: HP.textSoft }}>your taste matches.</em></>
   return (
     <section className="ff-people-section ff-people-activity" style={{ padding: '56px 88px', borderTop: `1px solid ${HP.border}` }}>
       <div style={{ marginBottom: 24 }}>
@@ -349,20 +349,20 @@ function CrewOverlap() {
   if (!loading && crewOverlap.length === 0) return null
   const sub = followingIds.size > 0
     ? 'Where your taste graph overlaps with the people you follow.'
-    : 'Where your taste graph overlaps with your taste twins. Follow them to lock these in.'
+    : 'Where your taste graph overlaps with the people whose film taste matches yours.'
   return (
     <section className="ff-people-section ff-people-crew" style={{ padding: '56px 88px', borderTop: `1px solid ${HP.border}`, background: 'rgba(255,255,255,0.012)' }}>
       <div className="ff-people-crew-grid" style={{ display: 'grid', gridTemplateColumns: '1fr 1.6fr', gap: 64, alignItems: 'flex-start' }}>
         <div>
           <Eyebrow size={10} style={{ marginBottom: 12 }}>Shared lineage</Eyebrow>
-          <h2 className="ff-people-h2" style={{ fontFamily: 'Outfit', fontSize: 32, lineHeight: 1.05, fontWeight: 500, letterSpacing: '-0.03em', color: HP.text, margin: 0 }}>Directors your <em style={{ fontStyle: 'italic', fontWeight: 400, color: HP.textSoft }}>circle loves.</em></h2>
+          <h2 className="ff-people-h2" style={{ fontFamily: 'Outfit', fontSize: 32, lineHeight: 1.05, fontWeight: 500, letterSpacing: '-0.03em', color: HP.text, margin: 0 }}>Directors you <em style={{ fontStyle: 'italic', fontWeight: 400, color: HP.textSoft }}>share.</em></h2>
           <p style={{ marginTop: 14, fontSize: 13, color: HP.textMuted, fontFamily: 'Outfit, Inter, sans-serif', lineHeight: 1.55, maxWidth: 320 }}>{sub}</p>
         </div>
         <div style={{ borderTop: `1px solid ${HP.border}` }}>
           {crewOverlap.map(c => (
             <div key={c.name} style={{ display: 'grid', gridTemplateColumns: '1fr auto', gap: 24, alignItems: 'center', padding: '16px 0', borderBottom: `1px solid ${HP.border}` }}>
               <div style={{ fontFamily: 'Outfit', fontSize: 18, fontWeight: 500, color: HP.text, letterSpacing: '-0.015em' }}>{c.name}</div>
-              <div style={{ fontSize: 11, color: HP.textMuted, fontFamily: 'Outfit', letterSpacing: '0.04em', textAlign: 'right' }}>{c.friends} {followingIds.size > 0 ? 'friend' : 'twin'}{c.friends === 1 ? '' : 's'} · {c.you}</div>
+              <div style={{ fontSize: 11, color: HP.textMuted, fontFamily: 'Outfit', letterSpacing: '0.04em', textAlign: 'right' }}>{c.friends} shared · {c.you}</div>
             </div>
           ))}
         </div>
@@ -396,8 +396,8 @@ function Suggested() {
               </button>
               <div style={{ fontSize: 11, color: HP.textMuted, fontFamily: 'Outfit', marginTop: 2 }}>
                 {p.viaFriend
-                  ? <>via <span style={{ color: HP.text }}>{p.viaFriend}</span> · {p.mood}</>
-                  : <>{p.mutuals} films in common · {p.mood}</>}
+                  ? <>via <span style={{ color: HP.text }}>{p.viaFriend}</span>{p.matchPresentation?.band ? <> · {p.matchPresentation.band}</> : null}</>
+                  : <>{p.matchPresentation?.evidence || p.matchPresentation?.band || p.matchPresentation?.caption || 'Suggested for you'}</>}
               </div>
             </div>
             <FollowBtn following={false} onToggle={() => toggleFollow(p.id)} />

--- a/src/features/people/__tests__/PeopleProjectionPrivacy.test.jsx
+++ b/src/features/people/__tests__/PeopleProjectionPrivacy.test.jsx
@@ -93,3 +93,37 @@ describe('F8.2 — People resolves cross-user identity via narrow RPCs, never a 
     expect(peopleSource).not.toMatch(/from\(\s*['"]user_follows['"]\s*\)[\s\S]{0,120}\.in\(\s*['"]follower_id['"]/)
   })
 })
+
+describe('F8.3 — taste-match trust + de-precision (no friendship, no exact %)', () => {
+  it('renders no exact taste-match percentage (qualitative bands only)', () => {
+    // the prominent "{p.match}%" / "% match" presentation is gone from the rendered UI
+    expect(peopleJsxSource).not.toMatch(/\{p\.match\}\s*<span[^>]*>%/)   // big "82%" number block
+    expect(peopleJsxSource).not.toMatch(/\{p\.match\}%\s*match/)         // "82% match" caption
+    expect(peopleJsxSource).not.toMatch(/\}% match</)
+  })
+
+  it('uses the pure presentation module for the match band/evidence', () => {
+    expect(peopleSource).toContain('deriveTasteMatchPresentation')
+    expect(peopleSource).toContain('matchPresentation')
+    expect(peopleJsxSource).toContain('matchPresentation')
+  })
+
+  it('no production copy calls algorithmic matches or one-way follows "friends" or claims they "predict you"', () => {
+    // strip the legitimate real-world invite copy ("Invite a friend" / "A friend thinks you'd like…")
+    const copy = peopleJsxSource
+      .replace(/Invite a friend to FeelFlick/g, '')
+      .replace(/'A friend'/g, '')
+    expect(copy).not.toMatch(/[Ff]riends? whose/)         // "Friends whose ratings predict yours"
+    expect(copy).not.toMatch(/predict[s]? you/i)          // "predicts you"
+    expect(copy).not.toMatch(/your\s+circle/i)            // "your circle watched/loves"
+    expect(copy).not.toMatch(/your\s+taste twins?\b/i)    // hero "Your taste twins"
+  })
+
+  it('the only relationship label is the one-way follow (Follow / Following), never friend', () => {
+    expect(peopleJsxSource).toMatch(/aria-label=\{following \? 'Unfollow' : 'Follow'\}/)
+  })
+
+  it('MatchBar is decorative (aria-hidden) and only shown when the match is evidence-qualified', () => {
+    expect(peopleJsxSource).toMatch(/qualified &&[\s\S]{0,80}aria-hidden="true"[\s\S]{0,40}MatchBar/)
+  })
+})

--- a/src/features/people/derive/__tests__/peoplePresentation.test.js
+++ b/src/features/people/derive/__tests__/peoplePresentation.test.js
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import {
+  classifySocialEvidence, SOCIAL_EVIDENCE, tasteBand, TASTE_BANDS,
+  formatTasteEvidence, deriveTasteMatchPresentation, deriveRelationshipLabel, formatFollowCount,
+  MIN_IN_COMMON, STRONG_IN_COMMON, MIN_WATCHED,
+} from '../peoplePresentation'
+
+describe('F8.3 classifySocialEvidence — evidence floor + forming gate', () => {
+  it('insufficient shared films (null / below floor) → INSUFFICIENT', () => {
+    expect(classifySocialEvidence({ moviesInCommon: null, total: 40 })).toBe(SOCIAL_EVIDENCE.INSUFFICIENT)
+    expect(classifySocialEvidence({ moviesInCommon: 0, total: 40 })).toBe(SOCIAL_EVIDENCE.INSUFFICIENT)
+    expect(classifySocialEvidence({ moviesInCommon: MIN_IN_COMMON - 1, total: 40 })).toBe(SOCIAL_EVIDENCE.INSUFFICIENT)
+  })
+  it('enough overlap but a tiny counterpart profile → FORMING', () => {
+    expect(classifySocialEvidence({ moviesInCommon: 5, total: MIN_WATCHED - 1 })).toBe(SOCIAL_EVIDENCE.FORMING)
+  })
+  it('strong overlap OR mature profile → ESTABLISHED', () => {
+    expect(classifySocialEvidence({ moviesInCommon: STRONG_IN_COMMON, total: null })).toBe(SOCIAL_EVIDENCE.ESTABLISHED)
+    expect(classifySocialEvidence({ moviesInCommon: 4, total: 30 })).toBe(SOCIAL_EVIDENCE.ESTABLISHED)
+  })
+  it('moderate overlap, unknown/medium profile → EMERGING', () => {
+    expect(classifySocialEvidence({ moviesInCommon: 4, total: null })).toBe(SOCIAL_EVIDENCE.EMERGING)
+    expect(classifySocialEvidence({ moviesInCommon: 6, total: 10 })).toBe(SOCIAL_EVIDENCE.EMERGING)
+  })
+})
+
+describe('F8.3 tasteBand — conservative qualitative bands (no exact %)', () => {
+  it('threshold boundaries', () => {
+    expect(tasteBand(75)).toBe(TASTE_BANDS.VERY_CLOSE)
+    expect(tasteBand(74)).toBe(TASTE_BANDS.STRONG)
+    expect(tasteBand(55)).toBe(TASTE_BANDS.STRONG)
+    expect(tasteBand(54)).toBe(TASTE_BANDS.SOME)
+    expect(tasteBand(0)).toBe(TASTE_BANDS.SOME)
+  })
+  it('null / undefined / NaN → null; out-of-range clamped', () => {
+    expect(tasteBand(null)).toBeNull()
+    expect(tasteBand(undefined)).toBeNull()
+    expect(tasteBand(NaN)).toBeNull()
+    expect(tasteBand(200)).toBe(TASTE_BANDS.VERY_CLOSE)   // clamped to 100
+    expect(tasteBand(-5)).toBe(TASTE_BANDS.SOME)          // clamped to 0
+  })
+  it('no band string is a raw percentage / forbidden word', () => {
+    for (const v of Object.values(TASTE_BANDS)) {
+      expect(v).not.toMatch(/%|\d/)
+      expect(v).not.toMatch(/perfect|soulmate|best friend|guaranteed|predict/i)
+    }
+  })
+})
+
+describe('F8.3 formatTasteEvidence — films-in-common grammar, never fabricated', () => {
+  it('one / multiple films → singular/plural', () => {
+    expect(formatTasteEvidence({ moviesInCommon: 1 })).toBe('Based on 1 film in common')
+    expect(formatTasteEvidence({ moviesInCommon: 18 })).toBe('Based on 18 films in common')
+  })
+  it('zero / null / invalid → null (hidden, never fabricated)', () => {
+    expect(formatTasteEvidence({ moviesInCommon: 0 })).toBeNull()
+    expect(formatTasteEvidence({ moviesInCommon: null })).toBeNull()
+    expect(formatTasteEvidence({})).toBeNull()
+    expect(formatTasteEvidence({ moviesInCommon: NaN })).toBeNull()
+  })
+})
+
+describe('F8.3 deriveTasteMatchPresentation — honest, evidence-qualified', () => {
+  it('forming counterpart → NO percentage, NO band, cautious caption', () => {
+    const p = deriveTasteMatchPresentation({ matchPct: 92, moviesInCommon: 4, total: 3 })
+    expect(p.qualified).toBe(false)
+    expect(p.band).toBeNull()
+    expect(p.caption).toBe('Taste still forming')
+    expect(JSON.stringify(p)).not.toMatch(/\d+%|92/)
+  })
+  it('insufficient overlap → NO claim even with a high match', () => {
+    const p = deriveTasteMatchPresentation({ matchPct: 95, moviesInCommon: 1, total: 50 })
+    expect(p.qualified).toBe(false)
+    expect(p.band).toBeNull()
+    expect(p.caption).toBe('Not enough shared evidence yet')
+  })
+  it('emerging → cautious band (never the top band) + evidence', () => {
+    const p = deriveTasteMatchPresentation({ matchPct: 90, moviesInCommon: 5, total: 10 })
+    expect(p.qualified).toBe(true)
+    expect(p.band).toBe(TASTE_BANDS.STRONG)         // capped down from VERY_CLOSE
+    expect(p.evidence).toBe('Based on 5 films in common')
+  })
+  it('established → strongest supported band + evidence', () => {
+    const p = deriveTasteMatchPresentation({ matchPct: 88, moviesInCommon: 18, total: 40 })
+    expect(p.qualified).toBe(true)
+    expect(p.band).toBe(TASTE_BANDS.VERY_CLOSE)
+    expect(p.evidence).toBe('Based on 18 films in common')
+    expect(JSON.stringify(p)).not.toMatch(/88|%/)
+  })
+  it('invalid match degrades honestly (no band, evidence still shown when present)', () => {
+    const p = deriveTasteMatchPresentation({ matchPct: NaN, moviesInCommon: 18, total: 40 })
+    expect(p.band).toBeNull()
+    expect(p.evidence).toBe('Based on 18 films in common')
+  })
+})
+
+describe('F8.3 relationship terminology — never "friend"', () => {
+  it('relationship label is only the one-way follow state', () => {
+    expect(deriveRelationshipLabel({ following: false })).toBe('Follow')
+    expect(deriveRelationshipLabel({ following: true })).toBe('Following')
+    expect(deriveRelationshipLabel({ following: true })).not.toMatch(/friend/i)
+  })
+  it('follow count is "people you follow", never "friends"', () => {
+    expect(formatFollowCount(1)).toBe('1 person you follow')
+    expect(formatFollowCount(3)).toBe('3 people you follow')
+    expect(formatFollowCount(0)).not.toMatch(/friend/i)
+  })
+})

--- a/src/features/people/derive/peoplePresentation.js
+++ b/src/features/people/derive/peoplePresentation.js
@@ -1,0 +1,97 @@
+// peoplePresentation.js — PURE taste-match presentation derivation for People (F8.3).
+// No React, no Supabase, no side effects. Turns the raw similarity signals (overall_similarity →
+// matchPct, movies_in_common, and the discoverable fingerprint `total`) into HONEST, evidence-
+// qualified, de-precisioned presentation. It NEVER changes ranking, the raw similarity value, or
+// candidate order — it only decides what a card may truthfully claim.
+//
+// Honesty contract:
+//   * a taste match is an ALGORITHMIC estimate — never friendship, mutual interest, endorsement, or
+//     film-specific agreement;
+//   * exact percentages are not surfaced — only conservative qualitative bands;
+//   * a quantified compatibility claim requires real shared evidence (films in common), and a
+//     sparse / forming counterpart gets a cautious state instead of a confident band;
+//   * the only relationship state is the explicit one-way follow (Follow / Following).
+//
+// Cross-user RLS (F8.2) exposes only the other user's `total` (watched count, from the opt-in
+// discoverable fingerprint) and `moviesInCommon` (shared films) — NOT their ratings — so social
+// eligibility is built from those two signals. The watched floor below (5) deliberately matches the
+// Profile maturity model's forming watched-floor (classifyProfileMaturity in
+// src/features/profile/derive/profilePresentation.js); it is restated here rather than imported to
+// avoid an inappropriate People→Profile feature dependency and because the social inputs differ
+// (no ratedCount is available cross-user).
+
+export const MIN_IN_COMMON = 3       // below this many shared films we make NO quantified match claim
+export const STRONG_IN_COMMON = 12   // strong shared evidence → may show the top band
+export const MIN_WATCHED = 5         // the counterpart's profile must clear the forming watched-floor
+
+export const SOCIAL_EVIDENCE = {
+  INSUFFICIENT: 'insufficient', // not enough shared films to claim anything
+  FORMING: 'forming',           // counterpart profile too sparse
+  EMERGING: 'emerging',         // qualified but cautious
+  ESTABLISHED: 'established',    // qualified, full presentation
+}
+
+// Classify how much we can honestly say about a match, from the available cross-user evidence.
+export function classifySocialEvidence({ moviesInCommon = null, total = null } = {}) {
+  const inCommon = Number.isFinite(moviesInCommon) ? moviesInCommon : null
+  const watched = Number.isFinite(total) ? total : null
+  if (inCommon == null || inCommon < MIN_IN_COMMON) return SOCIAL_EVIDENCE.INSUFFICIENT
+  // counterpart's own profile is explicitly tiny → cautious even with some overlap
+  if (watched != null && watched < MIN_WATCHED) return SOCIAL_EVIDENCE.FORMING
+  if (inCommon >= STRONG_IN_COMMON || (watched != null && watched >= 15)) return SOCIAL_EVIDENCE.ESTABLISHED
+  return SOCIAL_EVIDENCE.EMERGING
+}
+
+// Conservative qualitative band from the match percentage — NEVER a raw percentage, never
+// "perfect / soulmate / predicts you" language. Returns null for invalid input.
+export const TASTE_BANDS = {
+  VERY_CLOSE: 'Very close taste',
+  STRONG: 'Strong taste overlap',
+  SOME: 'Some taste overlap',
+}
+export function tasteBand(matchPct) {
+  const m = Number.isFinite(matchPct) ? Math.max(0, Math.min(100, matchPct)) : null
+  if (m == null) return null
+  if (m >= 75) return TASTE_BANDS.VERY_CLOSE
+  if (m >= 55) return TASTE_BANDS.STRONG
+  return TASTE_BANDS.SOME
+}
+
+// "Based on N films in common" — only when the source value genuinely supports it. Correct
+// grammar; never fabricated; never derived from a total-watched count; hidden when 0/null/invalid.
+export function formatTasteEvidence({ moviesInCommon = null } = {}) {
+  const n = Number.isFinite(moviesInCommon) ? moviesInCommon : null
+  if (n == null || n <= 0) return null
+  return `Based on ${n} film${n === 1 ? '' : 's'} in common`
+}
+
+// The full presentation for a taste-match card.
+//   { qualified, band, evidence, caption, maturity }
+// - qualified=false → no quantified claim; `caption` is the cautious fallback, `band`/`evidence` null.
+// - qualified=true  → `band` is the qualitative label, `evidence` the films-in-common context (may be
+//   null if the source value is absent for this rail), `caption` defaults to the band.
+// Emerging counterparts never receive the top "Very close" band.
+export function deriveTasteMatchPresentation({ matchPct = null, moviesInCommon = null, total = null } = {}) {
+  const maturity = classifySocialEvidence({ moviesInCommon, total })
+  if (maturity === SOCIAL_EVIDENCE.INSUFFICIENT) {
+    return { qualified: false, band: null, evidence: null, caption: 'Not enough shared evidence yet', maturity }
+  }
+  if (maturity === SOCIAL_EVIDENCE.FORMING) {
+    return { qualified: false, band: null, evidence: null, caption: 'Taste still forming', maturity }
+  }
+  let band = tasteBand(matchPct)
+  if (maturity === SOCIAL_EVIDENCE.EMERGING && band === TASTE_BANDS.VERY_CLOSE) band = TASTE_BANDS.STRONG
+  const evidence = formatTasteEvidence({ moviesInCommon })
+  return { qualified: true, band, evidence, caption: band, maturity }
+}
+
+// Relationship label — ONLY the explicit one-way follow state. Never "friend".
+export function deriveRelationshipLabel({ following = false } = {}) {
+  return following ? 'Following' : 'Follow'
+}
+
+// Count noun for a set of accounts the viewer FOLLOWS (never "friends").
+export function formatFollowCount(n) {
+  const c = Number.isFinite(n) ? Math.max(0, n) : 0
+  return `${c} ${c === 1 ? 'person' : 'people'} you follow`
+}

--- a/src/features/people/usePeopleData.jsx
+++ b/src/features/people/usePeopleData.jsx
@@ -7,6 +7,7 @@
 
 import { createContext, useContext, useEffect, useMemo, useState, useCallback } from 'react'
 import { supabase } from '@/shared/lib/supabase/client'
+import { deriveTasteMatchPresentation } from './derive/peoplePresentation'
 import { useAuthSession } from '@/shared/hooks/useAuthSession'
 
 const PeopleDataContext = createContext(null)
@@ -175,6 +176,16 @@ function deriveTwins(similarityRows, followingIds, meta, fingerprintByUser) {
       avatarBg: avatarBg(u.id),
       match: Math.max(0, Math.min(100, Math.round((row.overall_similarity ?? 0) * 100))),
       films: watchCount,
+      // F8.3 evidence: films-in-common (the honest shared-evidence basis) + the discoverable
+      // fingerprint total (counterpart maturity), turned into the de-precisioned, evidence-qualified
+      // taste-match presentation by the pure module (no exact % surfaced; no relationship implied).
+      inCommon: Number.isFinite(row.movies_in_common) ? row.movies_in_common : null,
+      total: fingerprintByUser.get(u.id)?.total ?? null,
+      matchPresentation: deriveTasteMatchPresentation({
+        matchPct: Math.max(0, Math.min(100, Math.round((row.overall_similarity ?? 0) * 100))),
+        moviesInCommon: Number.isFinite(row.movies_in_common) ? row.movies_in_common : null,
+        total: fingerprintByUser.get(u.id)?.total ?? null,
+      }),
       mood: meta.topMood.get(u.id) || 'Building taste',
       bio: deriveBio({ fingerprint: fingerprintByUser.get(u.id), watchCount }),
       recent: r
@@ -202,6 +213,16 @@ function deriveRising(similarityRows, followingIds, meta, fingerprintByUser) {
       avatarBg: avatarBg(u.id),
       match: Math.max(0, Math.min(100, Math.round((row.overall_similarity ?? 0) * 100))),
       films: watchCount,
+      // F8.3 evidence: films-in-common (the honest shared-evidence basis) + the discoverable
+      // fingerprint total (counterpart maturity), turned into the de-precisioned, evidence-qualified
+      // taste-match presentation by the pure module (no exact % surfaced; no relationship implied).
+      inCommon: Number.isFinite(row.movies_in_common) ? row.movies_in_common : null,
+      total: fingerprintByUser.get(u.id)?.total ?? null,
+      matchPresentation: deriveTasteMatchPresentation({
+        matchPct: Math.max(0, Math.min(100, Math.round((row.overall_similarity ?? 0) * 100))),
+        moviesInCommon: Number.isFinite(row.movies_in_common) ? row.movies_in_common : null,
+        total: fingerprintByUser.get(u.id)?.total ?? null,
+      }),
       mood: meta.topMood.get(u.id) || 'Building taste',
       bio: deriveBio({ fingerprint: fingerprintByUser.get(u.id), watchCount }),
       recent: r
@@ -328,7 +349,16 @@ function deriveSuggested(similarityRows, followingIds, currentUserId, fingerprin
         initial: initialOf(u.name),
         avatarBg: avatarBg(u.id),
         mutuals: row.movies_in_common ?? 0,
-        mood: `${Math.round((row.overall_similarity ?? 0) * 100)}% match`,
+        // F8.3: keep the raw match + evidence; the qualitative band/evidence is derived in the
+        // pure presentation module at render (no exact % surfaced).
+        match: Math.max(0, Math.min(100, Math.round((row.overall_similarity ?? 0) * 100))),
+        inCommon: Number.isFinite(row.movies_in_common) ? row.movies_in_common : null,
+        total: fingerprintByUser.get(u.id)?.total ?? null,
+        matchPresentation: deriveTasteMatchPresentation({
+          matchPct: Math.max(0, Math.min(100, Math.round((row.overall_similarity ?? 0) * 100))),
+          moviesInCommon: Number.isFinite(row.movies_in_common) ? row.movies_in_common : null,
+          total: fingerprintByUser.get(u.id)?.total ?? null,
+        }),
         bio: deriveBio({ fingerprint: fingerprintByUser.get(u.id), watchCount }),
         viaFriend: null,
       }


### PR DESCRIPTION
F8.3 — make People's taste-match presentation honest, evidence-qualified and understandable. Pure-derivation + presentation only (no DB/RPC/RLS/consent/ranking/similarity change). New pure module peoplePresentation.js: qualitative similarity bands (no exact %), evidence-maturity gate (cross-user total + movies_in_common; forming/insufficient → cautious, no %), films-in-common evidence context, follow-only relationship labels. Removed friendship/predict/circle/'taste twin' copy; relabelled Rising; MatchBar decorative+aria-hidden+qualified-only. Ranking + raw overall_similarity unchanged. +21 tests (full 1407). F8.2 privacy boundary unchanged; no live action/write. 🤖 Generated with [Claude Code](https://claude.com/claude-code)