### PR TITLE
Harden Supabase view and function grants

### DIFF
--- a/scripts/verify-s12-grants.sql
+++ b/scripts/verify-s12-grants.sql
@@ -1,0 +1,128 @@
+-- scripts/verify-s12-grants.sql
+-- READ-ONLY verification for S1.2 (view + function + anon-grant hardening).
+-- Emits one row per check: (check_name, expected, ok). No private row contents,
+-- no PII — only catalog booleans/counts. Safe to run against any environment.
+-- Run:  psql "$DATABASE_URL" -f scripts/verify-s12-grants.sql
+--   or paste into the Supabase SQL editor / MCP execute_sql.
+
+with checks as (
+  -- ---- Views: security_invoker ----
+  select 'view.list_follower_counts.security_invoker' as check_name, 'true' as expected,
+    coalesce((select reloptions from pg_class where oid = 'public.list_follower_counts'::regclass)
+             @> array['security_invoker=true'], false) as ok
+  union all
+  select 'view.vw_movies_scored.security_invoker', 'true',
+    coalesce((select reloptions from pg_class where oid = 'public.vw_movies_scored'::regclass)
+             @> array['security_invoker=true'], false)
+
+  -- ---- Views: no write grants to browser roles ----
+  union all
+  select 'view.list_follower_counts.no_browser_write_grants', '0', (
+    select count(*) = 0 from information_schema.role_table_grants
+    where table_schema='public' and table_name='list_follower_counts'
+      and grantee in ('anon','authenticated')
+      and privilege_type in ('INSERT','UPDATE','DELETE','TRUNCATE','REFERENCES','TRIGGER'))
+  union all
+  select 'view.vw_movies_scored.no_browser_write_grants', '0', (
+    select count(*) = 0 from information_schema.role_table_grants
+    where table_schema='public' and table_name='vw_movies_scored'
+      and grantee in ('anon','authenticated')
+      and privilege_type in ('INSERT','UPDATE','DELETE','TRUNCATE','REFERENCES','TRIGGER'))
+
+  -- ---- Function: increment_session_interactions ----
+  union all
+  select 'fn.increment_session_interactions.anon_execute_denied', 'false',
+    has_function_privilege('anon','public.increment_session_interactions(uuid)','EXECUTE') = false
+  union all
+  select 'fn.increment_session_interactions.authenticated_execute', 'true',
+    has_function_privilege('authenticated','public.increment_session_interactions(uuid)','EXECUTE') = true
+  union all
+  select 'fn.increment_session_interactions.search_path_pinned', 'true', (
+    select p.proconfig is not null and exists (
+      select 1 from unnest(p.proconfig) c where c like 'search_path=%')
+    from pg_proc p join pg_namespace n on n.oid=p.pronamespace
+    where n.nspname='public' and p.proname='increment_session_interactions')
+  union all
+  select 'fn.increment_session_interactions.returns_void', 'true', (
+    select (select typname from pg_type where oid=p.prorettype) = 'void'
+    from pg_proc p join pg_namespace n on n.oid=p.pronamespace
+    where n.nspname='public' and p.proname='increment_session_interactions')
+
+  -- ---- Anon grants removed from RLS-protected per-user tables ----
+  union all
+  select 'tables.no_anon_grants_remaining', '0', (
+    select count(*) = 0 from information_schema.role_table_grants
+    where table_schema='public' and grantee='anon'
+      and table_name in ('user_history','user_ratings','user_profiles_computed','user_settings',
+                         'user_preferences','user_events','user_interactions','user_sessions',
+                         'user_similarity','mood_sessions','user_watchlist'))
+  union all
+  -- Stronger than the direct-grant check above: has_table_privilege accounts for
+  -- PUBLIC + role membership, proving anon has NO effective SELECT path.
+  select 'tables.anon_effective_select_denied', 'true', (
+    select bool_and(not has_table_privilege('anon','public.'||t,'SELECT'))
+    from unnest(array['user_history','user_ratings','user_profiles_computed','user_settings',
+                     'user_preferences','user_events','user_interactions','user_sessions',
+                     'user_similarity','mood_sessions','user_watchlist']) t)
+  union all
+  select 'tables.rls_enabled_on_all_candidates', 'true', (
+    select bool_and(c.relrowsecurity)
+    from pg_class c join pg_namespace n on n.oid=c.relnamespace
+    where n.nspname='public'
+      and c.relname in ('user_history','user_ratings','user_profiles_computed','user_settings',
+                       'user_preferences','user_events','user_interactions','user_sessions',
+                       'user_similarity','mood_sessions','user_watchlist'))
+
+  -- ---- Regression: F8.6-SEC scheduler functions stay denied ----
+  union all
+  select 'regression.get_cron_secret.anon_denied', 'false',
+    coalesce((select has_function_privilege('anon', p.oid, 'EXECUTE')
+              from pg_proc p join pg_namespace n on n.oid=p.pronamespace
+              where n.nspname='public' and p.proname='get_cron_secret' limit 1), false) = false
+  union all
+  select 'regression.get_cron_secret.authenticated_denied', 'false',
+    coalesce((select has_function_privilege('authenticated', p.oid, 'EXECUTE')
+              from pg_proc p join pg_namespace n on n.oid=p.pronamespace
+              where n.nspname='public' and p.proname='get_cron_secret' limit 1), false) = false
+  union all
+  select 'regression.list_daily_briefing_subscribers.anon_denied', 'false',
+    coalesce((select has_function_privilege('anon', p.oid, 'EXECUTE')
+              from pg_proc p join pg_namespace n on n.oid=p.pronamespace
+              where n.nspname='public' and p.proname='list_daily_briefing_subscribers' limit 1), false) = false
+  union all
+  select 'regression.list_daily_briefing_subscribers.authenticated_denied', 'false',
+    coalesce((select has_function_privilege('authenticated', p.oid, 'EXECUTE')
+              from pg_proc p join pg_namespace n on n.oid=p.pronamespace
+              where n.nspname='public' and p.proname='list_daily_briefing_subscribers' limit 1), false) = false
+
+  -- ---- Regression: B1.4a beta_members — no anon grant, no authenticated client write ----
+  union all
+  select 'regression.beta_members.no_anon_grant', '0', (
+    select count(*) = 0 from information_schema.role_table_grants
+    where table_schema='public' and table_name='beta_members' and grantee='anon')
+  union all
+  select 'regression.beta_members.no_authenticated_dml_write', '0', (
+    select count(*) = 0 from information_schema.role_table_grants
+    where table_schema='public' and table_name='beta_members' and grantee='authenticated'
+      and privilege_type in ('INSERT','UPDATE','DELETE'))
+
+  -- ---- Regression: F9.2 owner-only RLS on watchlist + mood_sessions ----
+  union all
+  select 'regression.user_watchlist.rls_owner_scoped', 'true', (
+    select c.relrowsecurity and exists (
+      select 1 from pg_policies pol
+      where pol.schemaname='public' and pol.tablename='user_watchlist'
+        and coalesce(pol.qual,'') ilike '%auth.uid()%')
+    from pg_class c where c.oid='public.user_watchlist'::regclass)
+  union all
+  select 'regression.mood_sessions.rls_owner_scoped', 'true', (
+    select c.relrowsecurity and exists (
+      select 1 from pg_policies pol
+      where pol.schemaname='public' and pol.tablename='mood_sessions'
+        and coalesce(pol.qual,'') ilike '%auth.uid()%')
+    from pg_class c where c.oid='public.mood_sessions'::regclass)
+)
+select check_name, expected, ok from checks
+union all
+select '== ALL CHECKS PASS ==', 'true', bool_and(ok) from checks
+order by 1;

--- a/supabase/migrations/20260611130000_harden_view_and_function_grants.sql
+++ b/supabase/migrations/20260611130000_harden_view_and_function_grants.sql
@@ -1,0 +1,80 @@
+-- S1.2 — Global Security Hardening: view options, function grants, anon table grants.
+--
+-- SCOPE: grants / view security model / function EXECUTE only.
+--   * No schema change. No row mutation. No data backfill. No RLS-policy change.
+--   * No app-source change. No route/analytics/beta-gate change.
+--
+-- IDEMPOTENT: ALTER VIEW ... SET, REVOKE (of an absent privilege is a no-op), and
+--   GRANT are all safe to re-run.
+--
+-- FROZEN CONTRACTS PRESERVED (untouched here):
+--   * F8.6-SEC: get_cron_secret() / list_daily_briefing_subscribers() stay anon+auth-denied.
+--   * F9.2: user_watchlist / mood_sessions owner-only RLS + authenticated grants unchanged
+--           (we only remove the inert ANON grants below).
+--   * B1.4a: beta_members owner-only SELECT, no client write — not touched.
+--   * B1.4b analytics events, F8 People RPCs, public list sharing — not touched.
+--
+-- Addresses S1.1 P2 findings: two SECURITY DEFINER views (advisor ERRORs), an
+-- anon-executable SECURITY DEFINER counter function, and inert anonymous grants on
+-- RLS-protected per-user tables.
+
+-- ---------------------------------------------------------------------------
+-- 1) SECURITY DEFINER views -> security_invoker (advisor: security_definer_view)
+-- ---------------------------------------------------------------------------
+-- Both views are owned by postgres, ran as SECURITY DEFINER, and are unused by app
+-- source (grep: 0 references). list_follower_counts exposes aggregate follower counts;
+-- vw_movies_scored exposes catalog-only movie scoring. security_invoker makes them
+-- evaluate with the querying role's privileges + RLS, so they can never silently
+-- bypass row security.
+-- ROLLBACK: alter view ... set (security_invoker = false);
+alter view public.list_follower_counts set (security_invoker = true);
+alter view public.vw_movies_scored     set (security_invoker = true);
+
+-- Remove inert/unnecessary non-SELECT grants from the browser roles on the views.
+-- A view is not a write surface for anon/authenticated; these default grants
+-- (INSERT/UPDATE/DELETE/TRUNCATE/REFERENCES/TRIGGER) are inert and unnecessary.
+-- SELECT is intentionally retained (harmless: views are unused by app source, and
+-- security_invoker now scopes any read through the caller's RLS).
+-- ROLLBACK: re-grant the listed privileges to the roles.
+revoke insert, update, delete, truncate, references, trigger
+  on public.list_follower_counts from anon, authenticated;
+revoke insert, update, delete, truncate, references, trigger
+  on public.vw_movies_scored from anon, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 2) increment_session_interactions(uuid): drop anon EXECUTE
+-- ---------------------------------------------------------------------------
+-- SECURITY DEFINER, pinned search_path (public, extensions, pg_catalog), returns void,
+-- only bumps user_sessions.interactions_count for a given session id. The sole caller
+-- is authenticated: src/shared/services/interactions.js -> trackInteraction(), which
+-- early-returns when there is no signed-in user (and initSession likewise). Anonymous
+-- EXECUTE was an unnecessary surface (counter inflation for a guessed session uuid).
+-- NOTE: Postgres default-grants EXECUTE on functions to PUBLIC, so revoking from
+-- anon alone is NOT enough (anon inherits EXECUTE via PUBLIC). We revoke from
+-- PUBLIC and anon, then grant explicitly to authenticated (the only caller).
+-- ROLLBACK: grant execute on function public.increment_session_interactions(uuid) to public;
+revoke execute on function public.increment_session_interactions(uuid) from public;
+revoke execute on function public.increment_session_interactions(uuid) from anon;
+grant  execute on function public.increment_session_interactions(uuid) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 3) Remove ALL anonymous grants from RLS-protected per-user tables (defense in depth)
+-- ---------------------------------------------------------------------------
+-- Every table below has RLS enabled with owner-only policies, so anon already sees
+-- zero rows. These are per-user data tables; the app only ever reads/writes them as the
+-- authenticated role, scoped by user_id (no anonymous/public route touches them). The
+-- inert anon grants (SELECT + assorted write grants) are removed so anonymous requests
+-- are denied at the grant layer too, not only by RLS. authenticated grants are LEFT
+-- INTACT — RLS owner policies continue to scope them.
+-- ROLLBACK: grant select (and any prior write privileges) on each table to anon.
+revoke all on table public.user_history          from anon;
+revoke all on table public.user_ratings           from anon;
+revoke all on table public.user_profiles_computed from anon;
+revoke all on table public.user_settings          from anon;
+revoke all on table public.user_preferences       from anon;
+revoke all on table public.user_events            from anon;
+revoke all on table public.user_interactions      from anon;
+revoke all on table public.user_sessions          from anon;
+revoke all on table public.user_similarity        from anon;
+revoke all on table public.mood_sessions          from anon;
+revoke all on table public.user_watchlist         from anon;


### PR DESCRIPTION
S1.2 of the Global Security Hardening initiative. Narrow SQL/security phase — **grants, view options, and function grants only**. No schema change, no row mutation, no app-source change, no route/analytics/beta-gate change.

## S1.1 findings addressed (P2)
- `security_definer_view` advisor ERRORs on `public.list_follower_counts` and `public.vw_movies_scored`.
- `anon_security_definer_function_executable` on `public.increment_session_interactions(uuid)`.
- Inert anonymous grants on RLS-protected per-user tables.

## View changes
Both views are owned by postgres, ran SECURITY DEFINER, and are **unused by app source** (0 refs). Set `security_invoker = true` on both (they now evaluate with the caller's privileges + RLS), and revoked the inert non-SELECT grants (`INSERT/UPDATE/DELETE/TRUNCATE/REFERENCES/TRIGGER`) from `anon` + `authenticated`. SELECT retained (harmless; unused; now RLS-scoped).

## Function grant decision
`increment_session_interactions(uuid)` is SECURITY DEFINER, pinned `search_path`, returns `void`, bumps a session counter. Its **only caller is authenticated** (`src/shared/services/interactions.js → trackInteraction`, which early-returns with no signed-in user). Revoked EXECUTE from **PUBLIC** (the default grant that actually let anon in) and `anon`; granted to `authenticated`. Left SECURITY DEFINER (switching to INVOKER would be a behavior change — deferred). It now appears only under the *intentional* `authenticated_security_definer_function_executable` advisor class.

## Anon grant cleanup decision
Removed **all** `anon` grants from 11 RLS-protected per-user tables (`user_history, user_ratings, user_profiles_computed, user_settings, user_preferences, user_events, user_interactions, user_sessions, user_similarity, mood_sessions, user_watchlist`). All have RLS enabled with owner-only policies; the app only touches them as `authenticated` (user_id-scoped). `authenticated` grants left intact. Defense-in-depth: `has_table_privilege('anon', …, 'SELECT')` is now false for all 11 (accounts for PUBLIC).

## Verification (`scripts/verify-s12-grants.sql`)
All 19 checks pass live (views security_invoker + no write grants; fn anon-denied / authenticated-allowed / search_path pinned / returns void; 0 anon table grants + anon effective SELECT denied + RLS enabled; regressions below).

## Advisor results
- `security_definer_view` for both views → **cleared**.
- `anon_security_definer_function_executable` for the counter fn → **cleared** (now authenticated-only).
- **No new P0/P1.** Expected residual WARN/INFO remain: extensions-in-public (pg_trgm/pg_net), OTP expiry, leaked-password protection, Postgres patch, intentional authenticated SECURITY DEFINER RPCs (People/account-deletion + this counter), and 2 pre-existing INFO `rls_enabled_no_policy` (discovery_cursors, update_runs — out of scope).

## No row mutation
Only `ALTER VIEW SET`, `REVOKE`, `GRANT`. Zero `INSERT/UPDATE/DELETE`. Idempotent; per-statement rollback documented in the migration.

## Frozen contracts (verified intact)
F8.6-SEC (`get_cron_secret` / `list_daily_briefing_subscribers` still anon+auth-denied), F9.2 (watchlist/mood owner-only RLS), B1.4a (`beta_members` no anon grant, no authenticated DML write), B1.4b / F8 People RPCs / public list sharing — untouched.

## Persona credential-shaped working-tree warning handling
A pre-existing untracked `docs/personas/persona-test-accounts.json` was flagged as credential-shaped. Value-free inspection (no contents printed): 17 synthetic personas, all `@feelflick.test` emails, **no password/secret/token fields or values** → **not real credentials, nothing to rotate**. Per maintainer decision, persona files were **left untouched**; this PR never staged them (only the 2 SQL files added by explicit path; no `git add -A`).

## Deferred
- **S1.3**: Auth/dashboard settings — OTP expiry, leaked-password protection, Postgres patch; consider SECURITY INVOKER conversion / per-fn EXECUTE review for the intentional authenticated SECURITY DEFINER RPCs; `beta_members` authenticated `TRUNCATE` grant (latent, frozen this phase).
- **S1.4**: Scheduler/function source-of-truth migrations; `extension_in_public` (pg_trgm/pg_net) relocation; `rls_enabled_no_policy` on discovery_cursors/update_runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)