### PR TITLE
Fix People closest-matches identity resolution (RLS-dead rails)

### DIFF
--- a/src/features/people/__tests__/PeopleIdentityResolution.test.js
+++ b/src/features/people/__tests__/PeopleIdentityResolution.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { deriveTwins, deriveRising, deriveSuggested } from '../usePeopleData'
+
+// Regression for the closest-matches RLS-dead defect: public.users is owner-only (F8.2), so the
+// user_similarity embedded users() FK join returns null for every counterpart and the twin/rising/
+// similarity-suggested rails rendered EMPTY in production. The fix resolves identity from the
+// get_people_public_identities RPC (`usersById`) instead. These pure tests prove that contract.
+
+// 8 similarity rows ranked by overall_similarity (the slices: twins 0-4, rising 4-7, suggested 7-13).
+const ROWS = [
+  { user_b_id: 'u1', overall_similarity: 0.92, movies_in_common: 18 },
+  { user_b_id: 'u2', overall_similarity: 0.81, movies_in_common: 9 },
+  { user_b_id: 'u3', overall_similarity: 0.70, movies_in_common: 4 },
+  { user_b_id: 'u4', overall_similarity: 0.61, movies_in_common: 2 },
+  { user_b_id: 'u5', overall_similarity: 0.55, movies_in_common: 6 },
+  { user_b_id: 'u6', overall_similarity: 0.50, movies_in_common: 3 },
+  { user_b_id: 'u7', overall_similarity: 0.44, movies_in_common: 1 },
+  { user_b_id: 'u8', overall_similarity: 0.40, movies_in_common: 12 },
+]
+// Identities from the RPC. u4 is intentionally ABSENT (e.g. opted out of discovery) → must be dropped.
+const usersById = new Map([
+  ['u1', { id: 'u1', name: 'Ana', avatar_url: 'a.png' }],
+  ['u2', { id: 'u2', name: 'Bo', avatar_url: null }],
+  ['u3', { id: 'u3', name: 'Cy', avatar_url: null }],
+  ['u5', { id: 'u5', name: 'Eve', avatar_url: null }],
+  ['u6', { id: 'u6', name: 'Fin', avatar_url: null }],
+  ['u7', { id: 'u7', name: 'Gus', avatar_url: null }],
+  ['u8', { id: 'u8', name: 'Hal', avatar_url: null }],
+])
+const fp = new Map([['u1', { total: 40 }], ['u2', { total: 20 }]])
+const NO_FOLLOWS = new Set()
+
+describe('F8.8-prep — similarity rails resolve identity from the RPC, not the RLS-null embedded join', () => {
+  it('twins render from usersById (NOT row.users) — the rail is no longer empty', () => {
+    const twins = deriveTwins(ROWS, NO_FOLLOWS, usersById, fp)
+    expect(twins.length).toBeGreaterThan(0)                 // the defect was: always [] in prod
+    // ranks 0-3, but u4 has no RPC identity → dropped → twins = u1,u2,u3
+    expect(twins.map(t => t.id)).toEqual(['u1', 'u2', 'u3'])
+    expect(twins.map(t => t.name)).toEqual(['Ana', 'Bo', 'Cy']) // names come from the RPC
+  })
+
+  it('a candidate with no RPC identity (opted out) is dropped, not rendered Anonymous', () => {
+    const twins = deriveTwins(ROWS, NO_FOLLOWS, usersById, fp)
+    expect(twins.find(t => t.id === 'u4')).toBeUndefined()
+  })
+
+  it('rising uses the 4-7 slice and resolves identity from the RPC', () => {
+    const rising = deriveRising(ROWS, NO_FOLLOWS, usersById, fp)
+    expect(rising.map(r => r.id)).toEqual(['u5', 'u6', 'u7']) // ranks 4-6 (u4 already past)
+    expect(rising.map(r => r.name)).toEqual(['Eve', 'Fin', 'Gus'])
+  })
+
+  it('ranking/slice order is preserved (sorted-similarity order unchanged by the identity fix)', () => {
+    const twins = deriveTwins(ROWS, NO_FOLLOWS, usersById, fp)
+    const sims = twins.map(t => ROWS.find(r => r.user_b_id === t.id).overall_similarity)
+    expect(sims).toEqual([...sims].sort((a, b) => b - a)) // strictly descending
+  })
+
+  it('suggested (7-13) resolves from the RPC, excludes already-followed + self', () => {
+    const suggested = deriveSuggested(ROWS, new Set(['u8']), 'me', usersById, fp)
+    // u8 is the only rank ≥7 here and it is followed → excluded → empty
+    expect(suggested.map(s => s.id)).not.toContain('u8')
+  })
+
+  it('no card carries name/avatar from a row.users field (identity is RPC-only)', () => {
+    // even if a stray embedded users slipped onto a row, it must be ignored
+    const rowsWithStrayEmbed = [{ ...ROWS[0], users: { id: 'u1', name: 'WRONG', avatar_url: 'x' } }]
+    const twins = deriveTwins(rowsWithStrayEmbed, NO_FOLLOWS, usersById, fp)
+    expect(twins[0].name).toBe('Ana') // from usersById, never the embedded 'WRONG'
+  })
+})

--- a/src/features/people/__tests__/PeopleProjectionPrivacy.test.jsx
+++ b/src/features/people/__tests__/PeopleProjectionPrivacy.test.jsx
@@ -275,3 +275,20 @@ describe('F8.7 — accessibility, contrast, touch targets, responsive', () => {
     expect(peopleCssSource).toMatch(/prefers-reduced-motion/)
   })
 })
+
+describe('F8.8-prep — similarity-card identity resolves via the RPC, not the RLS-null embedded join', () => {
+  it('the similarity query no longer embeds the owner-only users() FK join', () => {
+    expect(peopleSource).not.toMatch(/users!user_similarity_user_[ab]_fkey/)
+  })
+
+  it('the merge keeps rows by user_b_id (not by the embedded join) — the rail is no longer always empty', () => {
+    expect(peopleSource).not.toMatch(/\.filter\(r => r\.users\)/)            // the old drop-everything gate is gone
+    expect(peopleSource).toMatch(/\.filter\(r => r\.user_b_id && r\.user_b_id !== userId\)/)
+  })
+
+  it('card shapers resolve identity from usersById (the get_people_public_identities RPC)', () => {
+    expect(peopleSource).toMatch(/const u = usersById\.get\(row\.user_b_id\)/)
+    expect(peopleSource).not.toMatch(/const u = row\.users/)                 // no embedded-join identity remains
+    expect(peopleSource).toMatch(/deriveTwins\(similarityRows, followingIds, usersById, fingerprintByUser\)/)
+  })
+})

--- a/src/features/people/usePeopleData.jsx
+++ b/src/features/people/usePeopleData.jsx
@@ -94,12 +94,13 @@ function deriveUser({ session, followingCount, followersCount }) {
 
 // recentByUser: Map<userId, { kind, film, rating, when }>
 // moodByUser:   Map<userId, string>  (top mood_tag across their watched films)
-// F8.5: a single card-shaper for the similarity rails (twins = ranks 1-4, rising = ranks 5-7). The
-// dead `meta`/mood/recent fields (fed by the removed cross-user behavioral reads) are gone; cards
-// carry only identity + the F8.3 evidence-qualified taste-match presentation + the follow state.
-function deriveSimilarityCards(similarityRows, followingIds, fingerprintByUser, from, to) {
+// A single card-shaper for the similarity rails (twins = ranks 1-4, rising = ranks 5-7). Identity
+// (name/avatar) is resolved from `usersById` — the get_people_public_identities RPC — NOT from an
+// embedded users() join: public.users is owner-only (F8.2), so the FK-embedded counterpart row is
+// always RLS-null. A candidate with no RPC identity (e.g. opted out of discovery) is dropped.
+function deriveSimilarityCards(similarityRows, followingIds, usersById, fingerprintByUser, from, to) {
   return similarityRows.slice(from, to).map(row => {
-    const u = row.users
+    const u = usersById.get(row.user_b_id)
     if (!u) return null
     const matchPct = Math.max(0, Math.min(100, Math.round((row.overall_similarity ?? 0) * 100)))
     const inCommon = Number.isFinite(row.movies_in_common) ? row.movies_in_common : null
@@ -121,20 +122,22 @@ function deriveSimilarityCards(similarityRows, followingIds, fingerprintByUser, 
   }).filter(Boolean)
 }
 
-const deriveTwins = (similarityRows, followingIds, fingerprintByUser) =>
-  deriveSimilarityCards(similarityRows, followingIds, fingerprintByUser, 0, 4)
-const deriveRising = (similarityRows, followingIds, fingerprintByUser) =>
-  deriveSimilarityCards(similarityRows, followingIds, fingerprintByUser, 4, 7)
+// Exported for unit testing the identity-resolution contract (twins/rising resolve from the RPC
+// usersById, never an embedded users() join). Pure: no React/Supabase.
+export const deriveTwins = (similarityRows, followingIds, usersById, fingerprintByUser) =>
+  deriveSimilarityCards(similarityRows, followingIds, usersById, fingerprintByUser, 0, 4)
+export const deriveRising = (similarityRows, followingIds, usersById, fingerprintByUser) =>
+  deriveSimilarityCards(similarityRows, followingIds, usersById, fingerprintByUser, 4, 7)
 
-function deriveSuggested(similarityRows, followingIds, currentUserId, fingerprintByUser) {
-  // "People you might know" — top-similarity users I don't follow, beyond the
-  // twins+rising rails. Cap at 6.
+export function deriveSuggested(similarityRows, followingIds, currentUserId, usersById, fingerprintByUser) {
+  // "People you might know" — top-similarity users I don't follow, beyond the twins+rising rails.
+  // Identity from the RPC (usersById), not the RLS-null embedded users() join. Cap at 6.
   return similarityRows
-    .filter(row => row.users && row.user_b_id !== currentUserId && !followingIds.has(row.user_b_id))
+    .filter(row => usersById.get(row.user_b_id) && row.user_b_id !== currentUserId && !followingIds.has(row.user_b_id))
     .slice(7, 13)
     .map(row => {
-      const u = row.users
-      const watchCount = u.user_history?.[0]?.count || row.movies_in_common || 0
+      const u = usersById.get(row.user_b_id)
+      const watchCount = row.movies_in_common || 0
       return {
         id: u.id,
         name: u.name || 'Anonymous',
@@ -238,21 +241,17 @@ export function PeopleDataProvider({ children }) {
           .from('user_follows')
           .select('follower_id', { count: 'exact', head: true })
           .eq('following_id', userId),
+        // No embedded users() join: public.users is owner-only (F8.2), so the FK-embedded counterpart
+        // is always RLS-null. Identity is resolved below via the get_people_public_identities RPC.
         supabase
           .from('user_similarity')
-          .select(`
-            user_b_id, overall_similarity, movies_in_common,
-            users!user_similarity_user_b_fkey ( id, name, avatar_url )
-          `)
+          .select('user_b_id, overall_similarity, movies_in_common')
           .eq('user_a_id', userId)
           .order('overall_similarity', { ascending: false })
           .limit(30),
         supabase
           .from('user_similarity')
-          .select(`
-            user_a_id, overall_similarity, movies_in_common,
-            users!user_similarity_user_a_fkey ( id, name, avatar_url )
-          `)
+          .select('user_a_id, overall_similarity, movies_in_common')
           .eq('user_b_id', userId)
           .order('overall_similarity', { ascending: false })
           .limit(30),
@@ -261,16 +260,11 @@ export function PeopleDataProvider({ children }) {
       const followingRows = followingRes.data || []
       const followingIds = new Set(followingRows.map(r => r.following_id))
       const followersCount = followersRes.count ?? 0
-      // Normalize both directions into a unified shape: { user_b_id (= friend id), overall_similarity, movies_in_common, users (= friend) }
-      const simAsA = (simAsARes.data || []).map(r => ({ ...r, users: r.users }))
-      const simAsB = (simAsBRes.data || []).map(r => ({
-        user_b_id: r.user_a_id, // remap so "user_b_id" always means the friend
-        overall_similarity: r.overall_similarity,
-        movies_in_common: r.movies_in_common,
-        users: r.users,
-      }))
+      // Normalize both directions to { user_b_id (= the counterpart), overall_similarity, movies_in_common }.
+      const simAsA = (simAsARes.data || []).map(r => ({ user_b_id: r.user_b_id, overall_similarity: r.overall_similarity, movies_in_common: r.movies_in_common }))
+      const simAsB = (simAsBRes.data || []).map(r => ({ user_b_id: r.user_a_id, overall_similarity: r.overall_similarity, movies_in_common: r.movies_in_common }))
       const mergedSimilarity = [...simAsA, ...simAsB]
-        .filter(r => r.users) // drop rows where the join didn't resolve
+        .filter(r => r.user_b_id && r.user_b_id !== userId) // identity comes from the RPC, not an embedded join
         .sort((a, b) => (b.overall_similarity ?? 0) - (a.overall_similarity ?? 0))
 
       // Privacy gate: drop candidates whose user_settings.privacy.showOnLeaderboards
@@ -322,9 +316,9 @@ export function PeopleDataProvider({ children }) {
         }])
       )
 
-      const twins = deriveTwins(similarityRows, followingIds, fingerprintByUser)
-      const rising = deriveRising(similarityRows, followingIds, fingerprintByUser)
-      const similaritySuggested = deriveSuggested(similarityRows, followingIds, userId, fingerprintByUser)
+      const twins = deriveTwins(similarityRows, followingIds, usersById, fingerprintByUser)
+      const rising = deriveRising(similarityRows, followingIds, usersById, fingerprintByUser)
+      const similaritySuggested = deriveSuggested(similarityRows, followingIds, userId, usersById, fingerprintByUser)
       // FOF fallback: when similarity Suggested doesn't fill the rail (<6
       // entries), walk the social graph one hop. Only fires when the user
       // has at least one follow (otherwise nothing to walk from).


### PR DESCRIPTION
**Pre-F8.8 product-correctness fix.** The closest-matches ("People who get it"), rising ("More people to discover") and similarity-suggested rails rendered **empty in production** — the headline taste-match discovery never appeared. Found while building F8.8 coverage; the user chose to fix the provider before continuing.

## Root cause (firsthand-verified)
`usePeopleData.jsx` resolved twin/rising/similarity-suggested **identity** from the embedded FK join `users!user_similarity_user_b_fkey(id,name,avatar_url)` on the `user_similarity` query, then dropped every row whose embedded `users` was null (`mergedSimilarity.filter(r => r.users)`), with the card shapers reading `const u = row.users`. But **`public.users` is owner-only** (F8.2 — only SELECT policy is `auth.uid() = id`, verified live) and **PostgREST applies RLS to embedded resources**. A similarity row's counterpart is always `user_b ≠ caller` (CHECK `user_a_id < user_b_id`), so the embedded `users` is always RLS-null → every similarity row dropped → twins/rising/similarity-suggested were always `[]`. Only FOF-suggested worked (it already used the `get_people_public_identities` RPC). F8.2 added that RPC precisely to resolve cross-user identity, but this path was never switched off the embedded join.

## Fix (identity source only — ranking + rail order unchanged)
- Similarity query: dropped the embedded `users()` select (RLS-null); now selects only `user_b_id`/`user_a_id`, `overall_similarity`, `movies_in_common`.
- Merge: keep rows by `r.user_b_id && r.user_b_id !== userId` instead of the always-false `r.users` gate; the sort (similarity desc) + the **0-4 / 4-7 / 7-13 slices are unchanged**.
- `deriveSimilarityCards`/`deriveTwins`/`deriveRising`/`deriveSuggested` take `usersById` and resolve `const u = usersById.get(row.user_b_id)`; a candidate with no RPC identity (e.g. opted out) is dropped rather than rendered.

## Contracts preserved
Opt-in respected (the `user_settings.showOnLeaderboards` filter runs upstream, unchanged, so the identity RPC is only requested for discoverable candidates). **No DB/RLS/RPC/grant change**; the change *removes* a cross-user embedded read (no new direct `users` read); F8.3 bands/evidence, F8.4 follow/Hide, F8.5 dead-surface removals, candidate ranking + rail order, and follow payloads untouched.

## Tests + validation
+9 (full **1445**): new `PeopleIdentityResolution.test.js` exercises the now-exported pure rail builders — twins/rising render from `usersById` (not `row.users`), opted-out (no-RPC-identity) candidates dropped, ranking/slice order preserved, a stray embedded `users` field ignored; source assertions — no embedded `users!user_similarity` join, merge keeps by `user_b_id`, identity via `usersById.get(row.user_b_id)`. lint clean · People **66 ×3** · full **1445** · build ✓. F8.2/F8.3/F8.4/F8.5/F8.7 tests remain green.

## No live action
No live `/people` opened; no follow/unfollow/hide; no row/setting mutated; no live RPC called. Browser confirmation that twins render lands in **F8.8**'s intercepted E2E (which can now mock `user_similarity` + the identity RPC honestly instead of masking this defect via the embedded join).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
