### PR TITLE
Document scheduler function source of truth

### DIFF
--- a/docs/security/s1-scheduler-function-source-of-truth.md
+++ b/docs/security/s1-scheduler-function-source-of-truth.md
@@ -1,0 +1,126 @@
+# S1.4 — Scheduler/function source-of-truth audit
+
+Status: **current** · Phase: S1 Global Security Hardening (final phase) · Audit + verification only.
+
+S1.4 closed the source-of-truth question for the scheduler/diagnostic functions and the
+remaining advisor INFO/WARN items. **No live migration was applied** — see §3 for why.
+No secrets, Vault values, function bodies, cron secrets, or PII appear here.
+
+---
+
+## 1. Outcome summary
+
+- **No function source-of-truth drift to close.** All 18 audited scheduler/diagnostic/
+  account functions are **already represented in repo migrations** (≥1 definition each).
+  Their live posture (SECURITY DEFINER, owner postgres, pinned search_path, grants) matches
+  the verified S1.2/S1.3/F8.6-SEC posture. → No capture migration created.
+- **RLS-INFO tables** (`discovery_cursors`, `update_runs`): service-role-only, browser
+  roles have **no grants**, RLS enabled → benign **P3**. No change.
+- **Extensions in public** (`pg_trgm`, `pg_net`): **defer** relocation (P2, maintenance task).
+- **Cron**: 3 jobs active + intact; F8.6-SEC secret bridge intact. No change.
+- **Out-of-repo Edge source gap** (`send-daily-briefings`, `process-account-deletions`): P2,
+  recommend a future edge-source tracking phase (§6).
+
+## 2. Function inventory (catalog facts; no bodies/secrets)
+
+All `public`, all `SECURITY DEFINER`, owner `postgres`, search_path pinned, **already in repo migrations**:
+
+| function | grants | repo? | notes |
+|---|---|---|---|
+| `get_cron_secret()` | svc only | ✅ | reads Vault; search_path=vault. **Defer re-capture** (secret-coupled) |
+| `list_daily_briefing_subscribers()` | svc only | ✅ | no secret literal; returns subscriber rows (PII) → svc-only |
+| `_call_process_account_deletions()` | svc only | ✅ | Vault + pg_net → Edge. **Defer** (secret/Edge-coupled) |
+| `_call_send_daily_briefings()` | svc only | ✅ | Vault + pg_net → Edge. **Defer** (secret/Edge-coupled) |
+| `refresh_feelflick_stats()` | svc only | ✅ | stats refresh |
+| `handle_new_auth_user()` | svc only (trigger) | ✅ | auth.users trigger; defer (trigger-wired) |
+| `get_watchlist_with_status(uuid,text)` | svc only | ✅ | takes user id; **not** browser-executable |
+| `get_positive_feedback_movies(uuid)` | svc only | ✅ | takes user id; **not** browser-executable |
+| `database_health_check()` | svc only | ✅ | diagnostic |
+| `check_foreign_keys(text)` / `check_indexes(text[])` / `check_unique_constraints(text[])` | svc only | ✅ | diagnostics |
+| `check_duplicate_feedback()` / `check_duplicate_ratings()` / `check_invalid_watchlist_statuses()` | svc only | ✅ | diagnostics |
+| `increment_session_interactions(uuid)` | auth + svc | ✅ | S1.2 (anon revoked); bounded counter |
+| `request_account_deletion(text)` / `cancel_account_deletion()` | auth + svc | ✅ | `auth.uid()`-scoped account-deletion |
+
+**Key invariant verified:** **no** SECURITY DEFINER function in `public` is anon-executable.
+
+## 3. Capture / defer / remove decision
+
+- **No capture migration.** Every target function already exists in repo migrations, so a
+  `CREATE OR REPLACE` "capture" would be redundant and could itself *introduce* drift (the
+  live body could differ in incidental formatting from the existing repo definition). The
+  secret/Edge-coupled functions (`get_cron_secret`, `_call_*`) are **defer-by-policy** —
+  re-capturing them risks the Vault/pg_net bridge and offers no security gain (grants already
+  correct). 
+- **Limitation (honest):** this audit confirms *presence* in repo + correct *grants/
+  search_path/SECURITY DEFINER*; it does not byte-compare each live body against its repo
+  definition (formatting-sensitive). If exact body parity is later required, do it as a
+  dedicated, reviewed pass — not an unreviewed live capture.
+- **Remove:** nothing. No unused function proven removable.
+
+## 4. RLS-enabled / no-policy INFO tables — **P3, intentional, no change**
+
+| table | rows | RLS | policies | anon | authenticated | service_role |
+|---|---|---|---|---|---|---|
+| `discovery_cursors` | 47 | on | 0 | none | none | full |
+| `update_runs` | 10 | on | 0 | none | none | full |
+
+Both are **service-role-only internal tables**. With RLS enabled, no policy, and **no
+browser-role grants**, anon/authenticated are denied at both the grant and RLS layers — the
+`rls_enabled_no_policy` advisor finding is INFO-level and benign here. Adding a no-op policy
+would be cosmetic and is not worth a behavior touch. **No action.** (Optional future: add an
+explicit `-- deny all` comment policy purely to silence the linter.)
+
+## 5. Extension-in-public decision — **defer (P2)**
+
+| ext | schema | version | in use |
+|---|---|---|---|
+| `pg_trgm` | public | 1.6 | yes — trigram search (`search_people_by_name`, ILIKE/similarity) |
+| `pg_net` | public | 0.14.0 | yes — cron→Edge bridge (`_call_*` `net.http_post`) |
+
+Relocating to a dedicated `extensions` schema requires updating qualified references /
+search_paths in dependent functions + indexes/operators, with breakage risk to search and the
+cron bridge. Non-trivial; needs a maintenance window + verification. **Do not relocate now.**
+Recommended **before public production** (not a beta blocker). Ref:
+https://supabase.com/docs/guides/database/database-linter?lint=0014_extension_in_public
+
+## 6. Cron dependency review
+
+| job | schedule | active | notes |
+|---|---|---|---|
+| `process_account_deletions_hourly` | `30 * * * *` | yes | calls `_call_process_account_deletions()` |
+| `send_daily_briefings_hourly` | `0 * * * *` | yes | calls `_call_send_daily_briefings()` |
+| `refresh_feelflick_stats_nightly` | `15 3 * * *` | yes | calls `refresh_feelflick_stats()` |
+
+The cron commands are thin wrappers; the Vault-secret + `pg_net` HTTP logic lives inside the
+service-role-only `_call_*` SQL functions (F8.6-SEC bridge intact, anon+auth denied). **No cron
+change made.**
+
+**Out-of-repo Edge Function source gap (P2):** the Edge functions invoked by the bridge —
+`send-daily-briefings` and `process-account-deletions` — are **not present in
+`supabase/functions/`** (only `ai-mood-context`, `generate-movie-overlay`,
+`generate-reflection-prompt`, `generate-taste-summary` are). This is a *source-of-truth* gap,
+not a live vulnerability. **Recommend a dedicated edge-source tracking phase** to vendor those
+functions into the repo; do not fake coverage here.
+
+## 7. Verification
+
+`scripts/verify-s14-scheduler-functions.sql` (read-only) — **all checks pass** live:
+no anon-executable SECURITY DEFINER fn; all 18 target fns exist + SECURITY DEFINER + pinned
+search_path; F8.6-SEC (`get_cron_secret`, `list_daily_briefing_subscribers`, `_call_*`) anon+auth
+denied; S1.2 (views invoker, `increment_session_interactions` anon-denied, user-table anon
+SELECT denied); S1.3 (`beta_members` authenticated SELECT-only, no anon); RLS-INFO tables
+service-role-only; 3 cron jobs active.
+
+## 8. Remaining security / operator backlog
+
+Dashboard/operator-owned (from S1.3, still advisor WARNs — unchanged here):
+- Enable leaked-password protection (before 5–10 / required public).
+- OTP expiry ≤ 1h (before 5–10).
+- Redirect-URL allowlist review (drop stray wildcards/localhost before public).
+- Apply Postgres security patch in an approved maintenance window (before public prod).
+
+Future engineering phases:
+- **Edge-source tracking** for `send-daily-briefings` + `process-account-deletions` (P2).
+- **Extension relocation** maintenance window for `pg_trgm` + `pg_net` (P2, before public prod).
+- Optional: byte-exact function-body parity pass; optional `discovery_cursors`/`update_runs`
+  comment-policy to silence the INFO linter (P3).

--- a/scripts/verify-s14-scheduler-functions.sql
+++ b/scripts/verify-s14-scheduler-functions.sql
@@ -1,0 +1,101 @@
+-- scripts/verify-s14-scheduler-functions.sql
+-- READ-ONLY verification for S1.4 (scheduler/diagnostic function posture +
+-- RLS-INFO tables + S1.2/S1.3/F8.6-SEC regression). Emits (check_name, ok).
+-- Catalog booleans/counts/signatures only — NO function bodies, NO secrets, NO PII.
+--
+-- S1.4 applied NO live migration (all target functions already exist in repo
+-- migrations; secret/Edge-coupled ones are defer-by-policy; no browser grant left to
+-- clean). This script confirms the live posture is the intended one.
+--
+-- Run:  psql "$DATABASE_URL" -f scripts/verify-s14-scheduler-functions.sql
+
+with checks as (
+  -- ---- No SECURITY DEFINER function in public is anon-executable (key invariant) ----
+  select 'no_anon_executable_security_definer_fn' as check_name, (
+    select count(*) = 0 from pg_proc p join pg_namespace n on n.oid=p.pronamespace
+    where n.nspname='public' and p.prosecdef
+      and has_function_privilege('anon', p.oid, 'EXECUTE')) as ok
+
+  -- ---- Every target scheduler/diagnostic fn exists, is SECURITY DEFINER, pinned search_path ----
+  union all
+  select 'target_fns_exist_secdef_searchpath_pinned', (
+    with want(fn) as (values
+      ('get_cron_secret'),('list_daily_briefing_subscribers'),('refresh_feelflick_stats'),
+      ('handle_new_auth_user'),('get_watchlist_with_status'),('get_positive_feedback_movies'),
+      ('database_health_check'),('check_foreign_keys'),('check_indexes'),('check_unique_constraints'),
+      ('check_duplicate_feedback'),('check_duplicate_ratings'),('check_invalid_watchlist_statuses'),
+      ('increment_session_interactions'),('request_account_deletion'),('cancel_account_deletion'),
+      ('_call_process_account_deletions'),('_call_send_daily_briefings'))
+    select bool_and(exists (
+      select 1 from pg_proc p join pg_namespace n on n.oid=p.pronamespace
+      where n.nspname='public' and p.proname=want.fn
+        and p.prosecdef
+        and p.proconfig is not null
+        and exists (select 1 from unnest(p.proconfig) c where c like 'search_path=%')))
+    from want)
+
+  -- ---- F8.6-SEC: secret/subscriber functions stay anon + authenticated denied ----
+  union all
+  select 'f86.get_cron_secret.denied',
+    has_function_privilege('anon','public.get_cron_secret()','EXECUTE')=false
+    and has_function_privilege('authenticated','public.get_cron_secret()','EXECUTE')=false
+  union all
+  select 'f86.list_daily_briefing_subscribers.denied',
+    has_function_privilege('anon','public.list_daily_briefing_subscribers()','EXECUTE')=false
+    and has_function_privilege('authenticated','public.list_daily_briefing_subscribers()','EXECUTE')=false
+  union all
+  select 'f86.call_bridges.svc_only',
+    has_function_privilege('anon','public._call_process_account_deletions()','EXECUTE')=false
+    and has_function_privilege('authenticated','public._call_process_account_deletions()','EXECUTE')=false
+    and has_function_privilege('anon','public._call_send_daily_briefings()','EXECUTE')=false
+    and has_function_privilege('authenticated','public._call_send_daily_briefings()','EXECUTE')=false
+
+  -- ---- S1.2 regression ----
+  union all
+  select 's12.increment_session_interactions.anon_denied',
+    has_function_privilege('anon','public.increment_session_interactions(uuid)','EXECUTE')=false
+  union all
+  select 's12.views.security_invoker',
+    coalesce((select reloptions from pg_class where oid='public.list_follower_counts'::regclass) @> array['security_invoker=true'],false)
+    and coalesce((select reloptions from pg_class where oid='public.vw_movies_scored'::regclass) @> array['security_invoker=true'],false)
+  union all
+  select 's12.user_tables.anon_select_denied', (
+    select bool_and(not has_table_privilege('anon','public.'||t,'SELECT'))
+    from unnest(array['user_history','user_ratings','user_watchlist','mood_sessions','user_profiles_computed']) t)
+
+  -- ---- S1.3 regression: beta_members ----
+  union all
+  select 's13.beta_members.authenticated_select_only', (
+    select count(*) filter (where privilege_type='SELECT')=1
+       and count(*) filter (where privilege_type in ('INSERT','UPDATE','DELETE','TRUNCATE','REFERENCES','TRIGGER'))=0
+    from information_schema.role_table_grants
+    where table_schema='public' and table_name='beta_members' and grantee='authenticated')
+  union all
+  select 's13.beta_members.no_anon_grant', (
+    select count(*)=0 from information_schema.role_table_grants
+    where table_schema='public' and table_name='beta_members' and grantee='anon')
+
+  -- ---- RLS-INFO tables are service-role-only (no browser grants), RLS enabled ----
+  union all
+  select 'info.discovery_cursors.service_role_only', (
+    select c.relrowsecurity
+      and (select count(*)=0 from information_schema.role_table_grants g
+           where g.table_schema='public' and g.table_name='discovery_cursors' and g.grantee in ('anon','authenticated'))
+    from pg_class c where c.oid='public.discovery_cursors'::regclass)
+  union all
+  select 'info.update_runs.service_role_only', (
+    select c.relrowsecurity
+      and (select count(*)=0 from information_schema.role_table_grants g
+           where g.table_schema='public' and g.table_name='update_runs' and g.grantee in ('anon','authenticated'))
+    from pg_class c where c.oid='public.update_runs'::regclass)
+
+  -- ---- pg_cron jobs intact (requires cron schema read access; informational) ----
+  union all
+  select 'cron.three_jobs_active', (
+    select count(*)=3 from cron.job
+    where active and jobname in ('process_account_deletions_hourly','refresh_feelflick_stats_nightly','send_daily_briefings_hourly'))
+)
+select check_name, ok from checks
+union all
+select '== ALL CHECKS PASS ==', bool_and(ok) from checks
+order by 1;


### PR DESCRIPTION
S1.4 (final phase) of the Global Security Hardening initiative. **Audit + verification only — no live migration.** Adds a read-only verify script + a source-of-truth doc.

## Function inventory
Audited 18 live `public` scheduler/diagnostic/account functions. All are SECURITY DEFINER, owner postgres, pinned search_path, with grants matching the verified S1.2/S1.3/F8.6-SEC posture: diagnostics/scheduler (`refresh_feelflick_stats`, `handle_new_auth_user`, `database_health_check`, `check_*`, `get_watchlist_with_status`, `get_positive_feedback_movies`, `_call_*`, `get_cron_secret`, `list_daily_briefing_subscribers`) are **service-role-only** (anon+auth denied); browser RPCs (`increment_session_interactions`, `request/cancel_account_deletion`) are auth+svc and `auth.uid()`-scoped. **Key invariant verified: no SECURITY DEFINER function in `public` is anon-executable.**

## Capture / defer decisions
**No capture migration.** Every target function is **already represented in repo migrations** (grep: ≥1 def each), so a `CREATE OR REPLACE` capture would be redundant and could itself introduce incidental-formatting drift. Secret/Edge-coupled functions (`get_cron_secret`, `_call_process_account_deletions`, `_call_send_daily_briefings`) are **defer-by-policy** (Vault/pg_net bridge — no security gain, real behavior risk). Honest limitation: presence + grants/search_path/SECURITY DEFINER verified; exact byte-level body parity not diffed (formatting-sensitive) → a dedicated reviewed pass if ever needed.

## Migration summary
None. Per the deferral path: no function was both safe *and* needed to capture, and there is no remaining browser grant to clean (S1.2/S1.3 already did the grant hardening). Deliverables are the verify script + doc.

## Cron dependency review
3 jobs active + intact — `process_account_deletions_hourly` (`30 * * * *`), `send_daily_briefings_hourly` (`0 * * * *`), `refresh_feelflick_stats_nightly` (`15 3 * * *`). Commands are thin wrappers; the Vault-secret + `pg_net` HTTP bridge lives in the service-role-only `_call_*` functions (F8.6-SEC intact). **No cron change.** **Out-of-repo Edge source gap (P2):** `send-daily-briefings` + `process-account-deletions` Edge functions are not in `supabase/functions/` → recommend a future edge-source tracking phase (not faked here).

## Extension-in-public decision
`pg_trgm` (search) + `pg_net` (cron bridge) in `public` — both in use. **Defer** relocation (P2, maintenance window; breakage risk to search + bridge). Recommended before public production; not a beta blocker.

## RLS INFO table decision
`discovery_cursors` (47 rows) + `update_runs` (10 rows): RLS on, 0 policies, **anon/authenticated have no grants**, service_role full → fully locked to browser roles. Benign **P3**; no change (optional future comment-policy to silence the linter).

## Verification results
`scripts/verify-s14-scheduler-functions.sql` (read-only) — **all checks pass** live: no anon-executable SECURITY DEFINER fn; 18 target fns exist + SECURITY DEFINER + pinned search_path; F8.6-SEC (cron secret / subscribers / `_call_*`) anon+auth denied; S1.2 (views invoker, increment anon-denied, user-table anon denied); S1.3 (beta_members SELECT-only, no anon); RLS-INFO tables service-role-only; 3 cron jobs active.

## Advisor results
**No new P0/P1; no ERROR-level findings.** Unchanged from S1.3 (no live change applied). Residual WARN/INFO: OTP expiry, leaked-password protection, Postgres patch (operator-owned), `extension_in_public` (×2, deferred), intentional authenticated SECURITY DEFINER RPCs (×7), pre-existing INFO `rls_enabled_no_policy` (discovery_cursors, update_runs, documented P3).

## No secret / no row mutation
Catalog inspection only (no function bodies, Vault values, cron secrets, or PII printed); no secret/PII-returning function executed. **Zero DML — no rows changed.**

## Persona WIP untouched
Pre-existing untracked persona harness (incl. synthetic `persona-test-accounts.json`) left byte-for-byte untouched; staged only the 2 S1.4 files by explicit path (no `git add -A`). `.gitignore`/`package.json`/`playwright.config.js` untouched.

## Deferred operator/dashboard items
Leaked-password protection, OTP ≤ 1h, redirect-URL review, Postgres patch (all operator-owned, from S1.3); edge-source tracking phase; extension relocation maintenance window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)