### PR TITLE
Document auth hardening and close beta gate grants

### DIFF
--- a/docs/security/s1-auth-dashboard-hardening.md
+++ b/docs/security/s1-auth-dashboard-hardening.md
@@ -1,0 +1,128 @@
+# S1.3 — Auth & dashboard security hardening (operator checklist)
+
+Status: **current** · Phase: S1 Global Security Hardening · Created during S1.3.
+
+This document records what S1.3 verified, the one SQL change it made, and the
+**dashboard-only operator actions** that cannot be expressed in repo migrations.
+Nothing in the "operator action" sections has been applied automatically — they
+require the Supabase Dashboard or Management API.
+
+No secrets, real emails, user IDs, or private data appear in this document.
+
+---
+
+## 1. What S1.3 changed in SQL (applied + verified)
+
+Migration `supabase/migrations/20260611140000_harden_beta_members_and_auth_security.sql`:
+
+- **`beta_members` latent grants closed.** `authenticated` held `REFERENCES, SELECT,
+  TRIGGER, TRUNCATE`. SELECT is the intended owner-only self-read (RLS:
+  `auth.uid() = user_id`). Revoked `INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES,
+  TRIGGER` from `anon` + `authenticated` (TRUNCATE bypasses RLS and could have wiped
+  the gate). `authenticated` now has **SELECT only**; `service_role` keeps full
+  management; `anon` has nothing. RLS + owner-only policy unchanged.
+
+Verify: `scripts/verify-s13-auth-security.sql` (read-only).
+
+## 2. What S1.3 verified (no change needed)
+
+- **Authenticated SECURITY DEFINER RPC review.** All 21 SECURITY DEFINER functions in
+  `public` were audited. Every `authenticated`-executable one is an intentional,
+  `auth.uid()`-scoped browser RPC:
+  - People least-data: `get_people_public_identities(uuid[])`, `search_people_by_name(text)`,
+    `get_follow_suggestions()`, `get_discoverable_taste_profiles()`
+  - Account deletion: `request_account_deletion(text)`, `cancel_account_deletion()`
+  - Bounded counter: `increment_session_interactions(uuid)` (returns void; worst case is
+    counter inflation for a guessed session id)
+  All service-role-only functions (cron `_call_*`, health/`check_*`, `get_cron_secret`,
+  `list_daily_briefing_subscribers`, `get_watchlist_with_status`, `get_positive_feedback_movies`,
+  `refresh_feelflick_stats`, `handle_new_auth_user`) are already `anon` + `authenticated`
+  denied. **No mis-granted function found → no EXECUTE tightening applied this phase.**
+- **S1.2 hardening intact**: both views `security_invoker=true`; `increment_session_interactions`
+  anon-denied; anon SELECT revoked on the 11 user tables; F8.6-SEC functions anon+auth denied.
+
+---
+
+## 3. Dashboard-only operator actions (NOT applied — require Dashboard/Management API)
+
+The Supabase MCP exposes no auth-config write path, so these were not changed here.
+Each shows current advisor state, target, and exact steps.
+
+### 3a. Leaked-password protection — **currently DISABLED → enable**
+- **Why:** blocks known-breached passwords (HaveIBeenPwned) at signup/password-change.
+- **Steps:** Supabase Dashboard → **Authentication → Policies / Password protection** →
+  enable **"Check passwords against HaveIBeenPwned"**. (Management API: `auth` config,
+  `security_update_password_require_reauthentication` / password-strength settings.)
+- **Verify:** re-run security advisors; `auth_leaked_password_protection` clears.
+- **Timing:** **recommended before 5–10 beta users; required before public.**
+- **Rollback:** toggle off (no data impact).
+- Ref: https://supabase.com/docs/guides/auth/password-security#password-strength-and-leaked-password-protection
+
+### 3b. OTP expiry — **currently > 1 hour → set ≤ 1 hour**
+- **Why:** long-lived email OTP/magic-link codes widen the phishing/replay window.
+- **Steps:** Dashboard → **Authentication → Email/Providers (Email) → OTP / Email OTP
+  Expiration** → set to **30 minutes** (or 60 min max). Confirm the email magic-link/OTP
+  login flow still completes (codes are short-lived but adequate).
+- **Verify:** advisors; `auth_otp_long_expiry` clears.
+- **Timing:** **before 5–10 beta users.**
+- **Rollback:** raise the value again.
+- Ref: https://supabase.com/docs/guides/platform/going-into-prod#security
+
+### 3c. Redirect URLs / allowed domains / signup posture — **review**
+- **Steps:** Dashboard → **Authentication → URL Configuration**:
+  - Confirm **Site URL** = production (`https://app.feelflick.com`).
+  - **Redirect Allow List**: keep only intended origins (prod + explicit preview/local
+    dev). **Remove stray wildcards / unused localhost** before public.
+  - **Authentication → Providers**: confirm Google OAuth redirect/authorized origins.
+  - **Signups**: confirm whether email signups are open; the beta gate (`beta_members`,
+    owner-only) is an **app-layer** allowlist and is **independent of** Supabase signup —
+    enabling Auth signups does not bypass the gate, but confirm that's the intended posture.
+- **Classify:** safe for 1–2; **review before 5–10**; tighten wildcards before public.
+- Ref: https://supabase.com/docs/guides/auth/redirect-urls
+
+### 3d. Postgres security patch — **patch available → schedule**
+- **Current:** `supabase-postgres-15.8.1.102` has outstanding security patches.
+- **Nature:** platform upgrade (Dashboard → **Settings → Infrastructure → Upgrade**);
+  involves a brief restart/downtime; not expressible as a repo migration.
+- **Pre-req:** confirm no in-flight migrations; take/confirm a backup; pick a low-traffic
+  maintenance window; have rollback/restore posture from the project's PITR/backups.
+- **Timing:** **before wider beta if desired; recommended before public production.**
+  Requires explicit operator approval of the maintenance window — do not auto-apply.
+- Ref: https://supabase.com/docs/guides/platform/upgrading
+
+### 3e. Extensions in `public` (`pg_trgm`, `pg_net`) — **do not relocate now**
+- **Decision (S1.3): defer.** Relocating to a dedicated schema (e.g. `extensions`) is
+  non-trivial: objects/functions referencing them (search, async HTTP) would need
+  `search_path`/qualified-reference updates; risk of breaking trigram search and pg_net
+  calls. Supabase flags it as a WARN, not an error.
+- **Recommended timing:** dedicated maintenance window in **S1.4** (source-of-truth
+  migration phase), with dependency mapping + verification. Do not apply without approval.
+- Ref: https://supabase.com/docs/guides/database/database-linter?lint=0014_extension_in_public
+
+---
+
+## 4. Timing summary
+
+| Item | before 1–2 | before 5–10 | before public beta | before public prod |
+|---|---|---|---|---|
+| beta_members grant cleanup | ✅ done (S1.3) | — | — | — |
+| Leaked-password protection | optional | **recommended** | required | required |
+| OTP expiry ≤ 1h | optional | **recommended** | required | required |
+| Redirect/signup review | safe | **review** | tighten | required |
+| Postgres patch | optional | optional | recommended | **required** |
+| Extensions relocation | no | no | optional | recommended (S1.4) |
+
+## 5. Rollback notes
+
+- beta_members grants: `grant truncate, references, trigger on table public.beta_members
+  to authenticated;` (restores prior state). No data is affected by either direction.
+- All dashboard items are toggles/settings — reversible from the Dashboard with no data
+  impact, except the Postgres patch (forward-only; rely on backup/PITR for recovery).
+
+## 6. Deferred to S1.4
+
+- Scheduler / function source-of-truth migrations (align remote function bodies with repo).
+- `extension_in_public` relocation (pg_trgm, pg_net) with dependency mapping.
+- `rls_enabled_no_policy` INFO findings on `discovery_cursors`, `update_runs`.
+- Optional: evaluate SECURITY INVOKER conversion for the intentional authenticated RPCs
+  (behavior-risk change — out of grant-only scope).

--- a/scripts/verify-s13-auth-security.sql
+++ b/scripts/verify-s13-auth-security.sql
@@ -1,0 +1,70 @@
+-- scripts/verify-s13-auth-security.sql
+-- READ-ONLY verification for S1.3 (beta_members grant cleanup + S1.2 regression).
+-- Emits (check_name, ok). Catalog booleans/counts only — no PII, no row contents.
+--
+-- NOTE: Supabase Auth dashboard settings (leaked-password protection, OTP expiry,
+-- redirect URLs, signup posture) and the Postgres patch are NOT queryable via SQL and
+-- are NOT faked here. Their status comes from the security advisors; operator steps
+-- live in docs/security/s1-auth-dashboard-hardening.md.
+--
+-- Run:  psql "$DATABASE_URL" -f scripts/verify-s13-auth-security.sql
+
+with checks as (
+  -- ---- beta_members desired posture ----
+  select 'beta_members.no_anon_grant' as check_name, (
+    select count(*) = 0 from information_schema.role_table_grants
+    where table_schema='public' and table_name='beta_members' and grantee='anon') as ok
+  union all
+  select 'beta_members.authenticated_select_present', (
+    select count(*) = 1 from information_schema.role_table_grants
+    where table_schema='public' and table_name='beta_members' and grantee='authenticated'
+      and privilege_type='SELECT')
+  union all
+  select 'beta_members.authenticated_no_write_or_ddl_grants', (
+    select count(*) = 0 from information_schema.role_table_grants
+    where table_schema='public' and table_name='beta_members' and grantee='authenticated'
+      and privilege_type in ('INSERT','UPDATE','DELETE','TRUNCATE','REFERENCES','TRIGGER'))
+  union all
+  select 'beta_members.rls_enabled', (
+    select relrowsecurity from pg_class where oid='public.beta_members'::regclass)
+  union all
+  select 'beta_members.owner_only_select_policy', (
+    select exists (select 1 from pg_policies
+      where schemaname='public' and tablename='beta_members' and cmd='SELECT'
+        and coalesce(qual,'') ilike '%auth.uid()%'))
+  union all
+  select 'beta_members.no_client_write_policy', (
+    select count(*) = 0 from pg_policies
+    where schemaname='public' and tablename='beta_members'
+      and cmd in ('INSERT','UPDATE','DELETE')
+      and array['authenticated']::name[] && roles)
+
+  -- ---- S1.2 regression ----
+  union all
+  select 'regression.view.list_follower_counts.security_invoker', (
+    coalesce((select reloptions from pg_class where oid='public.list_follower_counts'::regclass) @> array['security_invoker=true'], false))
+  union all
+  select 'regression.view.vw_movies_scored.security_invoker', (
+    coalesce((select reloptions from pg_class where oid='public.vw_movies_scored'::regclass) @> array['security_invoker=true'], false))
+  union all
+  select 'regression.increment_session_interactions.anon_denied',
+    has_function_privilege('anon','public.increment_session_interactions(uuid)','EXECUTE') = false
+  union all
+  select 'regression.user_tables.anon_select_denied', (
+    select bool_and(not has_table_privilege('anon','public.'||t,'SELECT'))
+    from unnest(array['user_history','user_ratings','user_profiles_computed','user_settings',
+                     'user_preferences','user_events','user_interactions','user_sessions',
+                     'user_similarity','mood_sessions','user_watchlist']) t)
+  union all
+  select 'regression.get_cron_secret.denied',
+    has_function_privilege('anon','public.get_cron_secret()','EXECUTE') = false
+    and has_function_privilege('authenticated','public.get_cron_secret()','EXECUTE') = false
+  union all
+  select 'regression.list_daily_briefing_subscribers.denied',
+    has_function_privilege('anon','public.list_daily_briefing_subscribers()','EXECUTE') = false
+    and has_function_privilege('authenticated','public.list_daily_briefing_subscribers()','EXECUTE') = false
+)
+select check_name, ok from checks
+union all
+select '== ALL CHECKS PASS ==', bool_and(ok) from checks
+order by 1;

--- a/supabase/migrations/20260611140000_harden_beta_members_and_auth_security.sql
+++ b/supabase/migrations/20260611140000_harden_beta_members_and_auth_security.sql
@@ -1,0 +1,31 @@
+-- S1.3 — close the latent beta_members browser grants.
+--
+-- SCOPE: grant-only. No schema change, no row mutation, no RLS-policy change, no
+--   app-source change. Idempotent. Per-statement rollback below.
+--
+-- DASHBOARD-ONLY ITEMS (NOT changed here — not representable in SQL):
+--   Supabase Auth leaked-password protection, OTP expiry, redirect URLs / signup
+--   posture, the Postgres security patch, and the extensions-in-public relocation
+--   are operator/dashboard actions. They are documented with exact steps + timing in
+--   docs/security/s1-auth-dashboard-hardening.md and were intentionally NOT applied by
+--   this migration.
+--
+-- AUTHENTICATED SECURITY DEFINER RPC review (S1.3): audited all SECURITY DEFINER
+--   functions in `public`. Every authenticated-executable one is an intentional,
+--   auth.uid()-scoped browser RPC (F8 People least-data RPCs + account-deletion +
+--   the bounded session counter). All service-role-only functions are already
+--   anon+authenticated-denied. No mis-grant found, so no EXECUTE tightening is applied
+--   in this phase (see the doc for the full inventory + S1.4 follow-ups).
+--
+-- FROZEN CONTRACTS PRESERVED: B1.4a beta gate (owner-only SELECT kept), F9.2, S1.2,
+--   F8.6-SEC, F8 People RPCs, account-deletion semantics.
+
+-- beta_members (B1.4a): `authenticated` held REFERENCES, SELECT, TRIGGER, TRUNCATE.
+-- SELECT is the intended owner self-read (RLS policy: auth.uid() = user_id). The rest
+-- are inert/unnecessary default grants — TRUNCATE in particular bypasses RLS and would
+-- let a signed-in user wipe the gate table. Remove all non-SELECT grants from the
+-- browser roles. `service_role` keeps full management privileges; `anon` already holds
+-- nothing here (the revoke is a no-op for anon).
+-- ROLLBACK: grant truncate, references, trigger on table public.beta_members to authenticated;
+revoke insert, update, delete, truncate, references, trigger
+  on table public.beta_members from anon, authenticated;


### PR DESCRIPTION
S1.3 of the Global Security Hardening initiative. One scoped grant-only migration + a read-only verify script + an operator checklist doc. No schema change, no row mutation, no app-source change.

## beta_members grant cleanup (applied + verified)
`authenticated` held `REFERENCES, SELECT, TRIGGER, TRUNCATE`. SELECT is the intended owner-only self-read (RLS: `auth.uid() = user_id`). Revoked `INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER` from `anon` + `authenticated` — closing the latent **TRUNCATE** (which bypasses RLS and could have wiped the gate). After: `authenticated` = **SELECT only**; `service_role` = full management; `anon` = nothing. RLS + owner-only policy unchanged. App source only ever SELECTs `beta_members` (`useBetaAccess.js`).

## Authenticated SECURITY DEFINER RPC review
Audited all 21 SECURITY DEFINER functions in `public`. Every `authenticated`-executable one is an **intentional, `auth.uid()`-scoped browser RPC**: People least-data (`get_people_public_identities`, `search_people_by_name`, `get_follow_suggestions`, `get_discoverable_taste_profiles`), account-deletion (`request/cancel_account_deletion`), and the bounded `increment_session_interactions`. All service-role-only functions (cron `_call_*`, `check_*`/health, `get_cron_secret`, `list_daily_briefing_subscribers`, `get_watchlist_with_status`, `get_positive_feedback_movies`, `refresh_feelflick_stats`, `handle_new_auth_user`) are already `anon`+`authenticated` denied. **No mis-grant → no EXECUTE tightening applied this phase** (SECURITY INVOKER conversion is a behavior-risk change, deferred to S1.4).

## Auth dashboard findings + decisions (dashboard-only — NOT changed here)
The Supabase MCP has no auth-config write path, so these are documented as operator actions in `docs/security/s1-auth-dashboard-hardening.md` with exact steps + timing — **not** silently claimed as done:
- **Leaked-password protection**: DISABLED → enable (recommended before 5–10; required before public).
- **OTP expiry**: > 1h → set ≤ 1h (before 5–10).
- **Redirect URLs / signup posture**: review checklist (beta gate is app-layer, independent of Auth signup).
- **Postgres patch** (`15.8.1.102`): platform upgrade; schedule a maintenance window with backup/rollback before wider beta/public — requires operator approval.
- **Extensions in public** (`pg_trgm`, `pg_net`): **defer** relocation (non-trivial; dependency/breakage risk) → S1.4 maintenance window.

## Verification results
`scripts/verify-s13-auth-security.sql` — **all 12 checks pass** live (beta_members posture: no anon, authenticated SELECT-only, no write/DDL grants, RLS enabled, owner-only SELECT policy, no client write policy; + S1.2 regression: views security_invoker, fn anon-denied, anon user-tables denied, F8.6-SEC denied).

## Advisor results
**No new P0/P1; no ERROR-level findings.** State unchanged from S1.2 (the grant cleanup isn't an advisor lint). Residual WARN/INFO are the documented dashboard items (OTP, leaked-password, Postgres patch), `extension_in_public` (pg_trgm/pg_net), the intentional authenticated SECURITY DEFINER RPCs, and 2 pre-existing INFO `rls_enabled_no_policy` (discovery_cursors, update_runs).

## No row mutation
Only `REVOKE`. Zero INSERT/UPDATE/DELETE; no beta members added/removed; no gate semantics changed; no secret/PII RPC executed; no private identifiers printed.

## Persona working-tree hygiene
Pre-existing untracked persona WIP (incl. the synthetic `persona-test-accounts.json` — confirmed not real credentials in S1.2) was **left byte-for-byte untouched**; this PR staged only the 3 S1.3 files by explicit path (no `git add -A`). `.gitignore` / `package.json` / `playwright.config.js` (pre-existing dirty) untouched.

## Deferred to S1.4
Scheduler/function source-of-truth migrations; `extension_in_public` relocation; `rls_enabled_no_policy` on discovery_cursors/update_runs; optional SECURITY INVOKER evaluation for the intentional RPCs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)