### PR TITLE
Harden public list grants

### DIFF
--- a/scripts/verify-s15-list-grants.sql
+++ b/scripts/verify-s15-list-grants.sql
@@ -1,0 +1,81 @@
+-- scripts/verify-s15-list-grants.sql
+-- READ-ONLY verification for S1.5 (lists/list_movies grant hygiene, Option A:
+-- anon SELECT kept for public sharing, anon writes revoked). Emits (check_name, ok).
+-- Counts/booleans only — NO list titles, owner IDs, user IDs, or row contents.
+--
+-- Two parts:
+--   Part 1 — grants/RLS/policies/regression via has_*_privilege + catalog (role-agnostic).
+--   Part 2 — adversarial anon-impersonation read-proof (SET LOCAL ROLE anon, rolled back).
+--
+-- Run:  psql "$DATABASE_URL" -f scripts/verify-s15-list-grants.sql
+
+-- ── Part 1 ──────────────────────────────────────────────────────────────────────
+with checks as (
+  -- Grants: anon SELECT kept, all anon WRITE/DDL revoked (lists + list_movies)
+  select 'lists.anon_select_kept' as check_name, has_table_privilege('anon','public.lists','SELECT') = true as ok
+  union all select 'lists.anon_no_write_ddl', (
+    select bool_and(has_table_privilege('anon','public.lists',p) = false)
+    from unnest(array['INSERT','UPDATE','DELETE','TRUNCATE','REFERENCES','TRIGGER']) p)
+  union all select 'list_movies.anon_select_kept', has_table_privilege('anon','public.list_movies','SELECT') = true
+  union all select 'list_movies.anon_no_write_ddl', (
+    select bool_and(has_table_privilege('anon','public.list_movies',p) = false)
+    from unnest(array['INSERT','UPDATE','DELETE','TRUNCATE','REFERENCES','TRIGGER']) p)
+
+  -- authenticated retains create/edit/delete (RLS-constrained to owner); service_role manages
+  union all select 'lists.authenticated_can_write', (
+    select bool_and(has_table_privilege('authenticated','public.lists',p) = true)
+    from unnest(array['SELECT','INSERT','UPDATE','DELETE']) p)
+  union all select 'list_movies.authenticated_can_write', (
+    select bool_and(has_table_privilege('authenticated','public.list_movies',p) = true)
+    from unnest(array['SELECT','INSERT','UPDATE','DELETE']) p)
+  union all select 'lists.service_role_full', (
+    select bool_and(has_table_privilege('service_role','public.lists',p) = true)
+    from unnest(array['SELECT','INSERT','UPDATE','DELETE']) p)
+
+  -- RLS enabled + new lists default private + intended policies present
+  union all select 'lists.rls_enabled', (select relrowsecurity from pg_class where oid='public.lists'::regclass)
+  union all select 'list_movies.rls_enabled', (select relrowsecurity from pg_class where oid='public.list_movies'::regclass)
+  union all select 'lists.is_public_default_false', (
+    select coalesce(column_default,'') in ('false','false::boolean')
+    from information_schema.columns where table_schema='public' and table_name='lists' and column_name='is_public')
+  union all select 'lists.public_read_policy_scoped', (
+    select exists (select 1 from pg_policies where schemaname='public' and tablename='lists'
+      and cmd='SELECT' and qual ilike '%is_public%' and qual ilike '%auth.uid()%'))
+  union all select 'lists.owner_manage_policy', (
+    select exists (select 1 from pg_policies where schemaname='public' and tablename='lists'
+      and cmd='ALL' and coalesce(with_check,'') ilike '%auth.uid()%'))
+  union all select 'list_movies.visibility_follows_parent', (
+    select exists (select 1 from pg_policies where schemaname='public' and tablename='list_movies'
+      and cmd='SELECT' and qual ilike '%lists%' and qual ilike '%is_public%'))
+
+  -- Regression: F9.2 owner-only + S1.2/S1.3 still intact
+  union all select 'regression.owner_only_rls', (
+    select bool_and(exists(select 1 from pg_policies p where p.schemaname='public' and p.tablename=t
+      and coalesce(p.qual,'') ilike '%auth.uid()%'))
+    from unnest(array['user_watchlist','mood_sessions','user_ratings','user_history']) t)
+  union all select 'regression.user_tables_anon_denied', (
+    select bool_and(not has_table_privilege('anon','public.'||t,'SELECT'))
+    from unnest(array['user_watchlist','mood_sessions','user_ratings','user_history']) t)
+  union all select 'regression.beta_members_hardened', (
+    (select count(*)=0 from information_schema.role_table_grants where table_schema='public' and table_name='beta_members' and grantee='anon')
+    and (select count(*) filter (where privilege_type='SELECT')=1 and count(*) filter (where privilege_type<>'SELECT')=0
+         from information_schema.role_table_grants where table_schema='public' and table_name='beta_members' and grantee='authenticated'))
+  union all select 'regression.s12_views_security_invoker', (
+    coalesce((select reloptions from pg_class where oid='public.list_follower_counts'::regclass) @> array['security_invoker=true'],false)
+    and coalesce((select reloptions from pg_class where oid='public.vw_movies_scored'::regclass) @> array['security_invoker=true'],false))
+)
+select check_name, ok from checks
+union all
+select '== PART 1 ALL PASS ==', bool_and(ok) from checks
+order by 1;
+
+-- ── Part 2: adversarial anon-impersonation read-proof (no mutation; rolled back) ──
+begin;
+set local role anon;
+select 'anon.no_private_list_visible' as check_name,
+       (select count(*) = 0 from public.lists where is_public is not true) as ok
+union all
+select 'anon.no_private_list_movies_visible',
+       (select count(*) = 0 from public.list_movies lm
+          where not exists (select 1 from public.lists l where l.id = lm.list_id and l.is_public = true)) as ok;
+rollback;

--- a/supabase/migrations/20260611150000_harden_list_grants.sql
+++ b/supabase/migrations/20260611150000_harden_list_grants.sql
@@ -1,0 +1,34 @@
+-- S1.5 — harden public list grants (defense-in-depth).
+--
+-- DECISION: Option A — KEEP anonymous SELECT for explicit public-list sharing.
+--   public.lists has an opt-in public-share feature (is_public flag, default FALSE per F9.2;
+--   shareable /lists/:id links render signed-out). The "Public lists are readable by anyone"
+--   RLS policy already scopes anon reads to is_public=true rows (private lists stay owner-only),
+--   and list_movies visibility follows its parent list. We PRESERVE that sharing behavior and
+--   only remove the inert, unnecessary anonymous WRITE grants.
+--
+-- SCOPE: grant-only. No schema change, no RLS-policy change, no row mutation, no is_public
+--   change, no ownership change, no app source. Idempotent. Rollback below.
+--
+-- Pre-state (audited live): anon, authenticated, and service_role each held FULL table
+--   privileges (SELECT/INSERT/UPDATE/DELETE/TRUNCATE/REFERENCES/TRIGGER) on both tables; the
+--   PUBLIC role holds NO grant (verified) so no PUBLIC revoke is needed. RLS is enabled on both;
+--   the only write policy ("Users can manage own lists" / "...movies in own lists") requires
+--   auth.uid() = user_id, so anonymous writes are ALREADY RLS-blocked — the anon write grants
+--   are inert. This removes them so anon has no write path at the grant layer either.
+--   Live anon-impersonation confirmed anon sees only is_public=true lists (0 private visible).
+--
+-- After: anon = SELECT only (public-list read via RLS); authenticated = full (RLS-constrained to
+--   the owner); service_role = full (management). Private lists remain owner-only.
+--
+-- FROZEN CONTRACTS PRESERVED: F9.2 (new lists default private), explicit public-list sharing,
+--   owner-only private lists, F9.3 list create/delete reliability, F8.6-SEC, S1.2/S1.3/S1.4.
+--
+-- ROLLBACK: grant insert, update, delete, truncate, references, trigger
+--   on table public.lists, public.list_movies to anon;
+
+revoke insert, update, delete, truncate, references, trigger
+  on table public.lists from anon;
+
+revoke insert, update, delete, truncate, references, trigger
+  on table public.list_movies from anon;


### PR DESCRIPTION
S1.5 of the Global Security Hardening initiative — the scoped `lists`/`list_movies` grant hygiene + public-list pre-auth visibility decision from B2.3. One grant-only migration + a read-only verify script. No schema/RLS-policy/row/`is_public`/ownership change; no app source change.

## Public-list visibility decision — **Option A (keep anon SELECT)**
Public-list sharing is an intended opt-in feature (`is_public` flag, **default private** per F9.2; `PersonalList.jsx` creates shareable `/lists/:id` links that render signed-out; `"Public lists are readable by anyone"` RLS policy). So we **preserve anonymous SELECT** (private lists stay owner-only via RLS) and only **revoke the inert anonymous write grants**. Option B (require auth for all lists) was rejected — it would remove a real product capability with no security justification (private lists are already protected).

## Grants before → after
| table · role | before | after |
|---|---|---|
| `lists` · anon | SELECT/INSERT/UPDATE/DELETE/TRUNCATE/REFERENCES/TRIGGER | **SELECT only** |
| `list_movies` · anon | (same full set) | **SELECT only** |
| `lists`/`list_movies` · authenticated | full | full (unchanged; RLS-constrained to owner) |
| `lists`/`list_movies` · service_role | full | full (unchanged) |
| PUBLIC role | (none) | (none) — nothing to revoke |

Anon writes were already **RLS-blocked** (the only write policy requires `auth.uid() = user_id`, NULL for anon) — this closes the path at the grant layer too (defense-in-depth, same class as the S1.3 `beta_members` cleanup).

## RLS / private-list proof (firsthand, anon impersonation)
Under `SET LOCAL ROLE anon` (rolled back): anon sees **0 private lists**, **0 private `list_movies`**, and **can still read public lists** (count > 0). RLS enabled on both; `is_public` default **false**; `list_movies` visibility **follows its parent list**. No private-list leak; public sharing preserved.

## Verification script result
`scripts/verify-s15-list-grants.sql` — **Part 1 ALL PASS** (18 checks: anon write/DDL denied + SELECT kept on both tables; authenticated can write; service_role full; RLS on; default private; public-read + owner-manage policies; list_movies follows parent; **regression**: owner-only RLS on watchlist/mood/ratings/history, user-tables anon-denied, beta_members hardened, S1.2 views security_invoker). **Part 2** anon impersonation all-true.

## Advisor result
**No new P0/P1; no ERROR.** Unchanged set (the grant revoke isn't an advisor lint): the 3 operator Auth items (leaked-password, OTP, Postgres patch — still pending/manual), 7 intentional authenticated SECURITY DEFINER RPCs, 2 `extension_in_public`, 2 INFO `rls_enabled_no_policy`.

## Tests / build
`npm run lint` clean · `npx vitest run src/features/lists/` 11/11 · `npm run test` **1537 passed** (146 files) · `npm run build` ✓. No Lists test assumed anon DB grants → no test change needed.

## No row mutation
Only `REVOKE`. Zero INSERT/UPDATE/DELETE; no list rows created/edited/deleted; no `is_public`/ownership change; no private list metadata printed.

## Persona WIP untouched
Staged only the 2 S1.5 files by explicit path (no `git add -A`). Persona files, `.gitignore`, `package.json`, `playwright.config.js`, `CLAUDE.md`, `.claude/**` not staged. (Note: branch was based on `origin/main` `d6ee8bc2`, not the diverged local-main persona commit, so the PR contains only the 2 S1.5 files.)

## Remaining B2.3 pre-5–10 operator tasks (unchanged by this PR)
- Verify PostHog prod capture (`VITE_POSTHOG_KEY`) or accept server-side-only observability (elevated).
- Decide gate posture + enable/populate `beta_members` if gated.
- Auth dashboard: enable leaked-password protection, OTP ≤ 1h, redirect-URL audit.
- PostHog historical residue surgical deletion (manual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)