### PR TITLE
Add beta funnel and health instrumentation

### DIFF
--- a/docs/beta/operator-dashboard-b1.md
+++ b/docs/beta/operator-dashboard-b1.md
@@ -49,6 +49,18 @@ First-party event/session tables are purged on account deletion by the `process-
 
 The Privacy page therefore (correctly) makes **no** PostHog-deletion claim. **Follow-up (B1.x):** add a server-side PostHog `DELETE /api/person` (by distinct id = user id, no email/name) to the account-deletion pipeline once that function is in-repo and the secret is provisioned, plus a documented PostHog retention window. Until then, treat PostHog as retaining pseudonymous (id-only) event data per its project retention.
 
-## Retained gaps (deferred to B1.4b)
+## B1.4b funnel + health (shipped)
 
-Deeper funnel instrumentation — the Discover recommendation funnel (`discover_opened`/`recommendation_shown`/`_opened`/`_saved`/`_error`) + onboarding step events (`onboarding_started`/`step_completed`/`abandoned`) — and the Discover-recommendations kill-switch wiring + Edge/RLS error-bucket capture at client call sites. Deferred to avoid touching the recommendation/onboarding flows in this access-control phase. The `EVENTS` names are already reserved in `betaEvents.js`.
+**Onboarding funnel:** `onboarding_started` (mount), `onboarding_step_completed` (`step_key` = `mood`/`genres`/`movies`), `onboarding_error` (`error_kind`), `onboarding_completed` (now through the central wrapper with **bucketed** counts — `genre_count_bucket` etc., never raw counts/titles/genres). *`onboarding_abandoned` not wired — no clean abandonment signal exists; revisit if drop-off needs it.*
+
+**Discover funnel:** `discover_opened` (mount), `recommendation_requested` (resolve stage), `recommendation_shown` (`result_count` + `from_cache`), `recommendation_error` (`error_kind`), `recommendation_opened` + `recommendation_saved` (carry `movie_id` only — never title/context). These are a **minimal PostHog funnel bridge**; `recommendation_impressions` remains the first-party source of truth for detailed outcomes.
+
+**Discover funnel suggestion:** `discover_opened` → `recommendation_requested` → `recommendation_shown` → `recommendation_opened`/`recommendation_saved`; watch `recommendation_error` by `error_kind`.
+
+**Discover kill-switch (now wired):** `VITE_ENABLE_DISCOVER_RECOMMENDATIONS=false` → the scoring (`scoreMovieForUser`) is **not** run and the pick stage shows an honest "Tonight's pick is paused" fallback (`DiscoverPaused`) with a Start-over button — no request, no spinner hang, no crash. Default on.
+
+**Safe error buckets:** failures emit `error_kind` only (via `errorKind()`) — onboarding (`onboarding_error`), Discover save/resolve (`recommendation_error`), Profile refresh (`profile_reflection_refresh_failed`), People follow (`people_follow_failed`), route (`route_error`). Never raw error text / Supabase error objects / SQL / tokens.
+
+## Retained gaps (B1.x)
+
+`onboarding_abandoned` (no signal); `edge_function_error`/`supabase_error` are reserved in `EVENTS` but emitted only where a clean swallowed-error boundary exists; an operator dashboard UI; the PostHog account-deletion implementation (below).

--- a/src/features/discover/Discover.jsx
+++ b/src/features/discover/Discover.jsx
@@ -7,6 +7,8 @@ import { usePageMeta } from '@/shared/hooks/usePageMeta'
 import { scoreMovieForUser } from '@/shared/services/recommendations'
 import { computeMatchPercent } from '@/shared/services/matchScore'
 import { DiscoverDataProvider, useDiscoverData } from './useDiscoverData'
+import { trackEvent, EVENTS } from '@/shared/services/betaEvents'
+import { isEnabled } from '@/shared/config/betaFlags'
 import { MOODS, ONBOARDING_TO_DISCOVER, diversifyTop3, predictDiscoverDefaults } from './derive'
 import { HP, TIME_OPTIONS } from './constants'
 import StageMood from './sections/StageMood'
@@ -191,6 +193,23 @@ async function commitDiscoverPreferences({ userId, intention, time, who, energy 
   }
 }
 
+// B1.4b kill-switch fallback — shown at the pick stage when Discover recommendations are disabled.
+// Honest, no spinner, no crash; the mood/context stages still work and the user can restart.
+function DiscoverPaused({ onRestart }) {
+  return (
+    <div style={{ maxWidth: 560, margin: '0 auto', padding: '100px 24px', textAlign: 'center' }}>
+      <h2 style={{ fontSize: 24, fontWeight: 800, marginBottom: 12 }}>Tonight&rsquo;s pick is paused</h2>
+      <p style={{ color: 'rgba(250,250,250,0.62)', fontSize: 15, lineHeight: 1.6, marginBottom: 20 }}>
+        Recommendations are taking a short break during beta. Please check back soon.
+      </p>
+      <button type="button" onClick={onRestart}
+        style={{ minHeight: 44, padding: '0 20px', borderRadius: 10, border: '1px solid rgba(250,250,250,0.18)', background: 'transparent', color: '#fafafa', fontWeight: 600, cursor: 'pointer' }}>
+        Start over
+      </button>
+    </div>
+  )
+}
+
 function DiscoverBody() {
   // /discover opens directly on the mood front door (stage 1) — the separate
   // hero/"How do you feel?" launch screen was removed in F3.5 (it re-asked mood
@@ -315,7 +334,12 @@ function DiscoverBody() {
     return MOODS.find(m => m.id === selected[0])?.hex || HP.purple;
   }, [selected]);
 
+  // B1.4b kill-switch: when Discover recommendations are disabled for beta, compute NO picks
+  // (scoreMovieForUser is never called) and show an honest "paused" fallback at the pick stage.
+  // Defaults to enabled → the normal scoring path below is unchanged.
+  const recsEnabled = isEnabled('discoverRecommendations')
   const allResults = useMemo(() => {
+    if (!recsEnabled) return [];
     const runtimeBand = TIME_OPTIONS.find(t => t.id === time)?.v || [0,300];
     // Save-affinity lookup sets — directors and primary_genres the user
     // has saved (user_watchlist) in the last 90 days. Built once per
@@ -433,7 +457,19 @@ function DiscoverBody() {
     // already shown in this /discover session get demoted, giving the
     // user fresh picks when they tweak moods/inputs across scenarios.
     return diversifyTop3(scored, sessionShownIds.current);
-  }, [selected, time, who, energy, intention, films, profile, recentSaves]);
+  }, [recsEnabled, selected, time, who, energy, intention, films, profile, recentSaves]);
+
+  // ── B1.4b privacy-safe Discover funnel (additive; no raw context/mood/title text) ──────────────
+  useEffect(() => { trackEvent(EVENTS.discover_opened, { surface: 'discover' }) }, [])
+  useEffect(() => {
+    if (stage === 2.3) trackEvent(EVENTS.recommendation_requested, { surface: 'discover' })
+  }, [stage])
+  useEffect(() => {
+    if (stage !== 3 || !recsEnabled) return
+    if (isFallback) trackEvent(EVENTS.recommendation_error, { surface: 'discover', source: 'resolve', error_kind: fallbackReason ? 'supabase_error' : 'unknown' })
+    else trackEvent(EVENTS.recommendation_shown, { surface: 'discover', result_count: allResults.length, from_cache: !usingLiveFilms })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stage])
 
   return (
     <div className="ff-discover" style={{ minHeight:'100vh', background:HP.bgDeep, color:HP.text, fontFamily:'Inter, sans-serif', position:'relative', overflow:'hidden' }}>
@@ -442,7 +478,9 @@ function DiscoverBody() {
         {stage === 1   && <StageMood selected={selected} setSelected={setSelected} onNext={()=>setStage(2)} blendHex={blendHex} bursts={bursts} fireBurst={fireBurst} audioToggle={<AudioToggle />} playMoodCue={(id)=>FFAudio.pluck(id)} playContinueCue={()=>FFAudio.whoom()} />}
         {stage === 2   && <StageNightContext time={time} setTime={setTime} who={who} setWho={setWho} energy={energy} setEnergy={setEnergy} intention={intention} setIntention={setIntention} onUserEdit={()=>{ contextTouchedRef.current = true }} onNext={()=>{ handleCommitStage2(); setStage(2.3); }} onBack={()=>setStage(1)} blendHex={blendHex} playOptionCue={()=>FFAudio.pluck('cozy')} playContinueCue={()=>FFAudio.whoom()} />}
         {stage === 2.3 && <StageResolve blendHex={blendHex} onDone={()=>setStage(3)} />}
-        {stage === 3   && <StagePick selected={selected.length>0?selected:['slow','tender']} who={who} energy={energy} intention={intention} time={time} results={allResults} profile={profile} sessionShownIds={sessionShownIds} isFallback={isFallback} fallbackReason={fallbackReason} onRestart={()=>{ setStage(1); setSelected([]); contextTouchedRef.current = false; didPredictDefaultsRef.current = false; setIntention('move'); setTime('std'); setWho('alone'); setEnergy('steady'); }} onBack={()=>setStage(2)} blendHex={blendHex} audioToggle={<AudioToggle />} />}
+        {stage === 3   && (recsEnabled
+          ? <StagePick selected={selected.length>0?selected:['slow','tender']} who={who} energy={energy} intention={intention} time={time} results={allResults} profile={profile} sessionShownIds={sessionShownIds} isFallback={isFallback} fallbackReason={fallbackReason} onRestart={()=>{ setStage(1); setSelected([]); contextTouchedRef.current = false; didPredictDefaultsRef.current = false; setIntention('move'); setTime('std'); setWho('alone'); setEnergy('steady'); }} onBack={()=>setStage(2)} blendHex={blendHex} audioToggle={<AudioToggle />} />
+          : <DiscoverPaused onRestart={()=>setStage(1)} />)}
       </div>
     </div>
   );

--- a/src/features/discover/__tests__/DiscoverInstrumentation.test.jsx
+++ b/src/features/discover/__tests__/DiscoverInstrumentation.test.jsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+// Spy trackEvent (keep EVENTS/errorKind real) to prove the Discover result actions emit safe
+// funnel events carrying ONLY a catalog movie_id — never a title or Stage-2 context.
+const trackEventMock = vi.hoisted(() => vi.fn())
+vi.mock('@/shared/services/betaEvents', async (orig) => ({ ...(await orig()), trackEvent: trackEventMock }))
+
+const supa = vi.hoisted(() => ({ insertError: null }))
+vi.mock('@/shared/lib/supabase/client', () => ({
+  supabase: { from: () => ({ insert: async () => ({ error: supa.insertError }) }) },
+}))
+vi.mock('@/shared/services/recommendations', () => ({ updateImpression: vi.fn(() => ({ catch: () => {} })) }))
+vi.mock('@/shared/services/interactions', () => ({ trackInteraction: vi.fn(() => ({ catch: () => {} })) }))
+
+import { useDiscoverResultActions } from '../hooks/useDiscoverResultActions'
+import { EVENTS } from '@/shared/services/betaEvents'
+import discoverSrc from '../Discover.jsx?raw'
+
+const navigate = vi.fn()
+const setup = (top) =>
+  renderHook(() => useDiscoverResultActions({
+    top, user: { id: 'me' }, selected: ['slow'], intention: 'move', energy: 'steady', who: 'alone',
+    setHiddenTopIds: () => {}, setSelectedTopId: () => {}, navigate,
+  }))
+
+const noTitleLeak = (title) => {
+  for (const [, payload] of trackEventMock.mock.calls) {
+    expect(JSON.stringify(payload || {})).not.toContain(title)
+  }
+}
+
+describe('Discover funnel — safe events (movie_id only, no title/context)', () => {
+  beforeEach(() => { trackEventMock.mockClear(); supa.insertError = null })
+
+  it('recommendation_opened on "See more" carries movie_id only', () => {
+    const { result } = setup({ id: 'm1', tmdbId: 550, title: 'Fight Club' })
+    act(() => result.current.handleSeeMore())
+    expect(trackEventMock).toHaveBeenCalledWith(EVENTS.recommendation_opened, { surface: 'discover', movie_id: 'm1' })
+    noTitleLeak('Fight Club')
+  })
+
+  it('recommendation_saved on save carries movie_id only', async () => {
+    const { result } = setup({ id: 'm2', tmdbId: 551, title: 'Se7en' })
+    await act(async () => { await result.current.handleSaveForLater() })
+    expect(trackEventMock).toHaveBeenCalledWith(EVENTS.recommendation_saved, { surface: 'discover', movie_id: 'm2' })
+    noTitleLeak('Se7en')
+  })
+
+  it('recommendation_error (with error_kind bucket) on a failed save — no raw error', async () => {
+    supa.insertError = { code: '42501', message: 'permission denied for table user_watchlist' }
+    const { result } = setup({ id: 'm3', tmdbId: 552, title: 'Alien' })
+    await act(async () => { await result.current.handleSaveForLater() })
+    const call = trackEventMock.mock.calls.find((c) => c[0] === EVENTS.recommendation_error)
+    expect(call).toBeTruthy()
+    expect(call[1]).toEqual({ surface: 'discover', source: 'save', error_kind: 'permission_denied' })
+    noTitleLeak('permission denied')
+  })
+})
+
+describe('Discover kill-switch — gates scoring + shows an honest fallback (source guard)', () => {
+  it('skips scoring before scoreMovieForUser and renders DiscoverPaused when disabled', () => {
+    expect(discoverSrc).toMatch(/isEnabled\('discoverRecommendations'\)/)
+    // allResults short-circuits to [] BEFORE the scoreMovieForUser loop runs
+    const gateIdx = discoverSrc.indexOf('if (!recsEnabled) return []')
+    const scoreIdx = discoverSrc.indexOf('scoreMovieForUser(')
+    expect(gateIdx).toBeGreaterThan(0)
+    expect(gateIdx).toBeLessThan(scoreIdx)
+    expect(discoverSrc).toMatch(/<DiscoverPaused/)
+  })
+})

--- a/src/features/discover/hooks/useDiscoverResultActions.js
+++ b/src/features/discover/hooks/useDiscoverResultActions.js
@@ -9,6 +9,7 @@ import { useState, useEffect, useRef } from 'react'
 import { supabase } from '@/shared/lib/supabase/client'
 import { updateImpression } from '@/shared/services/recommendations'
 import { trackInteraction } from '@/shared/services/interactions'
+import { trackEvent, EVENTS, errorKind } from '@/shared/services/betaEvents'
 
 export function useDiscoverResultActions({ top, user, selected, intention, energy, who, setHiddenTopIds, setSelectedTopId, navigate }) {
   const [savedState, setSavedState] = useState('idle'); // idle | saving | saved | error
@@ -42,6 +43,8 @@ export function useDiscoverResultActions({ top, user, selected, intention, energ
       updateImpression(user.id, top.id, 'clicked').catch(() => {})
       trackInteraction('click', interactionContext('see_more')).catch(() => {})
     }
+    // B1.4b: minimal PostHog funnel bridge (movie_id is catalog-safe; no title/context text).
+    trackEvent(EVENTS.recommendation_opened, { surface: 'discover', movie_id: top.id })
     navigate(`/movie/${top.tmdbId}`);
   };
   const handleSaveForLater = async () => {
@@ -59,9 +62,11 @@ export function useDiscoverResultActions({ top, user, selected, intention, energ
       // the watchlist write succeeds so we don't credit a failed save.
       updateImpression(user.id, filmId, 'saved').catch(() => {})
       trackInteraction('save', interactionContext('save_for_later')).catch(() => {})
+      trackEvent(EVENTS.recommendation_saved, { surface: 'discover', movie_id: filmId })
     } catch (e) {
       console.error('[Discover.saveForLater]', e);
       setSavedState('error');
+      trackEvent(EVENTS.recommendation_error, { surface: 'discover', source: 'save', error_kind: errorKind(e) })
     }
   };
   // Skip Tonight — auto-advances to the next pick instead of bouncing home.

--- a/src/features/onboarding/Onboarding.jsx
+++ b/src/features/onboarding/Onboarding.jsx
@@ -33,6 +33,7 @@ import RatingStep from './steps/RatingStep'
 
 import { MOODS_LS_KEY, SENTIMENT_RATINGS } from './data'
 import { loadDraft, saveDraft, clearDraft } from './draft'
+import { trackEvent, EVENTS, errorKind } from '@/shared/services/betaEvents'
 import './onboarding.css'
 
 // Drafts the in-flight onboarding (per signed-in user) so a refresh doesn't wipe
@@ -46,6 +47,7 @@ export default function Onboarding() {
   const reduced = useReducedMotion()
 
   usePageMeta({ title: 'Taste profile · FeelFlick' })
+  useEffect(() => { trackEvent(EVENTS.onboarding_started, { surface: 'onboarding' }) }, []) // B1.4b funnel entry
 
   const [checking, setChecking] = useState(true)
   const [celebrate, setCelebrate] = useState(false)
@@ -247,6 +249,7 @@ export default function Onboarding() {
       await markOnboardingAuthComplete()
     } catch (e) {
       console.error('Onboarding save failed:', e)
+      trackEvent(EVENTS.onboarding_error, { surface: 'onboarding', source: 'finish', error_kind: errorKind(e) })
       setError(e.message || 'Could not save your preferences. Please try again.')
       setLoading(false)
       setCelebrate(false)
@@ -321,7 +324,7 @@ export default function Onboarding() {
                 <MoodStep
                   moods={moods}
                   setMoods={setMoods}
-                  onNext={() => { setError(''); setStep(1) }}
+                  onNext={() => { setError(''); setStep(1); trackEvent(EVENTS.onboarding_step_completed, { surface: 'onboarding', step_key: 'mood' }) }}
                   firstName={session?.user?.user_metadata?.name?.split(' ')[0] ?? null}
                 />
               )}
@@ -330,7 +333,7 @@ export default function Onboarding() {
                   selectedGenres={selectedGenres}
                   toggleGenre={toggleGenre}
                   onBack={() => { setError(''); setStep(0) }}
-                  onNext={() => { setError(''); setStep(2) }}
+                  onNext={() => { setError(''); setStep(2); trackEvent(EVENTS.onboarding_step_completed, { surface: 'onboarding', step_key: 'genres' }) }}
                 />
               )}
               {step === 2 && (
@@ -342,7 +345,7 @@ export default function Onboarding() {
                   removeMovie={removeMovie}
                   isMovieSelected={isMovieSelected}
                   onBack={() => { setError(''); setStep(1) }}
-                  onFinish={() => { setError(''); setStep(3) }}
+                  onFinish={() => { setError(''); setStep(3); trackEvent(EVENTS.onboarding_step_completed, { surface: 'onboarding', step_key: 'movies' }) }}
                   loading={false}
                   error={error}
                 />

--- a/src/features/onboarding/__tests__/OnboardingSteps.test.jsx
+++ b/src/features/onboarding/__tests__/OnboardingSteps.test.jsx
@@ -55,6 +55,8 @@ vi.mock('@/shared/services/recommendations', () => ({
 vi.mock('@/shared/services/analytics', () => ({
   track: vi.fn(),
 }))
+// B1.4b: onboarding_completed now flows through the central betaEvents wrapper (bucketed counts).
+vi.mock('@/shared/services/betaEvents', async (orig) => ({ ...(await orig()), trackEvent: vi.fn() }))
 
 // framer-motion's useReducedMotion reads window.matchMedia, which jsdom doesn't
 // provide. Stub it (test-local, guarded) so the real step components render.
@@ -224,7 +226,7 @@ describe('RatingStep — real sentiment buttons (auto-finishes; no confirm butto
 import { completeOnboarding } from '@/shared/services/onboarding'
 import { supabase } from '@/shared/lib/supabase/client'
 import { computeUserProfileV3 } from '@/shared/services/recommendations'
-import { track } from '@/shared/services/analytics'
+import { trackEvent, EVENTS, countBucket } from '@/shared/services/betaEvents'
 
 const MOCK_SESSION = {
   user: {
@@ -296,10 +298,11 @@ describe('completeOnboarding — service writes', () => {
       ratings: { 1: 9, 2: 7 },
     })
 
-    expect(track).toHaveBeenCalledWith('onboarding_completed', expect.objectContaining({
-      genre_count: 3,
-      movie_count: 5,
-      rating_count: 2,
+    expect(trackEvent).toHaveBeenCalledWith(EVENTS.onboarding_completed, expect.objectContaining({
+      surface: 'onboarding',
+      genre_count_bucket: countBucket(3),
+      movie_count_bucket: countBucket(5),
+      rating_count_bucket: countBucket(2),
     }))
   })
 
@@ -311,8 +314,8 @@ describe('completeOnboarding — service writes', () => {
       ratings: {},
     })
 
-    expect(track).toHaveBeenCalledWith('onboarding_completed', expect.objectContaining({
-      rating_count: 0,
+    expect(trackEvent).toHaveBeenCalledWith(EVENTS.onboarding_completed, expect.objectContaining({
+      rating_count_bucket: countBucket(0),
     }))
   })
 

--- a/src/shared/services/__tests__/betaEvents.test.js
+++ b/src/shared/services/__tests__/betaEvents.test.js
@@ -43,6 +43,23 @@ describe('betaEvents — fail-closed event contract', () => {
     trackEvent(EVENTS.recommendation_shown, { movie_id: 12345, source: null, result_count: undefined })
     expect(analyticsTrack).toHaveBeenCalledWith('recommendation_shown', { movie_id: 12345 })
   })
+
+  it('allows the B1.4b onboarding + Discover funnel events (bucketed/safe payloads)', () => {
+    trackEvent(EVENTS.onboarding_started, { surface: 'onboarding' })
+    trackEvent(EVENTS.onboarding_step_completed, { surface: 'onboarding', step_key: 'mood' })
+    trackEvent(EVENTS.onboarding_completed, { surface: 'onboarding', genre_count_bucket: '3-5', rating_count_bucket: '1-2' })
+    trackEvent(EVENTS.recommendation_requested, { surface: 'discover' })
+    trackEvent(EVENTS.recommendation_shown, { surface: 'discover', result_count: 3, from_cache: false })
+    trackEvent(EVENTS.edge_function_error, { surface: 'profile', error_kind: 'edge_error' })
+    expect(analyticsTrack).toHaveBeenCalledTimes(6)
+  })
+
+  it('drops raw context / title / genre text from Discover & onboarding events', () => {
+    trackEvent(EVENTS.recommendation_shown, {
+      surface: 'discover', context: 'cozy rainy night', movie_title: 'Jaws', genre: 'horror', prompt: 'find me something',
+    })
+    expect(analyticsTrack).toHaveBeenCalledWith('recommendation_shown', { surface: 'discover' })
+  })
 })
 
 describe('betaEvents — helpers never leak raw text', () => {

--- a/src/shared/services/__tests__/onboarding.test.js
+++ b/src/shared/services/__tests__/onboarding.test.js
@@ -45,11 +45,13 @@ vi.mock('@/shared/api/tmdb', () => ({ fetchJson: vi.fn().mockResolvedValue({ id:
 vi.mock('@/shared/services/recommendations', () => ({ computeUserProfileV3: vi.fn().mockResolvedValue(undefined) }))
 vi.mock('@/shared/services/tasteCache', () => ({ getTasteFingerprint: vi.fn().mockResolvedValue({}) }))
 vi.mock('@/shared/services/analytics', () => ({ track: vi.fn() }))
+// B1.4b: onboarding_completed now routes through the central betaEvents wrapper (bucketed counts).
+vi.mock('@/shared/services/betaEvents', async (orig) => ({ ...(await orig()), trackEvent: vi.fn() }))
 
 import { completeOnboarding } from '../onboarding'
 import { computeUserProfileV3 } from '@/shared/services/recommendations'
 import { getTasteFingerprint } from '@/shared/services/tasteCache'
-import { track } from '@/shared/services/analytics'
+import { trackEvent, EVENTS, countBucket } from '@/shared/services/betaEvents'
 
 const session = { user: { id: 'u1', email: 'u1@test.dev', user_metadata: {} } }
 const baseArgs = () => ({
@@ -79,7 +81,7 @@ describe('completeOnboarding — first completion writes', () => {
     expect(byTable('users', 'update')[0].vals).toMatchObject({ onboarding_complete: true })
     expect(computeUserProfileV3).toHaveBeenCalledWith('u1', { forceRefresh: true })
     expect(getTasteFingerprint).toHaveBeenCalledWith('u1')
-    expect(track).toHaveBeenCalledWith('onboarding_completed', expect.objectContaining({ movie_count: 3 }))
+    expect(trackEvent).toHaveBeenCalledWith(EVENTS.onboarding_completed, expect.objectContaining({ movie_count_bucket: countBucket(3) }))
   })
 
   it('inserts the users row when it does not yet exist', async () => {

--- a/src/shared/services/betaEvents.js
+++ b/src/shared/services/betaEvents.js
@@ -13,10 +13,15 @@ import { track as analyticsTrack } from './analytics'
 
 // ── Event allow-list (add here intentionally; the test fails on un-listed names) ──────────────
 export const EVENTS = Object.freeze({
-  // Onboarding (onboarding_completed predates B1.3 and is emitted via analytics.track directly)
+  // Onboarding
+  onboarding_started: 'onboarding_started',
+  onboarding_step_completed: 'onboarding_step_completed',
+  onboarding_abandoned: 'onboarding_abandoned',
+  onboarding_error: 'onboarding_error',
   onboarding_completed: 'onboarding_completed',
   // Discover
   discover_opened: 'discover_opened',
+  recommendation_requested: 'recommendation_requested',
   recommendation_shown: 'recommendation_shown',
   recommendation_opened: 'recommendation_opened',
   recommendation_saved: 'recommendation_saved',
@@ -44,6 +49,7 @@ export const EVENTS = Object.freeze({
   route_error: 'route_error',
   auth_error: 'auth_error',
   supabase_error: 'supabase_error',
+  edge_function_error: 'edge_function_error',
 })
 
 const EVENT_NAMES = new Set(Object.values(EVENTS))
@@ -53,7 +59,7 @@ export const ALLOWED_KEYS = new Set([
   'event_version', 'surface', 'source', 'step_key', 'reaction', 'placement',
   'result_count', 'result_kind', 'has_results', 'from_cache',
   'movie_id', // catalog id — safe + useful
-  'genre_count_bucket', 'mood_count_bucket', 'count_bucket',
+  'genre_count_bucket', 'movie_count_bucket', 'rating_count_bucket', 'mood_count_bucket', 'count_bucket',
   'query_length_bucket', 'latency_bucket', 'retry_count_bucket', 'status_bucket',
   'error_kind',
 ])

--- a/src/shared/services/onboarding.js
+++ b/src/shared/services/onboarding.js
@@ -3,7 +3,7 @@ import { supabase } from '@/shared/lib/supabase/client'
 import { fetchJson } from '@/shared/api/tmdb'
 import { computeUserProfileV3 } from './recommendations'
 import { getTasteFingerprint } from './tasteCache'
-import { track } from './analytics'
+import { trackEvent, EVENTS, countBucket } from './betaEvents'
 
 // === HELPERS ===
 
@@ -255,11 +255,13 @@ export async function completeOnboarding({ session, selectedGenres, favoriteMovi
     console.warn('Taste fingerprint pre-warm failed (non-fatal):', err)
   }
 
-  // 8. Analytics
-  track('onboarding_completed', {
-    genre_count: selectedGenres.length,
-    movie_count: favoriteMovies.length,
-    rating_count: ratingEntries.length,
-    mood_count: Array.isArray(moods) ? moods.length : 0,
+  // 8. Analytics — B1.4b: through the central fail-closed wrapper, COARSE BUCKETS only
+  // (no raw counts that could fingerprint a taste profile, no titles/genres/moods text).
+  trackEvent(EVENTS.onboarding_completed, {
+    surface: 'onboarding',
+    genre_count_bucket: countBucket(selectedGenres.length),
+    movie_count_bucket: countBucket(favoriteMovies.length),
+    rating_count_bucket: countBucket(ratingEntries.length),
+    mood_count_bucket: countBucket(Array.isArray(moods) ? moods.length : 0),
   })
 }


### PR DESCRIPTION
**B1.4b** — completes the funnel instrumentation + Discover kill-switch + error buckets deferred from **B1.4a**. No recommendation-scoring change, no DB/RLS/RPC change, no analytics-privacy weakening, no PII. B1.2/B1.3/B1.4a contracts frozen + still green.

## B1.4a split note
B1.4 was split: B1.4a shipped the beta gate + path redaction + operator controls; this is **B1.4b** — the deeper funnel + health instrumentation.

## Onboarding events added
`onboarding_started` (mount), `onboarding_step_completed` (`step_key` = mood/genres/movies), `onboarding_error` (`error_kind`), and `onboarding_completed` **rerouted through the central wrapper with bucketed counts** (`genre_count_bucket`… via `countBucket`) — no raw counts/titles/genres/moods. `onboarding_abandoned` not wired (no clean signal). **Completion behavior unchanged.**

## Discover events added
`discover_opened` (mount), `recommendation_requested` (resolve stage), `recommendation_shown` (`result_count`+`from_cache`), `recommendation_error` (`error_kind`), `recommendation_opened` + `recommendation_saved` (**`movie_id` only — never title/context**). A minimal PostHog funnel bridge; `recommendation_impressions` stays the first-party source of truth for detailed outcomes.

## Discover kill-switch behavior
`VITE_ENABLE_DISCOVER_RECOMMENDATIONS` (default **on**). When disabled: `allResults` short-circuits to `[]` **before** `scoreMovieForUser` runs (no recommendation request) and the pick stage renders an honest `DiscoverPaused` fallback (Start-over button, no spinner hang, no crash). The enabled/default scoring path is unchanged.

## Error buckets
Failures emit `error_kind` only (`errorKind()`): `onboarding_error`, `recommendation_error` (save/resolve), plus the existing `profile_reflection_refresh_failed` / `people_follow_failed` / `route_error`. Never raw error text/objects/SQL/tokens. `edge_function_error`/`supabase_error` reserved in `EVENTS`.

## PostHog retention decision
**Re-verified + still deferred.** `process-account-deletions` remains out-of-band (not in `supabase/functions/`) and a PostHog person-delete needs an unprovisioned secret — so it stays documented (the Privacy page makes no deletion claim). No browser-side PostHog deletion added.

## Docs update
`docs/beta/operator-dashboard-b1.md` — B1.4b events, Discover funnel + disabled fallback, safe error buckets, retained gaps.

## Tests
+ updates (run 3×): `betaEvents` (new events allow-listed; raw context/title/genre/prompt dropped); `DiscoverInstrumentation` (recommendation_opened/saved/error carry `movie_id`+`error_kind` only, no title; kill-switch **source-guard** proves the scoring gate precedes `scoreMovieForUser` + the `DiscoverPaused` fallback); two onboarding tests updated to the bucketed `trackEvent` payload.

## Validation
lint clean; **discover 194** (enabled path unchanged); onboarding 153; people 71; profile 66; B1.2 analytics-privacy + B1.3 + B1.4a green; **full 1499** (1493 + 6 net new); build ✓. Instrumentation is side-effect-only in the default state → Discover visual baseline unaffected.

## No-live-action confirmation
No real Discover recommendation request run for testing; no analytics toggled on a real user; no live analytics with real data; no list/preference/Diary/follow mutation; no real identities/secrets/raw errors/private text printed. Tests use mocked analytics + `renderHook` + source guards.

## Deferred (B1.x)
`onboarding_abandoned`; an operator dashboard UI; the PostHog deletion implementation (awaits the deletion fn in-repo + a provisioned secret). Residual F8.9 security-backlog P2s stay parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
