### PR TITLE
Close cross-user watchlist and mood reads

### DIFF
--- a/scripts/verify-f9-route-privacy.sql
+++ b/scripts/verify-f9-route-privacy.sql
@@ -1,0 +1,65 @@
+-- verify-f9-route-privacy.sql — READ-ONLY verification for the F9.2 cross-user-read closure.
+--
+-- Confirms (no row contents printed; aggregate / policy / privilege checks + one rolled-back
+-- role-simulation that uses a SYNTHETIC uuid, never a real user id):
+--   * user_watchlist  SELECT is owner-only (no broad authenticated policy)
+--   * mood_sessions   SELECT is owner-only (no broad authenticated policy)
+--   * owner INSERT/UPDATE/DELETE (watchlist) + owner INSERT/SELECT (mood) policies still exist
+--   * lists.is_public column default is false
+--   * a random authenticated user sees ZERO watchlist / mood rows (the fix actually bites)
+--
+-- Run with the service role / SQL editor. Nothing is mutated (the simulation is rolled back).
+
+\echo '== 1. user_watchlist + mood_sessions: NO broad authenticated SELECT policy should remain =='
+select c.relname as tbl, pol.polname,
+       pg_get_expr(pol.polqual, pol.polrelid) as using_expr
+from pg_policy pol
+join pg_class c on c.oid = pol.polrelid
+join pg_namespace n on n.oid = c.relnamespace
+where n.nspname = 'public'
+  and c.relname in ('user_watchlist','mood_sessions')
+  and pol.polcmd = 'r'
+  and pg_get_expr(pol.polqual, pol.polrelid) ilike '%is not null%';   -- expect: 0 rows
+
+\echo '== 2. Owner-only SELECT (auth.uid() = user_id) + write policies still present =='
+select c.relname as tbl,
+       count(*) filter (where pol.polcmd = 'r'
+             and pg_get_expr(pol.polqual, pol.polrelid) ilike '%= user_id%'
+             and pg_get_expr(pol.polqual, pol.polrelid) not ilike '%is not null%') as owner_select_policies,
+       count(*) filter (where pol.polcmd in ('a','*')) as insert_or_all_policies,
+       count(*) filter (where pol.polcmd in ('w','*')) as update_or_all_policies,
+       count(*) filter (where pol.polcmd in ('d','*')) as delete_or_all_policies
+from pg_policy pol
+join pg_class c on c.oid = pol.polrelid
+join pg_namespace n on n.oid = c.relnamespace
+where n.nspname = 'public' and c.relname in ('user_watchlist','mood_sessions')
+group by c.relname order by c.relname;
+-- expect: user_watchlist owner_select >=1, insert/update/delete >=1 each;
+--         mood_sessions  owner_select >=1, insert_or_all >=1.
+
+\echo '== 3. lists.is_public column default must be false =='
+select column_name, column_default
+from information_schema.columns
+where table_schema = 'public' and table_name = 'lists' and column_name = 'is_public';
+-- expect: column_default = false
+
+\echo '== 4. Role simulation (ROLLED BACK): a random authenticated user must see ZERO rows =='
+begin;
+set local role authenticated;
+-- synthetic uuid, not a real user — before the fix this would see ALL rows via the broad policy.
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-0000-0000-000000000000","role":"authenticated"}', true);
+select
+  (select count(*) from public.user_watchlist) as watchlist_rows_visible_to_random_authed,  -- expect 0
+  (select count(*) from public.mood_sessions)  as mood_rows_visible_to_random_authed,        -- expect 0
+  (select count(*) from public.lists where is_public = false) as private_lists_visible_to_random_authed; -- expect 0 (non-owner can't read private)
+rollback;
+
+\echo '== 5. anon must see ZERO private/owned rows (RLS), public lists still readable =='
+begin;
+set local role anon;
+select
+  (select count(*) from public.user_watchlist) as watchlist_rows_visible_to_anon,   -- expect 0
+  (select count(*) from public.mood_sessions)  as mood_rows_visible_to_anon,         -- expect 0
+  (select count(*) from public.lists where is_public = false) as private_lists_visible_to_anon; -- expect 0
+rollback;

--- a/src/features/lists/CreateListModal.jsx
+++ b/src/features/lists/CreateListModal.jsx
@@ -22,7 +22,9 @@ export default function CreateListModal({ onClose, onSave, existingList = null, 
   const isEdit = !!existingList
   const [title, setTitle] = useState(existingList?.title || '')
   const [description, setDescription] = useState(existingList?.description || '')
-  const [isPublic, setIsPublic] = useState(existingList?.is_public ?? true)
+  // F9.2: new lists default PRIVATE. Editing keeps the existing list's value. The user opts in
+  // to public via the explicit "Public — anyone can see this list" checkbox below.
+  const [isPublic, setIsPublic] = useState(existingList?.is_public ?? false)
   const [saving, setSaving] = useState(false)
 
   const canSubmit = title.trim().length > 0 && !saving

--- a/src/features/lists/PersonalList.jsx
+++ b/src/features/lists/PersonalList.jsx
@@ -343,7 +343,7 @@ export default function PersonalList() {
           user_id: user.id,
           title: savedTitle,
           description: resolved.description || null,
-          is_public: true,
+          is_public: false, // F9.2: snapshots default private; owner can make public from /lists.
         })
         .select('id')
         .single()

--- a/src/features/lists/__tests__/CreateListModal.test.jsx
+++ b/src/features/lists/__tests__/CreateListModal.test.jsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+// CreateListModal imports the supabase client for the submit path; the default-state tests below
+// never submit, so a minimal stub keeps the module import side-effect-free.
+vi.mock('@/shared/lib/supabase/client', () => ({ supabase: { from: () => ({}) } }))
+
+import CreateListModal from '../CreateListModal'
+
+const noop = () => {}
+
+describe('CreateListModal — F9.2 default-private', () => {
+  it('a NEW list defaults to private (public toggle unchecked)', () => {
+    render(<CreateListModal onClose={noop} onSave={noop} userId="u1" />)
+    expect(screen.getByRole('checkbox')).not.toBeChecked()
+  })
+
+  it('keeps the public-exposure copy clear and explicit', () => {
+    render(<CreateListModal onClose={noop} onSave={noop} userId="u1" />)
+    expect(screen.getByText('Public — anyone can see this list')).toBeInTheDocument()
+  })
+
+  it('the user can still explicitly make a list public', () => {
+    render(<CreateListModal onClose={noop} onSave={noop} userId="u1" />)
+    const toggle = screen.getByRole('checkbox')
+    fireEvent.click(toggle)
+    expect(toggle).toBeChecked()
+  })
+
+  it('editing an existing PUBLIC list preserves its public state', () => {
+    render(<CreateListModal onClose={noop} onSave={noop} userId="u1"
+      existingList={{ id: 'l1', title: 'Shared picks', is_public: true }} />)
+    expect(screen.getByRole('checkbox')).toBeChecked()
+  })
+
+  it('editing an existing PRIVATE list preserves its private state', () => {
+    render(<CreateListModal onClose={noop} onSave={noop} userId="u1"
+      existingList={{ id: 'l2', title: 'Private picks', is_public: false }} />)
+    expect(screen.getByRole('checkbox')).not.toBeChecked()
+  })
+})

--- a/supabase/migrations/20260610130000_close_cross_user_reads_default_lists_private.sql
+++ b/supabase/migrations/20260610130000_close_cross_user_reads_default_lists_private.sql
@@ -1,0 +1,33 @@
+-- F9.2 — Close cross-user reads (user_watchlist, mood_sessions) + default new Lists private.
+--
+-- F9.1 found two broad authenticated SELECT policies that let ANY signed-in user read
+-- every user's rows (the same any-authenticated-user behavioral-read pattern F7.2 closed
+-- for user_history/user_ratings):
+--   * user_watchlist : "Authenticated users can view any watchlist"  (USING auth.uid() IS NOT NULL)
+--   * mood_sessions  : "Authenticated users can view any mood sessions" (USING auth.uid() IS NOT NULL)
+-- Both tables already carry owner-only SELECT policies (auth.uid() = user_id), so dropping the
+-- broad policy leaves each table owner-only for SELECT with no other change. Every source read of
+-- both tables already filters by the signed-in user_id (verified in F9.2), and no app code SELECTs
+-- mood_sessions at all — so this is a pure exposure closure with no consumer impact.
+--
+-- It also flips the public.lists.is_public column default from true -> false so that NEW lists are
+-- private unless the creator explicitly opts in (the "Public — anyone can see this list" checkbox).
+--
+-- SAFETY: policy drops only; one column-DEFAULT change. No table columns altered, no rows updated,
+-- existing list visibility values untouched. Idempotent (IF EXISTS + SET DEFAULT). Reversible.
+
+begin;
+
+-- 1) user_watchlist: drop the broad authenticated SELECT policy. Owner SELECT policies
+--    ("select own", "uw_select_own", "watch self select", "wl_sel_own") + the owner ALL/INSERT/
+--    UPDATE/DELETE policies remain, so SELECT becomes owner-only (auth.uid() = user_id).
+drop policy if exists "Authenticated users can view any watchlist" on public.user_watchlist;
+
+-- 2) mood_sessions: drop the broad authenticated SELECT policy. "Users can view own sessions"
+--    (owner SELECT) + "Users can create own sessions" (owner INSERT) remain intact.
+drop policy if exists "Authenticated users can view any mood sessions" on public.mood_sessions;
+
+-- 3) lists: new lists default to private. Existing rows keep their current is_public value.
+alter table public.lists alter column is_public set default false;
+
+commit;


### PR DESCRIPTION
**F9.2 — close the cross-user read exposure + default-visibility gap found in F9.1.** Narrow, database-led private-beta privacy hardening. No redesign of /account, /preferences, /browse, /lists; no recommendation/People/Profile changes.

## F9.1 finding
Two broad authenticated SELECT policies let **any signed-in user read every user's rows** — the same any-authenticated-user behavioral-read pattern F7.2 closed for `user_history`/`user_ratings`. Verified live before the fix: a random authenticated user could read **all 21 watchlist rows (4 users) + 108 mood-session rows**. New lists also defaulted to public.

## `user_watchlist` — policy before/after
- **Before:** `"Authenticated users can view any watchlist"` — `SELECT USING (auth.uid() IS NOT NULL)` (any signed-in user reads all rows).
- **After:** that policy **dropped**. Owner SELECT policies remain (`select own`, `uw_select_own`, `watch self select`, `wl_sel_own` → `auth.uid() = user_id`); owner INSERT/UPDATE/DELETE/ALL untouched → **SELECT is owner-only**.

## `mood_sessions` — policy before/after
- **Before:** `"Authenticated users can view any mood sessions"` — `SELECT USING (auth.uid() IS NOT NULL)`.
- **After:** **dropped**. `Users can view own sessions` (owner SELECT) + `Users can create own sessions` (owner INSERT) remain → **SELECT is owner-only**. (No UPDATE/DELETE policy existed before or after — unchanged.)

## Lists default-public → default-private
- Migration: `ALTER TABLE public.lists ALTER COLUMN is_public SET DEFAULT false`.
- `CreateListModal` `isPublic` default `true → false` (editing keeps the existing value; the clear *"Public — anyone can see this list"* checkbox is unchanged and still opts in).
- `PersonalList` snapshot insert `is_public: true → false`.
- Explicit public sharing still works; **existing public/private rows are not changed**.

## Existing rows unchanged
4 lists (still 4 public — not backfilled), 21 watchlist rows, 108 mood rows — **all unchanged**. Migration is policy-drops + one column-DEFAULT only; no columns altered, no rows updated; idempotent.

## Verification script result (`scripts/verify-f9-route-privacy.sql`, read-only)
- 0 broad SELECT policies remain on either table; owner SELECT + write policies intact.
- `lists.is_public` default = **false**.
- Rolled-back role simulation: a random authenticated user **and** anon now see **0** watchlist / **0** mood / **0** private-list rows.
- Security advisors: unchanged residual P2/P3 backlog, **no new P0/P1**.

## Route/source regression checks
Every `user_watchlist` read already filters `.eq('user_id', …)` (Browse, Watchlist, Library, `useUserMovieStatus`, recommendations, homepageRows, discover). No app code SELECTs `mood_sessions` (only own insert + an already-RLS-denied update). → pure exposure closure, no consumer impact.

## Tests / build
+5 unit tests (`CreateListModal` default-private + copy + toggle + edit-preserves), run 3×. Suites: lists 5, discover 190, watchlist 45, history 56, people 66; **full 1450**; build ✓; lint clean.

## No live-data-mutation confirmation
No user/list/watchlist/mood rows created, edited, or deleted. The only live change is the scoped migration (2 policy drops + 1 column default). Role simulation was rolled back. No real identifiers/private content printed.

## Deferred
- **B1.2** analytics privacy P1 (PostHog email/name + replay of private text + false "no PII" copy).
- **F9.3** reliability/a11y P2 cluster (lists create/delete settlement, preferences save-error surfacing, account delete-modal a11y, browse exact "Match %").
- F8.9 security-backlog P2s (parallel security track).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
