### PR TITLE
Lock down scheduler security functions

### DIFF
--- a/scripts/verify-scheduler-security-functions.sql
+++ b/scripts/verify-scheduler-security-functions.sql
@@ -1,0 +1,59 @@
+-- verify-scheduler-security-functions.sql  (F8.6-SEC)
+--
+-- READ-ONLY verification that the scheduler / diagnostic SECURITY DEFINER functions are no
+-- longer browser-executable. This script NEVER executes get_cron_secret() or
+-- list_daily_briefing_subscribers() (or any secret/PII function) — it checks the catalog and
+-- privilege state only. Safe to run against production; returns no secret or email values.
+--
+-- Run with the Supabase SQL editor or psql. Expected results are noted inline.
+
+-- (1) EXECUTE privileges per role for every touched function.
+--   Expected:
+--     get_cron_secret / list_daily_briefing_subscribers / database_health_check / check_* /
+--       handle_new_auth_user  -> anon=f, authenticated=f, service_role=t
+--     request_account_deletion / cancel_account_deletion -> anon=f, authenticated=t, service_role=t
+--     increment_session_interactions (intentionally left) -> anon=t (residual backlog)
+select
+  'public.' || p.proname || '(' || pg_get_function_identity_arguments(p.oid) || ')' as fn_sig,
+  p.prosecdef                                              as security_definer,
+  pg_get_userbyid(p.proowner)                              as owner,
+  p.proconfig                                              as config,
+  has_function_privilege('anon',          p.oid, 'EXECUTE') as anon_exec,
+  has_function_privilege('authenticated', p.oid, 'EXECUTE') as auth_exec,
+  has_function_privilege('service_role',  p.oid, 'EXECUTE') as service_exec,
+  -- explicit PUBLIC grant still present? expected 0 for every locked-down function
+  (select count(*) from aclexplode(p.proacl) a where a.grantee = 0) as public_grants
+from pg_proc p
+join pg_namespace n on n.oid = p.pronamespace
+where n.nspname = 'public'
+  and p.proname in (
+    'get_cron_secret','list_daily_briefing_subscribers',
+    'database_health_check','check_foreign_keys','check_indexes','check_unique_constraints',
+    'check_duplicate_feedback','check_duplicate_ratings','check_invalid_watchlist_statuses',
+    'handle_new_auth_user','request_account_deletion','cancel_account_deletion',
+    'increment_session_interactions'
+  )
+order by p.proname;
+
+-- (2) Hard assertion: NO browser role may execute the two P0 functions.
+--   Expected: zero rows.
+select 'P0 STILL BROWSER-EXECUTABLE: ' || p.proname as violation
+from pg_proc p
+join pg_namespace n on n.oid = p.pronamespace
+where n.nspname = 'public'
+  and p.proname in ('get_cron_secret','list_daily_briefing_subscribers')
+  and (has_function_privilege('anon', p.oid, 'EXECUTE')
+       or has_function_privilege('authenticated', p.oid, 'EXECUTE'));
+
+-- (3) Hard assertion: the cron pipeline can still run.
+--   service_role must execute both P0 functions (the edge-function bridge), and the
+--   postgres owner always can. Expected: both true.
+select
+  has_function_privilege('service_role', 'public.get_cron_secret()', 'EXECUTE')                 as svc_can_read_secret,
+  has_function_privilege('service_role', 'public.list_daily_briefing_subscribers()', 'EXECUTE') as svc_can_list_subscribers;
+
+-- (4) cron jobs unchanged + run as the postgres owner (read-only).
+select jobid, jobname, schedule, username from cron.job order by jobid;
+
+-- NOTE: advisor confirmation is out-of-band — re-run get_advisors(security) and confirm the
+-- `anon_security_definer_function_executable` findings for the functions above are cleared.

--- a/supabase/migrations/20260610120000_lock_down_scheduler_security_functions.sql
+++ b/supabase/migrations/20260610120000_lock_down_scheduler_security_functions.sql
@@ -1,0 +1,68 @@
+-- Migration: lock down scheduler / diagnostic SECURITY DEFINER functions (F8.6-SEC)
+--
+-- The F8.6 audit found, via live advisor + grant inspection, that several public
+-- SECURITY DEFINER functions were EXECUTE-able by the browser roles (anon + authenticated)
+-- through PostgREST /rest/v1/rpc. Two were P0:
+--
+--   * public.get_cron_secret()                  — reads the vault `cron_secret` and returned
+--                                                 it to anyone holding the public anon key.
+--   * public.list_daily_briefing_subscribers()  — returned every briefing subscriber's email.
+--
+-- These objects exist in the live database but were created out-of-band (not previously
+-- tracked in repo migrations). This migration brings their grants back under migration
+-- control (the function bodies remain untracked — a follow-up should CREATE OR REPLACE them
+-- into source to fully close the drift).
+--
+-- Legitimate callers are the `postgres` owner (pg_cron jobs 1-3) and the SERVICE ROLE bridge
+-- used by the `send-daily-briefings` + `process-account-deletions` edge functions, both of
+-- which call get_cron_secret()/list_daily_briefing_subscribers() with the service role.
+-- Neither needs anon/authenticated EXECUTE. Revoking it does NOT affect the cron pipeline:
+-- the jobs run as `postgres` (the owner), which executes regardless of grants.
+--
+-- Also closes anon/authenticated EXECUTE on DBA-only diagnostic functions (verified: zero
+-- callers in app source), keeps the auth trigger function off the REST surface, and drops
+-- the pointless anon grant on the two AUTHENTICATED account-deletion RPCs.
+--
+-- NOT touched: public.increment_session_interactions(uuid) — a browser-called pre-auth
+-- session counter that legitimately needs anon (residual backlog: tighten only if it can be
+-- proven authenticated-only). The vault `cron_secret` is rotated out-of-band after this
+-- migration (vault-only — both edge functions read it via the get_cron_secret() RPC).
+--
+-- Forward-only. All grant changes are idempotent.
+
+begin;
+
+-- ── P0: secret + PII exposure — service_role bridge + postgres owner only ─────────────────
+revoke all on function public.get_cron_secret()                  from public, anon, authenticated;
+revoke all on function public.list_daily_briefing_subscribers()  from public, anon, authenticated;
+grant execute on function public.get_cron_secret()                 to service_role;
+grant execute on function public.list_daily_briefing_subscribers() to service_role;
+
+-- ── P2: DBA-only diagnostics (zero app/browser callers; info disclosure) ──────────────────
+revoke all on function public.database_health_check()              from public, anon, authenticated;
+revoke all on function public.check_foreign_keys(text)             from public, anon, authenticated;
+revoke all on function public.check_indexes(text[])                from public, anon, authenticated;
+revoke all on function public.check_unique_constraints(text[])     from public, anon, authenticated;
+revoke all on function public.check_duplicate_feedback()           from public, anon, authenticated;
+revoke all on function public.check_duplicate_ratings()            from public, anon, authenticated;
+revoke all on function public.check_invalid_watchlist_statuses()   from public, anon, authenticated;
+grant execute on function public.database_health_check()            to service_role;
+grant execute on function public.check_foreign_keys(text)           to service_role;
+grant execute on function public.check_indexes(text[])              to service_role;
+grant execute on function public.check_unique_constraints(text[])   to service_role;
+grant execute on function public.check_duplicate_feedback()         to service_role;
+grant execute on function public.check_duplicate_ratings()          to service_role;
+grant execute on function public.check_invalid_watchlist_statuses() to service_role;
+
+-- ── P2: auth trigger function must not be a REST RPC (trigger fires regardless of grants) ──
+revoke all on function public.handle_new_auth_user()               from public, anon, authenticated;
+grant execute on function public.handle_new_auth_user()             to service_role;
+
+-- ── P2: account-deletion RPCs are AUTHENTICATED app actions (Account page; use auth.uid()) ─
+-- Drop the useless anon grant (anon has no uid → no-op); KEEP authenticated for the app.
+revoke all on function public.request_account_deletion(text)       from public, anon, authenticated;
+revoke all on function public.cancel_account_deletion()            from public, anon, authenticated;
+grant execute on function public.request_account_deletion(text)     to authenticated, service_role;
+grant execute on function public.cancel_account_deletion()          to authenticated, service_role;
+
+commit;


### PR DESCRIPTION
**F8.6-SEC — Lock down scheduler security functions.** Closes the two live anonymous **P0** exposures found in the F8.6 audit, plus closely related anonymous SECURITY DEFINER diagnostic exposure. **Database grants only** — no app source / UI / product behavior change; no user rows modified.

## Confirmed prior P0 exposure
Live, verified via Supabase security advisors + `pg_proc` grants. These objects exist live but were created out-of-band (not in repo migrations → drift):
- **`public.get_cron_secret()`** — SECURITY DEFINER, reads the Vault cron secret, returns `text`; `anon` **and** `authenticated` had EXECUTE → anyone with the public anon key could read the cron secret via `/rest/v1/rpc/get_cron_secret`.
- **`public.list_daily_briefing_subscribers()`** — SECURITY DEFINER, returns `(user_id, email, name)`; `anon` had EXECUTE → bulk subscriber-**email harvest**.

## Dependency inspection (firsthand)
- **No app/browser source** calls either P0 function (repo grep: 0 `src/` usages).
- Legitimate callers: the **`postgres` owner** (pg_cron jobs run as owner → execute regardless of grants) and the **service-role bridge** in the `send-daily-briefings` + `process-account-deletions` edge functions, both of which load the secret via `admin.rpc('get_cron_secret')` and list subscribers via `admin.rpc('list_daily_briefing_subscribers')`. → revoking anon/authenticated does **not** affect the cron pipeline.
- Diagnostics (`database_health_check`, `check_*`) + the auth trigger `handle_new_auth_user` have **zero** app callers.
- `request_account_deletion`/`cancel_account_deletion` **are** authenticated app actions (Account page, use `auth.uid()`); `increment_session_interactions` **is** browser pre-auth → keep anon.

## Functions changed — grants before → after (anon / authenticated / service_role EXECUTE)
| Function | Before | After |
|---|---|---|
| `get_cron_secret()` **(P0)** | t/t/t | **f/f/t** |
| `list_daily_briefing_subscribers()` **(P0)** | t/t/t | **f/f/t** |
| `database_health_check()` | t/t/t | f/f/t |
| `check_foreign_keys(text)` | t/t/t | f/f/t |
| `check_indexes(text[])` | t/t/t | f/f/t |
| `check_unique_constraints(text[])` | t/t/t | f/f/t |
| `check_duplicate_feedback()` | t/t/t | f/f/t |
| `check_duplicate_ratings()` | t/t/t | f/f/t |
| `check_invalid_watchlist_statuses()` | t/t/t | f/f/t |
| `handle_new_auth_user()` (trigger) | t/t/t | f/f/t |
| `request_account_deletion(text)` | t/t/t | **f/t/t** (keep authenticated) |
| `cancel_account_deletion()` | t/t/t | **f/t/t** (keep authenticated) |
| `increment_session_interactions(uuid)` | t/t/t | **unchanged** (app pre-auth; residual) |

## Search-path hardening
Not performed — the fix is grant-only. Rewriting these out-of-band function bodies (CREATE OR REPLACE + pin search_path) and tracking them into source is **deferred** (residual backlog), to keep the P0 hotfix low-risk.

## Cron-secret rotation — performed
The Vault `cron_secret` was rotated in place via `vault.update_secret` with a **server-generated value (never selected/printed)**; `updated_at` advanced past `created_at`. Both edge functions read the secret through `get_cron_secret()` against this same Vault row, so the new value propagates to the pg_cron callers and the edge validators; per-instance edge caches self-heal on recycle (minutes), within the hourly cron / daily (hour-18 UTC) send cadence.

## Advisor result
`anon_security_definer_function_executable` findings **13 → 1** (only the intentionally retained `increment_session_interactions` remains). Both P0s cleared from the anon **and** authenticated lists. Remaining authenticated findings are intentional app RPCs (F8.2 People RPCs + account-deletion + session tracking). **No new ERROR introduced.**

## Verification script
`scripts/verify-scheduler-security-functions.sql` (read-only; **never executes** the secret/PII functions) asserts anon/authenticated EXECUTE = false for the P0s + diagnostics, service_role retained, authenticated retained for the account-deletion RPCs, and the 3 cron jobs unchanged (run as `postgres`).

## Tests / build
lint clean · People **50** · full **1429** · build ✓ (DB-only change; app unaffected).

## Confirmations
**No secret or subscriber email was executed or printed** at any point (P0 functions never called; secret generated/updated server-side without selecting it). **No live user rows modified** — grants + a single Vault secret-row rotation only.

## Residual security backlog (not this P0 hotfix)
SECURITY DEFINER views `list_follower_counts` + `vw_movies_scored` (advisor ERROR, P2 — dependency check before `security_invoker`); `pg_trgm`/`pg_net` in `public`; OTP expiry >1h; leaked-password protection off; Postgres `15.8.1.102` patch; verify `increment_session_interactions` can be authenticated-only; track the out-of-band scheduler/diagnostic function bodies into source migrations to fully close drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
