### PR TITLE
Harden People accessibility and responsive layout

### DIFF
--- a/src/features/people/People.jsx
+++ b/src/features/people/People.jsx
@@ -1,8 +1,8 @@
 // src/features/people/People.jsx
-// FeelFlick — People v2 ("Taste twins"). Editorial social surface backed by
-// live user_follows × user_similarity × user_ratings × user_history. Drops
-// the internal Nav (AppShell owns nav). All follow/unfollow flows through
-// the provider's optimistic toggleFollow.
+// FeelFlick — People: consent-led taste-match discovery (F8.2–F8.7). Reads only the caller's own
+// follows + own similarity pairs + the narrow authenticated identity/search/FOF RPCs (no cross-user
+// behavioral reads). Follow/Unfollow settle only after persistence (F8.4); Hide is session-local.
+// AppShell owns the page <main> + nav.
 
 import { useState, useMemo, useEffect, useRef, useCallback } from 'react'
 import { supabase } from '@/shared/lib/supabase/client'
@@ -16,8 +16,14 @@ import './people.css'
 
 const RESET_BTN = { background: 'none', border: 'none', padding: 0, margin: 0, font: 'inherit', color: 'inherit', cursor: 'pointer', textAlign: 'left' }
 
-// Avatar — renders the user's uploaded image when available, falls back to
-// a colored initial circle. Used by every twin/rising/suggested/activity card.
+// F8.7: hardened muted label colour for small (10–12px) load-bearing People text. The HP.textMuted
+// token (rgba(250,250,250,0.45)) is ~4.1:1 on the #06060a canvas → fails WCAG AA for small text; INK
+// at 0.62 is ~7.3:1 (AA + AAA), matching Profile's proven INK_LABEL value without coupling to it.
+const INK = 'rgba(250,250,250,0.62)'
+
+// Avatar — renders the user's uploaded image when available, falls back to a colored initial circle.
+// Used by every twin/rising/suggested/search card; decorative within cards (alt="" — the name is
+// adjacent text), so it renders as a plain image, not an interactive control.
 function Avatar({ url, initial, bg, size = 48, onClick, alt }) {
   const dim = { width: size, height: size }
   const ring = { ...dim, borderRadius: 999, overflow: 'hidden', flex: 'none' }
@@ -106,13 +112,14 @@ function Masthead({ onSearch, query, setQuery }) {
             placeholder="Search by name…"
             aria-label="Search for users by name"
             className="ff-people-search-input"
-            style={{ flex: 1, minWidth: 200, maxWidth: 480, padding: '12px 18px', borderRadius: 8, background: 'rgba(255,255,255,0.04)', border: `1px solid ${HP.border}`, color: HP.text, fontFamily: 'Outfit, Inter, sans-serif', fontSize: 14, outline: 'none' }}
+            style={{ flex: 1, minWidth: 200, maxWidth: 480, minHeight: 44, padding: '12px 18px', borderRadius: 8, background: 'rgba(255,255,255,0.04)', border: `1px solid ${HP.border}`, color: HP.text, fontFamily: 'Outfit, Inter, sans-serif', fontSize: 14 }}
           />
           <button
             type="button"
             onClick={handleInvite}
             aria-label="Invite a friend to FeelFlick"
-            style={{ padding: '12px 20px', borderRadius: 8, background: HP_GRAD, border: 'none', color: '#fff', fontFamily: 'Outfit', fontSize: 12, fontWeight: 600, letterSpacing: '0.04em', cursor: 'pointer' }}
+            className="ff-people-invite-btn"
+            style={{ minHeight: 44, padding: '0 20px', borderRadius: 8, background: HP_GRAD, border: 'none', color: '#fff', fontFamily: 'Outfit', fontSize: 12, fontWeight: 600, letterSpacing: '0.04em', cursor: 'pointer' }}
           >
             Invite a friend
           </button>
@@ -180,7 +187,7 @@ function HideBtn({ onHide, name }) {
       onClick={onHide}
       aria-label={`Hide ${name || 'this person'} from your suggestions`}
       className="ff-people-hidebtn"
-      style={{ minHeight: 44, minWidth: 44, padding: '0 10px', background: 'transparent', border: 'none', color: HP.textMuted, fontFamily: 'Outfit', fontSize: 10, letterSpacing: '0.04em', cursor: 'pointer' }}
+      style={{ minHeight: 44, minWidth: 44, padding: '0 10px', background: 'transparent', border: 'none', color: INK, fontFamily: 'Outfit', fontSize: 10, letterSpacing: '0.04em', cursor: 'pointer' }}
     >
       Hide
     </button>
@@ -214,19 +221,19 @@ function TwinsRail() {
   const { containerRef, onHide } = useRailHide(visibleTwins)
 
   return (
-    <section className="ff-people-section ff-people-twins" style={{ padding: '24px 88px 56px' }}>
+    <section className="ff-people-section ff-people-twins" aria-labelledby="ff-people-twins-h" style={{ padding: '24px 88px 56px' }}>
       <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', marginBottom: 24, gap: 16, flexWrap: 'wrap' }}>
         <div>
           <Eyebrow rule size={10} style={{ marginBottom: 12 }}>Strongest matches</Eyebrow>
-          <h2 className="ff-people-h2" style={{ fontFamily: 'Outfit', fontSize: 36, lineHeight: 1, fontWeight: 500, letterSpacing: '-0.03em', color: HP.text, margin: 0 }}>
+          <h2 id="ff-people-twins-h" className="ff-people-h2" style={{ fontFamily: 'Outfit', fontSize: 36, lineHeight: 1, fontWeight: 500, letterSpacing: '-0.03em', color: HP.text, margin: 0 }}>
             People who <em style={{ fontStyle: 'italic', fontWeight: 400, color: HP.textSoft }}>get it.</em>
           </h2>
         </div>
       </div>
       {loading ? (
-        <div className="ff-people-grid-4" style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 18 }}>
+        <div className="ff-people-grid-4" aria-busy="true" aria-label="Loading people" style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 18 }}>
           {[0, 1, 2, 3].map(i => (
-            <div key={i} style={{ height: 220, borderRadius: 8, background: 'rgba(255,255,255,0.025)', border: `1px solid ${HP.border}` }} className="animate-pulse" />
+            <div key={i} aria-hidden="true" style={{ height: 220, borderRadius: 8, background: 'rgba(255,255,255,0.025)', border: `1px solid ${HP.border}` }} className="animate-pulse" />
           ))}
         </div>
       ) : visibleTwins.length === 0 ? (
@@ -242,13 +249,13 @@ function TwinsRail() {
                 <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: 18, gap: 12 }}>
                   <Avatar url={p.avatarUrl} initial={p.initial} bg={p.avatarBg} size={48} alt="" />
                   <div style={{ textAlign: 'right', maxWidth: 150 }}>
-                    <div style={{ fontFamily: 'Outfit', fontSize: 14, fontWeight: 500, color: p.matchPresentation.qualified ? HP.text : HP.textMuted, letterSpacing: '-0.01em', lineHeight: 1.25 }}>{p.matchPresentation.band || p.matchPresentation.caption}</div>
-                    {p.matchPresentation.evidence && <div style={{ fontSize: 10, color: HP.textMuted, fontFamily: 'Outfit', marginTop: 3 }}>{p.matchPresentation.evidence}</div>}
+                    <div style={{ fontFamily: 'Outfit', fontSize: 14, fontWeight: 500, color: p.matchPresentation.qualified ? HP.text : INK, letterSpacing: '-0.01em', lineHeight: 1.25 }}>{p.matchPresentation.band || p.matchPresentation.caption}</div>
+                    {p.matchPresentation.evidence && <div style={{ fontSize: 10, color: INK, fontFamily: 'Outfit', marginTop: 3 }}>{p.matchPresentation.evidence}</div>}
                   </div>
                 </div>
                 {p.matchPresentation.qualified && <div aria-hidden="true"><MatchBar pct={p.match} hex={p.avatarBg} /></div>}
                 <div style={{ marginTop: 16, fontFamily: 'Outfit', fontSize: 18, fontWeight: 500, color: HP.text, letterSpacing: '-0.015em' }}>{p.name}</div>
-                <div style={{ fontSize: 11, color: HP.textMuted, fontFamily: 'Outfit', marginTop: 2 }}>{p.handle}</div>
+                <div style={{ fontSize: 11, color: INK, fontFamily: 'Outfit', marginTop: 2 }}>{p.handle}</div>
                 {p.bio && <p style={{ margin: '12px 0 0 0', fontSize: 12, color: HP.textSoft, fontFamily: 'Outfit, Inter, sans-serif', lineHeight: 1.5 }}>{p.bio}</p>}
                 <div style={{ marginTop: 14, paddingTop: 14, borderTop: `1px solid ${HP.border}`, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 6 }}>
                   {!p.following && <HideBtn onHide={() => onHide(p.id)} name={p.name} />}
@@ -263,8 +270,6 @@ function TwinsRail() {
   )
 }
 
-// Cold-start guidance that sits above the Popular rail. Tells the user
-// "twins are computed from your ratings — here's a head start while you log."
 // F8.5: honest empty state — no one discoverable yet (or all suggestions hidden this session). No
 // fabricated Popular/Activity fallback is shown to avoid an empty page.
 function ColdStartHero() {
@@ -282,11 +287,11 @@ function Rising() {
   if (!loading && visibleRising.length === 0) return null
 
   return (
-    <section className="ff-people-section ff-people-rising" style={{ padding: '48px 88px', borderTop: `1px solid ${HP.border}`, background: 'rgba(255,255,255,0.012)' }}>
+    <section className="ff-people-section ff-people-rising" aria-labelledby="ff-people-rising-h" style={{ padding: '48px 88px', borderTop: `1px solid ${HP.border}`, background: 'rgba(255,255,255,0.012)' }}>
       <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', marginBottom: 24, flexWrap: 'wrap', gap: 16 }}>
         <div>
           <Eyebrow rule size={10} style={{ marginBottom: 12 }}>More matches</Eyebrow>
-          <h2 className="ff-people-h2-sm" style={{ fontFamily: 'Outfit', fontSize: 30, lineHeight: 1, fontWeight: 500, letterSpacing: '-0.03em', color: HP.text, margin: 0 }}>More people to <em style={{ fontStyle: 'italic', fontWeight: 400, color: HP.textSoft }}>discover.</em></h2>
+          <h2 id="ff-people-rising-h" className="ff-people-h2-sm" style={{ fontFamily: 'Outfit', fontSize: 30, lineHeight: 1, fontWeight: 500, letterSpacing: '-0.03em', color: HP.text, margin: 0 }}>More people to <em style={{ fontStyle: 'italic', fontWeight: 400, color: HP.textSoft }}>discover.</em></h2>
         </div>
       </div>
       <div className="ff-people-grid-3" style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 16 }}>
@@ -295,9 +300,9 @@ function Rising() {
             <Avatar url={p.avatarUrl} initial={p.initial} bg={p.avatarBg} size={42} alt="" />
             <div style={{ minWidth: 0 }}>
               <div style={{ fontFamily: 'Outfit', fontSize: 14, fontWeight: 500, color: HP.text }}>{p.name}</div>
-              <div style={{ fontSize: 11, color: HP.textMuted, fontFamily: 'Outfit', marginTop: 2, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{p.bio}</div>
+              <div style={{ fontSize: 11, color: INK, fontFamily: 'Outfit', marginTop: 2, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{p.bio}</div>
               {p.matchPresentation.qualified && <div style={{ marginTop: 8 }} aria-hidden="true"><MatchBar pct={p.match} hex={p.avatarBg} /></div>}
-              <div style={{ marginTop: 6, fontSize: 10, color: HP.textMuted, fontFamily: 'Outfit', letterSpacing: '0.04em' }}>{p.matchPresentation.evidence || p.matchPresentation.band || p.matchPresentation.caption}</div>
+              <div style={{ marginTop: 6, fontSize: 10, color: INK, fontFamily: 'Outfit', letterSpacing: '0.04em' }}>{p.matchPresentation.evidence || p.matchPresentation.band || p.matchPresentation.caption}</div>
             </div>
             <FollowBtn id={p.id} following={p.following} pending={isPending(p.id)} errored={isErrored(p.id)} name={p.name} onFollow={() => follow(p.id, p.name)} onUnfollow={() => unfollow(p.id, p.name)} />
           </div>
@@ -314,10 +319,10 @@ function Suggested() {
   if (!loading && visibleSuggested.length === 0) return null
 
   return (
-    <section className="ff-people-section ff-people-suggested" style={{ padding: '56px 88px', borderTop: `1px solid ${HP.border}` }}>
+    <section className="ff-people-section ff-people-suggested" aria-labelledby="ff-people-suggested-h" style={{ padding: '56px 88px', borderTop: `1px solid ${HP.border}` }}>
       <div style={{ marginBottom: 24 }}>
         <Eyebrow size={10} style={{ marginBottom: 12 }}>Suggested</Eyebrow>
-        <h2 className="ff-people-h2-sm" style={{ fontFamily: 'Outfit', fontSize: 30, lineHeight: 1, fontWeight: 500, letterSpacing: '-0.03em', color: HP.text, margin: 0 }}>People you <em style={{ fontStyle: 'italic', fontWeight: 400, color: HP.textSoft }}>might know.</em></h2>
+        <h2 id="ff-people-suggested-h" className="ff-people-h2-sm" style={{ fontFamily: 'Outfit', fontSize: 30, lineHeight: 1, fontWeight: 500, letterSpacing: '-0.03em', color: HP.text, margin: 0 }}>People you <em style={{ fontStyle: 'italic', fontWeight: 400, color: HP.textSoft }}>might know.</em></h2>
       </div>
       <div ref={containerRef} tabIndex={-1} className="ff-people-grid-3" style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 16, outline: 'none' }}>
         {visibleSuggested.map(p => (
@@ -325,7 +330,7 @@ function Suggested() {
             <Avatar url={p.avatarUrl} initial={p.initial} bg={p.avatarBg} size={42} alt="" />
             <div style={{ minWidth: 0 }}>
               <div style={{ fontFamily: 'Outfit', fontSize: 15, fontWeight: 500, color: HP.text }}>{p.name}</div>
-              <div style={{ fontSize: 11, color: HP.textMuted, fontFamily: 'Outfit', marginTop: 2 }}>
+              <div style={{ fontSize: 11, color: INK, fontFamily: 'Outfit', marginTop: 2 }}>
                 {p.viaFriend
                   ? <>via <span style={{ color: HP.text }}>{p.viaFriend}</span>{p.matchPresentation?.band ? <> · {p.matchPresentation.band}</> : null}</>
                   : <>{p.matchPresentation?.evidence || p.matchPresentation?.band || p.matchPresentation?.caption || 'Suggested for you'}</>}
@@ -345,18 +350,18 @@ function Suggested() {
 function SearchResults({ results, loading, onClear }) {
   const { followingIds, follow, unfollow, isPending, isErrored } = usePeopleData()
   return (
-    <section className="ff-people-section ff-people-search-results" style={{ padding: '24px 88px 56px' }}>
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 24 }}>
+    <section className="ff-people-section ff-people-search-results" aria-labelledby="ff-people-search-h" style={{ padding: '24px 88px 56px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 24, gap: 12 }}>
         <div>
           <Eyebrow size={10} style={{ marginBottom: 12 }}>Search results</Eyebrow>
-          <h2 className="ff-people-h2-sm" style={{ fontFamily: 'Outfit', fontSize: 30, lineHeight: 1, fontWeight: 500, letterSpacing: '-0.03em', color: HP.text, margin: 0 }}>{results.length} match{results.length === 1 ? '' : 'es'}</h2>
+          <h2 id="ff-people-search-h" className="ff-people-h2-sm" style={{ fontFamily: 'Outfit', fontSize: 30, lineHeight: 1, fontWeight: 500, letterSpacing: '-0.03em', color: HP.text, margin: 0 }}>{results.length} match{results.length === 1 ? '' : 'es'}</h2>
         </div>
-        <button type="button" onClick={onClear} style={{ ...RESET_BTN, fontSize: 11, color: HP.textMuted, fontFamily: 'Outfit', letterSpacing: '0.08em', textTransform: 'uppercase' }}>Clear ×</button>
+        <button type="button" onClick={onClear} aria-label="Clear search results" className="ff-people-clear-btn" style={{ ...RESET_BTN, minHeight: 44, minWidth: 44, padding: '0 12px', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: 11, color: INK, fontFamily: 'Outfit', letterSpacing: '0.08em', textTransform: 'uppercase', flex: 'none' }}>Clear ×</button>
       </div>
       {loading ? (
-        <div style={{ fontSize: 13, color: HP.textMuted, fontFamily: 'Outfit, Inter, sans-serif' }}>Searching…</div>
+        <div style={{ fontSize: 13, color: INK, fontFamily: 'Outfit, Inter, sans-serif' }}>Searching…</div>
       ) : results.length === 0 ? (
-        <div style={{ fontSize: 14, color: HP.textMuted, fontFamily: 'Outfit, Inter, sans-serif', fontStyle: 'italic' }}>No people found. Try a different name.</div>
+        <div style={{ fontSize: 14, color: INK, fontFamily: 'Outfit, Inter, sans-serif', fontStyle: 'italic' }}>No people found. Try a different name.</div>
       ) : (
         <div className="ff-people-grid-3" style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 16 }}>
           {results.map(u => (
@@ -364,7 +369,7 @@ function SearchResults({ results, loading, onClear }) {
               <Avatar url={u.avatarUrl} initial={u.initial} bg={u.avatarBg} size={42} alt="" />
               <div style={{ minWidth: 0 }}>
                 <div style={{ fontFamily: 'Outfit', fontSize: 15, fontWeight: 500, color: HP.text }}>{u.name}</div>
-                <div style={{ fontSize: 11, color: HP.textMuted, fontFamily: 'Outfit', marginTop: 2 }}>{u.handle}</div>
+                <div style={{ fontSize: 11, color: INK, fontFamily: 'Outfit', marginTop: 2 }}>{u.handle}</div>
               </div>
               <FollowBtn id={u.id} following={followingIds.has(u.id)} pending={isPending(u.id)} errored={isErrored(u.id)} name={u.name} onFollow={() => follow(u.id, u.name)} onUnfollow={() => unfollow(u.id, u.name)} />
             </div>
@@ -379,7 +384,7 @@ function EmptyState({ label, body }) {
   return (
     <div style={{ border: `1px dashed ${HP.border}`, borderRadius: 12, padding: '32px 24px', textAlign: 'center', background: 'rgba(255,255,255,0.02)' }}>
       <div style={{ fontFamily: 'Outfit', fontSize: 14, fontWeight: 500, color: HP.text, marginBottom: 6 }}>{label}</div>
-      <div style={{ fontFamily: 'Outfit, Inter, sans-serif', fontSize: 13, color: HP.textMuted, maxWidth: 420, margin: '0 auto', lineHeight: 1.55 }}>{body}</div>
+      <div style={{ fontFamily: 'Outfit, Inter, sans-serif', fontSize: 13, color: INK, maxWidth: 420, margin: '0 auto', lineHeight: 1.55 }}>{body}</div>
     </div>
   )
 }

--- a/src/features/people/__tests__/PeopleProjectionPrivacy.test.jsx
+++ b/src/features/people/__tests__/PeopleProjectionPrivacy.test.jsx
@@ -4,6 +4,12 @@ import peopleSource from '../usePeopleData.jsx?raw'
 import peopleJsxSource from '../People.jsx?raw'
 import * as peopleData from '../data.js'
 import peopleDataSource from '../data.js?raw'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+// people.css read from disk — vitest returns '' for `*.css?raw`, so read the file directly (the same
+// pattern DiscoverResolve.test.jsx uses for discover.css).
+const peopleCssSource = readFileSync(resolve(import.meta.dirname, '../people.css'), 'utf8')
 
 // F7.9 — People taste-match must read the cross-user fingerprint through the narrow authenticated
 // RPC (get_discoverable_taste_profiles), never the now browser-inaccessible projection views. The
@@ -211,5 +217,61 @@ describe('F8.5 — dead social surfaces removed', () => {
     for (const fake of ['Marco Reyes', 'Priya Shah', 'Park Chan-wook', 'airport scene', 'Refn-coded']) {
       expect(peopleDataSource).not.toContain(fake)
     }
+  })
+})
+
+describe('F8.7 — accessibility, contrast, touch targets, responsive', () => {
+  it('exactly one h1, and each rail section is a heading-labelled region', () => {
+    const h1s = peopleJsxSource.match(/<h1\b/g) || []
+    expect(h1s).toHaveLength(1)
+    for (const id of ['ff-people-twins-h', 'ff-people-rising-h', 'ff-people-suggested-h', 'ff-people-search-h']) {
+      expect(peopleJsxSource).toContain(`aria-labelledby="${id}"`)
+      expect(peopleJsxSource).toContain(`id="${id}"`)
+    }
+  })
+
+  it('load-bearing muted card labels use the hardened INK token, not the failing HP.textMuted', () => {
+    // INK ≈ 7.3:1 on #06060a; HP.textMuted (0.45) ≈ 4.1:1 fails AA for small text.
+    expect(peopleJsxSource).toMatch(/const INK = 'rgba\(250,250,250,0\.62\)'/)
+    expect(peopleJsxSource).not.toMatch(/color: HP\.textMuted/) // no weak muted token applied to labels
+    expect(peopleJsxSource).toMatch(/color: INK/)              // INK actually applied
+  })
+
+  it('every actionable People control meets the 44px touch-target floor', () => {
+    // FollowBtn + HideBtn (F8.4) already asserted elsewhere; here: search input, invite, clear.
+    expect(peopleJsxSource).toMatch(/className="ff-people-search-input"[\s\S]{0,200}minHeight: 44/)
+    expect(peopleJsxSource).toMatch(/className="ff-people-invite-btn"[\s\S]{0,160}minHeight: 44/)
+    expect(peopleJsxSource).toMatch(/className="ff-people-clear-btn"[\s\S]{0,200}minHeight: 44/)
+  })
+
+  it('search + clear controls have accessible names and visible focus rings', () => {
+    expect(peopleJsxSource).toMatch(/aria-label="Search for users by name"/)
+    expect(peopleJsxSource).toMatch(/aria-label="Clear search results"/)
+    // the input no longer hard-disables its outline inline; CSS supplies a branded focus-visible ring
+    expect(peopleJsxSource).not.toMatch(/className="ff-people-search-input"[\s\S]{0,200}outline: 'none'/)
+    expect(peopleCssSource).toMatch(/\.ff-people-search-input:focus-visible/)
+    expect(peopleCssSource).toMatch(/\.ff-people-invite-btn:focus-visible/)
+    expect(peopleCssSource).toMatch(/\.ff-people-clear-btn:focus-visible/)
+  })
+
+  it('loading state is announced via aria-busy (without adding a second live region)', () => {
+    expect(peopleJsxSource).toMatch(/aria-busy="true" aria-label="Loading people"/)
+    expect((peopleJsxSource.match(/role="status"/g) || []).length).toBe(1) // still exactly one
+  })
+
+  it('responsive CSS stacks the rails at phone widths and the dead-section rules are gone', () => {
+    expect(peopleCssSource).toMatch(/@media \(max-width: 720px\)/)
+    expect(peopleCssSource).toMatch(/\.ff-people-grid-4 \{[\s\S]{0,80}grid-template-columns: 1fr/)
+    expect(peopleCssSource).toMatch(/\.ff-people-search-form \{[\s\S]{0,80}flex-direction: column/)
+    // F8.5 removed Activity + CrewOverlap → their responsive rules must not linger
+    expect(peopleCssSource).not.toContain('ff-people-activity-row')
+    expect(peopleCssSource).not.toContain('ff-people-crew-grid')
+  })
+
+  it('reduced motion: People introduces no keyframes/JS animation (relies on the global reset)', () => {
+    expect(peopleCssSource).not.toMatch(/@keyframes/)
+    expect(peopleJsxSource).not.toMatch(/framer-motion|requestAnimationFrame\(/)
+    // the only motion is the global-reset-covered button hover transition + Tailwind animate-pulse
+    expect(peopleCssSource).toMatch(/prefers-reduced-motion/)
   })
 })

--- a/src/features/people/people.css
+++ b/src/features/people/people.css
@@ -24,8 +24,7 @@
   }
 }
 
-/* Smaller tablet (≤ 880px): twin grid 3 → 2 cols, "3-col rails" → 2 cols,
-   crew overlap stacks. */
+/* Smaller tablet (≤ 880px): twin grid 3 → 2 cols, "3-col rails" → 2 cols. */
 @media (max-width: 880px) {
   .ff-people-grid-4 {
     grid-template-columns: repeat(2, 1fr) !important;
@@ -33,10 +32,6 @@
   .ff-people-grid-3 {
     grid-template-columns: repeat(2, 1fr) !important;
     gap: 14px !important;
-  }
-  .ff-people-crew-grid {
-    grid-template-columns: 1fr !important;
-    gap: 24px !important;
   }
 }
 
@@ -50,7 +45,7 @@
     padding-top: 48px !important;
     padding-bottom: 24px !important;
   }
-  /* Hero clamps so "Your taste twins." fits on two lines max instead of three. */
+  /* Hero clamps so "Your taste matches." fits on two lines max instead of three. */
   .ff-people-hero {
     font-size: clamp(44px, 13vw, 72px) !important;
     line-height: 1 !important;
@@ -81,24 +76,27 @@
   .ff-people-search-form > button {
     width: 100% !important;
   }
-  /* Activity row: drop the trailing "X mins ago" column → put it inline
-     under the meta line. */
-  .ff-people-activity-row {
-    grid-template-columns: auto 1fr !important;
-    gap: 12px !important;
-  }
-  .ff-people-activity-row > div:last-child {
-    grid-column: 2 / -1 !important;
-    margin-top: 4px !important;
-    text-align: left !important;
-  }
 }
 
-/* F8.4 — visible focus ring for the follow / hide controls (keyboard + AT) */
+/* F8.4 / F8.7 — visible focus ring for every People interactive control (keyboard + AT). */
 .ff-people-followbtn:focus-visible,
-.ff-people-hidebtn:focus-visible {
+.ff-people-hidebtn:focus-visible,
+.ff-people-invite-btn:focus-visible,
+.ff-people-clear-btn:focus-visible {
   outline: 2px solid #A78BFA;
   outline-offset: 2px;
   border-radius: 999px;
 }
 .ff-people-hidebtn:hover { color: rgba(250, 250, 250, 0.85); }
+
+/* F8.7 — the search input had outline:none inline; give it an explicit, branded focus ring + border. */
+.ff-people-search-input:focus-visible {
+  outline: 2px solid #A78BFA;
+  outline-offset: 1px;
+  border-color: rgba(167, 139, 250, 0.6);
+}
+
+/* F8.7 — reduced motion: People adds NO JS animation. The only motion is the button hover-brightness
+   transition above + the loading skeleton's Tailwind .animate-pulse; both are neutralised by the
+   global @media (prefers-reduced-motion: reduce) reset in src/index.css (transition-duration +
+   animation-duration → ~0). No People-specific guard is required; documented here for auditability. */


### PR DESCRIPTION
**F8.7 — Harden People accessibility and responsive layout.** Presentation only: **no** database/RLS/RPC/grant, ranking, similarity, taste-match-presentation, follow-payload, route, or Feed change; no provider change. People stays orientation/search + consent-qualified taste-match rails + settled Follow/Unfollow + session-local Hide + honest empty states.

## Accessibility fixes
- Each rail `<section>` is now a **heading-labelled region** (`aria-labelledby` → the `h2` id: `ff-people-twins-h` / `-rising-h` / `-suggested-h` / `-search-h`) for screen-reader landmark navigation.
- Still **exactly one `<h1>`** (masthead hero) and **one** persistent People relationship-status live region (`role=status`/`aria-live=polite`/`aria-atomic`).
- Loading skeleton gains `aria-busy="true"` + `aria-label="Loading people"` (pulse blocks `aria-hidden`) — announced **without** adding a second live region.
- Search input keeps its `aria-label`; the Clear control gains `aria-label="Clear search results"`.
- F8.3/F8.4 card semantics preserved + re-asserted: MatchBar decorative (`aria-hidden`) with band + evidence as text; Follow `aria-pressed`/`aria-busy`/`disabled`/named/44px; Hide named/gated/44px/focus-recovery; decorative avatars `alt=""`; no nested interactive controls; no dead profile links.

## Touch-target fixes (≥44×44 CSS px)
Search input → `minHeight 44`; "Invite a friend" → `minHeight 44`; the previously tiny **"Clear ×"** → 44×44 inline-flex. (Follow/Hide were already 44 from F8.4.)

## Contrast fixes
`HP.textMuted` (`rgba(250,250,250,0.45)`) ≈ **4.1:1** on `#06060a` → **fails AA** for the small (10–12px) load-bearing card labels/evidence/bands/empty-state/search-state. Added a local **`INK` token** (`rgba(250,250,250,0.62)`) ≈ **7.3:1** (AA + AAA) — matching Profile's proven `INK_LABEL` value without importing a Profile-specific constant — applied to all 13 of those labels. Headline/body (`HP.text` ~21:1, `HP.textSoft` ~9.6:1) already pass, unchanged.

## Focus visibility
The search input no longer hard-disables its outline inline; people.css supplies a branded `:focus-visible` ring + border for the input, and the focus-ring selector list now covers the invite + clear buttons (was follow + hide only).

## Responsive fixes
Retained the ≤1100 / ≤880 / ≤720 grid + sidewall + search-stack overrides; **removed the dead `.ff-people-activity-row` + `.ff-people-crew-grid` rules** (their sections were deleted in F8.5) and refreshed the stale "Your taste twins." comment. Rails stack to one column at phone widths; names/bands/evidence wrap; **no card-order/rail-order change**.

## Reduced motion
People adds **no** JS animation and **no** `@keyframes`. Its only motion — the button hover-brightness transition + the Tailwind `.animate-pulse` skeleton — is neutralised by the global `@media (prefers-reduced-motion: reduce)` reset in `src/index.css` (documented in people.css).

## Empty/degraded states (behavior unchanged, verified honest)
`ColdStartHero` "No taste matches yet"; search "No people found. Try a different name."; search RPC failure degrades to the empty result (no raw backend text); no fabricated social proof; no "friend" language for algorithmic matches; no exact percentage.

## Tests + validation
+7 (full **1436**): one h1 + heading-labelled regions; INK applied / no `HP.textMuted` on labels; search/invite/clear ≥44px; search + clear accessible names + focus-visible rings; loading `aria-busy` + still one live region; responsive phone-stack + dead-rule removal; no keyframes/JS animation. lint clean · People **57 ×3** · full **1436** · build ✓.

## Contracts unchanged + no live action
F8.2 privacy + RPCs + opt-in, F8.3 bands/evidence/terminology, F8.4 follow/Hide settlement, F8.5 dead-surface removals, ranking + rail order, Follow payloads, routes, `/feed`→`/home` all untouched. `/people` has **no visual baseline** (changed freely through F8.3–F8.5 with passing Visual Regression), so no committed snapshot changes. No DB/RPC/RLS change; no live route opened; no follow/unfollow/hide on real data; mocked unit/source tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
