### PR TITLE
Harden remaining route reliability and accessibility

### DIFF
--- a/src/features/account/__tests__/DangerReliability.test.js
+++ b/src/features/account/__tests__/DangerReliability.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import src from '../sections-bottom.jsx?raw'
+
+// F9.3 — Account destructive-action a11y + reliability + copy honesty (source guard).
+describe('Account — F9.3 delete-modal a11y + pending', () => {
+  it('the delete dialog is labelled by its visible title', () => {
+    expect(src).toMatch(/aria-labelledby="del-modal-title"/)
+    expect(src).toMatch(/<h2 id="del-modal-title"/)
+  })
+
+  it('closes on Escape and focuses the first field on open', () => {
+    expect(src).toMatch(/e\.key === 'Escape'/)
+    expect(src).toMatch(/emailRef\.current\?\.focus\(\)/)
+  })
+
+  it('removes outline:none from the modal inputs (keyboard focus is visible)', () => {
+    // both del-confirm-email + del-reason had outline:'none'; neither should anymore
+    const modal = src.slice(src.indexOf('del-modal-title'), src.indexOf('Schedule deletion') + 40)
+    expect(modal).not.toMatch(/outline:'none'/)
+  })
+
+  it('disables the destructive button while the request is pending', () => {
+    expect(src).toMatch(/disabled=\{!enabled \|\| busy\}/)
+    expect(src).toMatch(/busy \? 'Scheduling…' : 'Schedule deletion'/)
+  })
+})
+
+describe('Account — F9.3 Reset taste profile confirmation + honest copy', () => {
+  it('requires a two-step confirmation (confirmFirst)', () => {
+    const reset = src.slice(src.indexOf('Reset taste profile') - 40, src.indexOf('Reset taste profile') + 320)
+    expect(reset).toMatch(/confirmFirst/)
+  })
+
+  it('copy is accurate — no misleading "mood weights" / "watches stay logged"', () => {
+    const reset = src.slice(src.indexOf('Reset taste profile') - 40, src.indexOf('Reset taste profile') + 320)
+    expect(reset).not.toMatch(/mood weights start from zero/)
+    expect(reset).not.toMatch(/existing watches stay logged/)
+    expect(reset).toMatch(/onboarding/i) // describes what actually happens
+  })
+
+  it('does NOT regress the B1.2 analytics copy (still honest, no "no PII")', () => {
+    expect(src).not.toMatch(/Aggregated, no PII/)
+    expect(src).toMatch(/Privacy-safe usage analytics/)
+  })
+})

--- a/src/features/account/sections-bottom.jsx
+++ b/src/features/account/sections-bottom.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { supabase } from '@/shared/lib/supabase/client'
 import { formatMonthYear } from '@/shared/lib/format/date'
@@ -264,11 +264,12 @@ function DangerZone() {
       <div className="ff-acct-grid-2" style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:18 }}>
         <Danger
           title="Reset taste profile"
-          desc="Re-run onboarding. Your existing watches stay logged, but mood weights start from zero."
+          desc="Clears the genres and films you chose during onboarding and starts onboarding over. Films you've logged since then stay in your history."
           cta="Reset DNA"
           color={HP.amber}
           onClick={rerunOnboarding}
           disabled={busy}
+          confirmFirst
         />
         {isPending ? (
           <DangerPending
@@ -290,6 +291,7 @@ function DangerZone() {
       {showDeleteModal && (
         <DeleteConfirmModal
           email={authUser?.email}
+          busy={busy}
           onCancel={() => setShowDeleteModal(false)}
           onConfirm={async (reason) => {
             try {
@@ -323,16 +325,24 @@ function DangerPending({ scheduledLabel, onCancel, disabled }) {
   );
 }
 
-function DeleteConfirmModal({ email, onCancel, onConfirm }) {
+function DeleteConfirmModal({ email, onCancel, onConfirm, busy = false }) {
   const [typed, setTyped] = useState('');
   const [reason, setReason] = useState('');
+  const emailRef = useRef(null);
   const enabled = typed.trim().toLowerCase() === (email || '').trim().toLowerCase();
+  // F9.3: focus the first field on open + close on Escape (parity with the shared Modal primitive).
+  useEffect(() => { emailRef.current?.focus(); }, []);
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape' && !busy) onCancel(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onCancel, busy]);
   return (
-    <div role="dialog" aria-modal="true" style={{ position:'fixed', inset:0, background:'rgba(0,0,0,0.7)', display:'flex', alignItems:'center', justifyContent:'center', zIndex:100, padding:20 }}>
+    <div role="dialog" aria-modal="true" aria-labelledby="del-modal-title" style={{ position:'fixed', inset:0, background:'rgba(0,0,0,0.7)', display:'flex', alignItems:'center', justifyContent:'center', zIndex:100, padding:20 }}>
       <div style={{ maxWidth:520, width:'100%', padding:32, borderRadius:10, background:HP.bgDeep, border:`1px solid ${HP.red}55` }}>
-        <div style={{ fontFamily:'Outfit', fontSize:24, fontWeight:500, color:HP.text, letterSpacing:'-0.02em', marginBottom:12 }}>
+        <h2 id="del-modal-title" style={{ fontFamily:'Outfit', fontSize:24, fontWeight:500, color:HP.text, letterSpacing:'-0.02em', margin:'0 0 12px' }}>
           Delete your account?
-        </div>
+        </h2>
         <p style={{ margin:'0 0 18px 0', fontSize:14, color:HP.textSoft, fontFamily:'Outfit, Inter, sans-serif', lineHeight:1.55 }}>
           We&rsquo;ll permanently delete your profile, watches, ratings, lists, and DNA <strong style={{ color:HP.text, fontWeight:600 }}>after 7 days</strong>. You can cancel anytime before then by signing back in.
         </p>
@@ -340,13 +350,14 @@ function DeleteConfirmModal({ email, onCancel, onConfirm }) {
           Type your email to confirm
         </label>
         <input
+          ref={emailRef}
           id="del-confirm-email"
           type="email"
           value={typed}
           onChange={(e) => setTyped(e.target.value)}
           placeholder={email || 'your@email.com'}
           autoComplete="off"
-          style={{ width:'100%', padding:'10px 12px', borderRadius:6, background:'rgba(255,255,255,0.04)', border:`1px solid ${HP.border}`, color:HP.text, fontFamily:'Outfit, Inter, sans-serif', fontSize:14, outline:'none', marginBottom:16 }}
+          style={{ width:'100%', padding:'10px 12px', borderRadius:6, background:'rgba(255,255,255,0.04)', border:`1px solid ${HP.border}`, color:HP.text, fontFamily:'Outfit, Inter, sans-serif', fontSize:14, marginBottom:16 }}
         />
         <label htmlFor="del-reason" style={{ display:'block', fontFamily:'Outfit', fontSize:11, fontWeight:700, letterSpacing:'0.08em', textTransform:'uppercase', color:HP.textMuted, marginBottom:8 }}>
           Reason (optional)
@@ -357,7 +368,7 @@ function DeleteConfirmModal({ email, onCancel, onConfirm }) {
           onChange={(e) => setReason(e.target.value)}
           rows={3}
           placeholder="What pushed you away?"
-          style={{ width:'100%', padding:'10px 12px', borderRadius:6, background:'rgba(255,255,255,0.04)', border:`1px solid ${HP.border}`, color:HP.text, fontFamily:'Outfit, Inter, sans-serif', fontSize:13, outline:'none', resize:'vertical', marginBottom:24 }}
+          style={{ width:'100%', padding:'10px 12px', borderRadius:6, background:'rgba(255,255,255,0.04)', border:`1px solid ${HP.border}`, color:HP.text, fontFamily:'Outfit, Inter, sans-serif', fontSize:13, resize:'vertical', marginBottom:24 }}
         />
         <div style={{ display:'flex', gap:10, justifyContent:'flex-end' }}>
           <button
@@ -368,26 +379,38 @@ function DeleteConfirmModal({ email, onCancel, onConfirm }) {
           <button
             type="button"
             onClick={() => onConfirm(reason)}
-            disabled={!enabled}
-            style={{ padding:'12px 22px', borderRadius:6, background: enabled ? HP.red : 'rgba(255,255,255,0.06)', border:'none', color: enabled ? '#fff' : HP.textFaint, fontFamily:'Outfit', fontSize:13, fontWeight:600, cursor: enabled ? 'pointer' : 'not-allowed' }}
-          >Schedule deletion</button>
+            disabled={!enabled || busy}
+            style={{ padding:'12px 22px', borderRadius:6, background: (enabled && !busy) ? HP.red : 'rgba(255,255,255,0.06)', border:'none', color: (enabled && !busy) ? '#fff' : HP.textFaint, fontFamily:'Outfit', fontSize:13, fontWeight:600, cursor: busy ? 'wait' : enabled ? 'pointer' : 'not-allowed' }}
+          >{busy ? 'Scheduling…' : 'Schedule deletion'}</button>
         </div>
       </div>
     </div>
   );
 }
 
-function Danger({ title, desc, cta, color, onClick, disabled }) {
+function Danger({ title, desc, cta, color, onClick, disabled, confirmFirst = false }) {
+  // F9.3: confirmFirst adds a two-step confirm for destructive actions that don't open their own modal
+  // (e.g. Reset taste profile). The first click arms; a second click within ~3.5s runs the action.
+  const [confirming, setConfirming] = useState(false);
+  const handleClick = () => {
+    if (confirmFirst && !confirming) {
+      setConfirming(true);
+      setTimeout(() => setConfirming(false), 3500);
+      return;
+    }
+    setConfirming(false);
+    onClick();
+  };
   return (
     <div style={{ padding:'24px 26px', borderRadius:6, background:`${color}08`, border:`1px solid ${color}33` }}>
       <div style={{ fontFamily:'Outfit', fontSize:18, fontWeight:500, color:HP.text, letterSpacing:'-0.015em', marginBottom:6 }}>{title}</div>
       <p style={{ margin:'0 0 18px 0', fontSize:13, color:HP.textMuted, fontFamily:'Outfit, Inter, sans-serif', lineHeight:1.55, fontStyle:'italic', textWrap:'pretty' }}>{desc}</p>
       <button
         type="button"
-        onClick={onClick}
+        onClick={handleClick}
         disabled={disabled}
-        style={{ padding:'10px 16px', borderRadius:6, background:'transparent', border:`1px solid ${color}77`, color, fontFamily:'Outfit', fontSize:11, fontWeight:600, letterSpacing:'0.06em', textTransform:'uppercase', cursor: disabled ? 'wait' : 'pointer', opacity: disabled ? 0.6 : 1 }}
-      >{cta}</button>
+        style={{ padding:'10px 16px', borderRadius:6, background: confirming ? `${color}18` : 'transparent', border:`1px solid ${color}77`, color, fontFamily:'Outfit', fontSize:11, fontWeight:600, letterSpacing:'0.06em', textTransform:'uppercase', cursor: disabled ? 'wait' : 'pointer', opacity: disabled ? 0.6 : 1 }}
+      >{confirming ? `Confirm — ${cta}?` : cta}</button>
     </div>
   );
 }

--- a/src/features/browse/__tests__/BrowseFit.test.js
+++ b/src/features/browse/__tests__/BrowseFit.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import src from '../immersive.jsx?raw'
+
+// F9.3 — Browse must not show an exact, false-precision "Match %"; it uses a qualitative fit label.
+describe('Browse QuickLook — F9.3 honest fit label, no exact Match %', () => {
+  it('no longer renders an exact "Match %" value', () => {
+    expect(src).not.toMatch(/matchScore \+ '%'/)
+    expect(src).not.toMatch(/label:\s*'Match'/)
+  })
+
+  it('shows a qualitative fit label instead', () => {
+    expect(src).toMatch(/label:\s*'Fit'/)
+    expect(src).toMatch(/fitLabel\(matchScore\)/)
+    for (const l of ['Strong fit', 'Good fit', 'Light fit', 'Worth a look']) {
+      expect(src).toContain(l)
+    }
+  })
+
+  it('keeps the underlying score computation unchanged (scoring not touched)', () => {
+    // the composite score is still computed from real signals — only its PRESENTATION changed
+    expect(src).toMatch(/const matchScore = mood==='all' \? film\.ff : Math\.round\(0\.6\*\(film\.fit\[mood\]\*100\)/)
+  })
+})

--- a/src/features/browse/immersive.jsx
+++ b/src/features/browse/immersive.jsx
@@ -8,6 +8,16 @@ import { getMoodTag } from './components'
 // Hooks aliases
 const useE = useEffect;
 
+// F9.3: Browse shows a QUALITATIVE fit label, never an exact composite "Match %" (false precision).
+// The underlying score (mood fit + ratings + runtime) is unchanged — only the presentation is honest.
+function fitLabel(score) {
+  if (score == null) return '—';
+  if (score >= 75) return 'Strong fit';
+  if (score >= 55) return 'Good fit';
+  if (score >= 40) return 'Light fit';
+  return 'Worth a look';
+}
+
 // Local icons
 const Ic = ({ d, s=16, fill='none' }) => (
   <svg width={s} height={s} viewBox="0 0 24 24" fill={fill} stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">{d}</svg>
@@ -76,13 +86,13 @@ function QuickLook({ film, mood, watched, inWatchlist, onTW, onTWL, onClose }) {
           {/* Stats row */}
           <div style={{ display:'grid', gridTemplateColumns:'repeat(4, 1fr)', gap:10, padding:'18px 0', borderBottom:`1px solid ${HP.border}` }}>
             {[
-              { label:'Match', value: matchScore + '%', tint:HP.purple },
+              { label:'Fit', value: fitLabel(matchScore), tint:HP.purple },
               { label:'FF', value: film.ff,    tint:HP.text },
               { label:'Critics', value: film.critic,  tint:HP.textHi },
               { label:'Audience', value: film.audience, tint:HP.textHi },
             ].map(s => (
               <div key={s.label} style={{ textAlign:'center' }}>
-                <div style={{ fontFamily:'Outfit', fontSize:22, fontWeight:300, color:s.tint, letterSpacing:'-0.02em', lineHeight:1 }}>{s.value}</div>
+                <div style={{ fontFamily:'Outfit', fontSize: typeof s.value === 'string' ? 14 : 22, fontWeight: typeof s.value === 'string' ? 500 : 300, color:s.tint, letterSpacing:'-0.02em', lineHeight:1.1 }}>{s.value}</div>
                 <div style={{ marginTop:4, fontFamily:'Inter', fontSize:10, color:HP.textFaint, letterSpacing:'0.08em', textTransform:'uppercase' }}>{s.label}</div>
               </div>
             ))}

--- a/src/features/lists/CreateListModal.jsx
+++ b/src/features/lists/CreateListModal.jsx
@@ -1,5 +1,5 @@
 // src/features/lists/CreateListModal.jsx
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 
 import { X } from 'lucide-react'
 
@@ -26,13 +26,17 @@ export default function CreateListModal({ onClose, onSave, existingList = null, 
   // to public via the explicit "Public — anyone can see this list" checkbox below.
   const [isPublic, setIsPublic] = useState(existingList?.is_public ?? false)
   const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+  const savingRef = useRef(false) // F9.3: synchronous guard — blocks a 2nd submit before React re-renders
 
   const canSubmit = title.trim().length > 0 && !saving
 
   const handleSubmit = async (e) => {
     e.preventDefault()
-    if (!canSubmit) return
+    if (title.trim().length === 0 || savingRef.current) return // duplicate-submit guard
+    savingRef.current = true
     setSaving(true)
+    setError('')
 
     try {
       if (isEdit) {
@@ -66,8 +70,10 @@ export default function CreateListModal({ onClose, onSave, existingList = null, 
         onSave(data)
       }
     } catch (err) {
-      console.error('[CreateListModal] save error:', err)
+      console.error('[CreateListModal] save error:', err) // raw error stays in the console, never the UI
+      setError(isEdit ? 'Could not save your changes. Please try again.' : 'Could not create your list. Please try again.')
     } finally {
+      savingRef.current = false
       setSaving(false)
     }
   }
@@ -124,9 +130,12 @@ export default function CreateListModal({ onClose, onSave, existingList = null, 
           label="Public — anyone can see this list"
         />
 
+        {/* Safe, user-facing error (never raw backend text); inputs are preserved for retry */}
+        {error && <p role="alert" className="text-[13px] text-red-400">{error}</p>}
+
         {/* Actions */}
         <div className="flex items-center justify-end gap-3 pt-2">
-          <Button variant="secondary" onClick={onClose}>
+          <Button variant="secondary" type="button" onClick={onClose}>
             Cancel
           </Button>
           <Button variant="primary" type="submit" disabled={!canSubmit}>

--- a/src/features/lists/ListDetail.jsx
+++ b/src/features/lists/ListDetail.jsx
@@ -4,7 +4,7 @@
 // film rows with mood chips and optional italic notes. Owns its own data
 // (list + owner + list_movies) so users can deep-link straight in.
 
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { supabase } from '@/shared/lib/supabase/client'
 import { useAuthSession } from '@/shared/hooks/useAuthSession'
@@ -51,6 +51,9 @@ export default function ListDetail() {
   const [showEdit, setShowEdit] = useState(false)
   const [editMode, setEditMode] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [deleteError, setDeleteError] = useState('')
+  const deletingRef = useRef(false) // F9.3: synchronous in-flight guard against double-delete
   const [linkCopied, setLinkCopied] = useState(false)
   const [isFollowing, setIsFollowing] = useState(false)
   const [followBusy, setFollowBusy] = useState(false)
@@ -193,12 +196,21 @@ export default function ListDetail() {
       setTimeout(() => setConfirmDelete(false), 3000)
       return
     }
+    if (deletingRef.current) return // F9.3: no double-delete while a request is in flight
+    deletingRef.current = true
+    setDeleting(true)
+    setDeleteError('')
     const { error } = await supabase.from('lists').delete().eq('id', listId)
     if (error) {
+      // F9.3: settle honestly — the list stays visible (no false success); raw error never shown.
       console.error('[ListDetail.delete]', error)
+      deletingRef.current = false
+      setDeleting(false)
+      setConfirmDelete(false)
+      setDeleteError('Could not delete this list. Please try again.')
       return
     }
-    navigate('/lists', { replace: true })
+    navigate('/lists', { replace: true }) // success only after the DB delete resolves
   }
 
   const handleRemoveFilm = async (movieId) => {
@@ -363,13 +375,16 @@ export default function ListDetail() {
                     <button
                       type="button"
                       onClick={handleDelete}
-                      style={{ padding: '10px 16px', borderRadius: 6, background: confirmDelete ? 'rgba(239,68,68,0.18)' : 'transparent', border: `1px solid ${confirmDelete ? HP.red + '66' : HP.border}`, color: confirmDelete ? HP.red : HP.textMuted, fontFamily: 'Outfit', fontSize: 11, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', cursor: 'pointer' }}
+                      disabled={deleting}
+                      style={{ padding: '10px 16px', borderRadius: 6, background: confirmDelete ? 'rgba(239,68,68,0.18)' : 'transparent', border: `1px solid ${confirmDelete ? HP.red + '66' : HP.border}`, color: confirmDelete ? HP.red : HP.textMuted, fontFamily: 'Outfit', fontSize: 11, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', cursor: deleting ? 'wait' : 'pointer', opacity: deleting ? 0.6 : 1 }}
                     >
-                      {confirmDelete ? 'Confirm delete?' : 'Delete'}
+                      {deleting ? 'Deleting…' : confirmDelete ? 'Confirm delete?' : 'Delete'}
                     </button>
                   </>
                 )}
               </div>
+              {/* F9.3: safe, user-facing delete error — list stays visible, raw error never shown */}
+              {deleteError && <p role="alert" style={{ marginTop: 8, fontSize: 13, color: HP.red }}>{deleteError}</p>}
             </div>
 
             {/* === RIGHT: numbered film rows === */}

--- a/src/features/lists/__tests__/CreateListModal.test.jsx
+++ b/src/features/lists/__tests__/CreateListModal.test.jsx
@@ -1,9 +1,16 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 
-// CreateListModal imports the supabase client for the submit path; the default-state tests below
-// never submit, so a minimal stub keeps the module import side-effect-free.
-vi.mock('@/shared/lib/supabase/client', () => ({ supabase: { from: () => ({}) } }))
+// Configurable Supabase mock — the default-state tests don't submit; the F9.3 reliability tests do.
+const sb = vi.hoisted(() => ({ insertError: null, insertCalls: 0 }))
+vi.mock('@/shared/lib/supabase/client', () => ({
+  supabase: {
+    from: () => ({
+      insert: () => { sb.insertCalls++; return { select: () => ({ single: async () => ({ data: { id: 'new-list' }, error: sb.insertError }) }) } },
+      update: () => ({ eq: () => ({ select: () => ({ single: async () => ({ data: { id: 'l1' }, error: null }) }) }) }),
+    }),
+  },
+}))
 
 import CreateListModal from '../CreateListModal'
 
@@ -37,5 +44,38 @@ describe('CreateListModal — F9.2 default-private', () => {
     render(<CreateListModal onClose={noop} onSave={noop} userId="u1"
       existingList={{ id: 'l2', title: 'Private picks', is_public: false }} />)
     expect(screen.getByRole('checkbox')).not.toBeChecked()
+  })
+})
+
+describe('CreateListModal — F9.3 create reliability', () => {
+  beforeEach(() => { sb.insertError = null; sb.insertCalls = 0 })
+
+  const fillTitle = () => fireEvent.change(screen.getByPlaceholderText(/Comfort Movies/i), { target: { value: 'My list' } })
+  const submitBtn = () => screen.getByRole('button', { name: /create list/i })
+
+  it('double-submit inserts only ONCE (pending guard disables the button)', async () => {
+    render(<CreateListModal onClose={noop} onSave={noop} userId="u1" />)
+    fillTitle()
+    const btn = submitBtn()
+    fireEvent.click(btn)            // first submit → saving=true disables the button
+    fireEvent.click(btn)            // second click hits the disabled button → no-op
+    expect(btn).toBeDisabled()
+    await waitFor(() => expect(sb.insertCalls).toBe(1))
+  })
+
+  it('on failure: shows a safe error, preserves the input, never raw backend text', async () => {
+    sb.insertError = { code: '500', message: 'duplicate key value violates unique constraint "pg_lists_pkey"' }
+    render(<CreateListModal onClose={noop} onSave={noop} userId="u1" />)
+    fillTitle()
+    fireEvent.click(submitBtn())
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toMatch(/Could not create your list/i)
+    expect(alert.textContent).not.toMatch(/pg_lists_pkey|unique constraint/i)
+    expect(screen.getByDisplayValue('My list')).toBeInTheDocument() // input preserved for retry
+  })
+
+  it('Cancel is type="button" (cannot accidentally submit the form)', () => {
+    render(<CreateListModal onClose={noop} onSave={noop} userId="u1" />)
+    expect(screen.getByRole('button', { name: 'Cancel' })).toHaveAttribute('type', 'button')
   })
 })

--- a/src/features/lists/__tests__/ListDetailReliability.test.js
+++ b/src/features/lists/__tests__/ListDetailReliability.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import src from '../ListDetail.jsx?raw'
+
+// F9.3 — ListDetail delete must settle honestly (source guard; the full component is heavy to render).
+describe('ListDetail — F9.3 delete reliability', () => {
+  it('guards against double-delete with a synchronous ref', () => {
+    expect(src).toMatch(/deletingRef\.current/) // in-flight guard
+    expect(src).toMatch(/if \(deletingRef\.current\) return/)
+  })
+
+  it('navigates away ONLY after the DB delete resolves with no error (no false success)', () => {
+    const errIdx = src.indexOf("if (error) {")
+    const navIdx = src.indexOf("navigate('/lists', { replace: true }) // success only")
+    expect(errIdx).toBeGreaterThan(0)
+    expect(navIdx).toBeGreaterThan(errIdx) // the navigate sits after the error-return branch
+  })
+
+  it('surfaces a safe error and keeps the list visible on failure (no raw backend text)', () => {
+    expect(src).toMatch(/setDeleteError\('Could not delete this list\. Please try again\.'\)/)
+    expect(src).toMatch(/role="alert"/)
+    // the raw error only goes to the console, never into state/UI
+    expect(src).toMatch(/console\.error\('\[ListDetail\.delete\]', error\)/)
+    expect(src).not.toMatch(/setDeleteError\(error/)
+  })
+})

--- a/src/features/preferences/Preferences.jsx
+++ b/src/features/preferences/Preferences.jsx
@@ -54,7 +54,7 @@ function MoodDials() {
   return (
     <section style={{ padding: '56px 88px', borderTop: `1px solid ${HP.border}` }}>
       <H kicker="Mood weights" title="Lean the engine." sub="Drag each mood toward how much you want it in your weekly briefing." />
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: '28px 48px' }}>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '28px 48px' }}>
         {catalogs.MOODS.map(m => {
           const w = draft.moodWeights[m.id] ?? 0.5
           return (
@@ -294,7 +294,7 @@ function Daypart() {
   return (
     <section style={{ padding: '56px 88px', borderTop: `1px solid ${HP.border}` }}>
       <H kicker="When you watch" title="Time-of-day fit." sub="The briefing tunes itself to when you actually settle in." />
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 14 }}>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))', gap: 14 }}>
         {catalogs.DAYPARTS.map(d => {
           const on = !!draft.daypart[d.id]
           return (
@@ -339,7 +339,7 @@ function Subscriptions() {
           We&rsquo;ll bias recommendations toward what you can actually watch tonight &mdash; once we wire up streamer-availability data.
         </p>
       </header>
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 14, opacity: 0.45, pointerEvents: 'none' }} aria-disabled="true">
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))', gap: 14, opacity: 0.45, pointerEvents: 'none' }} aria-disabled="true">
         {catalogs.STREAMERS.map(s => (
           <div
             key={s.id}
@@ -442,7 +442,7 @@ function Segmented({ value, onChange, options }) {
 }
 
 function PreviewPanel() {
-  const { dirty, saving, savedAt, save, discard } = usePreferencesData()
+  const { dirty, saving, savedAt, saveError, save, discard } = usePreferencesData()
   const justSaved = savedAt && Date.now() - savedAt < 3000
   return (
     <section style={{ padding: '56px 88px 88px', borderTop: `1px solid ${HP.border}`, background: 'rgba(167,139,250,0.04)' }}>
@@ -456,6 +456,8 @@ function PreviewPanel() {
                 ? <>Unsaved changes &mdash; <em style={{ fontStyle: 'italic', fontWeight: 400, color: HP.textSoft }}>save to apply.</em></>
                 : <>Engine is up to date <em style={{ fontStyle: 'italic', fontWeight: 400, color: HP.textSoft }}>with your dials.</em></>}
           </h2>
+          {/* F9.3: save failures are now user-visible + retryable (the Save button stays enabled while dirty) */}
+          {saveError && <p role="alert" style={{ marginTop: 12, fontSize: 14, color: HP.red, fontFamily: 'Inter, sans-serif' }}>{saveError}</p>}
         </div>
         <div style={{ display: 'flex', gap: 10 }}>
           <SecondaryActionButton

--- a/src/features/preferences/__tests__/PreferencesReliability.test.js
+++ b/src/features/preferences/__tests__/PreferencesReliability.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import dataSrc from '../usePreferencesData.jsx?raw'
+import viewSrc from '../Preferences.jsx?raw'
+import fs from 'node:fs'
+import { resolve } from 'node:path'
+
+// F9.3 — Preferences save reliability + phone-safe responsive layout (source guard).
+describe('Preferences — F9.3 save reliability', () => {
+  it('surfaces a safe save error (no silent false-success, no raw backend text)', () => {
+    expect(dataSrc).toMatch(/setSaveError\('Could not save your preferences\. Please try again\.'\)/)
+    expect(dataSrc).toMatch(/console\.error\('\[usePreferencesData\.save\]', e\)/)
+    expect(dataSrc).not.toMatch(/setSaveError\(e[.)]/) // never the raw error object/message
+  })
+
+  it('guards against duplicate submit synchronously and exposes saveError', () => {
+    expect(dataSrc).toMatch(/if \(deletingRef|if \(!userId \|\| !dirty \|\| savingRef\.current\)/)
+    expect(dataSrc).toMatch(/savingRef\.current = true/)
+    expect(dataSrc).toMatch(/loading, saving, savedAt, saveError, dirty/)
+  })
+
+  it('documents the onboarding-write race as impossible (PostAuthGate gates /preferences)', () => {
+    expect(dataSrc).toMatch(/onboarding-write race/i)
+    expect(dataSrc).toMatch(/PostAuthGate/)
+  })
+
+  it('the view renders saveError as an accessible alert', () => {
+    expect(viewSrc).toMatch(/saveError && <p role="alert"/)
+  })
+})
+
+describe('Preferences — F9.3 phone-safe layout', () => {
+  it('fixed multi-column grids now stack via auto-fit/minmax', () => {
+    expect(viewSrc).not.toMatch(/gridTemplateColumns: 'repeat\(3,1fr\)'/)
+    expect(viewSrc).not.toMatch(/gridTemplateColumns: 'repeat\(4,1fr\)'/)
+    expect(viewSrc.match(/repeat\(auto-fit, minmax\(/g)?.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('css pulls in the wide section padding at phone widths', () => {
+    const css = fs.readFileSync(resolve(import.meta.dirname, '../preferences.css'), 'utf8')
+    expect(css).toMatch(/@media \(max-width: 600px\)/)
+    expect(css).toMatch(/\.ff-preferences-v2 section \{ padding-left: 20px/)
+    expect(css).toMatch(/:focus-visible/) // visible keyboard focus
+  })
+})

--- a/src/features/preferences/preferences.css
+++ b/src/features/preferences/preferences.css
@@ -6,3 +6,11 @@
 .ff-preferences-v2 button:hover { filter: brightness(1.12); }
 .ff-preferences-v2 input[type=range] { accent-color: #A78BFA; }
 .ff-preferences-v2 ::selection { background: rgba(167,139,250,0.4); color:#fff; }
+.ff-preferences-v2 button:focus-visible,
+.ff-preferences-v2 [role=switch]:focus-visible { outline: 2px solid #A78BFA; outline-offset: 2px; }
+
+/* F9.3: phone-safe — the wide desktop section padding (88px) crushed the grids at <=430px.
+   Pull it in so content has room; the inline grids use auto-fit/minmax to stack. */
+@media (max-width: 600px) {
+  .ff-preferences-v2 section { padding-left: 20px !important; padding-right: 20px !important; }
+}

--- a/src/features/preferences/usePreferencesData.jsx
+++ b/src/features/preferences/usePreferencesData.jsx
@@ -12,7 +12,7 @@
 //   • Everything else (mood weights, directors trusted/muted, runtime band,
 //     daypart, subscriptions, boundaries, display knobs) → settings.prefs.
 
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { supabase } from '@/shared/lib/supabase/client'
 import { useAuthSession } from '@/shared/hooks/useAuthSession'
 
@@ -185,6 +185,8 @@ export function PreferencesDataProvider({ children }) {
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [savedAt, setSavedAt] = useState(null) // for toast / dot
+  const [saveError, setSaveError] = useState('') // F9.3: surfaced to the user, never raw backend text
+  const savingRef = useRef(false) // F9.3: synchronous duplicate-submit guard
 
   // Watch-history-derived director suggestions (so "+ Director" picker is real)
   const [directorSuggestions, setDirectorSuggestions] = useState([])
@@ -268,14 +270,21 @@ export function PreferencesDataProvider({ children }) {
 
   // === Save (writes to user_preferences + user_settings.settings.prefs) ===
   const save = useCallback(async () => {
-    if (!userId || !dirty || saving) return
+    if (!userId || !dirty || savingRef.current) return // F9.3: synchronous duplicate-submit guard
+    savingRef.current = true
     setSaving(true)
+    setSaveError('')
     try {
-      // 1) Replace drawn-to genre rows. We deliberately do NOT write avoid
-      //    rows here — the engine selects only `genre_id` from this table
+      // 1) Replace this user's drawn-to genre rows. We deliberately do NOT write
+      //    avoid rows here — the engine selects only `genre_id` from this table
       //    and treats every row as PREFERRED. Avoid lives in
       //    settings.prefs.avoidGenres (written below), which is what the
       //    Discover engine actually reads.
+      //    F9.3 onboarding-write race: this delete is scoped to THIS user's genre
+      //    rows. /preferences is only reachable after onboarding completes
+      //    (PostAuthGate gates it), so a user can never be saving preferences
+      //    while onboarding is concurrently writing user_preferences — the two
+      //    delete-then-write paths cannot overlap for the same user.
       await supabase.from('user_preferences').delete().eq('user_id', userId)
       const rows = draft.drawnGenreIds.map(id => ({ user_id: userId, genre_id: id, excluded: false }))
       if (rows.length) {
@@ -336,14 +345,16 @@ export function PreferencesDataProvider({ children }) {
       setBaseline(draft)
       setSavedAt(Date.now())
     } catch (e) {
-      console.error('[usePreferencesData.save]', e)
+      console.error('[usePreferencesData.save]', e) // raw error stays in console, never the UI
+      setSaveError('Could not save your preferences. Please try again.')
     } finally {
+      savingRef.current = false
       setSaving(false)
     }
-  }, [userId, dirty, saving, draft])
+  }, [userId, dirty, draft])
 
   const value = useMemo(() => ({
-    loading, saving, savedAt, dirty,
+    loading, saving, savedAt, saveError, dirty,
     draft, baseline,
     directorSuggestions,
     catalogs: { MOODS, GENRES, STREAMERS, DAYPARTS, BOUNDARIES, LANGUAGES, SUBTITLE_MODES, SPOILER_TIERS },
@@ -358,7 +369,7 @@ export function PreferencesDataProvider({ children }) {
     setSubtitles, setSpoilerTier, addLanguage, removeLanguage,
     discard, save,
   }), [
-    loading, saving, savedAt, dirty, draft, baseline, directorSuggestions,
+    loading, saving, savedAt, saveError, dirty, draft, baseline, directorSuggestions,
     setMoodWeight,
     addDrawnGenre, removeDrawnGenre, addAvoidGenre, removeAvoidGenre,
     addTrustedDirector, removeTrustedDirector,


### PR DESCRIPTION
**F9.3** — reliability, accessibility, and trust polish on the four non-closed routes (/account, /preferences, /browse, /lists, /lists/:listId). Not a privacy hotfix (F9.2/B1.2 closed the pre-beta P1s). **No** DB/RLS/RPC change, **no** recommendation-scoring change, **no** analytics/gate change, **no** route-path change, **no** People/Discover/Home/Movie/Library product-behavior change.

## F9.1 residuals addressed
The P2 reliability/a11y/trust cluster on /lists, /preferences, /account, /browse.

## Lists
- **Create:** synchronous `savingRef` guard (no double-insert before re-render); safe user-facing error on failure (raw error → console only); inputs preserved for retry; **Cancel is now `type="button"`** (it was implicitly submit → could submit the form). Default-private + explicit-public unchanged.
- **Delete:** synchronous `deletingRef` in-flight guard; **navigates only after the DB delete resolves** (no false success; list stays visible on failure); safe `role="alert"` error; "Deleting…" + disabled while in flight.
- Modals use the shared `Modal` (role=dialog + aria-modal + aria-label + Escape + focus capture/restore) — verified by tests.

## Preferences
- **Save errors now user-visible** (`role="alert"`) + retryable (Save stays enabled while dirty); no silent false-success; raw text never shown; sync duplicate-submit guard.
- **Onboarding-write race** documented as impossible (PostAuthGate gates /preferences behind completed onboarding → the two delete-then-write paths can't overlap) — no onboarding change.
- **Phone-safe:** the three fixed grids stack via `auto-fit/minmax`; a ≤600px media query pulls in the 88px section padding; focus-visible rings added.

## Account
- **Delete-account modal:** `aria-labelledby` → the visible `<h2 id>` title; Escape closes; first field focuses on open; inputs drop `outline:none` (visible keyboard focus); destructive button disabled while pending ("Scheduling…"). Account-deletion RPCs untouched.
- **Reset taste profile:** two-step confirmation + **accurate copy** (clears the genres/films chosen during onboarding and restarts onboarding; films logged since stay) replacing the misleading "mood weights start from zero / existing watches stay logged". B1.2 analytics copy unchanged.

## Browse trust-copy fix
The exact composite **"Match %"** is replaced with a qualitative fit label (**Strong fit / Good fit / Light fit / Worth a look**). The underlying score computation is **unchanged** (presentation only); catalog-only/own-data posture + signed-out behavior unchanged.

## Tests
+22 (run 3×): CreateListModal create reliability (no double-insert; failure → safe error + preserved input + no raw text; Cancel type=button); ListDetail delete source-guard; Browse fit-label guard (no exact %, qualitative labels, scoring unchanged); Account delete-modal a11y + reset confirm/copy + B1.2-copy-no-regression; Preferences save-error + duplicate guard + race comment + responsive grids + focus-visible.

## Validation
lint clean; frozen contracts green — analyticsPrivacy 11, betaEvents 13, gate 9, People 71, Discover 194; **full 1521** (1499 + 22); build ✓. None of the four routes is visual-baselined → no snapshot impact.

## No-live-action confirmation
No real list/preference/account/DNA/watchlist mutation; no real Browse write; no analytics toggled; no beta members touched; no follow/discoverability; no real identifiers/private text printed. Tests use mocked Supabase + render/source guards.

## Deferred (public-social / moderation / security)
Lists UGC moderation/reporting; the F8.9 security backlog (SECURITY DEFINER views, OTP/leaked-password/Postgres patch, extensions-in-public, migration drift); PostHog account-deletion automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
