### PR TITLE
Harden analytics privacy for private beta

### DIFF
--- a/src/app/AppShell.jsx
+++ b/src/app/AppShell.jsx
@@ -90,10 +90,8 @@ export default function AppShell() {
   useEffect(() => {
     const uid = user?.id ?? null
     if (uid && uid !== prevUserIdRef.current) {
-      identify(uid, {
-        email: user.email,
-        name: user.user_metadata?.name,
-      })
+      // B1.2: identify by stable id ONLY — never email/name (no PII to PostHog).
+      identify(uid)
     } else if (!uid && prevUserIdRef.current) {
       resetAnalytics()
     }

--- a/src/app/header/components/SearchBar.jsx
+++ b/src/app/header/components/SearchBar.jsx
@@ -141,13 +141,23 @@ export default function SearchBar({ open, onClose }) {
     setRecentSearches(updated.slice(0, MAX_RECENT_SEARCHES))
   }
 
+  // B1.2: never send raw query text (freeform user input) to analytics — only a coarse
+  // length bucket + safe result metadata. movie_id is a catalog id (not user text).
+  function queryLengthBucket(len) {
+    if (len <= 0) return '0'
+    if (len <= 2) return '1-2'
+    if (len <= 5) return '3-5'
+    if (len <= 10) return '6-10'
+    return '11+'
+  }
+
   function goToMovie(movie) {
     saveRecentSearch(movie)
     track('search_performed', {
-      query: q.trim(),
       result_count: results.length,
+      result_kind: 'movie',
+      query_length_bucket: queryLengthBucket(q.trim().length),
       movie_id: movie.id,
-      movie_title: movie.title,
     })
     onClose?.()
     nav(`/movie/${movie.id}`)

--- a/src/features/account/sections-bottom.jsx
+++ b/src/features/account/sections-bottom.jsx
@@ -30,7 +30,7 @@ function Privacy() {
   // becomes visible to other signed-in members.
   const rows = [
     { k:'showOnLeaderboards', label:'Appear in taste-match discovery',  desc:'When on, other signed-in members may see your name, avatar, your top film-taste tags and film count when FeelFlick suggests compatible people. Your watched films, Diary, ratings, reviews and Cinematic DNA reflection stay private.' },
-    { k:'analytics',          label:'Product analytics',    desc:'Help us improve. Aggregated, no PII.' },
+    { k:'analytics',          label:'Product analytics',    desc:'Privacy-safe usage analytics to help us improve. We never send your email, name, search text, reviews, Diary, or Cinematic DNA reflection. May include privacy-masked session replay (all text and inputs masked) to diagnose bugs. Turn off any time.' },
   ];
   return (
     <section className="ff-acct-section ff-acct-section--body" style={{ padding:'56px 88px', borderTop:`1px solid ${HP.border}` }}>

--- a/src/features/legal/Privacy.jsx
+++ b/src/features/legal/Privacy.jsx
@@ -189,6 +189,9 @@ export default function Privacy() {
               We use trusted infrastructure providers to run FeelFlick. Today, that includes Supabase (authentication, database, hosting) and TMDB (movie metadata and artwork).
             </p>
             <p>
+              <span className="font-semibold text-white/85">Usage analytics &amp; error monitoring.</span> We use PostHog for privacy-safe product analytics and Sentry for error monitoring, to understand reliability and usability during our beta. We do <span className="font-semibold">not</span> send your email, name, search text, reviews, Diary entries, or Cinematic DNA reflection to PostHog &mdash; only a stable internal account identifier and coarse, non-identifying usage events. Where session replay is used, all text and form inputs are masked so private content is not captured. You can turn product analytics off any time in Account &rarr; Privacy.
+            </p>
+            <p>
               These providers process data on our behalf under strict contractual and security obligations. We do not grant them permission to use your personal information for their own marketing.
             </p>
             <p>

--- a/src/shared/services/__tests__/analyticsPrivacy.test.js
+++ b/src/shared/services/__tests__/analyticsPrivacy.test.js
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// B1.2 — fail-closed analytics privacy guard. Two layers:
+//   (1) behavior: identify/track/opt-out with a mocked PostHog;
+//   (2) source guards: scan ALL app source so a future change that re-introduces PII
+//       (email/name in identify, raw query in an event, a new un-allow-listed event,
+//       or un-masked replay) fails this test on purpose.
+
+// ── Mocked PostHog + Supabase for the behavior layer ──────────────────────────────
+// vi.hoisted so the (hoisted) vi.mock factory can reference the spy object safely.
+const ph = vi.hoisted(() => ({
+  init: vi.fn(), identify: vi.fn(), capture: vi.fn(),
+  opt_in_capturing: vi.fn(), opt_out_capturing: vi.fn(), reset: vi.fn(), debug: vi.fn(),
+}))
+vi.mock('posthog-js', () => ({ default: ph }))
+vi.mock('@/shared/lib/supabase/client', () => ({
+  supabase: {
+    from: () => ({ select: () => ({ eq: () => ({
+      maybeSingle: async () => ({ data: { settings: { privacy: { analytics: true } } } }),
+    }) }) }),
+  },
+}))
+
+import { initAnalytics, identify, track, setAnalyticsOptOut } from '../analytics.js'
+
+describe('analytics privacy — identify / track / opt-out behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubEnv('VITE_POSTHOG_KEY', 'phc_test')
+    initAnalytics()
+    setAnalyticsOptOut(false)
+  })
+  afterEach(() => vi.unstubAllEnvs())
+
+  it('identify sends ONLY the stable user id — no email/name/traits to PostHog', async () => {
+    await identify('user-uuid-123')
+    expect(ph.identify).toHaveBeenCalledTimes(1)
+    const [id, traits] = ph.identify.mock.calls[0]
+    expect(id).toBe('user-uuid-123')
+    const t = traits || {}
+    for (const k of ['email', 'name', 'display_name', 'username', 'avatar', 'avatar_url']) {
+      expect(t).not.toHaveProperty(k)
+    }
+  })
+
+  it('track is suppressed entirely when the user has opted out', () => {
+    setAnalyticsOptOut(true)
+    track('page_viewed', { path: '/home' })
+    expect(ph.capture).not.toHaveBeenCalled()
+  })
+
+  it('track fires when opted in', () => {
+    track('page_viewed', { path: '/home' })
+    expect(ph.capture).toHaveBeenCalledWith('page_viewed', { path: '/home' })
+  })
+
+  it('opt-out stops PostHog capture + replay (opt_out_capturing)', () => {
+    setAnalyticsOptOut(true)
+    expect(ph.opt_out_capturing).toHaveBeenCalled()
+  })
+})
+
+// ── Source guards (fail-closed) ───────────────────────────────────────────────────
+describe('analytics privacy — source guards', () => {
+  const ALLOWED_EVENTS = new Set([
+    'page_viewed', 'search_performed', 'signup', 'onboarding_completed',
+    'card_clicked', 'card_watchlisted', 'row_scrolled',
+  ])
+  const DISALLOWED_KEYS = new Set([
+    'email', 'name', 'display_name', 'username', 'full_name', 'avatar', 'avatar_url',
+    'phone', 'address', 'review', 'review_text', 'diary', 'diary_text', 'note', 'notes',
+    'query', 'search', 'prompt', 'text', 'body', 'content',
+    'token', 'secret', 'jwt', 'access_token', 'refresh_token',
+  ])
+
+  const all = import.meta.glob('/src/**/*.{js,jsx}', { query: '?raw', import: 'default', eager: true })
+  const appFiles = Object.entries(all).filter(([p]) => !p.includes('__tests__') && !p.includes('.test.'))
+
+  const trackCalls = (src) => {
+    const out = []
+    const re = /\btrack\(\s*['"]([\w-]+)['"]\s*(?:,\s*(\{[^}]*\}))?\s*\)/g
+    let m
+    while ((m = re.exec(src))) out.push({ event: m[1], payload: m[2] || '' })
+    return out
+  }
+
+  it('every emitted analytics event is in the allow-list (new events must opt in)', () => {
+    const seen = new Set()
+    for (const [, src] of appFiles) for (const c of trackCalls(src)) seen.add(c.event)
+    expect(seen.size).toBeGreaterThan(0)
+    for (const e of seen) expect(ALLOWED_EVENTS.has(e), `un-allow-listed analytics event "${e}"`).toBe(true)
+  })
+
+  it('no analytics payload contains a disallowed PII/freeform key (incl. raw query)', () => {
+    for (const [path, src] of appFiles) {
+      for (const c of trackCalls(src)) {
+        const keys = [...c.payload.matchAll(/(\w+)\s*:/g)].map((x) => x[1])
+        for (const k of keys) {
+          expect(DISALLOWED_KEYS.has(k), `${path}: event "${c.event}" sends disallowed key "${k}"`).toBe(false)
+        }
+      }
+    }
+  })
+
+  it('AppShell identify() passes no email/name', async () => {
+    const src = await import('@/app/AppShell.jsx?raw').then((m) => m.default)
+    const m = src.match(/[^.]identify\(([^)]*)\)/)   // the call, not the import
+    expect(m).toBeTruthy()
+    expect(m[1]).not.toMatch(/email|name/)
+  })
+
+  it('analytics.js identify forwards only the id to PostHog', async () => {
+    const src = await import('../analytics.js?raw').then((m) => m.default)
+    expect(src).toMatch(/posthog\.identify\(\s*userId\s*\)/)
+    expect(src).not.toMatch(/posthog\.identify\([^)]*(email|name|traits)/)
+  })
+
+  it('PostHog session replay masks ALL text and inputs', async () => {
+    const src = await import('../analytics.js?raw').then((m) => m.default)
+    expect(src).toMatch(/maskTextSelector:\s*['"]\*['"]/)
+    expect(src).toMatch(/maskAllInputs:\s*true/)
+  })
+
+  it('Account analytics copy is honest (no false "no PII" / "Aggregated" claim)', async () => {
+    const src = await import('@/features/account/sections-bottom.jsx?raw').then((m) => m.default)
+    const m = src.match(/k:'analytics'[^}]*desc:'([^']*)'/)
+    expect(m).toBeTruthy()
+    expect(m[1]).not.toMatch(/no PII/i)
+    expect(m[1]).not.toMatch(/aggregated/i)
+    expect(m[1]).toMatch(/email/i)            // states what is NOT sent
+  })
+
+  it('Privacy page discloses analytics accurately, without claiming PostHog deletion', async () => {
+    const src = await import('@/features/legal/Privacy.jsx?raw').then((m) => m.default)
+    expect(src).toMatch(/PostHog/)
+    expect(src).toMatch(/Sentry/)
+    expect(src).toMatch(/masked/i)
+    expect(src).toMatch(/turn product analytics off/i)
+    expect(src).not.toMatch(/deleted from PostHog|PostHog data is deleted/i)
+  })
+})

--- a/src/shared/services/analytics.js
+++ b/src/shared/services/analytics.js
@@ -22,12 +22,15 @@ export function initAnalytics() {
     // full autocapture.
     enable_heatmaps: true,
     // Session replay. Honors the same consent as events — opt_out_capturing()
-    // below also stops recording. Mask all form inputs so emails/passwords are
-    // never captured; add `data-ph-mask` to any other sensitive element.
+    // below also stops recording. B1.2 privacy hardening: mask ALL form inputs AND
+    // ALL rendered text (maskTextSelector: '*'), matching Sentry's maskAllText=true,
+    // so private surfaces (Diary, reviews/"Your Take", Cinematic DNA reflection,
+    // People names/search) can never be captured in a replay. Global, not per-element,
+    // so new private surfaces are masked by default.
     // NOTE: also enable Session Replay in the PostHog project settings.
     session_recording: {
       maskAllInputs: true,
-      maskTextSelector: '[data-ph-mask]',
+      maskTextSelector: '*',
     },
     loaded(ph) {
       if (import.meta.env.DEV) ph.debug()
@@ -39,12 +42,15 @@ export function initAnalytics() {
 /**
  * Associate the current session with an authenticated user.
  * Also reads their `user_settings.privacy.analytics` flag and honors opt-out.
+ *
+ * B1.2 privacy hardening: identify by the stable user id ONLY. We never send email,
+ * name, display name, username, avatar, or any freeform/profile trait to PostHog —
+ * the id is sufficient to stitch a session and is not directly identifying on its own.
  * @param {string} userId
- * @param {{ email?: string, name?: string }} [traits]
  */
-export async function identify(userId, traits = {}) {
-  if (!_initialized) return
-  posthog.identify(userId, traits)
+export async function identify(userId) {
+  if (!_initialized || !userId) return
+  posthog.identify(userId)
   // Best-effort opt-out check; failure leaves us opted-in (the safe default
   // for product analytics — explicit opt-out should be persisted by the time
   // we identify).


### PR DESCRIPTION
**B1.2 — harden analytics privacy before private-beta invites.** Fixes the active PostHog privacy defect from B1.1. No new event taxonomy, no analytics table, no beta gates, no DB/RLS/RPC change.

## Prior P1 analytics defect (B1.1)
PostHog `identify` sent **email + name**; session replay masked only inputs (not rendered private text — Diary/reviews/DNA/People); `search_performed` sent the **raw query**; and the Account toggle claimed *"Aggregated, no PII"* — which was **false**.

## `identify` before → after
- **Before:** `identify(uid, { email: user.email, name: user.user_metadata?.name })` → `posthog.identify(uid, {email, name})`.
- **After:** `identify(uid)` → `posthog.identify(userId)` — **stable id only**, never email/name/avatar/freeform. AppShell passes no traits and analytics.js forwards none (defense in depth).

## Replay decision
**Mask all text (not disable).** PostHog `session_recording` now `{ maskAllInputs: true, maskTextSelector: '*' }` — matching Sentry's `maskAllText: true`. Global (not per-element), so Diary, reviews/"Your Take", Cinematic DNA reflection, and People names/search can never be captured, and new private surfaces are masked by default.

## Search payload before → after
- **Before:** `{ query: q.trim(), result_count, movie_id, movie_title }`.
- **After:** `{ result_count, result_kind: 'movie', query_length_bucket, movie_id }` — no raw query, no catalog title text; coarse non-identifying metadata only.

## Account copy update
`"Help us improve. Aggregated, no PII."` → an honest description that names what is **not** sent (email, name, search text, reviews, Diary, Cinematic DNA reflection) and discloses privacy-masked session replay. The "Product analytics" label is unchanged.

## Privacy disclosure update
Added an accurate analytics section to the Privacy page's third-party block: PostHog (privacy-safe product analytics) + Sentry (error monitoring); no email/name/search/Diary/reviews/DNA to PostHog; masked replay; opt-out in Account → Privacy. **Does not** claim PostHog data is deleted on account deletion (not implemented).

## Opt-out behavior
Unchanged setting semantics, verified still complete: `setAnalyticsOptOut(true)` → `posthog.opt_out_capturing()` stops events **and** replay; `track()` no-ops when opted out; identify honors the persisted `user_settings.privacy.analytics` flag.

## Tests
New `src/shared/services/__tests__/analyticsPrivacy.test.js` (11 cases, run 3×): **behavior** — identify sends id only, track suppressed on opt-out, opt-out calls `opt_out_capturing`; **fail-closed source guards over all of `src`** — every emitted event is in a 7-event allow-list, no `track` payload contains a disallowed PII/freeform key (email/name/**query**/review/diary/token/…), AppShell identify passes no email/name, analytics.js forwards only the id, replay masks all text+inputs, Account copy drops the false claims, Privacy page discloses accurately. A future regression (re-adding PII or a new un-allow-listed event) fails this test.

## Validation
lint clean; shared/services 371; account 4; people 66; **full 1461** (1450 + 11); build ✓. F9.2 `mood_sessions`/`user_watchlist` verified still owner-only (read-only, not re-changed).

## No-live-action confirmation
No live route opened for replay testing; no list/preference/Diary/follow/discoverability/analytics-toggle mutation on a real user; no real emails/names/IDs/secrets/search/Diary/review text printed. Tests use a mocked PostHog + source scans.

## Deferred (B1.3)
Privacy-safe event taxonomy + new-funnel instrumentation (onboarding/Home/Library/Profile/People); beta kill-switches/feature-flags + server-enforced beta gate; error-capture hardening (global listeners, Sentry `beforeSend`, Edge→Sentry, RLS-error visibility, cron-health alert); PostHog account-deletion retention. Residual F8.9 security-backlog P2s stay on the parallel track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
