### PR TITLE
Add privacy-safe beta instrumentation controls

### DIFF
--- a/docs/beta/instrumentation-b1.md
+++ b/docs/beta/instrumentation-b1.md
@@ -1,0 +1,69 @@
+# Private-beta instrumentation (B1.x) — operator reference
+
+Status: **current**. Scope: how FeelFlick observes private beta safely. No secrets, no real dashboard URLs.
+
+The privacy posture from B1.2 is load-bearing: **identify sends a stable user id only** (no email/name), **PostHog + Sentry session replay mask all text**, **no raw search/Diary/review/DNA text is ever sent**. B1.3 adds a small event taxonomy, a fail-closed event wrapper, error buckets, and runtime kill-switches — all on top of that posture.
+
+## Event taxonomy (source of truth: `src/shared/services/betaEvents.js`)
+
+Every beta event goes through `trackEvent(EVENTS.x, payload)`, which delegates to `analytics.track` (opt-out aware). The allow-list of event names lives in `EVENTS`; a un-allow-listed name is dropped.
+
+**Instrumented in B1.3:**
+- People — `people_opened`, `people_search_used`, `people_search_empty`, `people_follow_succeeded`, `people_follow_failed`, `people_unfollow_succeeded`, `people_hide_suggestion`
+- Profile — `profile_reflection_refresh_started` / `_succeeded` / `_failed`
+- Home — `home_opened`
+- System — `route_error` (from the global ErrorBoundary)
+- Onboarding — `onboarding_completed` (predates B1.3, emitted via `analytics.track`)
+
+**Defined but not yet emitted** (reserved in `EVENTS`, wire in B1.4): the Discover recommendation funnel (`discover_opened`, `recommendation_shown`/`_opened`/`_saved`/`_error`), `home_error`, `nightly_pick_shown`, `profile_opened_self`, `profile_forming_state_seen`, `people_empty_state`, `auth_error`, `supabase_error`. These were deferred to avoid touching the Discover recommendation flow / hook-order-sensitive components in an instrumentation-only phase.
+
+## Safe payload policy
+
+`trackEvent` is fail-closed (enforced by `betaEvents.test.js`):
+- payload keys must be in `ALLOWED_KEYS` (e.g. `surface`, `result_count`, `result_kind`, `movie_id`, `*_bucket`, `error_kind`, `from_cache`, `has_results`) — anything else is dropped;
+- values that look like PII/freeform (email, JWT, URL, text > 64 chars, any object/array/Error) are dropped;
+- `null`/`undefined` are stripped.
+
+**Never sent:** email, name, username, avatar, phone; search query text; review / Diary / Cinematic-DNA / freeform text; user-entered movie titles; other users' ids (People events carry `surface` + buckets only — no target id/name); tokens/secrets/JWTs; raw backend error messages (use `errorKind()` → `auth` / `permission_denied` / `timeout` / `network` / `edge_error` / `supabase_error` / `unknown`).
+
+`movie_id` (catalog id) is allowed where useful. The current signed-in user is the PostHog distinct id via `identify` only.
+
+## Kill-switches (`src/shared/config/betaFlags.js`)
+
+`isEnabled(key)` reads a public env var, **defaults to enabled** (no behavior change), and disables on `false`/`0`/`off`. Set at deploy time to disable a misbehaving surface without a code change; the surface must then show an honest fallback.
+
+| Flag | Env var | Wired fallback |
+|---|---|---|
+| `people` | `VITE_ENABLE_PEOPLE` | `/people` shows "taking a short break" and mounts **no** provider/RPC |
+| `profileRefresh` | `VITE_ENABLE_PROFILE_REFRESH` | refresh shows the honest "couldn't refresh" state, no Edge call |
+| `dailyBriefing` | `VITE_ENABLE_DAILY_BRIEFING` | defined; not yet wired (server-side cron is the real control) |
+| `discoverRecommendations` | `VITE_ENABLE_DISCOVER_RECOMMENDATIONS` | defined; not yet wired |
+
+## PostHog funnel suggestions
+
+- **Activation:** `onboarding_completed` → `home_opened` → first `people_*` / `profile_reflection_refresh_*`.
+- **People engagement:** `people_opened` → `people_search_used` → `people_follow_succeeded`; watch `people_follow_failed` / `people_search_empty` / `people_hide_suggestion` rates.
+- **Profile reliability:** `profile_reflection_refresh_started` → `_succeeded` vs `_failed` (with `error_kind` breakdown).
+
+## Sentry alert suggestions
+
+- spike in `route_error` (or by `error_kind`);
+- spike in `profile_reflection_refresh_failed` `error_kind=edge_error` (the taste-summary Edge function);
+- spike in `people_follow_failed` `error_kind=permission_denied` (would indicate an RLS regression);
+- auth-error rate; new-issue alerts on the `production` environment.
+
+## Beta metrics
+
+Activation (onboarding→home→first action), People engagement (open/search/follow/hide rates), Profile refresh success rate, and reliability (route/Profile/People error buckets). All from the events above — no PII required.
+
+## Retained gaps / deferred
+
+- **Discover recommendation funnel** + Home `nightly_pick_shown` + onboarding step/abandon events — deferred to B1.4 (touching the recommendation flow needs the engine evaluation process, out of scope here).
+- **`page_viewed` path values** can contain dynamic ids (`/profile/:id`, `/lists/:id`). Consider redacting dynamic path segments in B1.4.
+- **Operator dashboard** — none built; use PostHog/Sentry directly per above.
+- Server-enforced **beta access gate** (allowlist) — only the client-side `VITE_ADMIN_EMAILS` exists; a real gate is a separate phase (B1.4).
+
+## Data retention
+
+- First-party event/session tables are purged on account deletion by `process-account-deletions`.
+- **PostHog retention gap:** PostHog data is **not** automatically deleted on account deletion, and no app-side PostHog delete call exists. The Privacy page therefore does **not** claim PostHog deletion. Closing this (a PostHog person-delete on account deletion, plus a documented retention window) is a B1.4 item. Sentry replays sample at 10% and mask all text.

--- a/src/app/ErrorBoundary.jsx
+++ b/src/app/ErrorBoundary.jsx
@@ -3,6 +3,7 @@ import { Component } from 'react'
 import * as Sentry from '@sentry/react'
 import { AlertTriangle, RefreshCw, Home, Mail } from 'lucide-react'
 import Button from '@/shared/ui/Button'
+import { trackEvent, EVENTS } from '@/shared/services/betaEvents'
 
 /**
  * Production-grade Error Boundary with:
@@ -37,7 +38,9 @@ export default class ErrorBoundary extends Component {
     
     // Report to error tracking service (Sentry, LogRocket, etc.)
     this.reportError(error, errorInfo)
-    
+    // B1.3: privacy-safe reliability signal — coarse error bucket only, never raw error text.
+    trackEvent(EVENTS.route_error, { error_kind: this.state.errorType || 'unknown' })
+
     // Auto-retry for network errors (max 3 attempts)
     if (this.state.errorType === 'network' && this.state.retryCount < 3) {
       this.scheduleRetry()

--- a/src/features/home/Home.jsx
+++ b/src/features/home/Home.jsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { useAuthSession } from '@/shared/hooks/useAuthSession'
+import { trackEvent, EVENTS } from '@/shared/services/betaEvents'
 import { usePageMeta } from '@/shared/hooks/usePageMeta'
 import { trackInteraction } from '@/shared/services/interactions'
 import { updateImpression } from '@/shared/services/recommendations'
@@ -42,6 +43,7 @@ function HomeBody() {
   const { loading, error, moods: liveMoods } = useHomeData()
   const [currentMood, setMood] = useState(MOOD_META[0])
   const [userPickedMood, setUserPickedMood] = useState(false)
+  useEffect(() => { trackEvent(EVENTS.home_opened, { surface: 'home' }) }, []) // B1.3 funnel entry
 
   // When the data hook finishes, snap the initial mood tab to the user's first
   // baseline pick from Onboarding Step 1 (useHomeData reorders `moods` so the

--- a/src/features/people/People.jsx
+++ b/src/features/people/People.jsx
@@ -11,6 +11,9 @@ import { usePageMeta } from '@/shared/hooks/usePageMeta'
 import Eyebrow from '@/shared/ui/Eyebrow'
 import { HP, HP_GRAD } from './data'
 import { PeopleDataProvider, usePeopleData } from './usePeopleData'
+import { trackEvent, EVENTS, queryLengthBucket } from '@/shared/services/betaEvents'
+import { isEnabled } from '@/shared/config/betaFlags'
+import PeopleUnavailable from './PeopleUnavailable'
 import { nextFocusId, scheduleFocus } from './hooks/usePeopleFollowActions'
 import './people.css'
 
@@ -405,6 +408,9 @@ function PeopleV2Body() {
   const { user: authUser } = useAuthSession()
   const { relStatus } = usePeopleData()
 
+  // B1.3: privacy-safe open signal (no ids/names).
+  useEffect(() => { trackEvent(EVENTS.people_opened, { surface: 'people' }) }, [])
+
   // Debounce 300ms
   useEffect(() => {
     if (!query.trim()) {
@@ -431,6 +437,10 @@ function PeopleV2Body() {
         const { data, error } = await supabase.rpc('search_people_by_name', { search_query: debouncedQuery })
         if (error) throw error
         if (!abort) {
+          // B1.3: search telemetry — coarse only, NEVER the typed query text or any result id/name.
+          const n = (data || []).length
+          if (n === 0) trackEvent(EVENTS.people_search_empty, { surface: 'people', query_length_bucket: queryLengthBucket(debouncedQuery.length) })
+          else trackEvent(EVENTS.people_search_used, { surface: 'people', result_count: n, result_kind: 'person', query_length_bucket: queryLengthBucket(debouncedQuery.length) })
           setResults((data || []).map(u => ({
             id: u.id,
             name: u.name || 'Anonymous',
@@ -477,6 +487,9 @@ function PeopleV2Body() {
 
 export default function People() {
   usePageMeta({ title: 'People — FeelFlick' })
+  // B1.3 kill-switch: when People is disabled for beta, show an honest fallback and load NO data
+  // (the provider — and every People RPC — is never mounted). Defaults to enabled (no behavior change).
+  if (!isEnabled('people')) return <PeopleUnavailable />
   return (
     <PeopleDataProvider>
       <PeopleV2Body />

--- a/src/features/people/PeopleUnavailable.jsx
+++ b/src/features/people/PeopleUnavailable.jsx
@@ -1,0 +1,13 @@
+// B1.3 — honest fallback shown when the People surface is disabled via the VITE_ENABLE_PEOPLE
+// kill-switch. It loads NO data (the data provider + every People RPC are never mounted) and
+// exposes nothing private. Its own <h1> keeps the disabled page accessible.
+export default function PeopleUnavailable() {
+  return (
+    <main style={{ maxWidth: 680, margin: '0 auto', padding: '120px 24px', textAlign: 'center' }}>
+      <h1 style={{ fontSize: 28, fontWeight: 800, marginBottom: 12 }}>People is taking a short break</h1>
+      <p style={{ color: 'rgba(250,250,250,0.62)', fontSize: 15, lineHeight: 1.6 }}>
+        Taste-match discovery is paused during beta. It&rsquo;ll be back soon &mdash; your follows and settings are safe.
+      </p>
+    </main>
+  )
+}

--- a/src/features/people/__tests__/PeopleInstrumentation.test.jsx
+++ b/src/features/people/__tests__/PeopleInstrumentation.test.jsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+// Spy trackEvent but keep EVENTS/errorKind real, so we assert the exact event + that NO target
+// id/name ever appears in a People analytics payload.
+const trackEventMock = vi.hoisted(() => vi.fn())
+vi.mock('@/shared/services/betaEvents', async (orig) => ({ ...(await orig()), trackEvent: trackEventMock }))
+
+const supa = vi.hoisted(() => ({ insertError: null, deleteError: null, rpc: vi.fn(async () => ({ data: [], error: null })) }))
+vi.mock('@/shared/lib/supabase/client', () => ({
+  supabase: {
+    rpc: supa.rpc,
+    from: () => ({
+      insert: async () => ({ error: supa.insertError }),
+      delete: () => ({ eq: () => ({ eq: async () => ({ error: supa.deleteError }) }) }),
+    }),
+  },
+}))
+
+import { usePeopleFollowActions } from '../hooks/usePeopleFollowActions'
+import People from '../People'
+import { EVENTS } from '@/shared/services/betaEvents'
+
+const setup = (followingIds = new Set()) =>
+  renderHook(() => usePeopleFollowActions({ userId: 'me', followingIds, applyFollowState: () => {} }))
+
+describe('People instrumentation — safe events, never a target id/name', () => {
+  beforeEach(() => { trackEventMock.mockClear(); supa.insertError = null; supa.deleteError = null })
+
+  const noTargetLeak = () => {
+    for (const [, payload] of trackEventMock.mock.calls) {
+      const s = JSON.stringify(payload || {})
+      expect(s).not.toContain('target-123')
+      expect(s).not.toContain('Ana')
+    }
+  }
+
+  it('follow success → people_follow_succeeded (surface only)', async () => {
+    const { result } = setup()
+    await act(async () => { await result.current.follow('target-123', 'Ana Okafor') })
+    expect(trackEventMock).toHaveBeenCalledWith(EVENTS.people_follow_succeeded, { surface: 'people' })
+    noTargetLeak()
+  })
+
+  it('follow failure → people_follow_failed with an error_kind bucket', async () => {
+    supa.insertError = { code: '42501', message: 'permission denied' }
+    const { result } = setup()
+    await act(async () => { await result.current.follow('target-123', 'Ana Okafor') })
+    const call = trackEventMock.mock.calls.find((c) => c[0] === EVENTS.people_follow_failed)
+    expect(call).toBeTruthy()
+    expect(call[1]).toEqual({ surface: 'people', error_kind: 'permission_denied' })
+    noTargetLeak()
+  })
+
+  it('unfollow success → people_unfollow_succeeded', async () => {
+    const { result } = setup(new Set(['target-123']))
+    await act(async () => { await result.current.unfollow('target-123', 'Ana Okafor') })
+    expect(trackEventMock).toHaveBeenCalledWith(EVENTS.people_unfollow_succeeded, { surface: 'people' })
+    noTargetLeak()
+  })
+
+  it('hide suggestion → people_hide_suggestion (no id)', () => {
+    const { result } = setup()
+    act(() => { result.current.hideSuggestion('target-123') })
+    expect(trackEventMock).toHaveBeenCalledWith(EVENTS.people_hide_suggestion, { surface: 'people' })
+    noTargetLeak()
+  })
+})
+
+describe('People kill-switch — disabled flow shows fallback, loads no data', () => {
+  afterEach(() => vi.unstubAllEnvs())
+
+  it('VITE_ENABLE_PEOPLE=false → fallback copy, and no People RPC is called', () => {
+    vi.stubEnv('VITE_ENABLE_PEOPLE', 'false')
+    supa.rpc.mockClear()
+    render(<MemoryRouter><People /></MemoryRouter>)
+    expect(screen.getByText(/People is taking a short break/i)).toBeInTheDocument()
+    expect(supa.rpc).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/people/hooks/usePeopleFollowActions.js
+++ b/src/features/people/hooks/usePeopleFollowActions.js
@@ -13,6 +13,7 @@
 
 import { useState, useRef, useCallback, useEffect } from 'react'
 import { supabase } from '@/shared/lib/supabase/client'
+import { trackEvent, EVENTS, errorKind } from '@/shared/services/betaEvents'
 
 // ── pure focus-after-removal (People-local; neutral, kept out of Library to avoid coupling) ──────
 // The id to focus after `removedId` leaves `orderedIds`: prefer the NEXT, else PREVIOUS, else null.
@@ -79,9 +80,11 @@ export function usePeopleFollowActions({ userId, followingIds, applyFollowState 
         .insert({ follower_id: userId, following_id: targetId })
       if (error && error.code !== '23505') throw error        // 23505 = already following → success
       if (mounted.current) { applyFollowState(targetId, true); announce(`You're now following ${name || 'this person'}.`) }
+      trackEvent(EVENTS.people_follow_succeeded, { surface: 'people' }) // no target id/name
     } catch (e) {
       if (import.meta.env?.DEV) console.error('[people.follow]', e)
       if (mounted.current) { mark(setErrored, targetId, true); announce(`Could not follow ${name || 'this person'}. Try again.`) }
+      trackEvent(EVENTS.people_follow_failed, { surface: 'people', error_kind: errorKind(e) })
     } finally {
       inFlight.current.delete(targetId)
       mark(setPending, targetId, false)
@@ -103,6 +106,7 @@ export function usePeopleFollowActions({ userId, followingIds, applyFollowState 
         .eq('following_id', targetId)
       if (error) throw error
       if (mounted.current) { applyFollowState(targetId, false); announce(`You stopped following ${name || 'this person'}.`) }
+      trackEvent(EVENTS.people_unfollow_succeeded, { surface: 'people' })
     } catch (e) {
       if (import.meta.env?.DEV) console.error('[people.unfollow]', e)
       if (mounted.current) { mark(setErrored, targetId, true); announce(`Could not unfollow ${name || 'this person'}. Try again.`) }
@@ -118,6 +122,7 @@ export function usePeopleFollowActions({ userId, followingIds, applyFollowState 
     if (!targetId) return
     mark(setHidden, targetId, true)
     announce('Hidden from your suggestions.')
+    trackEvent(EVENTS.people_hide_suggestion, { surface: 'people' })
   }, [announce, mark])
 
   const isPending = useCallback((id) => pending.has(id), [pending])

--- a/src/features/profile/useProfileData.jsx
+++ b/src/features/profile/useProfileData.jsx
@@ -10,6 +10,8 @@ import { supabase } from '@/shared/lib/supabase/client'
 import { getTasteFingerprint } from '@/shared/services/tasteCache'
 import { dedupeHistoryByMovie } from '@/shared/lib/canonicalHistory'
 import { classifyProfileMaturity, MATURITY } from './derive/profilePresentation'
+import { trackEvent, EVENTS, errorKind } from '@/shared/services/betaEvents'
+import { isEnabled } from '@/shared/config/betaFlags'
 import { PROFILE_EVIDENCE_VERSION, isEditorialVersionCurrent } from '@/shared/lib/profileEvidenceVersion'
 
 import {
@@ -87,9 +89,13 @@ export function useProfileDataFetch({ userId, authUser, isSelf = false }) {
     // Eligible only for the signed-in user with a non-forming profile — never from forming,
     // never from a non-self/private view. Duplicate rapid clicks collapse to one call.
     if (!inputs || !inputs.isSelf || inputs.maturity === MATURITY.FORMING) return
+    // B1.3 kill-switch: when reflection refresh is disabled for beta, surface the honest
+    // "couldn't refresh" state instead of calling the Edge function (safe fallback, no crash).
+    if (!isEnabled('profileRefresh')) { if (mountedRef.current) setRefreshStatus('error'); return }
     if (inFlightRef.current) return
     inFlightRef.current = true
     setRefreshStatus('generating')
+    trackEvent(EVENTS.profile_reflection_refresh_started, { surface: 'profile' })
     try {
       const updated = await regenerateEditorial(inputs)
       if (!updated) throw new Error('refresh_failed')
@@ -99,8 +105,10 @@ export function useProfileDataFetch({ userId, authUser, isSelf = false }) {
         setState(s => ({ ...s, editorial: { ...s.editorial, ...updated }, editorialStatus: 'current' }))
         setRefreshStatus('success')
       }
-    } catch {
+      trackEvent(EVENTS.profile_reflection_refresh_succeeded, { surface: 'profile' })
+    } catch (e) {
       if (mountedRef.current) setRefreshStatus('error')   // raw backend text never surfaced
+      trackEvent(EVENTS.profile_reflection_refresh_failed, { surface: 'profile', error_kind: errorKind(e) })
     } finally {
       inFlightRef.current = false
     }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -32,6 +32,17 @@ Sentry.init({
   tracesSampleRate: 0.2,
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
+  // B1.3: defense-in-depth PII scrub — never ship account email/name/IP in error context.
+  // (Sentry's default integrations already capture window.onerror + unhandledrejection.)
+  beforeSend(event) {
+    if (event.user) {
+      delete event.user.email
+      delete event.user.username
+      delete event.user.ip_address
+      delete event.user.name
+    }
+    return event
+  },
 })
 
 // Handle OAuth callback hash immediately, before React Router processes anything

--- a/src/shared/config/__tests__/betaFlags.test.js
+++ b/src/shared/config/__tests__/betaFlags.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { isEnabled, FLAG_KEYS } from '../betaFlags'
+
+describe('betaFlags — kill switches default safe', () => {
+  afterEach(() => vi.unstubAllEnvs())
+
+  it('every flag defaults to ENABLED when its env var is unset (current behavior)', () => {
+    for (const key of FLAG_KEYS) expect(isEnabled(key)).toBe(true)
+  })
+
+  it('disables on "false" / "0" / "off"', () => {
+    for (const v of ['false', 'FALSE', '0', 'off']) {
+      vi.stubEnv('VITE_ENABLE_PEOPLE', v)
+      expect(isEnabled('people')).toBe(false)
+    }
+  })
+
+  it('stays enabled for "true" / "1" / any other value', () => {
+    for (const v of ['true', '1', 'yes', 'on']) {
+      vi.stubEnv('VITE_ENABLE_PROFILE_REFRESH', v)
+      expect(isEnabled('profileRefresh')).toBe(true)
+    }
+  })
+
+  it('an unknown flag never gates (returns true)', () => {
+    expect(isEnabled('nope')).toBe(true)
+  })
+})

--- a/src/shared/config/betaFlags.js
+++ b/src/shared/config/betaFlags.js
@@ -1,0 +1,29 @@
+// src/shared/config/betaFlags.js
+//
+// B1.3 — the smallest safe runtime kill-switch layer for private beta. NOT a feature-flag platform:
+// flags are read from public build-time env vars and default to ENABLED (current behavior). When a
+// flag is explicitly set to 'false' or '0', the owning surface must show an honest fallback — never
+// crash, never expose private data. This lets us disable a misbehaving surface during beta without a
+// code change, while regular users see no difference unless a flag is flipped.
+//
+// To disable a surface for a deploy, set the env var to 'false', e.g. VITE_ENABLE_PEOPLE=false.
+
+const FLAG_ENV = Object.freeze({
+  people: 'VITE_ENABLE_PEOPLE',
+  profileRefresh: 'VITE_ENABLE_PROFILE_REFRESH',
+  dailyBriefing: 'VITE_ENABLE_DAILY_BRIEFING',
+  discoverRecommendations: 'VITE_ENABLE_DISCOVER_RECOMMENDATIONS',
+})
+
+// Read live from import.meta.env each call so tests can stub a single flag without reloading.
+export function isEnabled(key) {
+  const envKey = FLAG_ENV[key]
+  if (!envKey) return true // unknown flag → never gate
+  let raw
+  try { raw = import.meta.env?.[envKey] } catch { raw = undefined }
+  if (raw === undefined || raw === null || raw === '') return true // default ON
+  const v = String(raw).toLowerCase()
+  return !(v === 'false' || v === '0' || v === 'off')
+}
+
+export const FLAG_KEYS = Object.freeze(Object.keys(FLAG_ENV))

--- a/src/shared/services/__tests__/betaEvents.test.js
+++ b/src/shared/services/__tests__/betaEvents.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// betaEvents delegates to analytics.track (which owns opt-out). Mock it to inspect what — if
+// anything — actually reaches the analytics layer after the fail-closed sanitiser runs.
+const analyticsTrack = vi.hoisted(() => vi.fn())
+vi.mock('../analytics', () => ({ track: analyticsTrack }))
+
+import {
+  trackEvent, EVENTS, isUnsafeValue, errorKind, countBucket, latencyBucket, queryLengthBucket,
+} from '../betaEvents'
+
+describe('betaEvents — fail-closed event contract', () => {
+  beforeEach(() => analyticsTrack.mockClear())
+
+  it('drops un-allow-listed event names (nothing reaches analytics)', () => {
+    trackEvent('totally_made_up_event', { surface: 'x' })
+    expect(analyticsTrack).not.toHaveBeenCalled()
+  })
+
+  it('emits an allow-listed event through analytics.track', () => {
+    trackEvent(EVENTS.people_opened, { surface: 'people' })
+    expect(analyticsTrack).toHaveBeenCalledWith('people_opened', { surface: 'people' })
+  })
+
+  it('drops disallowed payload keys (email/name/query/review/diary/token)', () => {
+    trackEvent(EVENTS.people_search_used, {
+      result_count: 3, email: 'a@b.com', query: 'jaws', review: 'loved it', name: 'Bob', token: 'xyz',
+    })
+    expect(analyticsTrack).toHaveBeenCalledWith('people_search_used', { result_count: 3 })
+  })
+
+  it('drops PII-shaped values even on an allowed key', () => {
+    trackEvent(EVENTS.route_error, { error_kind: 'someone@example.com' })
+    expect(analyticsTrack).toHaveBeenCalledWith('route_error', {})
+  })
+
+  it('never sends a raw Error object or any nested object', () => {
+    trackEvent(EVENTS.people_follow_failed, { error_kind: new Error('boom'), surface: 'people' })
+    expect(analyticsTrack).toHaveBeenCalledWith('people_follow_failed', { surface: 'people' })
+  })
+
+  it('allows movie_id (catalog-safe) and strips null/undefined', () => {
+    trackEvent(EVENTS.recommendation_shown, { movie_id: 12345, source: null, result_count: undefined })
+    expect(analyticsTrack).toHaveBeenCalledWith('recommendation_shown', { movie_id: 12345 })
+  })
+})
+
+describe('betaEvents — helpers never leak raw text', () => {
+  it('errorKind maps to stable buckets, never raw error text', () => {
+    expect(errorKind(new Error('JWT expired'))).toBe('auth')
+    expect(errorKind({ code: '42501' })).toBe('permission_denied')
+    expect(errorKind(new Error('Failed to fetch'))).toBe('network')
+    expect(errorKind(new Error('request timed out'))).toBe('timeout')
+    expect(errorKind('a weird thing happened with secret token abc')).toBe('unknown')
+    // returns one of a fixed set — never the input string
+    expect(['auth', 'permission_denied', 'timeout', 'network', 'edge_error', 'supabase_error', 'unknown'])
+      .toContain(errorKind('anything'))
+  })
+
+  it('buckets are coarse and non-identifying', () => {
+    expect(countBucket(0)).toBe('0')
+    expect(countBucket(4)).toBe('3-5')
+    expect(countBucket(50)).toBe('11+')
+    expect(queryLengthBucket(1)).toBe('1-2')
+    expect(latencyBucket(50)).toBe('<200')
+    expect(latencyBucket(5000)).toBe('3s+')
+  })
+
+  it('isUnsafeValue flags emails/JWT/URL/long-text/objects, not enums/numbers/bools', () => {
+    expect(isUnsafeValue('a@b.com')).toBe(true)
+    expect(isUnsafeValue('eyJabcdef.payload')).toBe(true)
+    expect(isUnsafeValue('https://x.com?q=secret')).toBe(true)
+    expect(isUnsafeValue('x'.repeat(80))).toBe(true)
+    expect(isUnsafeValue({})).toBe(true)
+    expect(isUnsafeValue(['a'])).toBe(true)
+    expect(isUnsafeValue('people')).toBe(false)
+    expect(isUnsafeValue('permission_denied')).toBe(false)
+    expect(isUnsafeValue(42)).toBe(false)
+    expect(isUnsafeValue(true)).toBe(false)
+  })
+})

--- a/src/shared/services/betaEvents.js
+++ b/src/shared/services/betaEvents.js
@@ -1,0 +1,118 @@
+// src/shared/services/betaEvents.js
+//
+// B1.3 — the single source of truth for the private-beta event taxonomy and the ONE hardened
+// path every beta event flows through. Builds on B1.2: events go through analytics.track (which
+// honors opt-out + the absence of PostHog), and this wrapper additionally:
+//   * rejects any event name not in EVENTS (the allow-list);
+//   * drops any payload key not in ALLOWED_KEYS;
+//   * drops PII-shaped / freeform / Error values (email, JWT, URL, long text, objects);
+//   * strips null/undefined.
+// Product code must call trackEvent(EVENTS.x, {...}) — never a raw string, never posthog directly.
+
+import { track as analyticsTrack } from './analytics'
+
+// ── Event allow-list (add here intentionally; the test fails on un-listed names) ──────────────
+export const EVENTS = Object.freeze({
+  // Onboarding (onboarding_completed predates B1.3 and is emitted via analytics.track directly)
+  onboarding_completed: 'onboarding_completed',
+  // Discover
+  discover_opened: 'discover_opened',
+  recommendation_shown: 'recommendation_shown',
+  recommendation_opened: 'recommendation_opened',
+  recommendation_saved: 'recommendation_saved',
+  recommendation_error: 'recommendation_error',
+  // Home
+  home_opened: 'home_opened',
+  nightly_pick_shown: 'nightly_pick_shown',
+  home_error: 'home_error',
+  // Profile
+  profile_opened_self: 'profile_opened_self',
+  profile_reflection_refresh_started: 'profile_reflection_refresh_started',
+  profile_reflection_refresh_succeeded: 'profile_reflection_refresh_succeeded',
+  profile_reflection_refresh_failed: 'profile_reflection_refresh_failed',
+  profile_forming_state_seen: 'profile_forming_state_seen',
+  // People
+  people_opened: 'people_opened',
+  people_search_used: 'people_search_used',
+  people_search_empty: 'people_search_empty',
+  people_follow_succeeded: 'people_follow_succeeded',
+  people_follow_failed: 'people_follow_failed',
+  people_unfollow_succeeded: 'people_unfollow_succeeded',
+  people_hide_suggestion: 'people_hide_suggestion',
+  people_empty_state: 'people_empty_state',
+  // System / reliability
+  route_error: 'route_error',
+  auth_error: 'auth_error',
+  supabase_error: 'supabase_error',
+})
+
+const EVENT_NAMES = new Set(Object.values(EVENTS))
+
+// ── Payload key allow-list (everything else is dropped). All non-PII, non-freeform. ───────────
+export const ALLOWED_KEYS = new Set([
+  'event_version', 'surface', 'source', 'step_key', 'reaction', 'placement',
+  'result_count', 'result_kind', 'has_results', 'from_cache',
+  'movie_id', // catalog id — safe + useful
+  'genre_count_bucket', 'mood_count_bucket', 'count_bucket',
+  'query_length_bucket', 'latency_bucket', 'retry_count_bucket', 'status_bucket',
+  'error_kind',
+])
+
+// Reject obviously-PII / freeform / unsafe values. Numbers, booleans and short enum-ish strings
+// pass; emails, JWTs, URLs, long text, objects, arrays and Errors are dropped.
+export function isUnsafeValue(v) {
+  if (v == null) return false
+  const t = typeof v
+  if (t === 'number' || t === 'boolean') return false
+  if (t !== 'string') return true // objects / arrays / Error instances are never sent
+  if (v.length > 64) return true // long freeform text
+  if (/@/.test(v)) return true // email-ish
+  if (/^ey[A-Za-z0-9_-]{6,}\./.test(v)) return true // JWT
+  if (/https?:\/\//i.test(v)) return true // URL (may carry query params)
+  return false
+}
+
+const isDev = () => { try { return !!import.meta.env?.DEV } catch { return false } }
+
+/**
+ * Emit a private-beta analytics event. Fail-closed: unknown event → dropped; disallowed/unsafe
+ * payload keys → dropped. In dev it warns loudly so misuse is caught during development.
+ */
+export function trackEvent(name, payload = {}) {
+  if (!EVENT_NAMES.has(name)) {
+    if (isDev()) console.warn(`[betaEvents] dropped un-allow-listed event "${name}"`)
+    return
+  }
+  const safe = {}
+  for (const [k, v] of Object.entries(payload || {})) {
+    if (!ALLOWED_KEYS.has(k)) { if (isDev()) console.warn(`[betaEvents] "${name}": dropped key "${k}"`); continue }
+    if (v == null) continue
+    if (isUnsafeValue(v)) { if (isDev()) console.warn(`[betaEvents] "${name}": dropped unsafe value for "${k}"`); continue }
+    safe[k] = v
+  }
+  analyticsTrack(name, safe) // analytics.track respects opt-out + no-op when PostHog is absent
+}
+
+// ── Coarse, non-identifying bucket helpers ────────────────────────────────────────────────────
+export const countBucket = (n) =>
+  n == null ? undefined : n <= 0 ? '0' : n <= 2 ? '1-2' : n <= 5 ? '3-5' : n <= 10 ? '6-10' : '11+'
+
+export const latencyBucket = (ms) =>
+  ms == null ? undefined : ms < 200 ? '<200' : ms < 500 ? '200-500' : ms < 1000 ? '500-1000' : ms < 3000 ? '1-3s' : '3s+'
+
+export const queryLengthBucket = (len) =>
+  len == null ? undefined : len <= 0 ? '0' : len <= 2 ? '1-2' : len <= 5 ? '3-5' : len <= 10 ? '6-10' : '11+'
+
+/**
+ * Map any error to a stable, non-identifying bucket. NEVER returns raw error text.
+ */
+export function errorKind(err) {
+  const msg = String(err?.message || err?.code || err || '').toLowerCase()
+  if (/jwt|not authenticated|auth\b|\b401\b|session/.test(msg)) return 'auth'
+  if (/permission|denied|rls|\b403\b|42501/.test(msg)) return 'permission_denied'
+  if (/timeout|timed out|aborted/.test(msg)) return 'timeout'
+  if (/network|failed to fetch|offline|connection/.test(msg)) return 'network'
+  if (/edge|functions\/v1|non-2xx/.test(msg)) return 'edge_error'
+  if (/supabase|postgrest|pgrst/.test(msg)) return 'supabase_error'
+  return 'unknown'
+}


### PR DESCRIPTION
**B1.3 — the minimal privacy-safe private-beta observation + operational-control layer.** Builds on B1.2 (id-only identify, all-text replay masking, no raw search/private text). No new analytics table, no DB/RLS/RPC change, no recommendation-logic change, no product-flow change for regular users except a safe fallback when a kill-switch is flipped.

## Event taxonomy added
Single source of truth in `src/shared/services/betaEvents.js` (`EVENTS` allow-list + helpers). Emitted in B1.3: **People** (`people_opened`, `people_search_used`/`_empty`, `people_follow_succeeded`/`_failed`, `people_unfollow_succeeded`, `people_hide_suggestion`), **Profile** (`profile_reflection_refresh_started`/`_succeeded`/`_failed`), **Home** (`home_opened`), **System** (`route_error`). `onboarding_completed` predates B1.3. Reserved-but-deferred (B1.4): the Discover recommendation funnel, `nightly_pick_shown`, `profile_opened_self`, onboarding steps — left untouched to avoid changing the recommendation flow / hook-order-sensitive components.

## Payload privacy rules (fail-closed)
`trackEvent(EVENTS.x, payload)` → delegates to `analytics.track` (opt-out aware) and: drops un-allow-listed event names; drops any key not in `ALLOWED_KEYS`; drops PII-shaped/freeform values (email, JWT, URL, >64 chars, any object/array/**Error**); strips null/undefined. **People events carry `surface` + buckets only — never a target user id/name.** `errorKind()` maps any error to a stable bucket (`auth`/`permission_denied`/`timeout`/`network`/`edge_error`/`supabase_error`/`unknown`) — never raw text. `movie_id` (catalog) allowed.

## Surfaces instrumented
People follow/unfollow/hide hook, People open/search, Profile refresh lifecycle, Home open, and the global ErrorBoundary — each a 1–3 line additive touch. No Discover engine flow touched.

## Opt-out behavior
Unchanged: events flow through `analytics.track`, which no-ops when the user has opted out (or when PostHog is absent). identify still id-only.

## Error capture hardening
`src/main.jsx` Sentry `beforeSend` now strips account email/name/username/IP from error context. (Sentry's default integrations already capture `window.onerror` + `unhandledrejection`; replay already masks all text.)

## Feature flags / kill switches
`src/shared/config/betaFlags.js` — `isEnabled(key)` reads a public env var, **defaults to enabled** (no behavior change), disables on `false`/`0`/`off`. Wired with honest fallbacks: `people` (`VITE_ENABLE_PEOPLE` → `/people` shows a "short break" page and mounts **no** provider/RPC) and `profileRefresh` (`VITE_ENABLE_PROFILE_REFRESH` → refresh shows the honest "couldn't refresh" state, no Edge call). `dailyBriefing` + `discoverRecommendations` defined for future use.

## Beta instrumentation doc
`docs/beta/instrumentation-b1.md` — taxonomy, safe-payload policy, PostHog funnels + Sentry alerts, beta metrics, kill-switch table, retained gaps, and the PostHog account-deletion retention gap.

## Tests
+18 (run 3×): `betaEvents` contract (drops unknown events / disallowed keys / PII values / Error objects; allows `movie_id`; bucket + `errorKind` helpers); `betaFlags` (default-on; disables on `false`/`0`/`off`; unknown→true); People instrumentation via `renderHook` (follow/unfollow/hide emit the right event with **no target id/name**; follow-failure carries an `error_kind` bucket) + the kill-switch disabled-flow (fallback shown, **no RPC**). B1.2 `analyticsPrivacy` + F8 People + F9 suites stay green.

## Validation
lint clean; shared 519; discover 190; home 101; profile 66; people 71; **full 1479** (1461 + 18); build ✓. Instrumentation is side-effect-only in the default state → home/people/profile visual baselines unaffected.

## No-live-action confirmation
No analytics toggled on a real user; no list/preference/Diary/follow/discoverability mutation; no live analytics called with real data; no real identities/secrets/private text printed. Tests use mocked PostHog/analytics + `renderHook`.

## Deferred (B1.4)
Discover/onboarding funnel events; `page_viewed` dynamic-path-segment redaction; an operator dashboard; a server-enforced beta access gate; PostHog account-deletion retention. Residual F8.9 security-backlog P2s stay on the parallel track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
