### PR TITLE
Add private beta gate and operator controls

### DIFF
--- a/docs/beta/operator-dashboard-b1.md
+++ b/docs/beta/operator-dashboard-b1.md
@@ -1,0 +1,54 @@
+# Private-beta operator reference (B1.4)
+
+Status: **current**. How an operator runs and observes the private beta. No secrets, no real dashboard URLs, no PII.
+
+See also [`instrumentation-b1.md`](instrumentation-b1.md) (B1.3 event taxonomy + payload policy).
+
+## Beta access gate (B1.4)
+
+**Source of truth:** the `public.beta_members` table (`user_id`, `status`, `invited_by`, `created_at`). RLS lets a signed-in user read **only their own** row; no broad read; **no client write** (service-role only). No email/name is stored.
+
+**Enforcement is flag-controlled and OFF by default.** The app gate (`BetaAccessGate` → `useBetaAccess`) only enforces when `VITE_ENABLE_BETA_GATE` is `true`/`1`/`on` in the deployed build. Default (dev/CI/current prod): transparent pass-through — no query, no behavior change. This keeps E2E/visual + existing users unaffected until you flip it on for a beta deploy.
+
+**Operating the gate:**
+1. Enable: set `VITE_ENABLE_BETA_GATE=true` in the Cloudflare Pages production env and redeploy.
+2. Add a member (service-role / SQL editor only — never the browser):
+   ```sql
+   insert into public.beta_members (user_id, status) values ('<user-uuid>', 'active')
+   on conflict (user_id) do update set status = 'active';
+   ```
+3. Revoke: `update public.beta_members set status = 'revoked' where user_id = '<user-uuid>';`
+4. Verify RLS/grants: run `scripts/verify-beta-gate.sql` (read-only; proves owner-only read, no anon/broad read, no client write).
+
+**Behavior:** anonymous users see public/marketing/legal routes as today. A signed-in non-member (gate on) sees a calm "Private beta access required" page (`BetaAccessRequired`). Approved members proceed normally. Onboarding + auth callback are never gated. Loading shows the brand splash; a membership-check error shows a safe "try again" fallback (no raw error, no redirect loop).
+
+## DB-side health (read-only)
+
+Run `scripts/beta-health.sql` (service role) — aggregate counts only (never emails/names/ids/titles): beta members (total/active), onboarding completion, taste-discovery opt-in + analytics opt-out counts, 7-day recommendation impression→click→save→watch, daily-briefing send/fail by day, and per-job pg_cron last-run/status.
+
+## PostHog funnels (product events — see instrumentation-b1.md)
+
+- **Activation:** `onboarding_completed` → `home_opened` → first `people_*` / `profile_reflection_refresh_*`.
+- **People engagement:** `people_opened` → `people_search_used` → `people_follow_succeeded`; monitor `people_follow_failed` / `people_search_empty` / `people_hide_suggestion`.
+- **Profile reliability:** `profile_reflection_refresh_started` → `_succeeded` vs `_failed` (split by `error_kind`).
+- Paths in `page_viewed` are now **redacted** (`/profile/:id`, `/lists/:id`, `/movie/:id`, …) — no real ids leak (B1.4).
+
+## Sentry alerts
+
+Spike alerts on the `production` environment for: overall error rate; `route_error`; `profile_reflection_refresh_failed` with `error_kind=edge_error` (the taste-summary Edge function); `people_follow_failed` with `error_kind=permission_denied` (would flag an RLS regression). Sentry `beforeSend` strips account email/name/username/ip (B1.3).
+
+## Minimum beta metrics
+
+Beta members (active), active users, onboarding started/completed, Discover recommendation errors, People opened/follow/hide counts, Profile refresh failures, route errors, daily-briefing health, Edge-function failures, analytics opt-out + taste-discovery opt-in counts. All available from PostHog (events) + `beta-health.sql` (DB) + Sentry (errors) — none require PII.
+
+## PostHog account-deletion retention — **deferred (not implemented in B1.4)**
+
+First-party event/session tables are purged on account deletion by the `process-account-deletions` Edge function. **PostHog data is NOT deleted on account deletion**, and B1.4 does **not** implement it, because:
+- `process-account-deletions` is **out-of-band** (not in repo source / `supabase/functions/`), so it cannot be edited in this phase;
+- a server-side PostHog person-delete needs a PostHog **personal-API-key secret** that is not provisioned.
+
+The Privacy page therefore (correctly) makes **no** PostHog-deletion claim. **Follow-up (B1.x):** add a server-side PostHog `DELETE /api/person` (by distinct id = user id, no email/name) to the account-deletion pipeline once that function is in-repo and the secret is provisioned, plus a documented PostHog retention window. Until then, treat PostHog as retaining pseudonymous (id-only) event data per its project retention.
+
+## Retained gaps (deferred to B1.4b)
+
+Deeper funnel instrumentation — the Discover recommendation funnel (`discover_opened`/`recommendation_shown`/`_opened`/`_saved`/`_error`) + onboarding step events (`onboarding_started`/`step_completed`/`abandoned`) — and the Discover-recommendations kill-switch wiring + Edge/RLS error-bucket capture at client call sites. Deferred to avoid touching the recommendation/onboarding flows in this access-control phase. The `EVENTS` names are already reserved in `betaEvents.js`.

--- a/scripts/beta-health.sql
+++ b/scripts/beta-health.sql
@@ -1,0 +1,45 @@
+-- beta-health.sql — READ-ONLY aggregate operator health snapshot for private beta.
+-- Prints COUNTS ONLY — never emails, names, ids, titles, or any private row content.
+-- Run with the service role / SQL editor. Product-event funnels live in PostHog (see
+-- docs/beta/operator-dashboard-b1.md); this covers the first-party / DB-side signals.
+
+\echo '== Beta membership =='
+select
+  (select count(*) from public.beta_members) as beta_members_total,
+  (select count(*) from public.beta_members where status = 'active') as beta_members_active;
+
+\echo '== Activation (onboarding) — aggregate counts only =='
+select
+  (select count(*) from public.users) as users_total,
+  (select count(*) from public.users where onboarding_complete is true) as onboarding_complete;
+
+\echo '== Discovery opt-in / analytics opt-out (from user_settings.privacy) =='
+select
+  count(*) filter (where (settings->'privacy'->>'showOnLeaderboards')::boolean is true) as taste_discovery_opt_in,
+  count(*) filter (where (settings->'privacy'->>'analytics')::boolean is false)        as analytics_opted_out
+from public.user_settings;
+
+\echo '== Recommendation outcome health (first-party impressions, last 7 days) =='
+select
+  count(*) as impressions_7d,
+  count(*) filter (where clicked) as clicked_7d,
+  count(*) filter (where added_to_watchlist) as saved_7d,
+  count(*) filter (where marked_watched) as watched_7d
+from public.recommendation_impressions
+where shown_at > now() - interval '7 days';
+
+\echo '== Daily-briefing cron health (email_sends, last 3 days) — counts only, no recipients =='
+select sent_day,
+       count(*) filter (where status = 'sent')   as sent,
+       count(*) filter (where status <> 'sent')  as failed
+from public.email_sends
+where sent_day > (now() - interval '3 days')::date
+group by sent_day order by sent_day desc;
+
+\echo '== pg_cron job health (last run per FeelFlick job) =='
+select j.jobname,
+       max(r.start_time) as last_run,
+       (array_agg(r.status order by r.start_time desc))[1] as last_status
+from cron.job j left join cron.job_run_details r on r.jobid = j.jobid
+where j.jobname ilike '%feelflick%' or j.jobname ilike '%briefing%' or j.jobname ilike '%deletion%'
+group by j.jobname order by j.jobname;

--- a/scripts/verify-beta-gate.sql
+++ b/scripts/verify-beta-gate.sql
@@ -1,0 +1,40 @@
+-- verify-beta-gate.sql — READ-ONLY verification of the B1.4 private-beta gate.
+-- Confirms beta_members exists with RLS, owner-only SELECT, no broad read, and no client write.
+-- Aggregate / policy checks only; prints no user ids/emails.
+
+\echo '== 1. beta_members: RLS enabled, no email/name columns (user_id only) =='
+select c.relrowsecurity as rls_enabled,
+       (select string_agg(a.attname, ', ' order by a.attnum)
+          from pg_attribute a where a.attrelid = c.oid and a.attnum > 0 and not a.attisdropped) as columns
+from pg_class c join pg_namespace n on n.oid = c.relnamespace
+where n.nspname = 'public' and c.relname = 'beta_members';   -- expect rls_enabled = t; no email/name col
+
+\echo '== 2. SELECT policy is owner-only (auth.uid() = user_id), to authenticated; no broad/anon read =='
+select pol.polname,
+       case pol.polcmd when 'r' then 'SELECT' when '*' then 'ALL' when 'a' then 'INSERT'
+            when 'w' then 'UPDATE' when 'd' then 'DELETE' else pol.polcmd::text end as cmd,
+       coalesce((select string_agg(r.rolname, ',') from pg_roles r where r.oid = any(pol.polroles)), 'PUBLIC') as roles,
+       pg_get_expr(pol.polqual, pol.polrelid) as using_expr
+from pg_policy pol join pg_class c on c.oid = pol.polrelid join pg_namespace n on n.oid = c.relnamespace
+where n.nspname = 'public' and c.relname = 'beta_members';
+-- expect exactly one SELECT policy: roles=authenticated, using (auth.uid() = user_id). No INSERT/UPDATE/DELETE policy.
+
+\echo '== 3. Grants: authenticated may SELECT only; anon has nothing; no client write =='
+select grantee, string_agg(privilege_type, ', ' order by privilege_type) as privs
+from information_schema.role_table_grants
+where table_schema = 'public' and table_name = 'beta_members' and grantee in ('anon', 'authenticated')
+group by grantee order by grantee;   -- expect: authenticated = SELECT; anon = (no row)
+
+\echo '== 4. Role simulation (ROLLED BACK): a random authenticated user sees ZERO membership rows =='
+begin;
+set local role authenticated;
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-0000-0000-000000000000","role":"authenticated"}', true);
+select count(*) as rows_visible_to_random_authed from public.beta_members;   -- expect 0 (owner-only)
+rollback;
+
+\echo '== 5. anon sees ZERO =='
+begin;
+set local role anon;
+select count(*) as rows_visible_to_anon from public.beta_members;   -- expect 0
+rollback;

--- a/src/app/AppShell.jsx
+++ b/src/app/AppShell.jsx
@@ -9,6 +9,7 @@ import { useAuthSession } from '@/shared/hooks/useAuthSession'
 import { usePendingDeletion } from '@/shared/hooks/usePendingDeletion'
 import { useGoogleAuth } from '@/shared/hooks/useGoogleAuth'
 import { identify, resetAnalytics, track } from '@/shared/services/analytics'
+import { redactPath } from '@/shared/services/betaEvents'
 
 export default function AppShell() {
   const [searchOpen, setSearchOpen] = useState(false)
@@ -74,7 +75,9 @@ export default function AppShell() {
   // Reset header visibility on route change + track page view
   useEffect(() => {
     setHeaderVisible(true)
-    track('page_viewed', { path: location.pathname })
+    // B1.4: redact dynamic path segments (/profile/:id, /lists/:id, /movie/:id …) so no real
+    // user/content id ever reaches analytics in the page path.
+    track('page_viewed', { path: redactPath(location.pathname) })
 
     const prefersReducedMotion =
       window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false

--- a/src/app/router.jsx
+++ b/src/app/router.jsx
@@ -36,6 +36,7 @@ import Footer from '@/components/layout/Footer'
 
 // Auth/onboarding gate
 import PostAuthGate from '@/features/auth/PostAuthGate'
+import BetaAccessGate from '@/features/auth/BetaAccessGate'
 const OAuthCallback = lazy(() => import('@/features/auth/OAuthCallback'))
 
 // Import the new pages
@@ -298,20 +299,28 @@ export const router = sentryCreateBrowserRouter([
             element: <PostAuthGate />,
             errorElement: <ErrorBoundary />,
             children: [
-              { path: 'home', element: <LazyRoute Component={Home} />, errorElement: <ErrorBoundary /> },
-              { path: 'account', element: <LazyRoute Component={Account} />, errorElement: <ErrorBoundary /> },
-              { path: 'preferences', element: <LazyRoute Component={Preferences} />, errorElement: <ErrorBoundary /> },
-              { path: 'watchlist', element: <LazyRoute Component={Watchlist} />, errorElement: <ErrorBoundary /> },
-              { path: 'history', element: <LazyRoute Component={History} />, errorElement: <ErrorBoundary /> },
-              { path: 'watched', element: <LazyRoute Component={History} />, errorElement: <ErrorBoundary /> },
-              { path: 'profile', element: <LazyRoute Component={TasteProfile} />, errorElement: <ErrorBoundary /> },
-              { path: 'profile/:userId', element: <LazyRoute Component={TasteProfile} />, errorElement: <ErrorBoundary /> },
-              { path: 'people', element: <LazyRoute Component={People} />, errorElement: <ErrorBoundary /> },
-              { path: 'lists', element: <LazyRoute Component={Lists} />, errorElement: <ErrorBoundary /> },
-              // Confirmed unfinished — redirect until shipped
-              { path: 'feed', element: <Navigate to="/home" replace /> },
-              { path: 'challenges', element: <Navigate to="/home" replace /> },
-
+              // B1.4 private-beta gate. Transparent pass-through unless VITE_ENABLE_BETA_GATE is on
+              // (default off → no change for dev/CI/current users). Gates only the authenticated app
+              // surfaces below — never legal/auth/public-catalog/public-list routes.
+              {
+                element: <BetaAccessGate />,
+                errorElement: <ErrorBoundary />,
+                children: [
+                  { path: 'home', element: <LazyRoute Component={Home} />, errorElement: <ErrorBoundary /> },
+                  { path: 'account', element: <LazyRoute Component={Account} />, errorElement: <ErrorBoundary /> },
+                  { path: 'preferences', element: <LazyRoute Component={Preferences} />, errorElement: <ErrorBoundary /> },
+                  { path: 'watchlist', element: <LazyRoute Component={Watchlist} />, errorElement: <ErrorBoundary /> },
+                  { path: 'history', element: <LazyRoute Component={History} />, errorElement: <ErrorBoundary /> },
+                  { path: 'watched', element: <LazyRoute Component={History} />, errorElement: <ErrorBoundary /> },
+                  { path: 'profile', element: <LazyRoute Component={TasteProfile} />, errorElement: <ErrorBoundary /> },
+                  { path: 'profile/:userId', element: <LazyRoute Component={TasteProfile} />, errorElement: <ErrorBoundary /> },
+                  { path: 'people', element: <LazyRoute Component={People} />, errorElement: <ErrorBoundary /> },
+                  { path: 'lists', element: <LazyRoute Component={Lists} />, errorElement: <ErrorBoundary /> },
+                  // Confirmed unfinished — redirect until shipped
+                  { path: 'feed', element: <Navigate to="/home" replace /> },
+                  { path: 'challenges', element: <Navigate to="/home" replace /> },
+                ],
+              },
             ],
           },
         ],

--- a/src/features/auth/BetaAccessGate.jsx
+++ b/src/features/auth/BetaAccessGate.jsx
@@ -1,0 +1,20 @@
+import { Outlet, useOutletContext } from 'react-router-dom'
+import BrandSplash from '@/shared/ui/BrandSplash'
+import { useBetaAccess } from './useBetaAccess'
+import BetaAccessRequired from './BetaAccessRequired'
+
+/**
+ * B1.4 — gates the authenticated private-beta surfaces. Nested INSIDE PostAuthGate (so auth +
+ * onboarding are already resolved) and ABOVE the app routes. When the gate is disabled (default)
+ * `useBetaAccess` returns 'allowed' with no query, so this is a transparent pass-through; it only
+ * blocks when VITE_ENABLE_BETA_GATE is on AND the signed-in user is not an active beta member.
+ * Forwards PostAuthGate's outlet context unchanged so downstream routes keep { userId, user, … }.
+ */
+export default function BetaAccessGate() {
+  const ctx = useOutletContext()
+  const status = useBetaAccess()
+  if (status === 'loading') return <BrandSplash />
+  if (status === 'denied') return <BetaAccessRequired />
+  if (status === 'error') return <BetaAccessRequired errored />
+  return <Outlet context={ctx} />
+}

--- a/src/features/auth/BetaAccessRequired.jsx
+++ b/src/features/auth/BetaAccessRequired.jsx
@@ -1,0 +1,14 @@
+// B1.4 — calm, honest fallback shown to a signed-in user who is not (yet) in the private beta, or
+// when membership couldn't be confirmed. No raw backend error, no private data, no redirect loop.
+export default function BetaAccessRequired({ errored = false }) {
+  return (
+    <main style={{ maxWidth: 620, margin: '0 auto', padding: '120px 24px', textAlign: 'center' }}>
+      <h1 style={{ fontSize: 28, fontWeight: 800, marginBottom: 12 }}>Private beta access required</h1>
+      <p style={{ color: 'rgba(250,250,250,0.62)', fontSize: 15, lineHeight: 1.6 }}>
+        {errored
+          ? 'We couldn’t confirm your beta access just now. Please try again in a moment.'
+          : 'FeelFlick is in a small private beta. Your account isn’t on the invite list yet — if you were invited, check back soon, or reach out to the team at hello@feelflick.com.'}
+      </p>
+    </main>
+  )
+}

--- a/src/features/auth/__tests__/BetaAccessGate.test.jsx
+++ b/src/features/auth/__tests__/BetaAccessGate.test.jsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+
+// Mock Supabase: getUser + a spy-able from('beta_members').select().eq().maybeSingle().
+const state = vi.hoisted(() => ({ user: { id: 'me' }, row: null, error: null }))
+const fromSpy = vi.hoisted(() => vi.fn())
+vi.mock('@/shared/lib/supabase/client', () => ({
+  supabase: {
+    auth: { getUser: async () => ({ data: { user: state.user } }) },
+    from: fromSpy,
+  },
+}))
+// BrandSplash pulls app chrome; stub it to a marker so the loading branch is observable.
+vi.mock('@/shared/ui/BrandSplash', () => ({ default: () => <div>brand-splash</div> }))
+
+import { useBetaAccess } from '../useBetaAccess'
+import BetaAccessGate from '../BetaAccessGate'
+
+beforeEach(() => {
+  state.user = { id: 'me' }; state.row = null; state.error = null
+  fromSpy.mockReset()
+  fromSpy.mockReturnValue({
+    select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: state.row, error: state.error }) }) }),
+  })
+})
+afterEach(() => vi.unstubAllEnvs())
+
+describe('useBetaAccess — gate OFF by default (no behavior change)', () => {
+  it('returns allowed immediately and never queries beta_members', () => {
+    const { result } = renderHook(() => useBetaAccess())
+    expect(result.current).toBe('allowed')
+    expect(fromSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('useBetaAccess — gate ON', () => {
+  beforeEach(() => vi.stubEnv('VITE_ENABLE_BETA_GATE', 'true'))
+
+  it('active member → allowed (and reads beta_members)', async () => {
+    state.row = { status: 'active' }
+    const { result } = renderHook(() => useBetaAccess())
+    expect(result.current).toBe('loading')
+    await waitFor(() => expect(result.current).toBe('allowed'))
+    expect(fromSpy).toHaveBeenCalledWith('beta_members')
+  })
+
+  it('non-member (no row) → denied', async () => {
+    state.row = null
+    const { result } = renderHook(() => useBetaAccess())
+    await waitFor(() => expect(result.current).toBe('denied'))
+  })
+
+  it('revoked member → denied', async () => {
+    state.row = { status: 'revoked' }
+    const { result } = renderHook(() => useBetaAccess())
+    await waitFor(() => expect(result.current).toBe('denied'))
+  })
+
+  it('membership query error → safe error state (no throw)', async () => {
+    state.error = { message: 'boom' }
+    const { result } = renderHook(() => useBetaAccess())
+    await waitFor(() => expect(result.current).toBe('error'))
+  })
+
+  it('no session → denied (does not reveal anything)', async () => {
+    state.user = null
+    const { result } = renderHook(() => useBetaAccess())
+    await waitFor(() => expect(result.current).toBe('denied'))
+  })
+})
+
+const renderGate = (entry = '/x') =>
+  render(
+    <MemoryRouter initialEntries={[entry]}>
+      <Routes>
+        <Route element={<BetaAccessGate />}>
+          <Route path="x" element={<div>protected content</div>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  )
+
+describe('BetaAccessGate — render behavior', () => {
+  it('gate OFF → renders the protected child (transparent pass-through)', () => {
+    renderGate()
+    expect(screen.getByText('protected content')).toBeInTheDocument()
+  })
+
+  it('gate ON + non-member → shows "Private beta access required", hides the child', async () => {
+    vi.stubEnv('VITE_ENABLE_BETA_GATE', 'true')
+    state.row = null
+    renderGate()
+    await waitFor(() => expect(screen.getByText(/Private beta access required/i)).toBeInTheDocument())
+    expect(screen.queryByText('protected content')).not.toBeInTheDocument()
+  })
+
+  it('gate ON + active member → renders the protected child', async () => {
+    vi.stubEnv('VITE_ENABLE_BETA_GATE', 'true')
+    state.row = { status: 'active' }
+    renderGate()
+    await waitFor(() => expect(screen.getByText('protected content')).toBeInTheDocument())
+  })
+})

--- a/src/features/auth/useBetaAccess.js
+++ b/src/features/auth/useBetaAccess.js
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react'
+import { supabase } from '@/shared/lib/supabase/client'
+import { isBetaGateEnabled } from '@/shared/config/betaFlags'
+
+/**
+ * B1.4 — resolve the CURRENT user's private-beta access from the server-side `beta_members` table.
+ * RLS scopes the read to the caller's OWN row, so this can never reveal anyone else's membership.
+ *
+ * When the gate is disabled (the default — VITE_ENABLE_BETA_GATE unset), returns 'allowed'
+ * immediately with NO query, so dev/CI/E2E and current users are unaffected.
+ *
+ * @returns {'loading'|'allowed'|'denied'|'error'}
+ */
+export function useBetaAccess() {
+  const [status, setStatus] = useState(isBetaGateEnabled() ? 'loading' : 'allowed')
+
+  useEffect(() => {
+    if (!isBetaGateEnabled()) { setStatus('allowed'); return }
+    let cancelled = false
+    ;(async () => {
+      try {
+        const { data: { user } } = await supabase.auth.getUser()
+        if (cancelled) return
+        if (!user) { setStatus('denied'); return }
+        const { data, error } = await supabase
+          .from('beta_members')
+          .select('status')
+          .eq('user_id', user.id)
+          .maybeSingle()
+        if (cancelled) return
+        if (error) { setStatus('error'); return }      // safe fallback — never surface raw error
+        setStatus(data?.status === 'active' ? 'allowed' : 'denied')
+      } catch {
+        if (!cancelled) setStatus('error')
+      }
+    })()
+    return () => { cancelled = true }
+  }, [])
+
+  return status
+}

--- a/src/shared/config/__tests__/betaFlags.test.js
+++ b/src/shared/config/__tests__/betaFlags.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { isEnabled, FLAG_KEYS } from '../betaFlags'
+import { isEnabled, isBetaGateEnabled, FLAG_KEYS } from '../betaFlags'
 
 describe('betaFlags — kill switches default safe', () => {
   afterEach(() => vi.unstubAllEnvs())
@@ -24,5 +24,27 @@ describe('betaFlags — kill switches default safe', () => {
 
   it('an unknown flag never gates (returns true)', () => {
     expect(isEnabled('nope')).toBe(true)
+  })
+})
+
+describe('betaFlags — private-beta gate defaults OFF (inverse of kill-switches)', () => {
+  afterEach(() => vi.unstubAllEnvs())
+
+  it('is disabled by default (no env)', () => {
+    expect(isBetaGateEnabled()).toBe(false)
+  })
+
+  it('enables ONLY on true / 1 / on', () => {
+    for (const v of ['true', 'TRUE', '1', 'on']) {
+      vi.stubEnv('VITE_ENABLE_BETA_GATE', v)
+      expect(isBetaGateEnabled()).toBe(true)
+    }
+  })
+
+  it('stays OFF for false / 0 / empty / anything else', () => {
+    for (const v of ['false', '0', '', 'nope']) {
+      vi.stubEnv('VITE_ENABLE_BETA_GATE', v)
+      expect(isBetaGateEnabled()).toBe(false)
+    }
   })
 })

--- a/src/shared/config/betaFlags.js
+++ b/src/shared/config/betaFlags.js
@@ -27,3 +27,13 @@ export function isEnabled(key) {
 }
 
 export const FLAG_KEYS = Object.freeze(Object.keys(FLAG_ENV))
+
+// The private-beta access gate is the INVERSE of the feature kill-switches: it defaults to OFF
+// (only 'true'/'1' turns it on) so dev/CI/E2E and current users are unaffected until an operator
+// explicitly enables it for a production beta deploy via VITE_ENABLE_BETA_GATE.
+export function isBetaGateEnabled() {
+  let raw
+  try { raw = import.meta.env?.VITE_ENABLE_BETA_GATE } catch { raw = undefined }
+  const v = String(raw).toLowerCase()
+  return v === 'true' || v === '1' || v === 'on'
+}

--- a/src/shared/services/__tests__/betaEvents.test.js
+++ b/src/shared/services/__tests__/betaEvents.test.js
@@ -6,7 +6,7 @@ const analyticsTrack = vi.hoisted(() => vi.fn())
 vi.mock('../analytics', () => ({ track: analyticsTrack }))
 
 import {
-  trackEvent, EVENTS, isUnsafeValue, errorKind, countBucket, latencyBucket, queryLengthBucket,
+  trackEvent, EVENTS, isUnsafeValue, errorKind, countBucket, latencyBucket, queryLengthBucket, redactPath,
 } from '../betaEvents'
 
 describe('betaEvents — fail-closed event contract', () => {
@@ -77,5 +77,28 @@ describe('betaEvents — helpers never leak raw text', () => {
     expect(isUnsafeValue('permission_denied')).toBe(false)
     expect(isUnsafeValue(42)).toBe(false)
     expect(isUnsafeValue(true)).toBe(false)
+  })
+})
+
+describe('redactPath — no dynamic id/slug ever reaches the page path', () => {
+  it('replaces dynamic segments with a stable route pattern', () => {
+    expect(redactPath('/profile/9f1c-uuid')).toBe('/profile/:id')
+    expect(redactPath('/movie/550')).toBe('/movie/:id')
+    expect(redactPath('/lists/abc-123')).toBe('/lists/:id')
+    expect(redactPath('/lists/curated/best-of-2024')).toBe('/lists/curated/:slug')
+    expect(redactPath('/lists/personal/watchlist')).toBe('/lists/personal/:type')
+    expect(redactPath('/collection/99')).toBe('/collection/:id')
+    expect(redactPath('/mood/cozy')).toBe('/mood/:tag')
+    expect(redactPath('/tone/wistful')).toBe('/tone/:tag')
+    expect(redactPath('/browse/fit/slow-burn')).toBe('/browse/fit/:profile')
+  })
+
+  it('keeps static paths and strips any query/hash', () => {
+    expect(redactPath('/home')).toBe('/home')
+    expect(redactPath('/people')).toBe('/people')
+    expect(redactPath('/browse')).toBe('/browse')
+    expect(redactPath('/movie/5?ref=home#cast')).toBe('/movie/:id')
+    expect(redactPath('')).toBe('/')
+    expect(redactPath(null)).toBe('/')
   })
 })

--- a/src/shared/services/betaEvents.js
+++ b/src/shared/services/betaEvents.js
@@ -103,6 +103,27 @@ export const latencyBucket = (ms) =>
 export const queryLengthBucket = (len) =>
   len == null ? undefined : len <= 0 ? '0' : len <= 2 ? '1-2' : len <= 5 ? '3-5' : len <= 10 ? '6-10' : '11+'
 
+// Replace dynamic route segments (ids / uuids / slugs that could identify a user or their content)
+// with a stable route-pattern label, so `page_viewed` never carries a real id in its path value.
+// Order matters: the more specific /lists/curated|personal must run before the generic /lists/:id.
+const PATH_RULES = [
+  [/^\/profile\/[^/]+/, '/profile/:id'],
+  [/^\/movie\/[^/]+/, '/movie/:id'],
+  [/^\/collection\/[^/]+/, '/collection/:id'],
+  [/^\/lists\/curated\/[^/]+/, '/lists/curated/:slug'],
+  [/^\/lists\/personal\/[^/]+/, '/lists/personal/:type'],
+  [/^\/lists\/[^/]+/, '/lists/:id'],
+  [/^\/mood\/[^/]+/, '/mood/:tag'],
+  [/^\/tone\/[^/]+/, '/tone/:tag'],
+  [/^\/browse\/fit\/[^/]+/, '/browse/fit/:profile'],
+]
+export function redactPath(pathname) {
+  if (typeof pathname !== 'string' || !pathname) return '/'
+  const path = pathname.split('?')[0].split('#')[0] // drop any query/hash
+  for (const [re, label] of PATH_RULES) if (re.test(path)) return label
+  return path
+}
+
 /**
  * Map any error to a stable, non-identifying bucket. NEVER returns raw error text.
  */

--- a/supabase/migrations/20260611120000_add_beta_members_gate.sql
+++ b/supabase/migrations/20260611120000_add_beta_members_gate.sql
@@ -1,0 +1,29 @@
+-- B1.4 — server-side source of truth for private-beta access.
+--
+-- A signed-in user may read ONLY their own membership row; there is NO broad read and NO client
+-- write (membership is managed by the service role / an operator). No email/name is stored — only
+-- the stable user_id. The app enforces the gate ONLY when VITE_ENABLE_BETA_GATE is set (default off),
+-- so this table is inert until the operator turns the gate on for a production beta deploy.
+--
+-- SAFETY: additive — creates one table + RLS + grants. No existing rows touched. Idempotent.
+
+create table if not exists public.beta_members (
+  user_id    uuid primary key references auth.users (id) on delete cascade,
+  status     text not null default 'active',           -- 'active' | 'revoked'
+  invited_by uuid,                                      -- optional operator/inviter user_id
+  created_at timestamptz not null default now()
+);
+
+alter table public.beta_members enable row level security;
+
+-- Owner-only SELECT: a user can see only whether THEY are a member. No cross-user / broad read.
+drop policy if exists "Members can read own beta membership" on public.beta_members;
+create policy "Members can read own beta membership"
+  on public.beta_members for select to authenticated
+  using ((select auth.uid()) = user_id);
+
+-- No INSERT/UPDATE/DELETE policy for anon/authenticated → those ops are denied by RLS for the
+-- browser; only the service role (which bypasses RLS) can manage membership.
+revoke insert, update, delete on public.beta_members from anon, authenticated;
+revoke all on public.beta_members from anon;        -- anon cannot even attempt a read
+grant select on public.beta_members to authenticated;


### PR DESCRIPTION
**B1.4 (scoped to 1.4a — access + operating controls).** The deeper Discover/onboarding funnel events + Edge/RLS error buckets are deferred to **B1.4b** (they touch the recommendation/onboarding flows; kept out of this access-control phase). No recommendation-logic change, no analytics-privacy weakening, no PII.

## Beta gate model
Server-side source of truth: `public.beta_members` (`user_id`, `status`, `invited_by`, `created_at` — **no email/name**). RLS: a signed-in user reads **only their own** row (owner-only SELECT to `authenticated`); **no broad read**; **no client write** policy (service-role manages membership); anon has nothing. Membership is **not** in the client bundle (replaces reliance on `VITE_ADMIN_EMAILS`).

## Migration summary
`20260611120000_add_beta_members_gate.sql` (applied live; authorized). Additive — one table + RLS + grants, **no existing rows touched**. Verified live: RLS on, **1** owner-only SELECT policy, **0** client-write policies, authenticated = SELECT only, **0 rows** (no members inserted); advisors unchanged, **no new P0/P1**.

## Route behavior
`BetaAccessGate` (`src/features/auth/`) nests **inside** PostAuthGate and **above** the authenticated app routes (home/account/preferences/watchlist/history/profile/people/lists). **Flag-controlled, OFF by default** — `isBetaGateEnabled()` reads `VITE_ENABLE_BETA_GATE` (true only for `true`/`1`/`on`, the inverse of the feature kill-switches). Gate off → `useBetaAccess` returns `allowed` immediately with **no query** → transparent pass-through (forwards PostAuthGate's outlet context). Gate on → loading=BrandSplash, allowed=Outlet, denied/error=`BetaAccessRequired` ("Private beta access required", calm copy, no raw error, no redirect loop). Legal/auth/public-catalog/public-list routes are never gated; onboarding stays safe. So dev/CI/E2E + current users are unaffected until an operator flips it on for a beta deploy.

## Events added
None new in 1.4a (deferred to 1.4b). 

## Path redaction
`redactPath()` (betaEvents.js) replaces dynamic segments — `/profile/:id`, `/lists/:id`, `/movie/:id`, `/collection/:id`, `/lists/curated/:slug`, `/lists/personal/:type`, `/mood/:tag`, `/tone/:tag`, `/browse/fit/:profile` — and strips query/hash. AppShell's `page_viewed` now sends the **redacted** path, so no real user/content id reaches analytics.

## Operator visibility
`docs/beta/operator-dashboard-b1.md` (gate ops: enable flag + add/revoke members via service-role; PostHog funnels; Sentry alerts; metrics) + `scripts/beta-health.sql` (**aggregate counts only** — members, onboarding, opt-in/opt-out, 7-day rec outcomes, briefing/cron health; no PII) + `scripts/verify-beta-gate.sql` (read-only RLS proof).

## PostHog retention decision
**Deferred + documented honestly.** `process-account-deletions` is out-of-band (not in repo) and a PostHog person-delete needs an unprovisioned secret, so it can't be implemented here. The Privacy page makes no PostHog-deletion claim. Follow-up noted in the operator doc.

## Kill-switch behavior
Unchanged from B1.3 (people + profileRefresh wired). Discover-recommendations kill-switch wiring deferred to B1.4b (Discover-flow touch).

## Tests
+14 (run 3×): `useBetaAccess` (gate-off allowed + no query; gate-on allowed/denied/revoked/error/no-session) + `BetaAccessGate` render (off→child; on+non-member→access-required + child hidden; on+member→child); `redactPath` (all dynamic segments + query/hash strip); `isBetaGateEnabled` (default-off; true/1/on only). B1.2/B1.3 analytics-privacy + F8 People + F9 suites green.

## Validation
lint clean; people 71; discover 190; profile 66; **full 1493** (1479 + 14); build ✓. Gate is transparent by default → home/people/profile visual baselines unaffected.

## No-live-action confirmation
**No** beta_members rows inserted/removed; no analytics toggled on a real user; no live analytics with real data; no list/preference/Diary/follow/discoverability mutation; no real identities/secrets/private text printed. The migration is additive (no row changes); verification used a rolled-back role simulation.

## Deferred (B1.4b)
Discover recommendation funnel + onboarding step events; Discover-recommendations kill-switch wiring; Edge/RLS error-bucket capture; PostHog deletion implementation. Residual F8.9 security-backlog P2s stay on the parallel track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
