### PR TITLE
Harden People follow actions and beta safety

### DIFF
--- a/docs/people/private-beta-safety-f84.md
+++ b/docs/people/private-beta-safety-f84.md
@@ -1,0 +1,74 @@
+# People — private-beta safety decision record (F8.4)
+
+Status: current. Scope: the People taste-discovery surface during **private beta** (a small, trusted
+cohort). This records what relationship + safety affordances exist, what is deliberately deferred, and
+why. It is **not** a claim that People is safe for unrestricted public social use.
+
+## Relationship model
+
+- **Follow is one-way, explicit, and revocable.** It is persisted in `public.user_follows`
+  (participant-only RLS; INSERT/DELETE owner-scoped to the follower). Following someone is not
+  friendship, not mutual matching, and implies no endorsement or agreement.
+- **No relationship state is confirmed until the database write succeeds** (F8.4). The UI never
+  optimistically shows "Following"; it reads `Follow → Following…/Unfollowing… → Following/Follow`
+  from the settled result, announces each settlement once in a polite live region, and on failure
+  keeps the prior state with retry-capable copy. A duplicate-key (`23505`) follow is treated as
+  idempotent success.
+- **Self-follow is impossible** — the signed-in user is excluded from candidate sets (similarity rows
+  are always pairs with the *other* user; suggested/FOF filter `!== userId`) and the action hook
+  rejects a self target before any write.
+
+## Hide suggestion — what it is and is NOT
+
+People offers a quiet, tertiary **Hide** action on non-followed discovery cards.
+
+- **It is NOT a block.** It does not change the other person's account, does not notify them, does not
+  affect their discoverability setting, and exposes no social signal to them or anyone else.
+- It only removes that suggestion from the **caller's current People session** and announces
+  "Hidden from your suggestions."
+- It does **not** unfollow an already-followed person, and is not shown on followed cards or on the
+  signed-in user.
+- It changes no similarity value and no persisted relationship state. Hiding is the *only* permitted
+  session card-order change.
+
+### Persistence scope (honest limitation)
+
+**Hide is session-local.** Hidden ids live in React state for the current People session only; they
+are **not** persisted to a database and reset on reload. No new table or migration was added for this
+phase. Durable, cross-session suggestion controls are **deferred** — a persistent "don't suggest this
+person again" preference is future work and would require a deliberate schema + ranking-contract
+decision.
+
+## Deferred safety controls (required before unrestricted public rollout)
+
+The following are **not** implemented and are **required before any open/public rollout**, because at
+public scale People can surface *strangers*, supports *following*, and carries *user-generated text*
+(profile names, list titles/notes):
+
+- **Block** — prevent a user from following or seeing you; mutual visibility cut-off.
+- **Report user / Report content** — abuse escalation for profiles, list text, etc.
+- **Mute** — suppress a user without blocking.
+- **Remove follower** — eject an existing follower.
+- **Disable incoming follows / private mode** — opt out of being followed at all.
+- A real moderation workflow + audit logging behind these controls.
+
+For the **private beta** (small, trusted cohort, explicit opt-in discovery), the session-local Hide
+plus the existing opt-in/opt-out discovery control is an acceptable minimum. This is a deliberate,
+scoped decision — not a claim of public-scale safety.
+
+## Privacy + consent boundary (unchanged by F8.4)
+
+- No cross-user behavioral data is reopened: raw history, ratings, reviews, and the full follow graph
+  remain closed (F8.2). Cross-user identity comes only from the narrow authenticated identity/search
+  RPCs (id/name/avatar), and taste comes only from the opt-in least-data fingerprint RPC.
+- **RLS is access control — not consent and not moderation.** Being technically able to read a row is
+  not the same as a user consenting to social exposure or to being contacted.
+- Users control whether they appear in taste-match discovery via **Account → "Appear in taste-match
+  discovery"** (explicit opt-in as of F8.2). Turning it off removes them from future discovery
+  derivations.
+
+## Summary
+
+For private beta: Follow is honest and settled, self-follow is impossible, and an unwanted suggestion
+can be hidden for the session. Block, Report, Mute, and Remove-follower — and durable Hide — are
+deliberately deferred and are prerequisites for unrestricted public social use.

--- a/src/features/people/People.jsx
+++ b/src/features/people/People.jsx
@@ -4,7 +4,7 @@
 // the internal Nav (AppShell owns nav). All follow/unfollow flows through
 // the provider's optimistic toggleFollow.
 
-import { useState, useMemo, useEffect } from 'react'
+import { useState, useMemo, useEffect, useRef, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { supabase } from '@/shared/lib/supabase/client'
 import { useAuthSession } from '@/shared/hooks/useAuthSession'
@@ -12,6 +12,7 @@ import { usePageMeta } from '@/shared/hooks/usePageMeta'
 import Eyebrow from '@/shared/ui/Eyebrow'
 import { HP, HP_GRAD } from './data'
 import { PeopleDataProvider, usePeopleData } from './usePeopleData'
+import { nextFocusId, scheduleFocus } from './hooks/usePeopleFollowActions'
 import './people.css'
 
 const RESET_BTN = { background: 'none', border: 'none', padding: 0, margin: 0, font: 'inherit', color: 'inherit', cursor: 'pointer', textAlign: 'left' }
@@ -135,14 +136,23 @@ function MatchBar({ pct, hex = '#A78BFA' }) {
   )
 }
 
-function FollowBtn({ following, onToggle, style }) {
+function FollowBtn({ id, following, pending, errored, name, onFollow, onUnfollow, style }) {
+  // Text reflects the SETTLED state: it never reads "Following" until the DB write succeeds.
+  const label = pending ? (following ? 'Unfollowing…' : 'Following…') : errored ? 'Try again' : following ? 'Following' : 'Follow'
   return (
     <button
       type="button"
-      onClick={onToggle}
-      aria-label={following ? 'Unfollow' : 'Follow'}
+      onClick={() => (following ? onUnfollow() : onFollow())}
+      disabled={pending}
+      aria-pressed={following}
+      aria-busy={pending}
+      aria-label={`${following ? 'Unfollow' : 'Follow'} ${name || 'this person'}`}
+      data-follow-target={id}
+      className="ff-people-followbtn"
       style={{
-        padding: '7px 14px',
+        minHeight: 44,
+        minWidth: 44,
+        padding: '0 16px',
         borderRadius: 999,
         background: following ? 'transparent' : HP_GRAD,
         border: following ? `1px solid ${HP.border}` : 'none',
@@ -152,18 +162,58 @@ function FollowBtn({ following, onToggle, style }) {
         fontWeight: 600,
         letterSpacing: '0.08em',
         textTransform: 'uppercase',
-        cursor: 'pointer',
+        cursor: pending ? 'wait' : 'pointer',
+        opacity: pending ? 0.7 : 1,
         ...style,
       }}
     >
-      {following ? 'Following' : 'Follow'}
+      {label}
     </button>
   )
 }
 
+// Quiet tertiary "Hide" on discovery cards. NOT a block: it only removes the suggestion from the
+// caller's current People session (no account change, no notification, no relationship/similarity change).
+function HideBtn({ onHide, name }) {
+  return (
+    <button
+      type="button"
+      onClick={onHide}
+      aria-label={`Hide ${name || 'this person'} from your suggestions`}
+      className="ff-people-hidebtn"
+      style={{ minHeight: 44, minWidth: 44, padding: '0 10px', background: 'transparent', border: 'none', color: HP.textMuted, fontFamily: 'Outfit', fontSize: 10, letterSpacing: '0.04em', cursor: 'pointer' }}
+    >
+      Hide
+    </button>
+  )
+}
+
+// Coordinates session-local hide + deterministic focus recovery for one rail of visible cards.
+// Returns a container ref (stamped on the rail's grid) + an onHide(id) handler.
+function useRailHide(visibleCards) {
+  const { hideSuggestion } = usePeopleData()
+  const containerRef = useRef(null)
+  const cancelFocus = useRef(null)
+  useEffect(() => () => { if (cancelFocus.current) cancelFocus.current() }, [])
+  const onHide = useCallback((id) => {
+    const nextId = nextFocusId(visibleCards.map(c => c.id), id)
+    hideSuggestion(id)
+    if (cancelFocus.current) cancelFocus.current()
+    cancelFocus.current = scheduleFocus(() => {
+      const c = containerRef.current
+      if (!c) return null
+      // focus the next card's Follow control (stable id, never name); else the rail container.
+      return (nextId && c.querySelector(`[data-follow-target="${nextId}"]`)) || c
+    })
+  }, [visibleCards, hideSuggestion])
+  return { containerRef, onHide }
+}
+
 function TwinsRail() {
-  const { twins, popular, toggleFollow, loading } = usePeopleData()
+  const { twins, popular, follow, unfollow, isPending, isErrored, isHidden, loading } = usePeopleData()
   const navigate = useNavigate()
+  const visibleTwins = twins.filter(p => !isHidden(p.id))
+  const { containerRef, onHide } = useRailHide(visibleTwins)
 
   return (
     <section className="ff-people-section ff-people-twins" style={{ padding: '24px 88px 56px' }}>
@@ -198,14 +248,14 @@ function TwinsRail() {
                   <button type="button" onClick={() => navigate('/people')} style={{ ...RESET_BTN, fontFamily: 'Outfit', fontSize: 15, fontWeight: 500, color: HP.text, display: 'block', width: '100%', textAlign: 'left' }}>{p.name}</button>
                   <div style={{ fontSize: 11, color: HP.textMuted, fontFamily: 'Outfit', marginTop: 2, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{p.bio}</div>
                 </div>
-                <FollowBtn following={false} onToggle={() => toggleFollow(p.id)} />
+                <FollowBtn id={p.id} following={false} pending={isPending(p.id)} errored={isErrored(p.id)} name={p.name} onFollow={() => follow(p.id, p.name)} onUnfollow={() => unfollow(p.id, p.name)} />
               </article>
             ))}
           </div>
         </>
       ) : (
-        <div className="ff-people-grid-4" style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 18 }}>
-          {twins.map(p => (
+        <div ref={containerRef} tabIndex={-1} className="ff-people-grid-4" style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 18, outline: 'none' }}>
+          {visibleTwins.map(p => (
             <article key={p.id} className="ff-people-twin-card" style={{ padding: '26px 24px', borderRadius: 8, background: 'rgba(255,255,255,0.025)', border: `1px solid ${HP.border}`, position: 'relative', overflow: 'hidden' }}>
               <div style={{ position: 'absolute', top: -30, right: -30, width: 120, height: 120, borderRadius: 999, background: `radial-gradient(circle, ${p.avatarBg}33, transparent 70%)`, filter: 'blur(8px)' }} />
               <div style={{ position: 'relative' }}>
@@ -226,9 +276,9 @@ function TwinsRail() {
                 </button>
                 <div style={{ fontSize: 11, color: HP.textMuted, fontFamily: 'Outfit', marginTop: 2 }}>{p.handle}</div>
                 {p.bio && <p style={{ margin: '12px 0 0 0', fontSize: 12, color: HP.textSoft, fontFamily: 'Outfit, Inter, sans-serif', lineHeight: 1.5 }}>{p.bio}</p>}
-                <div style={{ marginTop: 14, paddingTop: 14, borderTop: `1px solid ${HP.border}`, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10 }}>
-                  <div style={{ fontSize: 11, color: HP.textMuted, fontFamily: 'Outfit', fontStyle: 'italic' }}>{p.recent}</div>
-                  <FollowBtn following={p.following} onToggle={() => toggleFollow(p.id)} />
+                <div style={{ marginTop: 14, paddingTop: 14, borderTop: `1px solid ${HP.border}`, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 6 }}>
+                  {!p.following && <HideBtn onHide={() => onHide(p.id)} name={p.name} />}
+                  <FollowBtn id={p.id} following={p.following} pending={isPending(p.id)} errored={isErrored(p.id)} name={p.name} onFollow={() => follow(p.id, p.name)} onUnfollow={() => unfollow(p.id, p.name)} style={{ marginLeft: 'auto' }} />
                 </div>
               </div>
             </article>
@@ -262,9 +312,10 @@ function ColdStartHero() {
 }
 
 function Rising() {
-  const { rising, toggleFollow, loading } = usePeopleData()
+  const { rising, follow, unfollow, isPending, isErrored, isHidden, loading } = usePeopleData()
   const navigate = useNavigate()
-  if (!loading && rising.length === 0) return null
+  const visibleRising = rising.filter(p => !isHidden(p.id))
+  if (!loading && visibleRising.length === 0) return null
 
   return (
     <section className="ff-people-section ff-people-rising" style={{ padding: '48px 88px', borderTop: `1px solid ${HP.border}`, background: 'rgba(255,255,255,0.012)' }}>
@@ -275,7 +326,7 @@ function Rising() {
         </div>
       </div>
       <div className="ff-people-grid-3" style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 16 }}>
-        {rising.map(p => (
+        {visibleRising.map(p => (
           <div key={p.id} style={{ padding: '18px 20px', borderRadius: 6, background: 'rgba(255,255,255,0.025)', border: `1px solid ${HP.border}`, display: 'grid', gridTemplateColumns: 'auto 1fr auto', gap: 16, alignItems: 'center' }}>
             <Avatar url={p.avatarUrl} initial={p.initial} bg={p.avatarBg} size={42} onClick={() => navigate('/people')} alt={`View ${p.name}'s profile`} />
             <div style={{ minWidth: 0 }}>
@@ -290,7 +341,7 @@ function Rising() {
               {p.matchPresentation.qualified && <div style={{ marginTop: 8 }} aria-hidden="true"><MatchBar pct={p.match} hex={p.avatarBg} /></div>}
               <div style={{ marginTop: 6, fontSize: 10, color: HP.textMuted, fontFamily: 'Outfit', letterSpacing: '0.04em' }}>{p.matchPresentation.evidence || p.matchPresentation.band || p.matchPresentation.caption}</div>
             </div>
-            <FollowBtn following={p.following} onToggle={() => toggleFollow(p.id)} />
+            <FollowBtn id={p.id} following={p.following} pending={isPending(p.id)} errored={isErrored(p.id)} name={p.name} onFollow={() => follow(p.id, p.name)} onUnfollow={() => unfollow(p.id, p.name)} />
           </div>
         ))}
       </div>
@@ -372,9 +423,11 @@ function CrewOverlap() {
 }
 
 function Suggested() {
-  const { suggested, toggleFollow, loading } = usePeopleData()
+  const { suggested, follow, unfollow, isPending, isErrored, isHidden, loading } = usePeopleData()
   const navigate = useNavigate()
-  if (!loading && suggested.length === 0) return null
+  const visibleSuggested = suggested.filter(p => !isHidden(p.id))
+  const { containerRef, onHide } = useRailHide(visibleSuggested)
+  if (!loading && visibleSuggested.length === 0) return null
 
   return (
     <section className="ff-people-section ff-people-suggested" style={{ padding: '56px 88px', borderTop: `1px solid ${HP.border}` }}>
@@ -382,8 +435,8 @@ function Suggested() {
         <Eyebrow size={10} style={{ marginBottom: 12 }}>Suggested</Eyebrow>
         <h2 className="ff-people-h2-sm" style={{ fontFamily: 'Outfit', fontSize: 30, lineHeight: 1, fontWeight: 500, letterSpacing: '-0.03em', color: HP.text, margin: 0 }}>People you <em style={{ fontStyle: 'italic', fontWeight: 400, color: HP.textSoft }}>might know.</em></h2>
       </div>
-      <div className="ff-people-grid-3" style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 16 }}>
-        {suggested.map(p => (
+      <div ref={containerRef} tabIndex={-1} className="ff-people-grid-3" style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 16, outline: 'none' }}>
+        {visibleSuggested.map(p => (
           <div key={p.id} style={{ padding: '18px 20px', borderRadius: 6, background: 'rgba(255,255,255,0.025)', border: `1px solid ${HP.border}`, display: 'grid', gridTemplateColumns: 'auto 1fr auto', gap: 16, alignItems: 'center' }}>
             <Avatar url={p.avatarUrl} initial={p.initial} bg={p.avatarBg} size={42} onClick={() => navigate('/people')} alt={`View ${p.name}'s profile`} />
             <div style={{ minWidth: 0 }}>
@@ -400,7 +453,10 @@ function Suggested() {
                   : <>{p.matchPresentation?.evidence || p.matchPresentation?.band || p.matchPresentation?.caption || 'Suggested for you'}</>}
               </div>
             </div>
-            <FollowBtn following={false} onToggle={() => toggleFollow(p.id)} />
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'flex-end' }}>
+              <FollowBtn id={p.id} following={false} pending={isPending(p.id)} errored={isErrored(p.id)} name={p.name} onFollow={() => follow(p.id, p.name)} onUnfollow={() => unfollow(p.id, p.name)} />
+              <HideBtn onHide={() => onHide(p.id)} name={p.name} />
+            </div>
           </div>
         ))}
       </div>
@@ -410,7 +466,7 @@ function Suggested() {
 
 function SearchResults({ results, loading, onClear }) {
   const navigate = useNavigate()
-  const { followingIds, toggleFollow } = usePeopleData()
+  const { followingIds, follow, unfollow, isPending, isErrored } = usePeopleData()
   return (
     <section className="ff-people-section ff-people-search-results" style={{ padding: '24px 88px 56px' }}>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 24 }}>
@@ -439,7 +495,7 @@ function SearchResults({ results, loading, onClear }) {
                 </button>
                 <div style={{ fontSize: 11, color: HP.textMuted, fontFamily: 'Outfit', marginTop: 2 }}>{u.handle}</div>
               </div>
-              <FollowBtn following={followingIds.has(u.id)} onToggle={() => toggleFollow(u.id)} />
+              <FollowBtn id={u.id} following={followingIds.has(u.id)} pending={isPending(u.id)} errored={isErrored(u.id)} name={u.name} onFollow={() => follow(u.id, u.name)} onUnfollow={() => unfollow(u.id, u.name)} />
             </div>
           ))}
         </div>
@@ -471,6 +527,7 @@ function PeopleV2Body() {
   const [results, setResults] = useState([])
   const [searching, setSearching] = useState(false)
   const { user: authUser } = useAuthSession()
+  const { relStatus } = usePeopleData()
 
   // Debounce 300ms
   useEffect(() => {
@@ -523,6 +580,9 @@ function PeopleV2Body() {
 
   return (
     <div className="ff-people-v2" style={{ minHeight: '100vh', background: HP.bgDeep, color: HP.text, fontFamily: 'Inter, sans-serif' }}>
+      {/* F8.4: single persistent People relationship-status live region — settlement-driven; never
+          announces raw backend text, percentages, or relationship state on unrelated rerenders. */}
+      <div role="status" aria-live="polite" aria-atomic="true" style={{ position: 'absolute', width: 1, height: 1, padding: 0, margin: -1, overflow: 'hidden', clip: 'rect(0,0,0,0)', whiteSpace: 'nowrap', border: 0 }}>{relStatus}</div>
       <div style={{ maxWidth: 1440, margin: '0 auto' }}>
         <Masthead query={query} setQuery={setQuery} onSearch={setQuery} />
         {hasQuery ? (

--- a/src/features/people/__tests__/PeopleProjectionPrivacy.test.jsx
+++ b/src/features/people/__tests__/PeopleProjectionPrivacy.test.jsx
@@ -120,10 +120,47 @@ describe('F8.3 — taste-match trust + de-precision (no friendship, no exact %)'
   })
 
   it('the only relationship label is the one-way follow (Follow / Following), never friend', () => {
-    expect(peopleJsxSource).toMatch(/aria-label=\{following \? 'Unfollow' : 'Follow'\}/)
+    // F8.4: the follow control's accessible name is "Follow|Unfollow {name}" — never "friend"
+    expect(peopleJsxSource).toMatch(/following \? 'Unfollow' : 'Follow'/)
+    expect(peopleJsxSource).toMatch(/following \? 'Following' : 'Follow'/) // visible label
   })
 
   it('MatchBar is decorative (aria-hidden) and only shown when the match is evidence-qualified', () => {
     expect(peopleJsxSource).toMatch(/qualified &&[\s\S]{0,80}aria-hidden="true"[\s\S]{0,40}MatchBar/)
+  })
+})
+
+describe('F8.4 — settled follow, button semantics, live region, Hide suggestion', () => {
+  it('no optimistic relationship swap: the provider has no toggleFollow / pre-write state flip', () => {
+    expect(peopleSource).not.toContain('toggleFollow')
+    expect(peopleSource).not.toMatch(/Optimistic UI swap/)
+    expect(peopleSource).toContain('applyFollowState')          // state flips only after settled success
+    expect(peopleSource).toContain('usePeopleFollowActions')
+  })
+
+  it('the follow control exposes aria-pressed, aria-busy, disabled-while-pending, a named label and a 44px target', () => {
+    expect(peopleJsxSource).toMatch(/aria-pressed=\{following\}/)
+    expect(peopleJsxSource).toMatch(/aria-busy=\{pending\}/)
+    expect(peopleJsxSource).toMatch(/disabled=\{pending\}/)
+    expect(peopleJsxSource).toMatch(/aria-label=\{`\$\{following \? 'Unfollow' : 'Follow'\} \$\{name/)
+    expect(peopleJsxSource).toMatch(/minHeight: 44/)
+    // settled, text-based feedback (no spinner-only): Following… / Unfollowing… / Try again
+    expect(peopleJsxSource).toMatch(/Following…|Unfollowing…/)
+    expect(peopleJsxSource).toContain("'Try again'")
+  })
+
+  it('exactly one persistent People status live region (role=status, polite, atomic) bound to relStatus', () => {
+    const regions = peopleJsxSource.match(/role="status"/g) || []
+    expect(regions).toHaveLength(1)
+    expect(peopleJsxSource).toMatch(/role="status"[\s\S]{0,80}aria-live="polite"[\s\S]{0,40}aria-atomic="true"/)
+    expect(peopleJsxSource).toMatch(/>\{relStatus\}</)
+  })
+
+  it('Hide suggestion is a named, 44px control shown only on non-followed discovery cards, with focus recovery', () => {
+    expect(peopleJsxSource).toMatch(/aria-label=\{`Hide \$\{name/)
+    expect(peopleJsxSource).toMatch(/!p\.following && <HideBtn/)        // gated on NOT following
+    expect(peopleJsxSource).toContain('nextFocusId')                   // focus-after-removal
+    expect(peopleJsxSource).toContain('scheduleFocus')
+    expect(peopleJsxSource).toMatch(/className="ff-people-hidebtn"[\s\S]{0,120}minHeight: 44/)
   })
 })

--- a/src/features/people/hooks/__tests__/usePeopleFollowActions.test.js
+++ b/src/features/people/hooks/__tests__/usePeopleFollowActions.test.js
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+
+// F8.4 — settled follow/unfollow: no relationship state is confirmed until the DB write succeeds;
+// 23505 (already following) is idempotent success; duplicate clicks collapse to one write; self is
+// rejected; Hide is session-local and never calls Supabase.
+
+let insertResult, deleteResult, insertPayloads, deleteFilters, insertDelayMs
+function makeInsert(payload) {
+  insertPayloads.push(payload)
+  return new Promise(res => { (insertDelayMs ? setTimeout : (f) => f())(() => res(insertResult), insertDelayMs) })
+}
+function makeDelete() {
+  const filt = {}
+  const chain = {
+    eq: (col, val) => { filt[col] = val; return chain },
+    then: (res, rej) => { deleteFilters.push(filt); return Promise.resolve(deleteResult).then(res, rej) },
+  }
+  return chain
+}
+vi.mock('@/shared/lib/supabase/client', () => ({
+  supabase: { from: () => ({ insert: (p) => makeInsert(p), delete: () => makeDelete() }) },
+}))
+
+import { usePeopleFollowActions, nextFocusId } from '../usePeopleFollowActions'
+
+const ME = 'me'
+function setup({ followingIds = new Set() } = {}) {
+  const applyFollowState = vi.fn()
+  const view = renderHook(({ ids }) => usePeopleFollowActions({ userId: ME, followingIds: ids, applyFollowState }), {
+    initialProps: { ids: followingIds },
+  })
+  return { ...view, applyFollowState }
+}
+
+beforeEach(() => {
+  insertResult = { error: null }; deleteResult = { error: null }
+  insertPayloads = []; deleteFilters = []; insertDelayMs = 0
+})
+
+describe('F8.4 follow settlement', () => {
+  it('success: ONE insert with the exact payload, settled Following + one announcement', async () => {
+    const { result, applyFollowState } = setup()
+    await act(async () => { await result.current.follow('B', 'Bob') })
+    expect(insertPayloads).toEqual([{ follower_id: ME, following_id: 'B' }])      // exact payload preserved
+    expect(applyFollowState).toHaveBeenCalledWith('B', true)                      // state flips only on success
+    expect(result.current.relStatus).toContain("You're now following Bob.")
+    expect(result.current.isPending('B')).toBe(false)
+  })
+
+  it('failure: resolved { error } → NOT Following, retry possible, no backend text announced', async () => {
+    insertResult = { error: { code: '42501', message: 'permission denied for table user_follows' } }
+    const { result, applyFollowState } = setup()
+    await act(async () => { await result.current.follow('B', 'Bob') })
+    expect(applyFollowState).not.toHaveBeenCalled()
+    expect(result.current.relStatus).toContain('Could not follow Bob. Try again.')
+    expect(result.current.relStatus).not.toMatch(/permission denied|42501/)
+    expect(result.current.isErrored('B')).toBe(true)
+    expect(result.current.isPending('B')).toBe(false)
+  })
+
+  it('duplicate-key 23505 is idempotent SUCCESS (already following), never a false failure', async () => {
+    insertResult = { error: { code: '23505', message: 'duplicate key' } }
+    const { result, applyFollowState } = setup()
+    await act(async () => { await result.current.follow('B', 'Bob') })
+    expect(applyFollowState).toHaveBeenCalledWith('B', true)
+    expect(result.current.relStatus).toContain("You're now following Bob.")
+    expect(result.current.isErrored('B')).toBe(false)
+  })
+
+  it('already-following → no-op (no insert)', async () => {
+    const { result } = setup({ followingIds: new Set(['B']) })
+    await act(async () => { await result.current.follow('B', 'Bob') })
+    expect(insertPayloads).toEqual([])
+  })
+})
+
+describe('F8.4 unfollow settlement', () => {
+  it('success: exact DELETE filters, state flips only after success, one announcement', async () => {
+    const { result, applyFollowState } = setup({ followingIds: new Set(['B']) })
+    await act(async () => { await result.current.unfollow('B', 'Bob') })
+    expect(deleteFilters).toEqual([{ follower_id: ME, following_id: 'B' }])       // exact filters preserved
+    expect(applyFollowState).toHaveBeenCalledWith('B', false)
+    expect(result.current.relStatus).toContain('You stopped following Bob.')
+  })
+
+  it('failure: keeps Following, one failure announcement, no backend text', async () => {
+    deleteResult = { error: { code: 'XX', message: 'boom' } }
+    const { result, applyFollowState } = setup({ followingIds: new Set(['B']) })
+    await act(async () => { await result.current.unfollow('B', 'Bob') })
+    expect(applyFollowState).not.toHaveBeenCalled()
+    expect(result.current.relStatus).toContain('Could not unfollow Bob. Try again.')
+    expect(result.current.relStatus).not.toMatch(/boom/)
+  })
+})
+
+describe('F8.4 concurrency + self-follow', () => {
+  it('rapid duplicate follow clicks → ONE request', async () => {
+    insertDelayMs = 20
+    const { result } = setup()
+    await act(async () => { await Promise.all([result.current.follow('B', 'Bob'), result.current.follow('B', 'Bob'), result.current.follow('B', 'Bob')]) })
+    expect(insertPayloads).toHaveLength(1)
+  })
+
+  it('a pending request for A does NOT block an action for B', async () => {
+    insertDelayMs = 30
+    const { result } = setup()
+    await act(async () => { await Promise.all([result.current.follow('A', 'Ann'), result.current.follow('B', 'Bob')]) })
+    expect(insertPayloads.map(p => p.following_id).sort()).toEqual(['A', 'B'])
+  })
+
+  it('self-follow is rejected: zero write, no announcement', async () => {
+    const { result, applyFollowState } = setup()
+    await act(async () => { await result.current.follow(ME, 'Me') })
+    expect(insertPayloads).toEqual([])
+    expect(applyFollowState).not.toHaveBeenCalled()
+    expect(result.current.relStatus).toBe('')
+  })
+
+  it('late completion after unmount does not throw / update state', async () => {
+    insertDelayMs = 40
+    const { result, unmount } = setup()
+    let p
+    act(() => { p = result.current.follow('B', 'Bob') })
+    unmount()
+    await act(async () => { await p })   // resolves after unmount — must be a safe no-op
+  })
+})
+
+describe('F8.4 Hide suggestion (session-local, not a block)', () => {
+  it('hides only the selected id, announces, and calls NO Supabase write', async () => {
+    const { result } = setup()
+    act(() => { result.current.hideSuggestion('B') })
+    expect(result.current.isHidden('B')).toBe(true)
+    expect(result.current.isHidden('C')).toBe(false)
+    expect(result.current.relStatus).toContain('Hidden from your suggestions.')
+    expect(insertPayloads).toEqual([])
+    expect(deleteFilters).toEqual([])
+  })
+})
+
+describe('F8.4 nextFocusId (focus-after-removal)', () => {
+  it('prefers next, then previous, then null', () => {
+    expect(nextFocusId(['a', 'b', 'c'], 'a')).toBe('b')
+    expect(nextFocusId(['a', 'b', 'c'], 'c')).toBe('b')   // last → previous
+    expect(nextFocusId(['a'], 'a')).toBeNull()            // only → null (fallback)
+    expect(nextFocusId(['a', 'b'], 'z')).toBeNull()       // not present
+    expect(nextFocusId(null, 'a')).toBeNull()
+  })
+})
+
+// keep waitFor imported for parity with the suite's async style
+void waitFor

--- a/src/features/people/hooks/usePeopleFollowActions.js
+++ b/src/features/people/hooks/usePeopleFollowActions.js
@@ -1,0 +1,128 @@
+// usePeopleFollowActions.js — F8.4 settled, honest, duplicate-resistant follow/unfollow + the
+// minimum private-beta safety affordance (session-local Hide suggestion). NO relationship state is
+// confirmed until the database write succeeds (the same honesty standard as Film File / Home /
+// Library). It owns per-target pending/error state, a duplicate-request guard, the settled writes
+// (the EXACT existing user_follows INSERT/DELETE payloads + filters — unchanged), the live-region
+// message, and the session-local hidden-suggestion set. It does NOT own ranking or candidate
+// derivation (the provider keeps the data load); it only flips follow state via `applyFollowState`
+// AFTER a write settles.
+//
+// 23505 (unique_violation) on a follow INSERT means the (follower_id, following_id) row already
+// exists — the relationship the user wanted is present — so it is treated as idempotent SUCCESS,
+// never a false failure.
+
+import { useState, useRef, useCallback, useEffect } from 'react'
+import { supabase } from '@/shared/lib/supabase/client'
+
+// ── pure focus-after-removal (People-local; neutral, kept out of Library to avoid coupling) ──────
+// The id to focus after `removedId` leaves `orderedIds`: prefer the NEXT, else PREVIOUS, else null.
+export function nextFocusId(orderedIds, removedId) {
+  if (!Array.isArray(orderedIds)) return null
+  const i = orderedIds.indexOf(removedId)
+  if (i === -1) return null
+  if (i + 1 < orderedIds.length) return orderedIds[i + 1]
+  if (i - 1 >= 0) return orderedIds[i - 1]
+  return null
+}
+// Schedule focus after the DOM settles (double rAF). `getEl` runs at fire time (post-removal DOM);
+// never focuses <body> or a non-focusable node. Returns a cancel fn (call on unmount / before re-scheduling).
+export function scheduleFocus(getEl, { raf } = {}) {
+  const schedule = raf || ((cb) => requestAnimationFrame(cb))
+  let cancelled = false
+  schedule(() => schedule(() => {
+    if (cancelled) return
+    const el = typeof getEl === 'function' ? getEl() : getEl
+    const body = typeof document !== 'undefined' ? document.body : null
+    if (el && el !== body && typeof el.focus === 'function') el.focus()
+  }))
+  return () => { cancelled = true }
+}
+
+export function usePeopleFollowActions({ userId, followingIds, applyFollowState }) {
+  const [pending, setPending] = useState(() => new Set()) // target ids with a write in flight
+  const [errored, setErrored] = useState(() => new Set()) // target ids whose last action failed
+  const [hidden, setHidden] = useState(() => new Set())   // session-hidden suggestion ids
+  const [relStatus, setRelStatus] = useState('')          // live-region text (settlement-driven)
+
+  const inFlight = useRef(new Set())                       // synchronous per-target duplicate guard
+  const announceSeq = useRef(0)
+  const mounted = useRef(true)
+  useEffect(() => { mounted.current = true; return () => { mounted.current = false } }, [])
+
+  // Re-announce even identical consecutive messages by toggling a trailing zero-width space, so a
+  // repeated follow/failure is still spoken. Never includes raw backend text or percentages.
+  const announce = useCallback((msg) => {
+    if (!mounted.current) return
+    announceSeq.current += 1
+    setRelStatus(msg + '​'.repeat(announceSeq.current % 2))
+  }, [])
+
+  const mark = useCallback((setter, id, on) => {
+    setter(prev => {
+      if (on === prev.has(id)) return prev
+      const next = new Set(prev)
+      if (on) next.add(id); else next.delete(id)
+      return next
+    })
+  }, [])
+
+  const follow = useCallback(async (targetId, name) => {
+    if (!userId || !targetId || targetId === userId) return   // self-follow guard (defence in depth)
+    if (inFlight.current.has(targetId)) return                // duplicate / overlap guard
+    if (followingIds.has(targetId)) return                    // already following — no-op
+    inFlight.current.add(targetId)
+    mark(setErrored, targetId, false)
+    mark(setPending, targetId, true)
+    try {
+      const { error } = await supabase
+        .from('user_follows')
+        .insert({ follower_id: userId, following_id: targetId })
+      if (error && error.code !== '23505') throw error        // 23505 = already following → success
+      if (mounted.current) { applyFollowState(targetId, true); announce(`You're now following ${name || 'this person'}.`) }
+    } catch (e) {
+      if (import.meta.env?.DEV) console.error('[people.follow]', e)
+      if (mounted.current) { mark(setErrored, targetId, true); announce(`Could not follow ${name || 'this person'}. Try again.`) }
+    } finally {
+      inFlight.current.delete(targetId)
+      mark(setPending, targetId, false)
+    }
+  }, [userId, followingIds, applyFollowState, announce, mark])
+
+  const unfollow = useCallback(async (targetId, name) => {
+    if (!userId || !targetId) return
+    if (inFlight.current.has(targetId)) return
+    if (!followingIds.has(targetId)) return                   // not following — no-op
+    inFlight.current.add(targetId)
+    mark(setErrored, targetId, false)
+    mark(setPending, targetId, true)
+    try {
+      const { error } = await supabase
+        .from('user_follows')
+        .delete()
+        .eq('follower_id', userId)
+        .eq('following_id', targetId)
+      if (error) throw error
+      if (mounted.current) { applyFollowState(targetId, false); announce(`You stopped following ${name || 'this person'}.`) }
+    } catch (e) {
+      if (import.meta.env?.DEV) console.error('[people.unfollow]', e)
+      if (mounted.current) { mark(setErrored, targetId, true); announce(`Could not unfollow ${name || 'this person'}. Try again.`) }
+    } finally {
+      inFlight.current.delete(targetId)
+      mark(setPending, targetId, false)
+    }
+  }, [userId, followingIds, applyFollowState, announce, mark])
+
+  // Session-local removal of an unwanted discovery suggestion. NOT a block: it touches no other
+  // account, persists nothing, and changes no relationship or similarity value.
+  const hideSuggestion = useCallback((targetId) => {
+    if (!targetId) return
+    mark(setHidden, targetId, true)
+    announce('Hidden from your suggestions.')
+  }, [announce, mark])
+
+  const isPending = useCallback((id) => pending.has(id), [pending])
+  const isErrored = useCallback((id) => errored.has(id), [errored])
+  const isHidden = useCallback((id) => hidden.has(id), [hidden])
+
+  return { follow, unfollow, hideSuggestion, isPending, isErrored, isHidden, relStatus, hidden }
+}

--- a/src/features/people/people.css
+++ b/src/features/people/people.css
@@ -93,3 +93,12 @@
     text-align: left !important;
   }
 }
+
+/* F8.4 — visible focus ring for the follow / hide controls (keyboard + AT) */
+.ff-people-followbtn:focus-visible,
+.ff-people-hidebtn:focus-visible {
+  outline: 2px solid #A78BFA;
+  outline-offset: 2px;
+  border-radius: 999px;
+}
+.ff-people-hidebtn:hover { color: rgba(250, 250, 250, 0.85); }

--- a/src/features/people/usePeopleData.jsx
+++ b/src/features/people/usePeopleData.jsx
@@ -8,6 +8,7 @@
 import { createContext, useContext, useEffect, useMemo, useState, useCallback } from 'react'
 import { supabase } from '@/shared/lib/supabase/client'
 import { deriveTasteMatchPresentation } from './derive/peoplePresentation'
+import { usePeopleFollowActions } from './hooks/usePeopleFollowActions'
 import { useAuthSession } from '@/shared/hooks/useAuthSession'
 
 const PeopleDataContext = createContext(null)
@@ -725,57 +726,29 @@ export function PeopleDataProvider({ children }) {
   }, [load])
 
   // === Follow / unfollow with optimistic update ===
-  const toggleFollow = useCallback(async (targetId) => {
-    if (!userId || !targetId || targetId === userId) return
-    const wasFollowing = state.followingIds.has(targetId)
-
-    // Optimistic UI swap
+  // F8.4: settled follow state — applied ONLY after a write succeeds (never optimistic). The action
+  // layer (usePeopleFollowActions) owns the user_follows writes (EXACT existing payloads/filters) +
+  // per-target pending/error + announcements + the session-local Hide suggestion; the provider just
+  // flips the server-backed state on settled success. No optimistic swap, no silent revert.
+  const applyFollowState = useCallback((targetId, isFollowing) => {
     setState(s => {
+      const had = s.followingIds.has(targetId)
+      if (had === isFollowing) return s
       const next = new Set(s.followingIds)
-      if (wasFollowing) next.delete(targetId)
-      else next.add(targetId)
+      if (isFollowing) next.add(targetId); else next.delete(targetId)
       return {
         ...s,
         followingIds: next,
-        twins: s.twins.map(p => p.id === targetId ? { ...p, following: !wasFollowing } : p),
-        rising: s.rising.map(p => p.id === targetId ? { ...p, following: !wasFollowing } : p),
-        user: { ...s.user, following: s.user.following + (wasFollowing ? -1 : 1) },
+        twins: s.twins.map(p => p.id === targetId ? { ...p, following: isFollowing } : p),
+        rising: s.rising.map(p => p.id === targetId ? { ...p, following: isFollowing } : p),
+        user: { ...s.user, following: Math.max(0, s.user.following + (isFollowing ? 1 : -1)) },
       }
     })
+  }, [])
 
-    try {
-      if (wasFollowing) {
-        const { error } = await supabase
-          .from('user_follows')
-          .delete()
-          .eq('follower_id', userId)
-          .eq('following_id', targetId)
-        if (error) throw error
-      } else {
-        const { error } = await supabase
-          .from('user_follows')
-          .insert({ follower_id: userId, following_id: targetId })
-        if (error) throw error
-      }
-    } catch (e) {
-      console.error('[usePeopleData.toggleFollow]', e)
-      // Revert
-      setState(s => {
-        const next = new Set(s.followingIds)
-        if (wasFollowing) next.add(targetId)
-        else next.delete(targetId)
-        return {
-          ...s,
-          followingIds: next,
-          twins: s.twins.map(p => p.id === targetId ? { ...p, following: wasFollowing } : p),
-          rising: s.rising.map(p => p.id === targetId ? { ...p, following: wasFollowing } : p),
-          user: { ...s.user, following: s.user.following + (wasFollowing ? 1 : -1) },
-        }
-      })
-    }
-  }, [userId, state.followingIds])
+  const followActions = usePeopleFollowActions({ userId, followingIds: state.followingIds, applyFollowState })
 
-  const value = useMemo(() => ({ ...state, toggleFollow }), [state, toggleFollow])
+  const value = useMemo(() => ({ ...state, ...followActions }), [state, followActions])
   return <PeopleDataContext.Provider value={value}>{children}</PeopleDataContext.Provider>
 }
 


### PR DESCRIPTION
**F8.4 — Harden People follow actions and beta safety.** Reliability + presentation only: **no** database, RPC, RLS, consent, ranking, candidate-set, follow-payload, or similarity change.

## Previous optimistic failure mode
`toggleFollow` swapped the UI to "Following" **before** the `user_follows` write, reverted silently on error (no announcement, no retry), had no per-target pending/duplicate guard, no `aria-pressed`/`aria-busy`, no live region, and treated a duplicate-key `23505` as a **false failure**.

## Settled follow/unfollow model
New `usePeopleFollowActions` hook owns the writes + per-target pending/error + announcements + the session-local hidden set; the provider's `applyFollowState` flips the server-backed follow state **only after a write settles** (no optimistic swap, no silent revert).
- **Follow:** self-guard → duplicate/overlap guard → already-following no-op → pending → the **exact existing** INSERT `{follower_id, following_id}` → inspect resolved `{error}`; **`23505` = idempotent success**; flip + announce *"You're now following {name}."* only on success; on failure keep prior state + *"Could not follow {name}. Try again."*
- **Unfollow:** the **exact existing** DELETE `.eq(follower_id).eq(following_id)`; flip + *"You stopped following {name}."* on success; keep Following + *"Could not unfollow {name}. Try again."* on failure.

## Duplicate-request + self-follow protection
A synchronous per-target `inFlight` ref collapses rapid clicks to **one** write; a pending A doesn't block B; follow/unfollow can't overlap for the same target; a `mountedRef` ignores late completions after unmount; pending always clears. Self-follow is rejected in depth: self is excluded from candidate sets **and** the hook rejects a self target before any write (zero INSERT, no announcement).

## Live-region + button semantics
**One** persistent visually-hidden status region (`role=status`, `aria-live=polite`, `aria-atomic`) bound to `relStatus` — settlement-driven, re-announceable, never raw backend text/percentages/unrelated rerenders. The follow control exposes `aria-pressed={following}`, `aria-busy={pending}`, `disabled` while pending, an accessible name *"Follow|Unfollow {name}"*, a **44×44** target, a `:focus-visible` ring, and text-based settled states (Follow / Following / Following… / Unfollowing… / Try again) — no spinner-only, not colour-only; semantically separate from the taste-match band.

## Hide suggestion + whether it persists
A quiet tertiary **Hide** on non-followed discovery cards (twins + suggested): removes the suggestion from the caller's **current session only**, announces *"Hidden from your suggestions."*, touches no other account/notification/discoverability/relationship/similarity, and calls **no Supabase**. **Session-local** (React state, resets on reload) — **not a block**; durable controls deferred. Hiding is the only permitted session card-order change.

## Focus behavior
People-local `nextFocusId` + `scheduleFocus` (replicated, neutral — kept out of the frozen Library to avoid coupling) move focus to the next card's Follow control (by stable id, never name), else the rail container; cancelled on unmount; `<body>` never targeted. Follow/unfollow itself does not move focus.

## Private-beta safety decision
`docs/people/private-beta-safety-f84.md`: Follow is one-way/revocable; **Hide ≠ Block**; Hide is session-local; **Block/Report/Mute/Remove-follower are deferred and required before public rollout**; no cross-user behavioral data reopened; **RLS ≠ consent/moderation**; beta assumes a small trusted cohort; opt-out via Account.

## Payloads + RLS unchanged
The `user_follows` INSERT/DELETE payloads + filters are **byte-unchanged**; F8.2 RLS + identity/search/FOF RPCs + opt-in, F8.3 maturity/bands/evidence, `overall_similarity`, candidate ranking + rail order (only session-hide filters the rendered set) are all untouched. No migration, no RPC/RLS change.

## Tests + validation
+16 (full **1423**): hook (12) — follow success/failure/`23505`/already-following, unfollow success/failure, rapid-dup→one request, A-pending-doesn't-block-B, self-follow rejected, late-completion-after-unmount safe, Hide session-local + no Supabase, `nextFocusId`; People source (4) — no optimistic swap / `applyFollowState`, FollowBtn `aria-pressed`+`aria-busy`+`disabled`+named+44px+settled states, exactly one `relStatus` live region, Hide named+44px+gated-on-`!following`+focus recovery. lint clean · people **44 ×3** · full **1423** · build ✓.

## No live social action
No DB/migration; no live `/people` opened; no follow/unfollow/hide on live data; no discoverability toggle; no user row mutated. Mocked Supabase/auth in tests. F8.2 privacy + F8.3 trust tests remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
